### PR TITLE
feat: add William Patton to Team & Credits in About tab

### DIFF
--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -774,6 +774,38 @@ export function SettingsModal({
                           </div>
                         </div>
                       </div>
+
+                      <div
+                        className="rounded-lg border px-3 py-2.5"
+                        style={{
+                          borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 45%)',
+                          background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-0) 93%)',
+                        }}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <div className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
+                              William Patton
+                            </div>
+                            <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                              PattonWebz
+                            </div>
+                            <div className="mt-0.5 text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                              Breaks stuff, maybe fixes it. Maybe.
+                            </div>
+                          </div>
+                          <div
+                            className="rounded-full border px-2 py-0.5 text-[10px] font-semibold"
+                            style={{
+                              color: 'var(--accent-secondary-contrast)',
+                              borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 38%)',
+                              background: 'color-mix(in srgb, var(--accent-secondary), transparent 18%)',
+                            }}
+                          >
+                            Contributor
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
 


### PR DESCRIPTION
This pull request introduces a new visual section to the `SettingsModal` component that highlights a contributor profile. The section displays the contributor's name, handle, a brief description, and a styled "Contributor" badge.

Contributor profile section added:

* Added a new styled block in `SettingsModal.tsx` to display contributor information, including name ("William Patton"), handle ("PattonWebz"), a short description, and a "Contributor" badge, all with custom color mixing for enhanced visual distinction.

<img width="237" height="260" alt="Screenshot from 2026-02-19 22-32-37" src="https://github.com/user-attachments/assets/81ab5dec-ca99-42a4-86fd-8a97c60b95ab" />