### PR TITLE
william/gpu-picking-not-targeting-correct-items-at-times

### DIFF
--- a/src/components/picking/PickingRenderer.tsx
+++ b/src/components/picking/PickingRenderer.tsx
@@ -180,16 +180,11 @@ export function PickingRenderer({
       registration.object.updateMatrixWorld(true);
       pickObject.matrixAutoUpdate = false;
 
-      // Decompose world matrix to get position/rotation/scale in world space
-      registration.object.matrixWorld.decompose(
-        pickObject.position,
-        pickObject.quaternion,
-        pickObject.scale
-      );
+      // Copy world matrix directly to preserve full transform (including shear)
+      pickObject.matrix.copy(registration.object.matrixWorld);
+      pickObject.matrixWorld.copy(registration.object.matrixWorld);
 
-      // Update matrices after setting position/rotation/scale
-      pickObject.updateMatrix();
-      pickObject.updateMatrixWorld(true);
+      // No need to call updateMatrix / updateMatrixWorld since we've set them explicitly
 
       pickScene.add(pickObject);
     }

--- a/src/components/picking/PickingRenderer.tsx
+++ b/src/components/picking/PickingRenderer.tsx
@@ -179,11 +179,18 @@ export function PickingRenderer({
       // Copy world transform - need to set both matrix and matrixWorld
       registration.object.updateMatrixWorld(true);
       pickObject.matrixAutoUpdate = false;
-      pickObject.matrix.copy(registration.object.matrixWorld);
-      pickObject.matrixWorld.copy(registration.object.matrixWorld);
-      // Decompose to position/rotation/scale for proper rendering
-      pickObject.matrix.decompose(pickObject.position, pickObject.quaternion, pickObject.scale);
-      
+
+      // Decompose world matrix to get position/rotation/scale in world space
+      registration.object.matrixWorld.decompose(
+        pickObject.position,
+        pickObject.quaternion,
+        pickObject.scale
+      );
+
+      // Update matrices after setting position/rotation/scale
+      pickObject.updateMatrix();
+      pickObject.updateMatrixWorld(true);
+
       pickScene.add(pickObject);
     }
     

--- a/src/components/picking/PickingRenderer.tsx
+++ b/src/components/picking/PickingRenderer.tsx
@@ -197,7 +197,7 @@ export function PickingRenderer({
     // Render to the pick target
     const currentRenderTarget = gl.getRenderTarget();
     gl.setRenderTarget(renderTargetRef.current);
-    gl.clear();
+    gl.clear(true, true, false); // clear color, clear depth, don't clear stencil
     gl.render(pickScene, pickCamera);
     
     // Read back pixels


### PR DESCRIPTION
This pull request updates the picking logic in `PickingRenderer.tsx` to improve the accuracy and reliability of object picking in the 3D scene. The main change is a more robust approach to synchronizing the transformation (position, rotation, scale) of pickable objects, ensuring they match the world space transformations of their source objects.

**Picking logic and rendering improvements:**

* Changed the way transformation is copied to `pickObject`: Instead of copying the world matrix directly, the code now decomposes the source object's world matrix into position, rotation, and scale, applies these to the `pickObject`, and then updates its matrices. This ensures correct world space alignment for picking.
* Updated the clear call for the render target: Now explicitly clears color and depth buffers (but not stencil) before rendering the pick scene, which can help prevent rendering artifacts during picking.