### PR TITLE
feat: Workspace Overhaul: Arrange, Duplicate, Various Workspace Improvements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -506,3 +506,37 @@ input[type="number"].no-spinners {
   border-radius: 9999px;
   animation: uiLoadingLoop 1.15s linear infinite;
 }
+
+/* Themed custom scrollbar */
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--accent), var(--surface-2) 58%) color-mix(in srgb, var(--surface-2), black 18%);
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: color-mix(in srgb, var(--surface-2), black 18%);
+  border-radius: 999px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent), white 8%),
+    color-mix(in srgb, var(--accent), var(--surface-2) 42%)
+  );
+  border-radius: 999px;
+  border: 2px solid color-mix(in srgb, var(--surface-2), black 18%);
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent), white 16%),
+    color-mix(in srgb, var(--accent), var(--surface-2) 34%)
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -839,7 +839,11 @@ export default function Home() {
   usePrepareTransformHotkeys({
     appMode: scene.mode,
     hasModels: scene.models.length > 0,
+    transformMode: transformMgr.transformMode,
     setTransformMode: transformMgr.setTransformMode,
+    onArrangeAll: () => {
+      void handleAutoArrangeModels('all');
+    },
   });
 
   // Auto-set cross-section mode based on app mode

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -404,10 +404,16 @@ export default function Home() {
     window.setTimeout(resolve, ms);
   }), []);
 
-  const handleAutoArrangeModels = React.useCallback(async () => {
+  const handleAutoArrangeModels = React.useCallback(async (scope: 'all' | 'selected') => {
     if (isAutoArranging) return;
 
-    const visibleModels = scene.models.filter((m) => m.visible);
+    const selectedIdSet = new Set(scene.selectedModelIds);
+    const visibleModels = scene.models.filter((m) => {
+      if (!m.visible) return false;
+      if (scope === 'selected') return selectedIdSet.has(m.id);
+      return true;
+    });
+
     if (visibleModels.length <= 1) return;
 
     const minSpinnerMs = 220;
@@ -1243,8 +1249,14 @@ export default function Home() {
                 onAllowRotateOnZChange={setArrangeAllowRotateOnZ}
                 anchorMode={arrangeAnchorMode}
                 onAnchorModeChange={setArrangeAnchorMode}
-                onApply={handleAutoArrangeModels}
+                onApplyAll={() => {
+                  void handleAutoArrangeModels('all');
+                }}
+                onApplySelected={() => {
+                  void handleAutoArrangeModels('selected');
+                }}
                 modelCount={scene.models.filter((m) => m.visible).length}
+                selectedModelCount={scene.models.filter((m) => m.visible && scene.selectedModelIds.includes(m.id)).length}
                 isApplying={isAutoArranging}
               />
             )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1596,15 +1596,17 @@ export default function Home() {
     await sleep(0);
 
     try {
-      if (duplicateSourcePreviewTransform) {
-        scene.updateModelTransform(scene.activeModelId, {
-          position: duplicateSourcePreviewTransform.position.clone(),
-          rotation: duplicateSourcePreviewTransform.rotation.clone(),
-          scale: duplicateSourcePreviewTransform.scale.clone(),
-        });
-      }
-
-      scene.duplicateModelWithTransforms(scene.activeModelId, duplicatePreviewTransforms);
+      scene.duplicateModelWithTransforms(
+        scene.activeModelId,
+        duplicatePreviewTransforms,
+        duplicateSourcePreviewTransform
+          ? {
+              position: duplicateSourcePreviewTransform.position.clone(),
+              rotation: duplicateSourcePreviewTransform.rotation.clone(),
+              scale: duplicateSourcePreviewTransform.scale.clone(),
+            }
+          : null,
+      );
       setDuplicateTotalCopies(2);
       setDuplicateSourcePreviewTransform(null);
       setDuplicatePreviewTransforms([]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -893,6 +893,13 @@ export default function Home() {
   }, [scene.mode]);
 
   React.useEffect(() => {
+    const workspaceSelectionHighlightMode = getSavedWorkspaceCameraSettings().selectionHighlightDefaults[scene.mode];
+    if (workspaceSelectionHighlightMode !== scene.selectionHighlightMode) {
+      scene.setSelectionHighlightMode(workspaceSelectionHighlightMode);
+    }
+  }, [scene.mode, scene.selectionHighlightMode, scene.setSelectionHighlightMode]);
+
+  React.useEffect(() => {
     if (scene.mode !== 'support') return;
     if (scene.activeModelId) return;
     if (scene.models.length === 0) return;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,6 +16,8 @@ import { DebugPrimitivesPanel } from '@/components/controls/DebugPrimitivesPanel
 import { ModelStatsCard } from '@/components/controls/ModelStatsCard';
 import { TransformToolbar } from '@/components/controls/TransformToolbar';
 import { TransformControls } from '@/components/controls/TransformControls';
+import { ArrangePanel } from '@/components/controls/ArrangePanel';
+import { DuplicatePanel } from '@/components/controls/DuplicatePanel';
 import { VisualSettingsPanel } from '@/components/controls/VisualSettingsPanel';
 import { SupportSidebar } from '@/supports/Settings';
 import { CurveSettingsCard } from '@/supports/Curves/CurveSettingsCard';
@@ -77,6 +79,21 @@ export default function Home() {
   const [debugPrimitivesPanelVisible, setDebugPrimitivesPanelVisible] = React.useState<boolean>(true);
   const [editorContextMenuPos, setEditorContextMenuPos] = React.useState<{ x: number; y: number } | null>(null);
   const [isSelectAllModelsActive, setIsSelectAllModelsActive] = React.useState(false);
+  const [arrangeSpacingMm, setArrangeSpacingMm] = React.useState(12);
+  const [isAutoArranging, setIsAutoArranging] = React.useState(false);
+  const [duplicateTotalCopies, setDuplicateTotalCopies] = React.useState(2);
+  const [duplicateSpacingMm, setDuplicateSpacingMm] = React.useState(12);
+  const [isDuplicating, setIsDuplicating] = React.useState(false);
+  const [duplicatePreviewTransforms, setDuplicatePreviewTransforms] = React.useState<Array<{
+    position: THREE.Vector3;
+    rotation: THREE.Euler;
+    scale: THREE.Vector3;
+  }>>([]);
+  const [duplicateSourcePreviewTransform, setDuplicateSourcePreviewTransform] = React.useState<{
+    position: THREE.Vector3;
+    rotation: THREE.Euler;
+    scale: THREE.Vector3;
+  } | null>(null);
   const dragDepthRef = React.useRef(0);
   const rightClickGestureRef = React.useRef<{ x: number; y: number; moved: boolean } | null>(null);
 
@@ -339,6 +356,83 @@ export default function Home() {
   // Temporary: LYS Ghost Viewer State
   const [ghostData, setGhostData] = React.useState<any>(null);
 
+  const getModelFootprintMm = React.useCallback((model: (typeof scene.models)[number]) => {
+    const size = model.geometry.size;
+    return {
+      width: Math.max(2, Math.abs(size.x * model.transform.scale.x)),
+      depth: Math.max(2, Math.abs(size.y * model.transform.scale.y)),
+    };
+  }, []);
+
+  const sleep = React.useCallback((ms: number) => new Promise<void>((resolve) => {
+    window.setTimeout(resolve, ms);
+  }), []);
+
+  const handleAutoArrangeModels = React.useCallback(async () => {
+    if (isAutoArranging) return;
+
+    const visibleModels = scene.models.filter((m) => m.visible);
+    if (visibleModels.length <= 1) return;
+
+    const minSpinnerMs = 220;
+    const startedAt = performance.now();
+    setIsAutoArranging(true);
+    await sleep(0);
+
+    try {
+      const maxWidth = visibleModels.reduce((acc, model) => Math.max(acc, getModelFootprintMm(model).width), 0);
+      const maxDepth = visibleModels.reduce((acc, model) => Math.max(acc, getModelFootprintMm(model).depth), 0);
+
+      const columns = Math.max(1, Math.ceil(Math.sqrt(visibleModels.length)));
+      const rows = Math.ceil(visibleModels.length / columns);
+      const stepX = maxWidth + arrangeSpacingMm;
+      const stepY = maxDepth + arrangeSpacingMm;
+      const centerX = scene.view3dSettings.originMode === 'front_left' ? scene.view3dSettings.widthMm * 0.5 : 0;
+      const centerY = scene.view3dSettings.originMode === 'front_left' ? scene.view3dSettings.depthMm * 0.5 : 0;
+      const startX = centerX - ((columns - 1) * stepX) * 0.5;
+      const startY = centerY - ((rows - 1) * stepY) * 0.5;
+
+      scene.updateModelTransforms(
+        visibleModels.map((model, index) => {
+          const col = index % columns;
+          const row = Math.floor(index / columns);
+
+          return {
+            id: model.id,
+            transform: {
+              position: new THREE.Vector3(startX + col * stepX, startY + row * stepY, model.transform.position.z),
+              rotation: model.transform.rotation.clone(),
+              scale: model.transform.scale.clone(),
+            },
+          };
+        }),
+      );
+
+      transformMgr.setTransformMode('select');
+    } finally {
+      const elapsed = performance.now() - startedAt;
+      if (elapsed < minSpinnerMs) {
+        await sleep(minSpinnerMs - elapsed);
+      }
+      setIsAutoArranging(false);
+    }
+  }, [arrangeSpacingMm, getModelFootprintMm, isAutoArranging, scene, sleep, transformMgr]);
+
+  const computeArrangeSlots = React.useCallback((count: number, stepX: number, stepY: number) => {
+    const columns = Math.max(1, Math.ceil(Math.sqrt(count)));
+    const rows = Math.ceil(count / columns);
+    const centerX = scene.view3dSettings.originMode === 'front_left' ? scene.view3dSettings.widthMm * 0.5 : 0;
+    const centerY = scene.view3dSettings.originMode === 'front_left' ? scene.view3dSettings.depthMm * 0.5 : 0;
+    const startX = centerX - ((columns - 1) * stepX) * 0.5;
+    const startY = centerY - ((rows - 1) * stepY) * 0.5;
+
+    return Array.from({ length: count }, (_, index) => {
+      const col = index % columns;
+      const row = Math.floor(index / columns);
+      return new THREE.Vector3(startX + col * stepX, startY + row * stepY, 0);
+    });
+  }, [scene.view3dSettings.depthMm, scene.view3dSettings.originMode, scene.view3dSettings.widthMm]);
+
   useUndoRedoHotkeys();
   useDeleteHotkey();
   useCameraProjectionHotkey();
@@ -516,6 +610,93 @@ export default function Home() {
     };
   }, [scene.mode, scene.models.length]);
 
+  React.useEffect(() => {
+    if (scene.mode !== 'prepare' || transformMgr.transformMode !== 'duplicate') {
+      setDuplicatePreviewTransforms([]);
+      setDuplicateSourcePreviewTransform(null);
+      return;
+    }
+
+    if (!scene.activeModel || duplicateTotalCopies <= 1) {
+      setDuplicatePreviewTransforms([]);
+      setDuplicateSourcePreviewTransform(null);
+      return;
+    }
+
+    const model = scene.activeModel;
+    const totalCount = Math.max(1, duplicateTotalCopies);
+    const { width, depth } = getModelFootprintMm(model);
+    const stepX = width + duplicateSpacingMm;
+    const stepY = depth + duplicateSpacingMm;
+
+    const slots = computeArrangeSlots(totalCount, stepX, stepY);
+
+    let sourceSlotIndex = 0;
+    let sourceSlotDistanceSq = Number.POSITIVE_INFINITY;
+
+    slots.forEach((slot, index) => {
+      const dx = slot.x - model.transform.position.x;
+      const dy = slot.y - model.transform.position.y;
+      const distSq = dx * dx + dy * dy;
+      if (distSq < sourceSlotDistanceSq) {
+        sourceSlotDistanceSq = distSq;
+        sourceSlotIndex = index;
+      }
+    });
+
+    const sourceSlot = slots[sourceSlotIndex];
+    setDuplicateSourcePreviewTransform({
+      position: new THREE.Vector3(sourceSlot.x, sourceSlot.y, model.transform.position.z),
+      rotation: model.transform.rotation.clone(),
+      scale: model.transform.scale.clone(),
+    });
+
+    const previews: Array<{ position: THREE.Vector3; rotation: THREE.Euler; scale: THREE.Vector3 }> = [];
+    slots.forEach((slot, index) => {
+      if (index === sourceSlotIndex) return;
+      previews.push({
+        position: new THREE.Vector3(slot.x, slot.y, model.transform.position.z),
+        rotation: model.transform.rotation.clone(),
+        scale: model.transform.scale.clone(),
+      });
+    });
+
+    setDuplicatePreviewTransforms(previews);
+  }, [computeArrangeSlots, duplicateSpacingMm, duplicateTotalCopies, getModelFootprintMm, scene.activeModel, scene.mode, transformMgr.transformMode]);
+
+  const handleConfirmDuplicate = React.useCallback(async () => {
+    if (isDuplicating) return;
+    if (!scene.activeModelId) return;
+    if (duplicatePreviewTransforms.length === 0) return;
+
+    const minSpinnerMs = 220;
+    const startedAt = performance.now();
+    setIsDuplicating(true);
+    await sleep(0);
+
+    try {
+      if (duplicateSourcePreviewTransform) {
+        scene.updateModelTransform(scene.activeModelId, {
+          position: duplicateSourcePreviewTransform.position.clone(),
+          rotation: duplicateSourcePreviewTransform.rotation.clone(),
+          scale: duplicateSourcePreviewTransform.scale.clone(),
+        });
+      }
+
+      scene.duplicateModelWithTransforms(scene.activeModelId, duplicatePreviewTransforms);
+      setDuplicateTotalCopies(2);
+      setDuplicateSourcePreviewTransform(null);
+      setDuplicatePreviewTransforms([]);
+      transformMgr.setTransformMode('select');
+    } finally {
+      const elapsed = performance.now() - startedAt;
+      if (elapsed < minSpinnerMs) {
+        await sleep(minSpinnerMs - elapsed);
+      }
+      setIsDuplicating(false);
+    }
+  }, [duplicatePreviewTransforms, duplicateSourcePreviewTransform, isDuplicating, scene, sleep, transformMgr]);
+
   return (
     <div className="ui-shell relative h-screen w-screen overflow-hidden">
       <TopBar
@@ -646,6 +827,31 @@ export default function Home() {
                   </div>
                 )}
               </div>
+            )}
+
+            {scene.geom && transformMgr.transformMode === 'arrange' && (
+              <ArrangePanel
+                key="prepare-arrange-panel"
+                spacingMm={arrangeSpacingMm}
+                onSpacingMmChange={setArrangeSpacingMm}
+                onApply={handleAutoArrangeModels}
+                modelCount={scene.models.filter((m) => m.visible).length}
+                isApplying={isAutoArranging}
+              />
+            )}
+
+            {scene.geom && transformMgr.transformMode === 'duplicate' && (
+              <DuplicatePanel
+                key="prepare-duplicate-panel"
+                activeModelName={scene.activeModel?.name ?? null}
+                totalCopies={duplicateTotalCopies}
+                onTotalCopiesChange={setDuplicateTotalCopies}
+                spacingMm={duplicateSpacingMm}
+                onSpacingMmChange={setDuplicateSpacingMm}
+                onConfirm={handleConfirmDuplicate}
+                previewCount={Math.max(0, duplicateTotalCopies - 1)}
+                isApplying={isDuplicating}
+              />
             )}
           </>
         ) : scene.mode === 'analysis' ? (
@@ -914,6 +1120,9 @@ export default function Home() {
             pxMm={islands.pxMm}
             supportsRef={supportsRef}
             ghostData={ghostData}
+            duplicatePreviewModel={transformMgr.transformMode === 'duplicate' ? scene.activeModel : null}
+            duplicatePreviewTransforms={duplicatePreviewTransforms}
+            duplicateActivePreviewTransform={duplicateSourcePreviewTransform}
             view3dSettings={scene.view3dSettings}
           >
             {scene.mode === 'prepare' && transformMgr.transformMode === 'smoothing' && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -903,6 +903,34 @@ export default function Home() {
     }
   }, [scene.mode, scene.activeModelId, scene.models, scene.setActiveModelId]);
 
+  React.useEffect(() => {
+    if (scene.mode !== 'support') return;
+    if (scene.selectedModelIds.length <= 1) return;
+
+    const selectedIdSet = new Set(scene.selectedModelIds);
+    const firstValidSelectedId = scene.selectedModelIds.find((id) => scene.models.some((model) => model.id === id));
+    const firstVisibleSelectedId = scene.models.find((model) => model.visible && selectedIdSet.has(model.id))?.id;
+    const keptId = firstVisibleSelectedId ?? firstValidSelectedId;
+
+    if (!keptId) {
+      scene.clearModelSelection();
+      return;
+    }
+
+    scene.setSelectedModelIds([keptId]);
+    if (scene.activeModelId !== keptId) {
+      scene.setActiveModelId(keptId);
+    }
+  }, [
+    scene.mode,
+    scene.selectedModelIds,
+    scene.models,
+    scene.activeModelId,
+    scene.setActiveModelId,
+    scene.setSelectedModelIds,
+    scene.clearModelSelection,
+  ]);
+
   const importOverlayState = React.useMemo(() => {
     if (scene.importProgress.active) {
       return {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1031,6 +1031,22 @@ export default function Home() {
 
   React.useEffect(() => {
     const unregister = registerDeleteHandler(
+      () => scene.mode === 'prepare' && scene.selectedModelIds.length > 0,
+      () => {
+        const ids = Array.from(new Set(scene.selectedModelIds));
+        ids.forEach((id) => scene.deleteModel(id));
+        setIsSelectAllModelsActive(false);
+      },
+      30,
+    );
+
+    return () => {
+      unregister();
+    };
+  }, [scene]);
+
+  React.useEffect(() => {
+    const unregister = registerDeleteHandler(
       () => scene.mode === 'prepare' && isSelectAllModelsActive && scene.models.length > 0,
       () => {
         const ids = scene.models.map((model) => model.id);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,6 +43,7 @@ import { useUndoRedoHotkeys } from '@/hotkeys/useUndoRedoHotkeys';
 import { useDeleteHotkey } from '@/features/delete/useDeleteHotkey';
 import { registerDeleteHandler } from '@/features/delete/deleteRegistry';
 import { useCameraProjectionHotkey } from '@/hotkeys/useCameraProjectionHotkey';
+import { usePrepareTransformHotkeys } from '@/hotkeys/usePrepareTransformHotkeys';
 import { getSavedCameraProjectionSettings, saveCameraProjectionSettings } from '@/components/settings/cameraProjectionPreferences';
 import { getSavedWorkspaceCameraSettings } from '@/components/settings/workspaceCameraPreferences';
 
@@ -835,6 +836,11 @@ export default function Home() {
   useUndoRedoHotkeys();
   useDeleteHotkey();
   useCameraProjectionHotkey();
+  usePrepareTransformHotkeys({
+    appMode: scene.mode,
+    hasModels: scene.models.length > 0,
+    setTransformMode: transformMgr.setTransformMode,
+  });
 
   // Auto-set cross-section mode based on app mode
   React.useEffect(() => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1383,6 +1383,95 @@ export default function Home() {
     }
   }, [duplicatePreviewTransforms, duplicateSourcePreviewTransform, isDuplicating, scene, sleep, transformMgr]);
 
+  const handleFillPlateDuplicate = React.useCallback(() => {
+    if (isDuplicating) return;
+    if (duplicateLayoutMode !== 'auto') return;
+    const model = scene.activeModel;
+    if (!model) return;
+
+    const baseWidth = Math.max(2, Math.abs(model.geometry.size.x * model.transform.scale.x));
+    const baseDepth = Math.max(2, Math.abs(model.geometry.size.y * model.transform.scale.y));
+    const rz = model.transform.rotation.z;
+    const rc = Math.abs(Math.cos(rz));
+    const rs = Math.abs(Math.sin(rz));
+    const width = (baseWidth * rc) + (baseDepth * rs);
+    const depth = (baseWidth * rs) + (baseDepth * rc);
+    const spacing = Math.max(0, duplicateSpacingMm);
+
+    const minX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
+    const maxX = minX + scene.view3dSettings.widthMm;
+    const minY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
+    const maxY = minY + scene.view3dSettings.depthMm;
+
+    const plateWidth = Math.max(1, maxX - minX);
+    const plateDepth = Math.max(1, maxY - minY);
+    const maxCols = Math.max(1, Math.floor((plateWidth + spacing) / (width + spacing)));
+    const maxRows = Math.max(1, Math.floor((plateDepth + spacing) / (depth + spacing)));
+
+    const totalUsedWidth = (maxCols * width) + Math.max(0, maxCols - 1) * spacing;
+    const totalUsedDepth = (maxRows * depth) + Math.max(0, maxRows - 1) * spacing;
+    const startX = minX + ((plateWidth - totalUsedWidth) * 0.5) + (width * 0.5);
+    const startY = minY + ((plateDepth - totalUsedDepth) * 0.5) + (depth * 0.5);
+
+    type Rect2D = { minX: number; maxX: number; minY: number; maxY: number };
+
+    const intersectsRect = (a: Rect2D, b: Rect2D) => {
+      return !(a.maxX <= b.minX || a.minX >= b.maxX || a.maxY <= b.minY || a.minY >= b.maxY);
+    };
+
+    const modelToRect = (m: (typeof scene.models)[number]): Rect2D => {
+      const mBaseW = Math.max(2, Math.abs(m.geometry.size.x * m.transform.scale.x));
+      const mBaseD = Math.max(2, Math.abs(m.geometry.size.y * m.transform.scale.y));
+      const z = m.transform.rotation.z;
+      const c = Math.abs(Math.cos(z));
+      const s = Math.abs(Math.sin(z));
+      const mW = (mBaseW * c) + (mBaseD * s);
+      const mD = (mBaseW * s) + (mBaseD * c);
+      return {
+        minX: m.transform.position.x - (mW * 0.5),
+        maxX: m.transform.position.x + (mW * 0.5),
+        minY: m.transform.position.y - (mD * 0.5),
+        maxY: m.transform.position.y + (mD * 0.5),
+      };
+    };
+
+    const blockedRects = scene.models
+      .filter((m) => m.visible && m.id !== model.id)
+      .map(modelToRect);
+
+    const candidateCenters: Array<{ x: number; y: number; distSq: number }> = [];
+    for (let row = 0; row < maxRows; row += 1) {
+      for (let col = 0; col < maxCols; col += 1) {
+        const x = startX + col * (width + spacing);
+        const y = startY + row * (depth + spacing);
+        const dx = x - model.transform.position.x;
+        const dy = y - model.transform.position.y;
+        candidateCenters.push({ x, y, distSq: dx * dx + dy * dy });
+      }
+    }
+    candidateCenters.sort((a, b) => a.distSq - b.distSq);
+
+    let capacity = 0;
+    for (const candidate of candidateCenters) {
+      const rect: Rect2D = {
+        minX: candidate.x - (width * 0.5),
+        maxX: candidate.x + (width * 0.5),
+        minY: candidate.y - (depth * 0.5),
+        maxY: candidate.y + (depth * 0.5),
+      };
+
+      if (blockedRects.some((blocked) => intersectsRect(rect, blocked))) {
+        continue;
+      }
+
+      blockedRects.push(rect);
+      capacity += 1;
+    }
+
+    const targetCopies = Math.min(128, Math.max(1, capacity));
+    setDuplicateTotalCopies(targetCopies);
+  }, [duplicateLayoutMode, duplicateSpacingMm, isDuplicating, scene]);
+
   return (
     <div className="ui-shell relative h-screen w-screen overflow-hidden">
       <TopBar
@@ -1566,6 +1655,7 @@ export default function Home() {
                 onArrayGapYChange={setDuplicateArrayGapY}
                 onArrayGapZChange={setDuplicateArrayGapZ}
                 onConfirm={handleConfirmDuplicate}
+                onFillPlate={handleFillPlateDuplicate}
                 previewCount={duplicatePreviewTransforms.length}
                 isApplying={isDuplicating}
               />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -435,6 +435,60 @@ export default function Home() {
   // Temporary: LYS Ghost Viewer State
   const [ghostData, setGhostData] = React.useState<any>(null);
 
+  const computeModelWorldBounds = React.useCallback((model: (typeof scene.models)[number]) => {
+    const modelBox = model.geometry.bbox.clone();
+    const center = model.geometry.center;
+    modelBox.translate(new THREE.Vector3(-center.x, -center.y, -center.z));
+
+    const t = model.transform;
+    const matrix = new THREE.Matrix4().compose(
+      t.position,
+      new THREE.Quaternion().setFromEuler(t.rotation),
+      t.scale,
+    );
+    modelBox.applyMatrix4(matrix);
+    return modelBox;
+  }, [scene.models]);
+
+  const buildVolumeBounds = React.useMemo(() => {
+    if (!scene.view3dSettings.enabled) return null;
+
+    const width = scene.view3dSettings.widthMm;
+    const depth = scene.view3dSettings.depthMm;
+    const minX = scene.view3dSettings.originMode === 'front_left' ? 0 : -width * 0.5;
+    const minY = scene.view3dSettings.originMode === 'front_left' ? 0 : -depth * 0.5;
+
+    return new THREE.Box3(
+      new THREE.Vector3(minX, minY, 0),
+      new THREE.Vector3(minX + width, minY + depth, scene.view3dSettings.maxZMm),
+    );
+  }, [
+    scene.view3dSettings.depthMm,
+    scene.view3dSettings.enabled,
+    scene.view3dSettings.maxZMm,
+    scene.view3dSettings.originMode,
+    scene.view3dSettings.widthMm,
+  ]);
+
+  const outsidePlateModelIds = React.useMemo(() => {
+    if (!buildVolumeBounds) return [] as string[];
+
+    return scene.models
+      .filter((model) => model.visible)
+      .filter((model) => {
+        const bounds = computeModelWorldBounds(model);
+        return (
+          bounds.min.x < buildVolumeBounds.min.x
+          || bounds.max.x > buildVolumeBounds.max.x
+          || bounds.min.y < buildVolumeBounds.min.y
+          || bounds.max.y > buildVolumeBounds.max.y
+          || bounds.min.z < buildVolumeBounds.min.z
+          || bounds.max.z > buildVolumeBounds.max.z
+        );
+      })
+      .map((model) => model.id);
+  }, [buildVolumeBounds, computeModelWorldBounds, scene.models]);
+
   const getModelFootprintMm = React.useCallback((model: (typeof scene.models)[number]) => {
     const size = model.geometry.size;
     return {
@@ -1140,6 +1194,43 @@ export default function Home() {
     scene.clearModelSelection,
   ]);
 
+  React.useEffect(() => {
+    if (scene.mode !== 'support') return;
+    if (scene.models.length === 0) return;
+
+    const modelIdSet = new Set(scene.models.map((model) => model.id));
+    const activeId = scene.activeModelId;
+
+    if (activeId && modelIdSet.has(activeId)) {
+      if (scene.selectedModelIds.length === 1 && scene.selectedModelIds[0] === activeId) {
+        return;
+      }
+
+      if (scene.selectedModelIds.length === 0 || !scene.selectedModelIds.includes(activeId)) {
+        scene.setSelectedModelIds([activeId]);
+        return;
+      }
+
+      if (scene.selectedModelIds.length > 1) {
+        scene.setSelectedModelIds([activeId]);
+      }
+      return;
+    }
+
+    const fallback = scene.models.find((model) => model.visible) ?? scene.models[0];
+    if (!fallback) return;
+
+    scene.setActiveModelId(fallback.id);
+    scene.setSelectedModelIds([fallback.id]);
+  }, [
+    scene.mode,
+    scene.models,
+    scene.activeModelId,
+    scene.selectedModelIds,
+    scene.setActiveModelId,
+    scene.setSelectedModelIds,
+  ]);
+
   const importOverlayState = React.useMemo(() => {
     if (scene.importProgress.active) {
       return {
@@ -1755,6 +1846,7 @@ export default function Home() {
             <ModelManagerPanel
               key="prepare-models"
               models={scene.models}
+              outsidePlateModelIds={outsidePlateModelIds}
               activeModelId={scene.activeModelId}
               selectedModelIds={scene.selectedModelIds}
               onSelect={handleModelSelection}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1192,11 +1192,8 @@ export default function Home() {
 
       const maxCols = Math.max(1, Math.floor((plateWidth + spacing) / (width + spacing)));
       const maxRows = Math.max(1, Math.floor((plateDepth + spacing) / (depth + spacing)));
-      const inPlateCapacity = Math.max(1, maxCols * maxRows);
-      const inPlateCount = Math.min(totalCount, inPlateCapacity);
-
-      const usedCols = Math.min(maxCols, Math.max(1, inPlateCount));
-      const usedRows = Math.max(1, Math.ceil(inPlateCount / maxCols));
+      const usedCols = maxCols;
+      const usedRows = maxRows;
 
       const totalUsedWidth = (usedCols * width) + Math.max(0, usedCols - 1) * spacing;
       const totalUsedDepth = (usedRows * depth) + Math.max(0, usedRows - 1) * spacing;
@@ -1204,17 +1201,69 @@ export default function Home() {
       const startX = minX + ((plateWidth - totalUsedWidth) * 0.5) + (width * 0.5);
       const startY = minY + ((plateDepth - totalUsedDepth) * 0.5) + (depth * 0.5);
 
-      for (let i = 0; i < inPlateCount; i += 1) {
-        const col = i % maxCols;
-        const row = Math.floor(i / maxCols);
-        slots.push(new THREE.Vector3(
-          startX + col * (width + spacing),
-          startY + row * (depth + spacing),
-          model.transform.position.z,
-        ));
+      type Rect2D = { minX: number; maxX: number; minY: number; maxY: number };
+
+      const intersectsRect = (a: Rect2D, b: Rect2D) => {
+        return !(a.maxX <= b.minX || a.minX >= b.maxX || a.maxY <= b.minY || a.minY >= b.maxY);
+      };
+
+      const modelToRect = (m: (typeof scene.models)[number]): Rect2D => {
+        const mBaseW = Math.max(2, Math.abs(m.geometry.size.x * m.transform.scale.x));
+        const mBaseD = Math.max(2, Math.abs(m.geometry.size.y * m.transform.scale.y));
+        const rz = m.transform.rotation.z;
+        const rc = Math.abs(Math.cos(rz));
+        const rs = Math.abs(Math.sin(rz));
+        const mW = (mBaseW * rc) + (mBaseD * rs);
+        const mD = (mBaseW * rs) + (mBaseD * rc);
+        return {
+          minX: m.transform.position.x - (mW * 0.5),
+          maxX: m.transform.position.x + (mW * 0.5),
+          minY: m.transform.position.y - (mD * 0.5),
+          maxY: m.transform.position.y + (mD * 0.5),
+        };
+      };
+
+      const blockedRects = scene.models
+        .filter((m) => m.visible && m.id !== model.id)
+        .map(modelToRect);
+
+      const candidateCenters: Array<{ x: number; y: number; distSq: number }> = [];
+      for (let row = 0; row < maxRows; row += 1) {
+        for (let col = 0; col < maxCols; col += 1) {
+          const x = startX + col * (width + spacing);
+          const y = startY + row * (depth + spacing);
+          const dx = x - model.transform.position.x;
+          const dy = y - model.transform.position.y;
+          candidateCenters.push({ x, y, distSq: dx * dx + dy * dy });
+        }
       }
 
-      const overflowCount = totalCount - inPlateCount;
+      candidateCenters.sort((a, b) => a.distSq - b.distSq);
+
+      const chosenCenters: Array<{ x: number; y: number }> = [];
+      for (const candidate of candidateCenters) {
+        if (chosenCenters.length >= totalCount) break;
+
+        const rect: Rect2D = {
+          minX: candidate.x - (width * 0.5),
+          maxX: candidate.x + (width * 0.5),
+          minY: candidate.y - (depth * 0.5),
+          maxY: candidate.y + (depth * 0.5),
+        };
+
+        if (blockedRects.some((blocked) => intersectsRect(rect, blocked))) {
+          continue;
+        }
+
+        chosenCenters.push({ x: candidate.x, y: candidate.y });
+        blockedRects.push(rect);
+      }
+
+      for (const center of chosenCenters) {
+        slots.push(new THREE.Vector3(center.x, center.y, model.transform.position.z));
+      }
+
+      const overflowCount = totalCount - chosenCenters.length;
       if (overflowCount > 0) {
         const outsideGap = Math.max(8, spacing);
         let outsideLeftX = maxX + outsideGap;
@@ -1278,7 +1327,6 @@ export default function Home() {
 
     setDuplicatePreviewTransforms(previews);
   }, [
-    computeArrangeSlots,
     duplicateArrayCountX,
     duplicateArrayCountY,
     duplicateArrayCountZ,
@@ -1290,6 +1338,7 @@ export default function Home() {
     duplicateTotalCopies,
     getModelFootprintMm,
     scene.activeModel,
+    scene.models,
     scene.mode,
     transformMgr.transformMode,
   ]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ import { DebugPrimitivesPanel } from '@/components/controls/DebugPrimitivesPanel
 import { ModelStatsCard } from '@/components/controls/ModelStatsCard';
 import { TransformToolbar } from '@/components/controls/TransformToolbar';
 import { TransformControls } from '@/components/controls/TransformControls';
-import { ArrangePanel, type ArrangeAnchorMode } from '@/components/controls/ArrangePanel';
+import { ArrangePanel, type ArrangeAnchorMode, type ArrangeLayoutMode } from '@/components/controls/ArrangePanel';
 import { DuplicatePanel, type DuplicateLayoutMode } from '../components/controls/DuplicatePanel';
 import { VisualSettingsPanel } from '@/components/controls/VisualSettingsPanel';
 import { SupportSidebar } from '@/supports/Settings';
@@ -82,7 +82,14 @@ export default function Home() {
   const [isSelectAllModelsActive, setIsSelectAllModelsActive] = React.useState(false);
   const [arrangeSpacingMm, setArrangeSpacingMm] = React.useState(5);
   const [arrangeAllowRotateOnZ, setArrangeAllowRotateOnZ] = React.useState(false);
+  const [arrangeLayoutMode, setArrangeLayoutMode] = React.useState<ArrangeLayoutMode>('auto');
   const [arrangeAnchorMode, setArrangeAnchorMode] = React.useState<ArrangeAnchorMode>('center');
+  const [arrangeArrayCountX, setArrangeArrayCountX] = React.useState(3);
+  const [arrangeArrayCountY, setArrangeArrayCountY] = React.useState(2);
+  const [arrangeArrayCountZ, setArrangeArrayCountZ] = React.useState(1);
+  const [arrangeArrayGapX, setArrangeArrayGapX] = React.useState(5);
+  const [arrangeArrayGapY, setArrangeArrayGapY] = React.useState(5);
+  const [arrangeArrayGapZ, setArrangeArrayGapZ] = React.useState(5);
   const [isAutoArranging, setIsAutoArranging] = React.useState(false);
   const [duplicateTotalCopies, setDuplicateTotalCopies] = React.useState(2);
   const [duplicateSpacingMm, setDuplicateSpacingMm] = React.useState(5);
@@ -98,6 +105,14 @@ export default function Home() {
     position: THREE.Vector3;
     rotation: THREE.Euler;
     scale: THREE.Vector3;
+  }>>([]);
+  const [arrangeArrayPreviewItems, setArrangeArrayPreviewItems] = React.useState<Array<{
+    model: (typeof scene.models)[number];
+    transform: {
+      position: THREE.Vector3;
+      rotation: THREE.Euler;
+      scale: THREE.Vector3;
+    };
   }>>([]);
   const [duplicateSourcePreviewTransform, setDuplicateSourcePreviewTransform] = React.useState<{
     position: THREE.Vector3;
@@ -833,6 +848,191 @@ export default function Home() {
     }
   }, [arrangeAllowRotateOnZ, arrangeAnchorMode, arrangeSpacingMm, getModelFootprintMm, isAutoArranging, scene, sleep, transformMgr]);
 
+  const computeManualArrayArrangeUpdates = React.useCallback((scope: 'all' | 'selected', explicitSelectedIds?: string[]) => {
+    const selectedIdSet = new Set(explicitSelectedIds ?? scene.selectedModelIds);
+    const visibleModels = scene.models.filter((m) => {
+      if (!m.visible) return false;
+      if (scope === 'selected') return selectedIdSet.has(m.id);
+      return true;
+    });
+
+    if (visibleModels.length <= 1) return { models: visibleModels, updates: [] as Array<{ id: string; transform: { position: THREE.Vector3; rotation: THREE.Euler; scale: THREE.Vector3 } }> };
+
+    const countX = Math.max(1, Math.round(arrangeArrayCountX));
+    const countY = Math.max(1, Math.round(arrangeArrayCountY));
+    const countZ = Math.max(1, Math.round(arrangeArrayCountZ));
+
+    const gapX = Math.max(0, arrangeArrayGapX);
+    const gapY = Math.max(0, arrangeArrayGapY);
+    const gapZ = Math.max(0, arrangeArrayGapZ);
+
+    const baseDims = visibleModels.map((model) => {
+      const size = model.geometry.size;
+      const scaledWidth = Math.max(2, Math.abs(size.x * model.transform.scale.x));
+      const scaledDepth = Math.max(2, Math.abs(size.y * model.transform.scale.y));
+      const scaledHeight = Math.max(2, Math.abs(size.z * model.transform.scale.z));
+      const rz = model.transform.rotation.z;
+      const c = Math.abs(Math.cos(rz));
+      const s = Math.abs(Math.sin(rz));
+
+      return {
+        width: (scaledWidth * c) + (scaledDepth * s),
+        depth: (scaledWidth * s) + (scaledDepth * c),
+        height: scaledHeight,
+      };
+    });
+
+    const maxWidth = Math.max(...baseDims.map((d) => d.width));
+    const maxDepth = Math.max(...baseDims.map((d) => d.depth));
+    const maxHeight = Math.max(...baseDims.map((d) => d.height));
+
+    const stepX = maxWidth + gapX;
+    const stepY = maxDepth + gapY;
+    const stepZ = maxHeight + gapZ;
+
+    const minX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
+    const maxX = minX + scene.view3dSettings.widthMm;
+    const minY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
+    const maxY = minY + scene.view3dSettings.depthMm;
+
+    const slotsPerLayer = countX * countY;
+    const requiredLayers = Math.max(1, Math.ceil(visibleModels.length / slotsPerLayer));
+    const usedCountZ = Math.max(countZ, requiredLayers);
+
+    const totalWidth = (countX - 1) * stepX;
+    const totalDepth = (countY - 1) * stepY;
+
+    let startX = (scene.view3dSettings.originMode === 'front_left' ? scene.view3dSettings.widthMm * 0.5 : 0) - (totalWidth * 0.5);
+    let startY = (scene.view3dSettings.originMode === 'front_left' ? scene.view3dSettings.depthMm * 0.5 : 0) - (totalDepth * 0.5);
+
+    if (arrangeAnchorMode === 'front_left') {
+      startX = minX + (maxWidth * 0.5);
+      startY = minY + (maxDepth * 0.5);
+    } else if (arrangeAnchorMode === 'front_right') {
+      startX = maxX - (maxWidth * 0.5) - totalWidth;
+      startY = minY + (maxDepth * 0.5);
+    } else if (arrangeAnchorMode === 'back_left') {
+      startX = minX + (maxWidth * 0.5);
+      startY = maxY - (maxDepth * 0.5) - totalDepth;
+    } else if (arrangeAnchorMode === 'back_right') {
+      startX = maxX - (maxWidth * 0.5) - totalWidth;
+      startY = maxY - (maxDepth * 0.5) - totalDepth;
+    }
+
+    const baseZ = Math.min(...visibleModels.map((model) => model.transform.position.z));
+
+    const updates = visibleModels.map((model, index) => {
+      const xIndex = index % countX;
+      const yIndex = Math.floor(index / countX) % countY;
+      const zIndex = Math.floor(index / (countX * countY)) % usedCountZ;
+
+      return {
+        id: model.id,
+        transform: {
+          position: new THREE.Vector3(
+            startX + (xIndex * stepX),
+            startY + (yIndex * stepY),
+            baseZ + (zIndex * stepZ),
+          ),
+          rotation: model.transform.rotation.clone(),
+          scale: model.transform.scale.clone(),
+        },
+      };
+    });
+
+    return { models: visibleModels, updates };
+  }, [
+    arrangeAnchorMode,
+    arrangeArrayCountX,
+    arrangeArrayCountY,
+    arrangeArrayCountZ,
+    arrangeArrayGapX,
+    arrangeArrayGapY,
+    arrangeArrayGapZ,
+    scene.models,
+    scene.selectedModelIds,
+    scene.view3dSettings.depthMm,
+    scene.view3dSettings.originMode,
+    scene.view3dSettings.widthMm,
+  ]);
+
+  const handleManualArrayArrangeModels = React.useCallback(async (scope: 'all' | 'selected', explicitSelectedIds?: string[]) => {
+    if (isAutoArranging) return;
+
+    const minSpinnerMs = 220;
+    const startedAt = performance.now();
+    setIsAutoArranging(true);
+    await sleep(0);
+
+    try {
+      const { updates } = computeManualArrayArrangeUpdates(scope, explicitSelectedIds);
+      if (updates.length <= 1) return;
+
+      scene.updateModelTransforms(updates);
+      transformMgr.setTransformMode('select');
+    } finally {
+      const elapsed = performance.now() - startedAt;
+      if (elapsed < minSpinnerMs) {
+        await sleep(minSpinnerMs - elapsed);
+      }
+      setIsAutoArranging(false);
+    }
+  }, [
+    arrangeAnchorMode,
+    arrangeArrayCountX,
+    arrangeArrayCountY,
+    arrangeArrayCountZ,
+    arrangeArrayGapX,
+    arrangeArrayGapY,
+    arrangeArrayGapZ,
+    computeManualArrayArrangeUpdates,
+    isAutoArranging,
+    scene,
+    sleep,
+    transformMgr,
+  ]);
+
+  React.useEffect(() => {
+    if (scene.mode !== 'prepare' || transformMgr.transformMode !== 'arrange' || arrangeLayoutMode !== 'array') {
+      setArrangeArrayPreviewItems([]);
+      return;
+    }
+
+    const selectedVisibleCount = scene.models.filter((m) => m.visible && scene.selectedModelIds.includes(m.id)).length;
+    const previewScope: 'all' | 'selected' = selectedVisibleCount > 1 ? 'selected' : 'all';
+    const { models: previewModels, updates } = computeManualArrayArrangeUpdates(previewScope);
+
+    if (updates.length <= 1 || previewModels.length <= 1) {
+      setArrangeArrayPreviewItems([]);
+      return;
+    }
+
+    const updateMap = new Map(updates.map((update) => [update.id, update.transform]));
+    const previewItems = previewModels
+      .map((model) => {
+        const previewTransform = updateMap.get(model.id);
+        if (!previewTransform) return null;
+        return {
+          model,
+          transform: {
+            position: previewTransform.position.clone(),
+            rotation: previewTransform.rotation.clone(),
+            scale: previewTransform.scale.clone(),
+          },
+        };
+      })
+      .filter((item): item is { model: (typeof scene.models)[number]; transform: { position: THREE.Vector3; rotation: THREE.Euler; scale: THREE.Vector3 } } => item !== null);
+
+    setArrangeArrayPreviewItems(previewItems);
+  }, [
+    arrangeLayoutMode,
+    computeManualArrayArrangeUpdates,
+    scene.mode,
+    scene.models,
+    scene.selectedModelIds,
+    transformMgr.transformMode,
+  ]);
+
   const computeArrangeSlots = React.useCallback((count: number, stepX: number, stepY: number) => {
     const columns = Math.max(1, Math.ceil(Math.sqrt(count)));
     const rows = Math.ceil(count / columns);
@@ -857,7 +1057,9 @@ export default function Home() {
     transformMode: transformMgr.transformMode,
     setTransformMode: transformMgr.setTransformMode,
     onArrangeAll: () => {
-      void handleAutoArrangeModels('all');
+      void (arrangeLayoutMode === 'array'
+        ? handleManualArrayArrangeModels('all')
+        : handleAutoArrangeModels('all'));
     },
   });
 
@@ -1649,17 +1851,35 @@ export default function Home() {
             {scene.geom && transformMgr.transformMode === 'arrange' && (
               <ArrangePanel
                 key="prepare-arrange-panel"
+                layoutMode={arrangeLayoutMode}
+                onLayoutModeChange={setArrangeLayoutMode}
                 spacingMm={arrangeSpacingMm}
                 onSpacingMmChange={setArrangeSpacingMm}
                 allowRotateOnZ={arrangeAllowRotateOnZ}
                 onAllowRotateOnZChange={setArrangeAllowRotateOnZ}
+                arrayCountX={arrangeArrayCountX}
+                arrayCountY={arrangeArrayCountY}
+                arrayCountZ={arrangeArrayCountZ}
+                onArrayCountXChange={setArrangeArrayCountX}
+                onArrayCountYChange={setArrangeArrayCountY}
+                onArrayCountZChange={setArrangeArrayCountZ}
+                arrayGapX={arrangeArrayGapX}
+                arrayGapY={arrangeArrayGapY}
+                arrayGapZ={arrangeArrayGapZ}
+                onArrayGapXChange={setArrangeArrayGapX}
+                onArrayGapYChange={setArrangeArrayGapY}
+                onArrayGapZChange={setArrangeArrayGapZ}
                 anchorMode={arrangeAnchorMode}
                 onAnchorModeChange={setArrangeAnchorMode}
                 onApplyAll={() => {
-                  void handleAutoArrangeModels('all');
+                  void (arrangeLayoutMode === 'array'
+                    ? handleManualArrayArrangeModels('all')
+                    : handleAutoArrangeModels('all'));
                 }}
                 onApplySelected={() => {
-                  void handleAutoArrangeModels('selected');
+                  void (arrangeLayoutMode === 'array'
+                    ? handleManualArrayArrangeModels('selected')
+                    : handleAutoArrangeModels('selected'));
                 }}
                 modelCount={scene.models.filter((m) => m.visible).length}
                 selectedModelCount={scene.models.filter((m) => m.visible && scene.selectedModelIds.includes(m.id)).length}
@@ -1974,6 +2194,7 @@ export default function Home() {
                 ? duplicateApplySourceTransform
                 : duplicateSourcePreviewTransform
             }
+            arrangeArrayPreviewItems={arrangeArrayPreviewItems}
             hideDuplicateSourceDuringApply={isDuplicating}
             view3dSettings={scene.view3dSettings}
           >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ import { IslandOverlayControls } from '@/components/controls/IslandOverlayContro
 import { IslandVoxelControls } from '@/components/controls/IslandVoxelControls';
 import { TerritoryVoxelControls } from '@/components/controls/TerritoryVoxelControls';
 import { IslandListCard } from '@/components/controls/IslandListCard';
-import { ModelManagerPanel } from '@/components/controls/ModelManagerPanel';
+import { ModelManagerPanel } from '../components/controls/ModelManagerPanel';
 import { DebugPrimitivesPanel } from '@/components/controls/DebugPrimitivesPanel';
 import { ModelStatsCard } from '@/components/controls/ModelStatsCard';
 import { TransformToolbar } from '@/components/controls/TransformToolbar';
@@ -170,8 +170,42 @@ export default function Home() {
 
   const handleModelListContextMenu = React.useCallback((modelId: string, position: { x: number; y: number }) => {
     // Right-clicking a model row should target that model first.
-    scene.setActiveModelId(modelId);
+    if (!scene.selectedModelIds.includes(modelId)) {
+      scene.selectModel(modelId, 'single');
+    }
     setEditorContextMenuPos(position);
+  }, [scene]);
+
+  const handleModelSelection = React.useCallback((modelId: string, mode: 'single' | 'toggle' | 'add' = 'single') => {
+    scene.selectModel(modelId, mode);
+  }, [scene]);
+
+  const handleGroupSelection = React.useCallback((groupId: string, mode: 'single' | 'add' = 'single') => {
+    scene.selectGroup(groupId, mode);
+  }, [scene]);
+
+  const handleGroupSelectedModels = React.useCallback((modelIds: string[]) => {
+    scene.groupModels(modelIds);
+  }, [scene]);
+
+  const handleUngroupSelectedModels = React.useCallback((modelIds: string[]) => {
+    scene.ungroupModels(modelIds);
+  }, [scene]);
+
+  const handleUngroupFolder = React.useCallback((groupId: string) => {
+    scene.ungroupGroup(groupId);
+  }, [scene]);
+
+  const handleRenameFolder = React.useCallback((groupId: string, nextName: string) => {
+    scene.renameGroup(groupId, nextName);
+  }, [scene]);
+
+  const handleSceneModelSelection = React.useCallback((modelId: string | null, options?: { selectionMode?: 'single' | 'toggle' | 'add' }) => {
+    if (modelId == null) {
+      scene.clearModelSelection();
+      return;
+    }
+    scene.selectModel(modelId, options?.selectionMode ?? 'single');
   }, [scene]);
 
   const handleEditorPointerDownCapture = React.useCallback((e: React.PointerEvent<HTMLDivElement>) => {
@@ -913,7 +947,8 @@ export default function Home() {
     if (scene.mode === 'prepare') return;
     if (!isSelectAllModelsActive) return;
     setIsSelectAllModelsActive(false);
-  }, [isSelectAllModelsActive, scene.mode]);
+    scene.clearModelSelection();
+  }, [isSelectAllModelsActive, scene]);
 
   React.useEffect(() => {
     const unregister = registerDeleteHandler(
@@ -960,6 +995,11 @@ export default function Home() {
       // Prevent browser-level "select all text in the app" behavior and arm model select-all.
       event.preventDefault();
       event.stopPropagation();
+      const visibleIds = scene.models.filter((model) => model.visible).map((model) => model.id);
+      if (visibleIds.length > 0) {
+        scene.setSelectedModelIds(visibleIds);
+        scene.setActiveModelId(visibleIds[0]);
+      }
       setIsSelectAllModelsActive(true);
     };
 
@@ -967,7 +1007,7 @@ export default function Home() {
     return () => {
       window.removeEventListener('keydown', handleGlobalSelectAll, true);
     };
-  }, [scene.mode, scene.models.length]);
+  }, [scene]);
 
   React.useEffect(() => {
     if (scene.mode !== 'prepare' || transformMgr.transformMode !== 'duplicate') {
@@ -1101,7 +1141,13 @@ export default function Home() {
               key="prepare-models"
               models={scene.models}
               activeModelId={scene.activeModelId}
-              onSelect={scene.setActiveModelId}
+              selectedModelIds={scene.selectedModelIds}
+              onSelect={handleModelSelection}
+              onSelectGroup={handleGroupSelection}
+              onGroupModels={handleGroupSelectedModels}
+              onUngroupModels={handleUngroupSelectedModels}
+              onUngroupGroup={handleUngroupFolder}
+              onRenameGroup={handleRenameFolder}
               onModelContextMenu={handleModelListContextMenu}
               onDelete={scene.deleteModel}
               onVisibilityChange={scene.setModelVisibility}
@@ -1420,6 +1466,7 @@ export default function Home() {
           <SceneCanvas
             models={scene.models}
             activeModelId={displayActiveModelId}
+            selectedModelIds={scene.selectedModelIds}
             clipLower={slicing.clipLower}
             clipUpper={slicing.clipUpper}
             meshColor={scene.meshColor}
@@ -1460,7 +1507,7 @@ export default function Home() {
             mode={scene.mode}
             onSupportClick={supports.onModelClick}
             onSupportHover={supports.onModelHover}
-            onActiveModelChange={scene.setActiveModelId}
+            onActiveModelChange={handleSceneModelSelection}
             trunkPlacementPreview={supports.trunkPlacementV2.previewData}
             branchPlacementPreview={supports.branchPlacement.previewData}
             leafPlacementPreview={supports.leafPlacement.previewData}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -104,6 +104,12 @@ export default function Home() {
     rotation: THREE.Euler;
     scale: THREE.Vector3;
   } | null>(null);
+  const [duplicateApplySourceModel, setDuplicateApplySourceModel] = React.useState<(typeof scene.models)[number] | null>(null);
+  const [duplicateApplySourceTransform, setDuplicateApplySourceTransform] = React.useState<{
+    position: THREE.Vector3;
+    rotation: THREE.Euler;
+    scale: THREE.Vector3;
+  } | null>(null);
   const dragDepthRef = React.useRef(0);
   const rightClickGestureRef = React.useRef<{ x: number; y: number; moved: boolean } | null>(null);
   const cameraResumeTimeoutRef = React.useRef<number | null>(null);
@@ -1333,6 +1339,20 @@ export default function Home() {
     if (!scene.activeModelId) return;
     if (duplicatePreviewTransforms.length === 0) return;
 
+    const sourceModelAtApplyStart = scene.activeModel;
+    const sourcePreviewTransformAtApplyStart = duplicateSourcePreviewTransform;
+    if (sourceModelAtApplyStart && sourcePreviewTransformAtApplyStart) {
+      setDuplicateApplySourceModel(sourceModelAtApplyStart);
+      setDuplicateApplySourceTransform({
+        position: sourcePreviewTransformAtApplyStart.position.clone(),
+        rotation: sourcePreviewTransformAtApplyStart.rotation.clone(),
+        scale: sourcePreviewTransformAtApplyStart.scale.clone(),
+      });
+    } else {
+      setDuplicateApplySourceModel(null);
+      setDuplicateApplySourceTransform(null);
+    }
+
     const minSpinnerMs = 220;
     const startedAt = performance.now();
     setIsDuplicating(true);
@@ -1358,6 +1378,8 @@ export default function Home() {
         await sleep(minSpinnerMs - elapsed);
       }
       setIsDuplicating(false);
+      setDuplicateApplySourceModel(null);
+      setDuplicateApplySourceTransform(null);
     }
   }, [duplicatePreviewTransforms, duplicateSourcePreviewTransform, isDuplicating, scene, sleep, transformMgr]);
 
@@ -1816,9 +1838,18 @@ export default function Home() {
             pxMm={islands.pxMm}
             supportsRef={supportsRef}
             ghostData={ghostData}
-            duplicatePreviewModel={transformMgr.transformMode === 'duplicate' ? scene.activeModel : null}
+            duplicatePreviewModel={
+              isDuplicating
+                ? duplicateApplySourceModel
+                : (transformMgr.transformMode === 'duplicate' ? scene.activeModel : null)
+            }
             duplicatePreviewTransforms={duplicatePreviewTransforms}
-            duplicateActivePreviewTransform={duplicateSourcePreviewTransform}
+            duplicateActivePreviewTransform={
+              isDuplicating
+                ? duplicateApplySourceTransform
+                : duplicateSourcePreviewTransform
+            }
+            hideDuplicateSourceDuringApply={isDuplicating}
             view3dSettings={scene.view3dSettings}
           >
             {scene.mode === 'prepare' && transformMgr.transformMode === 'smoothing' && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1248,7 +1248,7 @@ export default function Home() {
       () => scene.mode === 'prepare' && scene.selectedModelIds.length > 0,
       () => {
         const ids = Array.from(new Set(scene.selectedModelIds));
-        ids.forEach((id) => scene.deleteModel(id));
+        scene.deleteModels(ids);
         setIsSelectAllModelsActive(false);
       },
       30,
@@ -1264,7 +1264,7 @@ export default function Home() {
       () => scene.mode === 'prepare' && isSelectAllModelsActive && scene.models.length > 0,
       () => {
         const ids = scene.models.map((model) => model.id);
-        ids.forEach((id) => scene.deleteModel(id));
+        scene.deleteModels(ids);
         setIsSelectAllModelsActive(false);
       },
       20,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ import { DebugPrimitivesPanel } from '@/components/controls/DebugPrimitivesPanel
 import { ModelStatsCard } from '@/components/controls/ModelStatsCard';
 import { TransformToolbar } from '@/components/controls/TransformToolbar';
 import { TransformControls } from '@/components/controls/TransformControls';
-import { ArrangePanel } from '@/components/controls/ArrangePanel';
+import { ArrangePanel, type ArrangeAnchorMode } from '@/components/controls/ArrangePanel';
 import { DuplicatePanel } from '@/components/controls/DuplicatePanel';
 import { VisualSettingsPanel } from '@/components/controls/VisualSettingsPanel';
 import { SupportSidebar } from '@/supports/Settings';
@@ -80,6 +80,8 @@ export default function Home() {
   const [editorContextMenuPos, setEditorContextMenuPos] = React.useState<{ x: number; y: number } | null>(null);
   const [isSelectAllModelsActive, setIsSelectAllModelsActive] = React.useState(false);
   const [arrangeSpacingMm, setArrangeSpacingMm] = React.useState(12);
+  const [arrangeAllowRotateOnZ, setArrangeAllowRotateOnZ] = React.useState(false);
+  const [arrangeAnchorMode, setArrangeAnchorMode] = React.useState<ArrangeAnchorMode>('center');
   const [isAutoArranging, setIsAutoArranging] = React.useState(false);
   const [duplicateTotalCopies, setDuplicateTotalCopies] = React.useState(2);
   const [duplicateSpacingMm, setDuplicateSpacingMm] = React.useState(12);
@@ -380,32 +382,389 @@ export default function Home() {
     await sleep(0);
 
     try {
-      const maxWidth = visibleModels.reduce((acc, model) => Math.max(acc, getModelFootprintMm(model).width), 0);
-      const maxDepth = visibleModels.reduce((acc, model) => Math.max(acc, getModelFootprintMm(model).depth), 0);
+      const modelsWithFootprints = visibleModels.map((model) => {
+        const baseFootprint = getModelFootprintMm(model);
+        return {
+          model,
+          baseWidth: baseFootprint.width,
+          baseDepth: baseFootprint.depth,
+        };
+      });
 
-      const columns = Math.max(1, Math.ceil(Math.sqrt(visibleModels.length)));
-      const rows = Math.ceil(visibleModels.length / columns);
-      const stepX = maxWidth + arrangeSpacingMm;
-      const stepY = maxDepth + arrangeSpacingMm;
-      const centerX = scene.view3dSettings.originMode === 'front_left' ? scene.view3dSettings.widthMm * 0.5 : 0;
-      const centerY = scene.view3dSettings.originMode === 'front_left' ? scene.view3dSettings.depthMm * 0.5 : 0;
-      const startX = centerX - ((columns - 1) * stepX) * 0.5;
-      const startY = centerY - ((rows - 1) * stepY) * 0.5;
+      const minX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
+      const maxX = minX + scene.view3dSettings.widthMm;
+      const minY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
+      const maxY = minY + scene.view3dSettings.depthMm;
+      const plateWidth = Math.max(1, maxX - minX);
+      const plateDepth = Math.max(1, maxY - minY);
+
+      type PackedEntry = {
+        model: (typeof visibleModels)[number];
+        width: number;
+        depth: number;
+        row: number;
+        indexInRow: number;
+        rotationZ: number;
+      };
+
+      type SpillEntry = {
+        model: (typeof visibleModels)[number];
+        width: number;
+        depth: number;
+        rotationZ: number;
+      };
+
+      type Row = {
+        widthUsed: number;
+        maxDepth: number;
+        items: PackedEntry[];
+      };
+
+      const evaluatePacking = (ordered: typeof modelsWithFootprints, targetRowWidth: number) => {
+        const rows: Row[] = [];
+        const spills: SpillEntry[] = [];
+
+        let occupiedArea = 0;
+        let totalDepthUsed = 0;
+
+        type PlacementOption = {
+          rotationZ: number;
+          width: number;
+          depth: number;
+        };
+
+        const normalizeToPi = (angle: number) => {
+          let a = angle % Math.PI;
+          if (a < 0) a += Math.PI;
+          return a;
+        };
+
+        const nearestEquivalentAngle = (reference: number, canonical: number) => {
+          const twoPi = Math.PI * 2;
+          const k = Math.round((reference - canonical) / twoPi);
+          return canonical + k * twoPi;
+        };
+
+        const footprintAtAngle = (baseWidth: number, baseDepth: number, angleZ: number) => {
+          const c = Math.abs(Math.cos(angleZ));
+          const s = Math.abs(Math.sin(angleZ));
+          return {
+            width: baseWidth * c + baseDepth * s,
+            depth: baseWidth * s + baseDepth * c,
+          };
+        };
+
+        const getAllOptions = (current: (typeof modelsWithFootprints)[number]): PlacementOption[] => (
+          (() => {
+            const currentZ = current.model.transform.rotation.z;
+            const currentCanonical = normalizeToPi(currentZ);
+
+            if (!arrangeAllowRotateOnZ) {
+              const dims = footprintAtAngle(current.baseWidth, current.baseDepth, currentCanonical);
+              return [{ rotationZ: currentZ, width: dims.width, depth: dims.depth }];
+            }
+
+            const coarseStepDeg = 6;
+            const refineStepDeg = 1;
+            const coarseAngles: number[] = [];
+            for (let deg = 0; deg < 180; deg += coarseStepDeg) {
+              coarseAngles.push(THREE.MathUtils.degToRad(deg));
+            }
+            coarseAngles.push(currentCanonical);
+
+            let bestCanonical = coarseAngles[0];
+            let bestArea = Number.POSITIVE_INFINITY;
+            for (const angle of coarseAngles) {
+              const dims = footprintAtAngle(current.baseWidth, current.baseDepth, angle);
+              const area = dims.width * dims.depth;
+              if (area < bestArea) {
+                bestArea = area;
+                bestCanonical = angle;
+              }
+            }
+
+            const refinedAngles = new Set<number>();
+            for (let delta = -coarseStepDeg; delta <= coarseStepDeg; delta += refineStepDeg) {
+              const rad = THREE.MathUtils.degToRad(delta);
+              refinedAngles.add(normalizeToPi(bestCanonical + rad));
+            }
+            refinedAngles.add(currentCanonical);
+
+            const options: PlacementOption[] = [];
+            for (const canonical of refinedAngles) {
+              const dims = footprintAtAngle(current.baseWidth, current.baseDepth, canonical);
+              options.push({
+                rotationZ: nearestEquivalentAngle(currentZ, canonical),
+                width: dims.width,
+                depth: dims.depth,
+              });
+            }
+
+            return options;
+          })()
+        );
+
+        for (const current of ordered) {
+          const options = getAllOptions(current);
+          const fitOptions = options.filter((opt) => opt.width <= plateWidth && opt.depth <= plateDepth);
+
+          if (fitOptions.length === 0) {
+            const fallback = options.reduce((best, candidate) => {
+              const bestOverflow = Math.max(0, best.width - plateWidth) + Math.max(0, best.depth - plateDepth);
+              const candidateOverflow = Math.max(0, candidate.width - plateWidth) + Math.max(0, candidate.depth - plateDepth);
+              if (candidateOverflow < bestOverflow) return candidate;
+              if (candidateOverflow === bestOverflow && (candidate.width * candidate.depth) < (best.width * best.depth)) return candidate;
+              return best;
+            }, options[0]);
+
+            spills.push({
+              model: current.model,
+              width: fallback.width,
+              depth: fallback.depth,
+              rotationZ: fallback.rotationZ,
+            });
+            continue;
+          }
+
+          let bestPlacement:
+            | { kind: 'same-row'; rowIndex: number; option: PlacementOption; score: number }
+            | { kind: 'new-row'; option: PlacementOption; score: number }
+            | null = null;
+
+          if (rows.length > 0) {
+            for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+              const row = rows[rowIndex];
+              for (const option of fitOptions) {
+                const nextWidth = row.widthUsed + (row.items.length > 0 ? arrangeSpacingMm : 0) + option.width;
+                if (nextWidth > plateWidth) continue;
+
+                const nextDepth = Math.max(row.maxDepth, option.depth);
+                const depthDelta = nextDepth - row.maxDepth;
+                const nextTotalDepth = totalDepthUsed + depthDelta;
+                if (nextTotalDepth > plateDepth) continue;
+
+                // Prefer tighter rows, less depth growth, and widths near target row width.
+                const depthPenalty = depthDelta * 40;
+                const widthPenalty = Math.abs(targetRowWidth - nextWidth) * 0.08;
+                const areaScore = nextWidth * nextDepth;
+                const score = areaScore + depthPenalty + widthPenalty;
+
+                if (!bestPlacement || score < bestPlacement.score) {
+                  bestPlacement = { kind: 'same-row', rowIndex, option, score };
+                }
+              }
+            }
+          }
+
+          for (const option of fitOptions) {
+            const nextTotalDepth = totalDepthUsed + (rows.length > 0 ? arrangeSpacingMm : 0) + option.depth;
+            if (nextTotalDepth > plateDepth) continue;
+
+            const widthPenalty = Math.abs(targetRowWidth - option.width) * 0.12;
+            const score = (option.width * option.depth) + widthPenalty + 10;
+            if (!bestPlacement || score < bestPlacement.score) {
+              bestPlacement = { kind: 'new-row', option, score };
+            }
+          }
+
+          if (!bestPlacement) {
+            const fallback = fitOptions.reduce((best, candidate) => {
+              if (candidate.width < best.width) return candidate;
+              if (candidate.width === best.width && candidate.depth < best.depth) return candidate;
+              return best;
+            }, fitOptions[0]);
+
+            spills.push({
+              model: current.model,
+              width: fallback.width,
+              depth: fallback.depth,
+              rotationZ: fallback.rotationZ,
+            });
+            continue;
+          }
+
+          if (bestPlacement.kind === 'new-row') {
+            const row: Row = { widthUsed: 0, maxDepth: 0, items: [] };
+            rows.push(row);
+            totalDepthUsed += (rows.length > 1 ? arrangeSpacingMm : 0) + bestPlacement.option.depth;
+            row.widthUsed = bestPlacement.option.width;
+            row.maxDepth = bestPlacement.option.depth;
+            row.items.push({
+              model: current.model,
+              width: bestPlacement.option.width,
+              depth: bestPlacement.option.depth,
+              row: rows.length - 1,
+              indexInRow: 0,
+              rotationZ: bestPlacement.option.rotationZ,
+            });
+            occupiedArea += bestPlacement.option.width * bestPlacement.option.depth;
+          } else {
+            const row = rows[bestPlacement.rowIndex];
+            const previousDepth = row.maxDepth;
+            row.widthUsed += (row.items.length > 0 ? arrangeSpacingMm : 0) + bestPlacement.option.width;
+            row.maxDepth = Math.max(row.maxDepth, bestPlacement.option.depth);
+            totalDepthUsed += row.maxDepth - previousDepth;
+            row.items.push({
+              model: current.model,
+              width: bestPlacement.option.width,
+              depth: bestPlacement.option.depth,
+              row: bestPlacement.rowIndex,
+              indexInRow: row.items.length,
+              rotationZ: bestPlacement.option.rotationZ,
+            });
+            occupiedArea += bestPlacement.option.width * bestPlacement.option.depth;
+          }
+        }
+
+        const rowDepths = rows.map((r) => r.maxDepth);
+        const rowWidths = rows.map((r) => r.widthUsed);
+        const totalWidth = Math.min(plateWidth, rowWidths.reduce((acc, width) => Math.max(acc, width), 0));
+        const totalDepth = rowDepths.reduce((acc, depth) => acc + depth, 0) + Math.max(0, rows.length - 1) * arrangeSpacingMm;
+
+        const layoutArea = totalWidth * totalDepth;
+        const deadSpace = Math.max(0, layoutArea - occupiedArea);
+        const spillArea = spills.reduce((acc, item) => acc + (item.width * item.depth), 0);
+        const spillPenalty = spills.length * 1_000_000 + spillArea * 100;
+        const aspectPenalty = Math.abs(totalWidth - totalDepth) * 0.05;
+
+        return {
+          rows,
+          spills,
+          rowDepths,
+          totalWidth,
+          totalDepth,
+          score: deadSpace + spillPenalty + aspectPenalty,
+        };
+      };
+
+      const byAreaDesc = [...modelsWithFootprints].sort((a, b) => (b.baseWidth * b.baseDepth) - (a.baseWidth * a.baseDepth));
+      const byMaxSideDesc = [...modelsWithFootprints].sort((a, b) => Math.max(b.baseWidth, b.baseDepth) - Math.max(a.baseWidth, a.baseDepth));
+      const orderingCandidates = [modelsWithFootprints, byAreaDesc, byMaxSideDesc];
+
+      const totalModelArea = modelsWithFootprints.reduce((acc, current) => acc + (current.baseWidth * current.baseDepth), 0);
+      const baseWidth = Math.min(plateWidth, Math.max(30, Math.sqrt(totalModelArea)));
+      const targetRowWidths = [
+        baseWidth * 0.8,
+        baseWidth,
+        baseWidth * 1.2,
+        plateWidth * 0.5,
+        plateWidth * 0.65,
+        plateWidth * 0.8,
+        plateWidth,
+      ]
+        .map((w) => Math.min(plateWidth, Math.max(20, w)));
+
+      const uniqueTargetRowWidths = [...new Set(targetRowWidths.map((w) => Number(w.toFixed(3))))];
+
+      let bestLayout: ReturnType<typeof evaluatePacking> | null = null;
+      for (const ordered of orderingCandidates) {
+        for (const targetRowWidth of uniqueTargetRowWidths) {
+          const layout = evaluatePacking(ordered, targetRowWidth);
+          if (!bestLayout || layout.score < bestLayout.score) {
+            bestLayout = layout;
+          }
+        }
+      }
+
+      if (!bestLayout) return;
+
+      const { rows, spills, rowDepths, totalWidth, totalDepth } = bestLayout;
+
+      let startX = minX + ((maxX - minX) - totalWidth) * 0.5;
+      let startY = minY + ((maxY - minY) - totalDepth) * 0.5;
+
+      if (arrangeAnchorMode === 'front_left') {
+        startX = minX;
+        startY = minY;
+      } else if (arrangeAnchorMode === 'front_right') {
+        startX = maxX - totalWidth;
+        startY = minY;
+      } else if (arrangeAnchorMode === 'back_left') {
+        startX = minX;
+        startY = maxY - totalDepth;
+      } else if (arrangeAnchorMode === 'back_right') {
+        startX = maxX - totalWidth;
+        startY = maxY - totalDepth;
+      }
+
+      const rowCenters: number[] = [];
+      let cursorY = startY;
+      for (let row = 0; row < rowDepths.length; row += 1) {
+        const depth = rowDepths[row];
+        rowCenters[row] = cursorY + depth * 0.5;
+        cursorY += depth + arrangeSpacingMm;
+      }
+
+      const packedWithPositions: Array<PackedEntry & { positionX: number; positionY: number }> = [];
+      rows.forEach((row, rowIndex) => {
+        let rowCursorX = startX;
+        row.items.forEach((item) => {
+          const centerX = rowCursorX + item.width * 0.5;
+          packedWithPositions.push({
+            ...item,
+            positionX: centerX,
+            positionY: rowCenters[rowIndex],
+          });
+          rowCursorX += item.width + arrangeSpacingMm;
+        });
+      });
+
+      const spillWithPositions: Array<SpillEntry & { positionX: number; positionY: number }> = [];
+      if (spills.length > 0) {
+        const outsideGap = Math.max(8, arrangeSpacingMm);
+        let columnLeftX = maxX + outsideGap;
+        let columnYCursor = minY;
+        let columnMaxWidth = 0;
+
+        spills.forEach((item) => {
+          if (columnYCursor > minY && (columnYCursor + item.depth) > maxY) {
+            columnLeftX += columnMaxWidth + outsideGap;
+            columnMaxWidth = 0;
+            columnYCursor = minY;
+          }
+
+          const positionX = columnLeftX + item.width * 0.5;
+          const positionY = columnYCursor + item.depth * 0.5;
+          spillWithPositions.push({ ...item, positionX, positionY });
+
+          columnYCursor += item.depth + arrangeSpacingMm;
+          columnMaxWidth = Math.max(columnMaxWidth, item.width);
+        });
+      }
 
       scene.updateModelTransforms(
-        visibleModels.map((model, index) => {
-          const col = index % columns;
-          const row = Math.floor(index / columns);
-
-          return {
-            id: model.id,
-            transform: {
-              position: new THREE.Vector3(startX + col * stepX, startY + row * stepY, model.transform.position.z),
-              rotation: model.transform.rotation.clone(),
-              scale: model.transform.scale.clone(),
-            },
-          };
-        }),
+        [
+          ...packedWithPositions.map(({ model, rotationZ, positionX, positionY }) => {
+            return {
+              id: model.id,
+              transform: {
+                position: new THREE.Vector3(positionX, positionY, model.transform.position.z),
+                rotation: new THREE.Euler(
+                  model.transform.rotation.x,
+                  model.transform.rotation.y,
+                  rotationZ,
+                  model.transform.rotation.order,
+                ),
+                scale: model.transform.scale.clone(),
+              },
+            };
+          }),
+          ...spillWithPositions.map(({ model, rotationZ, positionX, positionY }) => {
+            return {
+              id: model.id,
+              transform: {
+                position: new THREE.Vector3(positionX, positionY, model.transform.position.z),
+                rotation: new THREE.Euler(
+                  model.transform.rotation.x,
+                  model.transform.rotation.y,
+                  rotationZ,
+                  model.transform.rotation.order,
+                ),
+                scale: model.transform.scale.clone(),
+              },
+            };
+          }),
+        ],
       );
 
       transformMgr.setTransformMode('select');
@@ -416,7 +775,7 @@ export default function Home() {
       }
       setIsAutoArranging(false);
     }
-  }, [arrangeSpacingMm, getModelFootprintMm, isAutoArranging, scene, sleep, transformMgr]);
+  }, [arrangeAllowRotateOnZ, arrangeAnchorMode, arrangeSpacingMm, getModelFootprintMm, isAutoArranging, scene, sleep, transformMgr]);
 
   const computeArrangeSlots = React.useCallback((count: number, stepX: number, stepY: number) => {
     const columns = Math.max(1, Math.ceil(Math.sqrt(count)));
@@ -834,6 +1193,10 @@ export default function Home() {
                 key="prepare-arrange-panel"
                 spacingMm={arrangeSpacingMm}
                 onSpacingMmChange={setArrangeSpacingMm}
+                allowRotateOnZ={arrangeAllowRotateOnZ}
+                onAllowRotateOnZChange={setArrangeAllowRotateOnZ}
+                anchorMode={arrangeAnchorMode}
+                onAnchorModeChange={setArrangeAnchorMode}
                 onApply={handleAutoArrangeModels}
                 modelCount={scene.models.filter((m) => m.visible).length}
                 isApplying={isAutoArranging}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -84,7 +84,6 @@ export default function Home() {
   const [arrangeAllowRotateOnZ, setArrangeAllowRotateOnZ] = React.useState(false);
   const [arrangeAnchorMode, setArrangeAnchorMode] = React.useState<ArrangeAnchorMode>('center');
   const [isAutoArranging, setIsAutoArranging] = React.useState(false);
-  const [pasteArrangeNonce, setPasteArrangeNonce] = React.useState(0);
   const [duplicateTotalCopies, setDuplicateTotalCopies] = React.useState(2);
   const [duplicateSpacingMm, setDuplicateSpacingMm] = React.useState(5);
   const [duplicateLayoutMode, setDuplicateLayoutMode] = React.useState<DuplicateLayoutMode>('auto');
@@ -107,7 +106,6 @@ export default function Home() {
   } | null>(null);
   const dragDepthRef = React.useRef(0);
   const rightClickGestureRef = React.useRef<{ x: number; y: number; moved: boolean } | null>(null);
-  const lastHandledPasteArrangeNonceRef = React.useRef(0);
   const cameraResumeTimeoutRef = React.useRef<number | null>(null);
 
   const handleDroppedMeshFiles = React.useCallback((files: File[]) => {
@@ -273,9 +271,7 @@ export default function Home() {
         }
         break;
       case 'paste':
-        if (scene.pasteCopiedModelsAutoArrange().length > 0) {
-          setPasteArrangeNonce((prev) => prev + 1);
-        }
+        scene.pasteCopiedModelsAutoArrange(arrangeSpacingMm);
         break;
       case 'duplicate':
       case 'arrange':
@@ -285,7 +281,7 @@ export default function Home() {
         break;
     }
     closeEditorContextMenu();
-  }, [closeEditorContextMenu, scene]);
+  }, [arrangeSpacingMm, closeEditorContextMenu, scene]);
 
   React.useEffect(() => {
     if (!editorContextMenuPos) return;
@@ -430,14 +426,10 @@ export default function Home() {
     window.setTimeout(resolve, ms);
   }), []);
 
-  const queueArrangeAfterPaste = React.useCallback(() => {
-    setPasteArrangeNonce((prev) => prev + 1);
-  }, []);
-
-  const handleAutoArrangeModels = React.useCallback(async (scope: 'all' | 'selected') => {
+  const handleAutoArrangeModels = React.useCallback(async (scope: 'all' | 'selected', explicitSelectedIds?: string[]) => {
     if (isAutoArranging) return;
 
-    const selectedIdSet = new Set(scene.selectedModelIds);
+    const selectedIdSet = new Set(explicitSelectedIds ?? scene.selectedModelIds);
     const visibleModels = scene.models.filter((m) => {
       if (!m.visible) return false;
       if (scope === 'selected') return selectedIdSet.has(m.id);
@@ -524,55 +516,43 @@ export default function Home() {
           };
         };
 
-        const getAllOptions = (current: (typeof modelsWithFootprints)[number]): PlacementOption[] => (
-          (() => {
-            const currentZ = current.model.transform.rotation.z;
-            const currentCanonical = normalizeToPi(currentZ);
+        const getAllOptions = (current: (typeof modelsWithFootprints)[number]): PlacementOption[] => {
+          const currentZ = current.model.transform.rotation.z;
+          const currentCanonical = normalizeToPi(currentZ);
 
-            if (!arrangeAllowRotateOnZ) {
-              const dims = footprintAtAngle(current.baseWidth, current.baseDepth, currentCanonical);
-              return [{ rotationZ: currentZ, width: dims.width, depth: dims.depth }];
-            }
+          if (!arrangeAllowRotateOnZ) {
+            const dims = footprintAtAngle(current.baseWidth, current.baseDepth, currentCanonical);
+            return [{ rotationZ: currentZ, width: dims.width, depth: dims.depth }];
+          }
 
-            const coarseStepDeg = 6;
-            const refineStepDeg = 1;
-            const coarseAngles: number[] = [];
-            for (let deg = 0; deg < 180; deg += coarseStepDeg) {
-              coarseAngles.push(THREE.MathUtils.degToRad(deg));
-            }
-            coarseAngles.push(currentCanonical);
+          const candidateCanonicals: number[] = [currentCanonical];
+          const coarseStepDeg = 15;
+          for (let deg = 0; deg < 180; deg += coarseStepDeg) {
+            candidateCanonicals.push(THREE.MathUtils.degToRad(deg));
+          }
 
-            let bestCanonical = coarseAngles[0];
-            let bestArea = Number.POSITIVE_INFINITY;
-            for (const angle of coarseAngles) {
-              const dims = footprintAtAngle(current.baseWidth, current.baseDepth, angle);
-              const area = dims.width * dims.depth;
-              if (area < bestArea) {
-                bestArea = area;
-                bestCanonical = angle;
-              }
-            }
+          // Ensure we always evaluate the width/depth-swapped alternative from the current pose.
+          candidateCanonicals.push(normalizeToPi(currentCanonical + (Math.PI * 0.5)));
 
-            const refinedAngles = new Set<number>();
-            for (let delta = -coarseStepDeg; delta <= coarseStepDeg; delta += refineStepDeg) {
-              const rad = THREE.MathUtils.degToRad(delta);
-              refinedAngles.add(normalizeToPi(bestCanonical + rad));
-            }
-            refinedAngles.add(currentCanonical);
+          const seenFootprints = new Set<string>();
+          const options: PlacementOption[] = [];
 
-            const options: PlacementOption[] = [];
-            for (const canonical of refinedAngles) {
-              const dims = footprintAtAngle(current.baseWidth, current.baseDepth, canonical);
-              options.push({
-                rotationZ: nearestEquivalentAngle(currentZ, canonical),
-                width: dims.width,
-                depth: dims.depth,
-              });
-            }
+          for (const rawCanonical of candidateCanonicals) {
+            const canonical = normalizeToPi(rawCanonical);
+            const dims = footprintAtAngle(current.baseWidth, current.baseDepth, canonical);
+            const key = `${dims.width.toFixed(3)}:${dims.depth.toFixed(3)}`;
+            if (seenFootprints.has(key)) continue;
+            seenFootprints.add(key);
 
-            return options;
-          })()
-        );
+            options.push({
+              rotationZ: nearestEquivalentAngle(currentZ, canonical),
+              width: dims.width,
+              depth: dims.depth,
+            });
+          }
+
+          return options;
+        };
 
         for (const current of ordered) {
           const options = getAllOptions(current);
@@ -846,15 +826,6 @@ export default function Home() {
       setIsAutoArranging(false);
     }
   }, [arrangeAllowRotateOnZ, arrangeAnchorMode, arrangeSpacingMm, getModelFootprintMm, isAutoArranging, scene, sleep, transformMgr]);
-
-  React.useEffect(() => {
-    if (pasteArrangeNonce === 0) return;
-    if (pasteArrangeNonce === lastHandledPasteArrangeNonceRef.current) return;
-    if (scene.mode !== 'prepare') return;
-
-    lastHandledPasteArrangeNonceRef.current = pasteArrangeNonce;
-    void handleAutoArrangeModels('all');
-  }, [handleAutoArrangeModels, pasteArrangeNonce, scene.mode]);
 
   const computeArrangeSlots = React.useCallback((count: number, stepX: number, stepY: number) => {
     const columns = Math.max(1, Math.ceil(Math.sqrt(count)));
@@ -1134,9 +1105,7 @@ export default function Home() {
         if (!scene.canPasteModel) return;
         event.preventDefault();
         event.stopPropagation();
-        if (scene.pasteCopiedModelsAutoArrange().length > 0) {
-          queueArrangeAfterPaste();
-        }
+        scene.pasteCopiedModelsAutoArrange(arrangeSpacingMm);
       }
     };
 
@@ -1144,7 +1113,7 @@ export default function Home() {
     return () => {
       window.removeEventListener('keydown', handleClipboardHotkeys, true);
     };
-  }, [queueArrangeAfterPaste, scene]);
+  }, [arrangeSpacingMm, scene]);
 
   React.useEffect(() => {
     if (scene.mode !== 'prepare' || transformMgr.transformMode !== 'duplicate') {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -84,6 +84,7 @@ export default function Home() {
   const [arrangeAllowRotateOnZ, setArrangeAllowRotateOnZ] = React.useState(false);
   const [arrangeAnchorMode, setArrangeAnchorMode] = React.useState<ArrangeAnchorMode>('center');
   const [isAutoArranging, setIsAutoArranging] = React.useState(false);
+  const [pasteArrangeNonce, setPasteArrangeNonce] = React.useState(0);
   const [duplicateTotalCopies, setDuplicateTotalCopies] = React.useState(2);
   const [duplicateSpacingMm, setDuplicateSpacingMm] = React.useState(12);
   const [isDuplicating, setIsDuplicating] = React.useState(false);
@@ -99,6 +100,7 @@ export default function Home() {
   } | null>(null);
   const dragDepthRef = React.useRef(0);
   const rightClickGestureRef = React.useRef<{ x: number; y: number; moved: boolean } | null>(null);
+  const lastHandledPasteArrangeNonceRef = React.useRef(0);
 
   const handleDroppedMeshFiles = React.useCallback((files: File[]) => {
     if (scene.mode !== 'prepare') return;
@@ -240,7 +242,9 @@ export default function Home() {
         }
         break;
       case 'copy':
-        if (scene.activeModelId) {
+        if (scene.selectedModelIds.length > 0) {
+          scene.copySelectedModels();
+        } else if (scene.activeModelId) {
           scene.copyModel(scene.activeModelId);
         }
         break;
@@ -250,7 +254,9 @@ export default function Home() {
         }
         break;
       case 'paste':
-        scene.pasteModel();
+        if (scene.pasteCopiedModelsAutoArrange().length > 0) {
+          setPasteArrangeNonce((prev) => prev + 1);
+        }
         break;
       case 'duplicate':
       case 'arrange':
@@ -404,6 +410,10 @@ export default function Home() {
   const sleep = React.useCallback((ms: number) => new Promise<void>((resolve) => {
     window.setTimeout(resolve, ms);
   }), []);
+
+  const queueArrangeAfterPaste = React.useCallback(() => {
+    setPasteArrangeNonce((prev) => prev + 1);
+  }, []);
 
   const handleAutoArrangeModels = React.useCallback(async (scope: 'all' | 'selected') => {
     if (isAutoArranging) return;
@@ -818,6 +828,15 @@ export default function Home() {
     }
   }, [arrangeAllowRotateOnZ, arrangeAnchorMode, arrangeSpacingMm, getModelFootprintMm, isAutoArranging, scene, sleep, transformMgr]);
 
+  React.useEffect(() => {
+    if (pasteArrangeNonce === 0) return;
+    if (pasteArrangeNonce === lastHandledPasteArrangeNonceRef.current) return;
+    if (scene.mode !== 'prepare') return;
+
+    lastHandledPasteArrangeNonceRef.current = pasteArrangeNonce;
+    void handleAutoArrangeModels('all');
+  }, [handleAutoArrangeModels, pasteArrangeNonce, scene.mode]);
+
   const computeArrangeSlots = React.useCallback((count: number, stepX: number, stepY: number) => {
     const columns = Math.max(1, Math.ceil(Math.sqrt(count)));
     const rows = Math.ceil(count / columns);
@@ -1024,6 +1043,48 @@ export default function Home() {
       window.removeEventListener('keydown', handleGlobalSelectAll, true);
     };
   }, [scene]);
+
+  React.useEffect(() => {
+    const isEditableTarget = (target: EventTarget | null) => {
+      if (!(target instanceof HTMLElement)) return false;
+      return Boolean(target.closest('input, textarea, select, [contenteditable="true"]'));
+    };
+
+    const handleClipboardHotkeys = (event: KeyboardEvent) => {
+      if (!(event.ctrlKey || event.metaKey)) return;
+      if (event.altKey) return;
+      if (isEditableTarget(event.target)) return;
+      if (scene.mode !== 'prepare') return;
+
+      const key = event.key.toLowerCase();
+      if (key === 'c') {
+        if (scene.selectedModelIds.length === 0 && !scene.activeModelId) return;
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (scene.selectedModelIds.length > 0) {
+          scene.copySelectedModels();
+        } else if (scene.activeModelId) {
+          scene.copyModel(scene.activeModelId);
+        }
+        return;
+      }
+
+      if (key === 'v') {
+        if (!scene.canPasteModel) return;
+        event.preventDefault();
+        event.stopPropagation();
+        if (scene.pasteCopiedModelsAutoArrange().length > 0) {
+          queueArrangeAfterPaste();
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleClipboardHotkeys, true);
+    return () => {
+      window.removeEventListener('keydown', handleClipboardHotkeys, true);
+    };
+  }, [queueArrangeAfterPaste, scene]);
 
   React.useEffect(() => {
     if (scene.mode !== 'prepare' || transformMgr.transformMode !== 'duplicate') {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,13 +80,13 @@ export default function Home() {
   const [debugPrimitivesPanelVisible, setDebugPrimitivesPanelVisible] = React.useState<boolean>(true);
   const [editorContextMenuPos, setEditorContextMenuPos] = React.useState<{ x: number; y: number } | null>(null);
   const [isSelectAllModelsActive, setIsSelectAllModelsActive] = React.useState(false);
-  const [arrangeSpacingMm, setArrangeSpacingMm] = React.useState(12);
+  const [arrangeSpacingMm, setArrangeSpacingMm] = React.useState(5);
   const [arrangeAllowRotateOnZ, setArrangeAllowRotateOnZ] = React.useState(false);
   const [arrangeAnchorMode, setArrangeAnchorMode] = React.useState<ArrangeAnchorMode>('center');
   const [isAutoArranging, setIsAutoArranging] = React.useState(false);
   const [pasteArrangeNonce, setPasteArrangeNonce] = React.useState(0);
   const [duplicateTotalCopies, setDuplicateTotalCopies] = React.useState(2);
-  const [duplicateSpacingMm, setDuplicateSpacingMm] = React.useState(12);
+  const [duplicateSpacingMm, setDuplicateSpacingMm] = React.useState(5);
   const [isDuplicating, setIsDuplicating] = React.useState(false);
   const [duplicatePreviewTransforms, setDuplicatePreviewTransforms] = React.useState<Array<{
     position: THREE.Vector3;
@@ -181,6 +181,17 @@ export default function Home() {
 
   const handleModelSelection = React.useCallback((modelId: string, mode: 'single' | 'toggle' | 'add' = 'single') => {
     scene.selectModel(modelId, mode);
+  }, [scene]);
+
+  const handleModelRangeSelection = React.useCallback((ids: string[], activeId: string, mode: 'replace' | 'add' = 'replace') => {
+    if (ids.length === 0) return;
+
+    if (mode === 'add') {
+      scene.setSelectedModelIds((prev) => Array.from(new Set([...prev, ...ids])));
+    } else {
+      scene.setSelectedModelIds(ids);
+    }
+    scene.setActiveModelId(activeId);
   }, [scene]);
 
   const handleGroupSelection = React.useCallback((groupId: string, mode: 'single' | 'add' = 'single') => {
@@ -1220,6 +1231,7 @@ export default function Home() {
               activeModelId={scene.activeModelId}
               selectedModelIds={scene.selectedModelIds}
               onSelect={handleModelSelection}
+              onSelectRange={handleModelRangeSelection}
               onSelectGroup={handleGroupSelection}
               onGroupModels={handleGroupSelectedModels}
               onUngroupModels={handleUngroupSelectedModels}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ import { ModelStatsCard } from '@/components/controls/ModelStatsCard';
 import { TransformToolbar } from '@/components/controls/TransformToolbar';
 import { TransformControls } from '@/components/controls/TransformControls';
 import { ArrangePanel, type ArrangeAnchorMode } from '@/components/controls/ArrangePanel';
-import { DuplicatePanel } from '@/components/controls/DuplicatePanel';
+import { DuplicatePanel, type DuplicateLayoutMode } from '../components/controls/DuplicatePanel';
 import { VisualSettingsPanel } from '@/components/controls/VisualSettingsPanel';
 import { SupportSidebar } from '@/supports/Settings';
 import { CurveSettingsCard } from '@/supports/Curves/CurveSettingsCard';
@@ -87,6 +87,13 @@ export default function Home() {
   const [pasteArrangeNonce, setPasteArrangeNonce] = React.useState(0);
   const [duplicateTotalCopies, setDuplicateTotalCopies] = React.useState(2);
   const [duplicateSpacingMm, setDuplicateSpacingMm] = React.useState(5);
+  const [duplicateLayoutMode, setDuplicateLayoutMode] = React.useState<DuplicateLayoutMode>('auto');
+  const [duplicateArrayCountX, setDuplicateArrayCountX] = React.useState(2);
+  const [duplicateArrayCountY, setDuplicateArrayCountY] = React.useState(1);
+  const [duplicateArrayCountZ, setDuplicateArrayCountZ] = React.useState(1);
+  const [duplicateArrayGapX, setDuplicateArrayGapX] = React.useState(5);
+  const [duplicateArrayGapY, setDuplicateArrayGapY] = React.useState(5);
+  const [duplicateArrayGapZ, setDuplicateArrayGapZ] = React.useState(5);
   const [isDuplicating, setIsDuplicating] = React.useState(false);
   const [duplicatePreviewTransforms, setDuplicatePreviewTransforms] = React.useState<Array<{
     position: THREE.Vector3;
@@ -101,6 +108,7 @@ export default function Home() {
   const dragDepthRef = React.useRef(0);
   const rightClickGestureRef = React.useRef<{ x: number; y: number; moved: boolean } | null>(null);
   const lastHandledPasteArrangeNonceRef = React.useRef(0);
+  const cameraResumeTimeoutRef = React.useRef<number | null>(null);
 
   const handleDroppedMeshFiles = React.useCallback((files: File[]) => {
     if (scene.mode !== 'prepare') return;
@@ -986,8 +994,33 @@ export default function Home() {
     }, 0);
   };
 
-  const handleCameraChange = React.useCallback(() => { }, []);
-  const handleCameraEnd = React.useCallback(() => { }, []);
+  const handleCameraChange = React.useCallback(() => {
+    if (cameraResumeTimeoutRef.current !== null) {
+      window.clearTimeout(cameraResumeTimeoutRef.current);
+      cameraResumeTimeoutRef.current = null;
+    }
+    scene.setBackgroundGeometryWorkPaused(true);
+  }, [scene]);
+
+  const handleCameraEnd = React.useCallback(() => {
+    if (cameraResumeTimeoutRef.current !== null) {
+      window.clearTimeout(cameraResumeTimeoutRef.current);
+    }
+
+    cameraResumeTimeoutRef.current = window.setTimeout(() => {
+      scene.setBackgroundGeometryWorkPaused(false);
+      cameraResumeTimeoutRef.current = null;
+    }, 140);
+  }, [scene]);
+
+  React.useEffect(() => {
+    return () => {
+      if (cameraResumeTimeoutRef.current !== null) {
+        window.clearTimeout(cameraResumeTimeoutRef.current);
+      }
+      scene.setBackgroundGeometryWorkPaused(false);
+    };
+  }, [scene]);
 
   React.useEffect(() => {
     if (scene.mode === 'prepare') return;
@@ -1104,19 +1137,55 @@ export default function Home() {
       return;
     }
 
-    if (!scene.activeModel || duplicateTotalCopies <= 1) {
+    if (!scene.activeModel) {
       setDuplicatePreviewTransforms([]);
       setDuplicateSourcePreviewTransform(null);
       return;
     }
 
     const model = scene.activeModel;
-    const totalCount = Math.max(1, duplicateTotalCopies);
     const { width, depth } = getModelFootprintMm(model);
-    const stepX = width + duplicateSpacingMm;
-    const stepY = depth + duplicateSpacingMm;
+    const height = Math.max(2, Math.abs(model.geometry.size.z * model.transform.scale.z));
 
-    const slots = computeArrangeSlots(totalCount, stepX, stepY);
+    const slots: THREE.Vector3[] = [];
+
+    if (duplicateLayoutMode === 'array') {
+      const countX = Math.max(1, Math.round(duplicateArrayCountX));
+      const countY = Math.max(1, Math.round(duplicateArrayCountY));
+      const countZ = Math.max(1, Math.round(duplicateArrayCountZ));
+      const stepX = width + Math.max(0, duplicateArrayGapX);
+      const stepY = depth + Math.max(0, duplicateArrayGapY);
+      const stepZ = height + Math.max(0, duplicateArrayGapZ);
+
+      const originOffsetX = ((countX - 1) * stepX) * 0.5;
+      const originOffsetY = ((countY - 1) * stepY) * 0.5;
+      const originOffsetZ = ((countZ - 1) * stepZ) * 0.5;
+
+      for (let z = 0; z < countZ; z += 1) {
+        for (let y = 0; y < countY; y += 1) {
+          for (let x = 0; x < countX; x += 1) {
+            slots.push(new THREE.Vector3(
+              model.transform.position.x + (x * stepX) - originOffsetX,
+              model.transform.position.y + (y * stepY) - originOffsetY,
+              model.transform.position.z + (z * stepZ) - originOffsetZ,
+            ));
+          }
+        }
+      }
+    } else {
+      const totalCount = Math.max(1, duplicateTotalCopies);
+      const stepX = width + duplicateSpacingMm;
+      const stepY = depth + duplicateSpacingMm;
+      slots.push(...computeArrangeSlots(totalCount, stepX, stepY).map((slot) => (
+        new THREE.Vector3(slot.x, slot.y, model.transform.position.z)
+      )));
+    }
+
+    if (slots.length <= 1) {
+      setDuplicatePreviewTransforms([]);
+      setDuplicateSourcePreviewTransform(null);
+      return;
+    }
 
     let sourceSlotIndex = 0;
     let sourceSlotDistanceSq = Number.POSITIVE_INFINITY;
@@ -1133,7 +1202,7 @@ export default function Home() {
 
     const sourceSlot = slots[sourceSlotIndex];
     setDuplicateSourcePreviewTransform({
-      position: new THREE.Vector3(sourceSlot.x, sourceSlot.y, model.transform.position.z),
+      position: new THREE.Vector3(sourceSlot.x, sourceSlot.y, sourceSlot.z),
       rotation: model.transform.rotation.clone(),
       scale: model.transform.scale.clone(),
     });
@@ -1142,14 +1211,29 @@ export default function Home() {
     slots.forEach((slot, index) => {
       if (index === sourceSlotIndex) return;
       previews.push({
-        position: new THREE.Vector3(slot.x, slot.y, model.transform.position.z),
+        position: new THREE.Vector3(slot.x, slot.y, slot.z),
         rotation: model.transform.rotation.clone(),
         scale: model.transform.scale.clone(),
       });
     });
 
     setDuplicatePreviewTransforms(previews);
-  }, [computeArrangeSlots, duplicateSpacingMm, duplicateTotalCopies, getModelFootprintMm, scene.activeModel, scene.mode, transformMgr.transformMode]);
+  }, [
+    computeArrangeSlots,
+    duplicateArrayCountX,
+    duplicateArrayCountY,
+    duplicateArrayCountZ,
+    duplicateArrayGapX,
+    duplicateArrayGapY,
+    duplicateArrayGapZ,
+    duplicateLayoutMode,
+    duplicateSpacingMm,
+    duplicateTotalCopies,
+    getModelFootprintMm,
+    scene.activeModel,
+    scene.mode,
+    transformMgr.transformMode,
+  ]);
 
   const handleConfirmDuplicate = React.useCallback(async () => {
     if (isDuplicating) return;
@@ -1348,12 +1432,26 @@ export default function Home() {
               <DuplicatePanel
                 key="prepare-duplicate-panel"
                 activeModelName={scene.activeModel?.name ?? null}
+                layoutMode={duplicateLayoutMode}
+                onLayoutModeChange={setDuplicateLayoutMode}
                 totalCopies={duplicateTotalCopies}
                 onTotalCopiesChange={setDuplicateTotalCopies}
                 spacingMm={duplicateSpacingMm}
                 onSpacingMmChange={setDuplicateSpacingMm}
+                arrayCountX={duplicateArrayCountX}
+                arrayCountY={duplicateArrayCountY}
+                arrayCountZ={duplicateArrayCountZ}
+                onArrayCountXChange={setDuplicateArrayCountX}
+                onArrayCountYChange={setDuplicateArrayCountY}
+                onArrayCountZChange={setDuplicateArrayCountZ}
+                arrayGapX={duplicateArrayGapX}
+                arrayGapY={duplicateArrayGapY}
+                arrayGapZ={duplicateArrayGapZ}
+                onArrayGapXChange={setDuplicateArrayGapX}
+                onArrayGapYChange={setDuplicateArrayGapY}
+                onArrayGapZChange={setDuplicateArrayGapZ}
                 onConfirm={handleConfirmDuplicate}
-                previewCount={Math.max(0, duplicateTotalCopies - 1)}
+                previewCount={duplicatePreviewTransforms.length}
                 isApplying={isDuplicating}
               />
             )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1144,7 +1144,13 @@ export default function Home() {
     }
 
     const model = scene.activeModel;
-    const { width, depth } = getModelFootprintMm(model);
+    const baseWidth = Math.max(2, Math.abs(model.geometry.size.x * model.transform.scale.x));
+    const baseDepth = Math.max(2, Math.abs(model.geometry.size.y * model.transform.scale.y));
+    const z = model.transform.rotation.z;
+    const c = Math.abs(Math.cos(z));
+    const s = Math.abs(Math.sin(z));
+    const width = (baseWidth * c) + (baseDepth * s);
+    const depth = (baseWidth * s) + (baseDepth * c);
     const height = Math.max(2, Math.abs(model.geometry.size.z * model.transform.scale.z));
 
     const slots: THREE.Vector3[] = [];
@@ -1174,11 +1180,64 @@ export default function Home() {
       }
     } else {
       const totalCount = Math.max(1, duplicateTotalCopies);
-      const stepX = width + duplicateSpacingMm;
-      const stepY = depth + duplicateSpacingMm;
-      slots.push(...computeArrangeSlots(totalCount, stepX, stepY).map((slot) => (
-        new THREE.Vector3(slot.x, slot.y, model.transform.position.z)
-      )));
+      const spacing = Math.max(0, duplicateSpacingMm);
+
+      const minX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
+      const maxX = minX + scene.view3dSettings.widthMm;
+      const minY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
+      const maxY = minY + scene.view3dSettings.depthMm;
+
+      const plateWidth = Math.max(1, maxX - minX);
+      const plateDepth = Math.max(1, maxY - minY);
+
+      const maxCols = Math.max(1, Math.floor((plateWidth + spacing) / (width + spacing)));
+      const maxRows = Math.max(1, Math.floor((plateDepth + spacing) / (depth + spacing)));
+      const inPlateCapacity = Math.max(1, maxCols * maxRows);
+      const inPlateCount = Math.min(totalCount, inPlateCapacity);
+
+      const usedCols = Math.min(maxCols, Math.max(1, inPlateCount));
+      const usedRows = Math.max(1, Math.ceil(inPlateCount / maxCols));
+
+      const totalUsedWidth = (usedCols * width) + Math.max(0, usedCols - 1) * spacing;
+      const totalUsedDepth = (usedRows * depth) + Math.max(0, usedRows - 1) * spacing;
+
+      const startX = minX + ((plateWidth - totalUsedWidth) * 0.5) + (width * 0.5);
+      const startY = minY + ((plateDepth - totalUsedDepth) * 0.5) + (depth * 0.5);
+
+      for (let i = 0; i < inPlateCount; i += 1) {
+        const col = i % maxCols;
+        const row = Math.floor(i / maxCols);
+        slots.push(new THREE.Vector3(
+          startX + col * (width + spacing),
+          startY + row * (depth + spacing),
+          model.transform.position.z,
+        ));
+      }
+
+      const overflowCount = totalCount - inPlateCount;
+      if (overflowCount > 0) {
+        const outsideGap = Math.max(8, spacing);
+        let outsideLeftX = maxX + outsideGap;
+        let outsideY = minY;
+        let currentColumnMaxWidth = 0;
+
+        for (let i = 0; i < overflowCount; i += 1) {
+          if (outsideY > minY && (outsideY + depth) > maxY) {
+            outsideLeftX += currentColumnMaxWidth + outsideGap;
+            currentColumnMaxWidth = 0;
+            outsideY = minY;
+          }
+
+          slots.push(new THREE.Vector3(
+            outsideLeftX + width * 0.5,
+            outsideY + depth * 0.5,
+            model.transform.position.z,
+          ));
+
+          outsideY += depth + spacing;
+          currentColumnMaxWidth = Math.max(currentColumnMaxWidth, width);
+        }
+      }
     }
 
     if (slots.length <= 1) {

--- a/src/components/controls/ArrangePanel.tsx
+++ b/src/components/controls/ArrangePanel.tsx
@@ -1,15 +1,30 @@
 import React from 'react';
-import { LayoutGrid, Loader2, RotateCw } from 'lucide-react';
+import { ChevronDown, ChevronUp, LayoutGrid, Loader2, RotateCw } from 'lucide-react';
 import { NumberInput } from '@/components/ui/NumberInput';
 import { Button, Card, CardHeader, IconButton, Select } from '@/components/ui/primitives';
 
 export type ArrangeAnchorMode = 'center' | 'front_left' | 'front_right' | 'back_left' | 'back_right';
+export type ArrangeLayoutMode = 'auto' | 'array';
 
 interface ArrangePanelProps {
+  layoutMode: ArrangeLayoutMode;
+  onLayoutModeChange: (value: ArrangeLayoutMode) => void;
   spacingMm: number;
   onSpacingMmChange: (value: number) => void;
   allowRotateOnZ: boolean;
   onAllowRotateOnZChange: (value: boolean) => void;
+  arrayCountX: number;
+  arrayCountY: number;
+  arrayCountZ: number;
+  onArrayCountXChange: (value: number) => void;
+  onArrayCountYChange: (value: number) => void;
+  onArrayCountZChange: (value: number) => void;
+  arrayGapX: number;
+  arrayGapY: number;
+  arrayGapZ: number;
+  onArrayGapXChange: (value: number) => void;
+  onArrayGapYChange: (value: number) => void;
+  onArrayGapZChange: (value: number) => void;
   anchorMode: ArrangeAnchorMode;
   onAnchorModeChange: (value: ArrangeAnchorMode) => void;
   onApplyAll: () => void;
@@ -19,11 +34,85 @@ interface ArrangePanelProps {
   isApplying?: boolean;
 }
 
+type MiniStepperFieldProps = {
+  value: number;
+  onChange: (value: number) => void;
+  min: number;
+  max: number;
+  disabled?: boolean;
+};
+
+function MiniStepperField({ value, onChange, min, max, disabled = false }: MiniStepperFieldProps) {
+  const safe = Number.isFinite(value) ? value : min;
+  const clamped = Math.min(max, Math.max(min, Math.round(safe)));
+
+  const apply = React.useCallback((next: number) => {
+    const normalized = Math.min(max, Math.max(min, Math.round(Number.isFinite(next) ? next : min)));
+    onChange(normalized);
+  }, [max, min, onChange]);
+
+  return (
+    <div
+      className="relative min-w-0"
+      onWheel={(e) => {
+        if (disabled) return;
+        e.preventDefault();
+        const delta = e.deltaY < 0 ? 1 : -1;
+        apply(clamped + delta);
+      }}
+    >
+      <NumberInput
+        value={clamped}
+        onChange={apply}
+        disabled={disabled}
+        className="ui-input h-8 w-full min-w-0 pl-1.5 pr-5 text-xs text-center no-spinners"
+      />
+
+      <div className="absolute inset-y-0 right-0.5 flex w-4 flex-col items-center justify-center gap-0.5">
+        <button
+          type="button"
+          className="inline-flex h-3 w-3 items-center justify-center rounded hover:bg-white/10 disabled:opacity-50"
+          onClick={() => apply(clamped + 1)}
+          disabled={disabled || clamped >= max}
+          tabIndex={-1}
+          aria-label="Increase value"
+        >
+          <ChevronUp className="h-2.5 w-2.5" />
+        </button>
+        <button
+          type="button"
+          className="inline-flex h-3 w-3 items-center justify-center rounded hover:bg-white/10 disabled:opacity-50"
+          onClick={() => apply(clamped - 1)}
+          disabled={disabled || clamped <= min}
+          tabIndex={-1}
+          aria-label="Decrease value"
+        >
+          <ChevronDown className="h-2.5 w-2.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function ArrangePanel({
+  layoutMode,
+  onLayoutModeChange,
   spacingMm,
   onSpacingMmChange,
   allowRotateOnZ,
   onAllowRotateOnZChange,
+  arrayCountX,
+  arrayCountY,
+  arrayCountZ,
+  onArrayCountXChange,
+  onArrayCountYChange,
+  onArrayCountZChange,
+  arrayGapX,
+  arrayGapY,
+  arrayGapZ,
+  onArrayGapXChange,
+  onArrayGapYChange,
+  onArrayGapZChange,
   anchorMode,
   onAnchorModeChange,
   onApplyAll,
@@ -33,6 +122,9 @@ export function ArrangePanel({
   isApplying = false,
 }: ArrangePanelProps) {
   const [expanded, setExpanded] = React.useState(true);
+
+  const clampCount = React.useCallback((value: number) => Math.min(64, Math.max(1, Math.round(value))), []);
+  const clampGap = React.useCallback((value: number) => Math.min(120, Math.max(0, Math.round(value))), []);
 
   return (
     <Card>
@@ -72,6 +164,43 @@ export function ArrangePanel({
       {expanded && (
         <div className="px-2.5 pb-2.5 space-y-2">
           <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+            <div className="ui-meta mb-1" style={{ color: 'var(--text-muted)' }}>Layout mode</div>
+            <div className="grid grid-cols-2 gap-1">
+              <button
+                type="button"
+                className="ui-button ui-button-secondary !h-8 text-[11px]"
+                onClick={() => onLayoutModeChange('auto')}
+                disabled={isApplying}
+                style={layoutMode === 'auto'
+                  ? {
+                      borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
+                      background: 'color-mix(in srgb, var(--accent), var(--surface-1) 85%)',
+                      color: 'var(--text-strong)',
+                    }
+                  : undefined}
+              >
+                Auto
+              </button>
+              <button
+                type="button"
+                className="ui-button ui-button-secondary !h-8 text-[11px]"
+                onClick={() => onLayoutModeChange('array')}
+                disabled={isApplying}
+                style={layoutMode === 'array'
+                  ? {
+                      borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
+                      background: 'color-mix(in srgb, var(--accent), var(--surface-1) 85%)',
+                      color: 'var(--text-strong)',
+                    }
+                  : undefined}
+              >
+                Array
+              </button>
+            </div>
+          </div>
+
+          {layoutMode === 'auto' ? (
+          <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
             <label className="ui-meta" style={{ color: 'var(--text-muted)' }}>Spacing (mm)</label>
             <NumberInput
               value={spacingMm}
@@ -84,6 +213,40 @@ export function ArrangePanel({
               className="ui-input mt-1 w-full !h-8 px-2 text-sm no-spinners"
             />
           </div>
+
+          ) : (
+            <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+              <div className="grid grid-cols-[24px_minmax(0,1fr)_minmax(0,1fr)] gap-1 items-center text-[10px] uppercase tracking-wide mb-1" style={{ color: 'var(--text-muted)' }}>
+                <span />
+                <span className="text-center">Count</span>
+                <span className="text-center">Gap</span>
+              </div>
+
+              {([
+                ['X', arrayCountX, onArrayCountXChange, arrayGapX, onArrayGapXChange],
+                ['Y', arrayCountY, onArrayCountYChange, arrayGapY, onArrayGapYChange],
+                ['Z', arrayCountZ, onArrayCountZChange, arrayGapZ, onArrayGapZChange],
+              ] as const).map(([axis, countValue, onCountChange, gapValue, onGapChange]) => (
+                <div key={axis} className="grid grid-cols-[24px_minmax(0,1fr)_minmax(0,1fr)] gap-1 items-center mb-1 last:mb-0 min-w-0">
+                  <span className="text-[11px] font-semibold" style={{ color: 'var(--text-muted)' }}>{axis}:</span>
+                  <MiniStepperField
+                    value={countValue}
+                    onChange={(next) => onCountChange(clampCount(next))}
+                    min={1}
+                    max={64}
+                    disabled={isApplying}
+                  />
+                  <MiniStepperField
+                    value={gapValue}
+                    onChange={(next) => onGapChange(clampGap(next))}
+                    min={0}
+                    max={120}
+                    disabled={isApplying}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
 
           <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
             <div className="ui-meta" style={{ color: 'var(--text-muted)' }}>Placement anchor</div>
@@ -101,31 +264,33 @@ export function ArrangePanel({
             </Select>
           </div>
 
-          <button
-            type="button"
-            className="w-full rounded-md border px-2 py-2 text-left transition-colors disabled:opacity-60"
-            style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
-            onClick={() => onAllowRotateOnZChange(!allowRotateOnZ)}
-            disabled={isApplying}
-            title="Allow auto-arrange to rotate models by 90° on Z when beneficial"
-          >
-            <div className="flex items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <RotateCw className="h-3.5 w-3.5" style={{ color: 'var(--accent)' }} />
-                <span className="text-xs font-medium" style={{ color: 'var(--text-strong)' }}>Allow Z-rotation</span>
+          {layoutMode === 'auto' && (
+            <button
+              type="button"
+              className="w-full rounded-md border px-2 py-2 text-left transition-colors disabled:opacity-60"
+              style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+              onClick={() => onAllowRotateOnZChange(!allowRotateOnZ)}
+              disabled={isApplying}
+              title="Allow auto-arrange to rotate models by 90° on Z when beneficial"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <RotateCw className="h-3.5 w-3.5" style={{ color: 'var(--accent)' }} />
+                  <span className="text-xs font-medium" style={{ color: 'var(--text-strong)' }}>Allow Z-rotation</span>
+                </div>
+                <span
+                  className="rounded-full border px-2 py-0.5 text-[10px]"
+                  style={{
+                    borderColor: 'var(--border-subtle)',
+                    color: allowRotateOnZ ? 'var(--accent)' : 'var(--text-muted)',
+                    background: allowRotateOnZ ? 'color-mix(in srgb, var(--accent), transparent 88%)' : 'transparent',
+                  }}
+                >
+                  {allowRotateOnZ ? 'ON' : 'OFF'}
+                </span>
               </div>
-              <span
-                className="rounded-full border px-2 py-0.5 text-[10px]"
-                style={{
-                  borderColor: 'var(--border-subtle)',
-                  color: allowRotateOnZ ? 'var(--accent)' : 'var(--text-muted)',
-                  background: allowRotateOnZ ? 'color-mix(in srgb, var(--accent), transparent 88%)' : 'transparent',
-                }}
-              >
-                {allowRotateOnZ ? 'ON' : 'OFF'}
-              </span>
-            </div>
-          </button>
+            </button>
+          )}
 
           <div className="grid grid-cols-2 gap-2">
             <Button

--- a/src/components/controls/ArrangePanel.tsx
+++ b/src/components/controls/ArrangePanel.tsx
@@ -12,8 +12,10 @@ interface ArrangePanelProps {
   onAllowRotateOnZChange: (value: boolean) => void;
   anchorMode: ArrangeAnchorMode;
   onAnchorModeChange: (value: ArrangeAnchorMode) => void;
-  onApply: () => void;
+  onApplyAll: () => void;
+  onApplySelected: () => void;
   modelCount: number;
+  selectedModelCount: number;
   isApplying?: boolean;
 }
 
@@ -24,8 +26,10 @@ export function ArrangePanel({
   onAllowRotateOnZChange,
   anchorMode,
   onAnchorModeChange,
-  onApply,
+  onApplyAll,
+  onApplySelected,
   modelCount,
+  selectedModelCount,
   isApplying = false,
 }: ArrangePanelProps) {
   const [expanded, setExpanded] = React.useState(true);
@@ -123,23 +127,43 @@ export function ArrangePanel({
             </div>
           </button>
 
-          <Button
-            onClick={onApply}
-            variant="accent"
-            size="sm"
-            className="w-full !h-8 text-[11px]"
-            disabled={modelCount <= 1 || isApplying}
-            title={modelCount <= 1 ? 'Need at least 2 models to arrange' : 'Arrange visible models in grid'}
-          >
-            {isApplying ? (
-              <span className="inline-flex items-center gap-1.5">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                Arranging…
-              </span>
-            ) : (
-              'Auto Arrange Models'
-            )}
-          </Button>
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              onClick={onApplyAll}
+              variant="accent"
+              size="sm"
+              className="w-full !h-8 text-[11px]"
+              disabled={modelCount <= 1 || isApplying}
+              title={modelCount <= 1 ? 'Need at least 2 visible models to arrange' : 'Arrange all visible models'}
+            >
+              {isApplying ? (
+                <span className="inline-flex items-center gap-1.5">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Arranging…
+                </span>
+              ) : (
+                'Arrange All'
+              )}
+            </Button>
+
+            <Button
+              onClick={onApplySelected}
+              variant="secondary"
+              size="sm"
+              className="w-full !h-8 text-[11px]"
+              disabled={selectedModelCount <= 1 || isApplying}
+              title={selectedModelCount <= 1 ? 'Select at least 2 visible models to arrange' : 'Arrange selected models only'}
+            >
+              {isApplying ? (
+                <span className="inline-flex items-center gap-1.5">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  Arranging…
+                </span>
+              ) : (
+                'Arrange Selected'
+              )}
+            </Button>
+          </div>
         </div>
       )}
     </Card>

--- a/src/components/controls/ArrangePanel.tsx
+++ b/src/components/controls/ArrangePanel.tsx
@@ -162,13 +162,13 @@ export function ArrangePanel({
       />
 
       {expanded && (
-        <div className="px-2.5 pb-2.5 space-y-2">
+        <div className="px-2 pb-2 space-y-2 sm:px-2.5 sm:pb-2.5">
           <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
             <div className="ui-meta mb-1" style={{ color: 'var(--text-muted)' }}>Layout mode</div>
             <div className="grid grid-cols-2 gap-1">
               <button
                 type="button"
-                className="ui-button ui-button-secondary !h-8 text-[11px]"
+                className="ui-button ui-button-secondary !h-8 whitespace-nowrap px-1.5 text-[10px] sm:text-[11px]"
                 onClick={() => onLayoutModeChange('auto')}
                 disabled={isApplying}
                 style={layoutMode === 'auto'
@@ -183,7 +183,7 @@ export function ArrangePanel({
               </button>
               <button
                 type="button"
-                className="ui-button ui-button-secondary !h-8 text-[11px]"
+                className="ui-button ui-button-secondary !h-8 whitespace-nowrap px-1.5 text-[10px] sm:text-[11px]"
                 onClick={() => onLayoutModeChange('array')}
                 disabled={isApplying}
                 style={layoutMode === 'array'
@@ -210,7 +210,7 @@ export function ArrangePanel({
                 }
               }}
               disabled={isApplying}
-              className="ui-input mt-1 w-full !h-8 px-2 text-sm no-spinners"
+              className="ui-input mt-1 w-full min-w-0 !h-8 px-2 text-xs sm:text-sm no-spinners"
             />
           </div>
 
@@ -297,7 +297,7 @@ export function ArrangePanel({
               onClick={onApplyAll}
               variant="accent"
               size="sm"
-              className="w-full !h-8 text-[11px]"
+              className="w-full !min-h-8 px-1.5 py-1 text-[10px] sm:text-[11px] whitespace-normal text-center leading-tight"
               disabled={modelCount <= 1 || isApplying}
               title={modelCount <= 1 ? 'Need at least 2 visible models to arrange' : 'Arrange all visible models'}
             >
@@ -315,7 +315,7 @@ export function ArrangePanel({
               onClick={onApplySelected}
               variant="secondary"
               size="sm"
-              className="w-full !h-8 text-[11px]"
+              className="w-full !min-h-8 px-1.5 py-1 text-[10px] sm:text-[11px] whitespace-normal text-center leading-tight"
               disabled={selectedModelCount <= 1 || isApplying}
               title={selectedModelCount <= 1 ? 'Select at least 2 visible models to arrange' : 'Arrange selected models only'}
             >

--- a/src/components/controls/ArrangePanel.tsx
+++ b/src/components/controls/ArrangePanel.tsx
@@ -1,17 +1,33 @@
 import React from 'react';
-import { LayoutGrid, Loader2 } from 'lucide-react';
+import { LayoutGrid, Loader2, RotateCw } from 'lucide-react';
 import { NumberInput } from '@/components/ui/NumberInput';
-import { Button, Card, CardHeader, IconButton } from '@/components/ui/primitives';
+import { Button, Card, CardHeader, IconButton, Select } from '@/components/ui/primitives';
+
+export type ArrangeAnchorMode = 'center' | 'front_left' | 'front_right' | 'back_left' | 'back_right';
 
 interface ArrangePanelProps {
   spacingMm: number;
   onSpacingMmChange: (value: number) => void;
+  allowRotateOnZ: boolean;
+  onAllowRotateOnZChange: (value: boolean) => void;
+  anchorMode: ArrangeAnchorMode;
+  onAnchorModeChange: (value: ArrangeAnchorMode) => void;
   onApply: () => void;
   modelCount: number;
   isApplying?: boolean;
 }
 
-export function ArrangePanel({ spacingMm, onSpacingMmChange, onApply, modelCount, isApplying = false }: ArrangePanelProps) {
+export function ArrangePanel({
+  spacingMm,
+  onSpacingMmChange,
+  allowRotateOnZ,
+  onAllowRotateOnZChange,
+  anchorMode,
+  onAnchorModeChange,
+  onApply,
+  modelCount,
+  isApplying = false,
+}: ArrangePanelProps) {
   const [expanded, setExpanded] = React.useState(true);
 
   return (
@@ -64,6 +80,48 @@ export function ArrangePanel({ spacingMm, onSpacingMmChange, onApply, modelCount
               className="ui-input mt-1 w-full !h-8 px-2 text-sm no-spinners"
             />
           </div>
+
+          <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+            <div className="ui-meta" style={{ color: 'var(--text-muted)' }}>Placement anchor</div>
+            <Select
+              value={anchorMode}
+              onChange={(e) => onAnchorModeChange(e.target.value as ArrangeAnchorMode)}
+              disabled={isApplying}
+              className="mt-1 w-full !h-8 px-2 text-xs"
+            >
+              <option value="center">Center</option>
+              <option value="front_left">Front Left</option>
+              <option value="front_right">Front Right</option>
+              <option value="back_left">Back Left</option>
+              <option value="back_right">Back Right</option>
+            </Select>
+          </div>
+
+          <button
+            type="button"
+            className="w-full rounded-md border px-2 py-2 text-left transition-colors disabled:opacity-60"
+            style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+            onClick={() => onAllowRotateOnZChange(!allowRotateOnZ)}
+            disabled={isApplying}
+            title="Allow auto-arrange to rotate models by 90° on Z when beneficial"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <RotateCw className="h-3.5 w-3.5" style={{ color: 'var(--accent)' }} />
+                <span className="text-xs font-medium" style={{ color: 'var(--text-strong)' }}>Allow Z-rotation</span>
+              </div>
+              <span
+                className="rounded-full border px-2 py-0.5 text-[10px]"
+                style={{
+                  borderColor: 'var(--border-subtle)',
+                  color: allowRotateOnZ ? 'var(--accent)' : 'var(--text-muted)',
+                  background: allowRotateOnZ ? 'color-mix(in srgb, var(--accent), transparent 88%)' : 'transparent',
+                }}
+              >
+                {allowRotateOnZ ? 'ON' : 'OFF'}
+              </span>
+            </div>
+          </button>
 
           <Button
             onClick={onApply}

--- a/src/components/controls/ArrangePanel.tsx
+++ b/src/components/controls/ArrangePanel.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { LayoutGrid, Loader2 } from 'lucide-react';
+import { NumberInput } from '@/components/ui/NumberInput';
+import { Button, Card, CardHeader, IconButton } from '@/components/ui/primitives';
+
+interface ArrangePanelProps {
+  spacingMm: number;
+  onSpacingMmChange: (value: number) => void;
+  onApply: () => void;
+  modelCount: number;
+  isApplying?: boolean;
+}
+
+export function ArrangePanel({ spacingMm, onSpacingMmChange, onApply, modelCount, isApplying = false }: ArrangePanelProps) {
+  const [expanded, setExpanded] = React.useState(true);
+
+  return (
+    <Card>
+      <CardHeader
+        left={(
+          <>
+            <IconButton
+              onClick={() => setExpanded((prev) => !prev)}
+              className="!p-0.5"
+              title={expanded ? 'Collapse card' : 'Expand card'}
+            >
+              <svg
+                className="w-3 h-3 transform transition-transform"
+                style={{ color: expanded ? 'var(--accent)' : 'var(--text-muted)' }}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                {expanded ? (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                ) : (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                )}
+              </svg>
+            </IconButton>
+            <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Arrange</h3>
+          </>
+        )}
+        right={(
+          <div className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5" style={{ borderColor: 'var(--border-subtle)' }}>
+            <LayoutGrid className="w-3 h-3" style={{ color: 'var(--accent)' }} />
+            <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>{modelCount} model{modelCount === 1 ? '' : 's'}</span>
+          </div>
+        )}
+      />
+
+      {expanded && (
+        <div className="px-2.5 pb-2.5 space-y-2">
+          <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+            <label className="ui-meta" style={{ color: 'var(--text-muted)' }}>Spacing (mm)</label>
+            <NumberInput
+              value={spacingMm}
+              onChange={(next) => {
+                if (next >= 2 && next <= 120) {
+                  onSpacingMmChange(next);
+                }
+              }}
+              disabled={isApplying}
+              className="ui-input mt-1 w-full !h-8 px-2 text-sm no-spinners"
+            />
+          </div>
+
+          <Button
+            onClick={onApply}
+            variant="accent"
+            size="sm"
+            className="w-full !h-8 text-[11px]"
+            disabled={modelCount <= 1 || isApplying}
+            title={modelCount <= 1 ? 'Need at least 2 models to arrange' : 'Arrange visible models in grid'}
+          >
+            {isApplying ? (
+              <span className="inline-flex items-center gap-1.5">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Arranging…
+              </span>
+            ) : (
+              'Auto Arrange Models'
+            )}
+          </Button>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/components/controls/DuplicatePanel.tsx
+++ b/src/components/controls/DuplicatePanel.tsx
@@ -183,7 +183,7 @@ export function DuplicatePanel({
       />
 
       {expanded && (
-        <div className="px-2.5 pb-2.5 space-y-2">
+        <div className="px-2 pb-2 space-y-2 sm:px-2.5 sm:pb-2.5">
           <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
             <div className="ui-meta" style={{ color: 'var(--text-muted)' }}>Selected model</div>
             <div className="mt-0.5 text-xs font-medium truncate" style={{ color: 'var(--text-strong)' }}>
@@ -193,10 +193,10 @@ export function DuplicatePanel({
 
           <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
             <div className="ui-meta mb-1" style={{ color: 'var(--text-muted)' }}>Layout mode</div>
-            <div className="grid grid-cols-2 gap-1">
+            <div className="grid grid-cols-2 gap-1 min-w-0">
               <button
                 type="button"
-                className="ui-button ui-button-secondary !h-8 text-[11px]"
+                className="ui-button ui-button-secondary !h-8 whitespace-nowrap px-1.5 text-[10px] sm:text-[11px]"
                 onClick={() => onLayoutModeChange('auto')}
                 disabled={isApplying}
                 style={layoutMode === 'auto'
@@ -211,7 +211,7 @@ export function DuplicatePanel({
               </button>
               <button
                 type="button"
-                className="ui-button ui-button-secondary !h-8 text-[11px]"
+                className="ui-button ui-button-secondary !h-8 whitespace-nowrap px-1.5 text-[10px] sm:text-[11px]"
                 onClick={() => onLayoutModeChange('array')}
                 disabled={isApplying}
                 style={layoutMode === 'array'
@@ -231,9 +231,9 @@ export function DuplicatePanel({
             <>
               <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
                 <label className="ui-meta" style={{ color: 'var(--text-muted)' }}>Total copies</label>
-                <div className="mt-1 flex items-center gap-1">
+                <div className="mt-1 flex min-w-0 items-center gap-1">
                   <IconButton
-                    className="!h-8 !w-8 !p-0"
+                    className="!h-8 !w-8 shrink-0 !p-0"
                     onClick={() => setClampedCopies(totalCopies - 1)}
                     disabled={totalCopies <= 1 || isApplying}
                     title="Decrease total copies"
@@ -250,11 +250,11 @@ export function DuplicatePanel({
                       setClampedCopies(totalCopies + (e.deltaY < 0 ? 1 : -1));
                     }}
                     disabled={isApplying}
-                    className="ui-input h-8 flex-1 px-0 text-sm text-center tabular-nums font-semibold no-spinners"
+                    className="ui-input h-8 w-0 min-w-0 flex-1 px-0 text-xs sm:text-sm text-center tabular-nums font-semibold no-spinners"
                   />
 
                   <IconButton
-                    className="!h-8 !w-8 !p-0"
+                    className="!h-8 !w-8 shrink-0 !p-0"
                     onClick={() => setClampedCopies(totalCopies + 1)}
                     disabled={totalCopies >= 128 || isApplying}
                     title="Increase total copies"
@@ -266,9 +266,9 @@ export function DuplicatePanel({
 
               <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
                 <label className="ui-meta" style={{ color: 'var(--text-muted)' }}>Arrange distance (mm)</label>
-                <div className="mt-1 flex items-center gap-1">
+                <div className="mt-1 flex min-w-0 items-center gap-1">
                   <IconButton
-                    className="!h-8 !w-8 !p-0"
+                    className="!h-8 !w-8 shrink-0 !p-0"
                     onClick={() => setClampedSpacing(spacingMm - 1)}
                     disabled={spacingMm <= 0 || isApplying}
                     title="Decrease spacing"
@@ -285,11 +285,11 @@ export function DuplicatePanel({
                       setClampedSpacing(spacingMm + (e.deltaY < 0 ? 1 : -1));
                     }}
                     disabled={isApplying}
-                    className="ui-input h-8 flex-1 px-0 text-sm text-center tabular-nums font-semibold no-spinners"
+                    className="ui-input h-8 w-0 min-w-0 flex-1 px-0 text-xs sm:text-sm text-center tabular-nums font-semibold no-spinners"
                   />
 
                   <IconButton
-                    className="!h-8 !w-8 !p-0"
+                    className="!h-8 !w-8 shrink-0 !p-0"
                     onClick={() => setClampedSpacing(spacingMm + 1)}
                     disabled={spacingMm >= 120 || isApplying}
                     title="Increase spacing"
@@ -344,7 +344,7 @@ export function DuplicatePanel({
             onClick={onConfirm}
             variant="accent"
             size="sm"
-            className="w-full !h-8 text-[11px]"
+            className="w-full !h-8 whitespace-nowrap px-1.5 text-[10px] sm:text-[11px]"
             disabled={!hasSelection || previewCount <= 0 || isApplying}
             title={!hasSelection ? 'Select a model to duplicate' : 'Generate duplicates from preview'}
           >
@@ -362,7 +362,7 @@ export function DuplicatePanel({
             onClick={onFillPlate}
             variant="secondary"
             size="sm"
-            className="w-full !h-8 text-[11px]"
+            className="w-full !h-8 whitespace-nowrap px-1.5 text-[10px] sm:text-[11px]"
             disabled={!hasSelection || isApplying || layoutMode !== 'auto'}
             title={
               layoutMode !== 'auto'

--- a/src/components/controls/DuplicatePanel.tsx
+++ b/src/components/controls/DuplicatePanel.tsx
@@ -26,6 +26,7 @@ interface DuplicatePanelProps {
   onArrayGapYChange: (value: number) => void;
   onArrayGapZChange: (value: number) => void;
   onConfirm: () => void;
+  onFillPlate: () => void;
   previewCount: number;
   isApplying?: boolean;
 }
@@ -111,6 +112,7 @@ export function DuplicatePanel({
   onArrayGapYChange,
   onArrayGapZChange,
   onConfirm,
+  onFillPlate,
   previewCount,
   isApplying = false,
 }: DuplicatePanelProps) {
@@ -354,6 +356,21 @@ export function DuplicatePanel({
             ) : (
               `Confirm Duplicate (${Math.max(0, previewCount)} new)`
             )}
+          </Button>
+
+          <Button
+            onClick={onFillPlate}
+            variant="secondary"
+            size="sm"
+            className="w-full !h-8 text-[11px]"
+            disabled={!hasSelection || isApplying || layoutMode !== 'auto'}
+            title={
+              layoutMode !== 'auto'
+                ? 'Fill Plate is available in Auto layout mode'
+                : (!hasSelection ? 'Select a model to fill the plate' : 'Set copies to fill current plate capacity')
+            }
+          >
+            Fill Plate
           </Button>
         </div>
       )}

--- a/src/components/controls/DuplicatePanel.tsx
+++ b/src/components/controls/DuplicatePanel.tsx
@@ -1,25 +1,115 @@
 import React from 'react';
-import { CopyPlus, Loader2, Minus, Plus } from 'lucide-react';
+import { ChevronDown, ChevronUp, CopyPlus, Loader2, Minus, Plus } from 'lucide-react';
 import { NumberInput } from '@/components/ui/NumberInput';
 import { Button, Card, CardHeader, IconButton } from '@/components/ui/primitives';
 
+export type DuplicateLayoutMode = 'auto' | 'array';
+
 interface DuplicatePanelProps {
   activeModelName: string | null;
+  layoutMode: DuplicateLayoutMode;
+  onLayoutModeChange: (value: DuplicateLayoutMode) => void;
   totalCopies: number;
   onTotalCopiesChange: (value: number) => void;
   spacingMm: number;
   onSpacingMmChange: (value: number) => void;
+  arrayCountX: number;
+  arrayCountY: number;
+  arrayCountZ: number;
+  onArrayCountXChange: (value: number) => void;
+  onArrayCountYChange: (value: number) => void;
+  onArrayCountZChange: (value: number) => void;
+  arrayGapX: number;
+  arrayGapY: number;
+  arrayGapZ: number;
+  onArrayGapXChange: (value: number) => void;
+  onArrayGapYChange: (value: number) => void;
+  onArrayGapZChange: (value: number) => void;
   onConfirm: () => void;
   previewCount: number;
   isApplying?: boolean;
 }
 
+type MiniStepperFieldProps = {
+  value: number;
+  onChange: (value: number) => void;
+  min: number;
+  max: number;
+  disabled?: boolean;
+};
+
+function MiniStepperField({ value, onChange, min, max, disabled = false }: MiniStepperFieldProps) {
+  const safe = Number.isFinite(value) ? value : min;
+  const clamped = Math.min(max, Math.max(min, Math.round(safe)));
+
+  const apply = React.useCallback((next: number) => {
+    const normalized = Math.min(max, Math.max(min, Math.round(Number.isFinite(next) ? next : min)));
+    onChange(normalized);
+  }, [max, min, onChange]);
+
+  return (
+    <div
+      className="relative min-w-0"
+      onWheel={(e) => {
+        if (disabled) return;
+        e.preventDefault();
+        const delta = e.deltaY < 0 ? 1 : -1;
+        apply(clamped + delta);
+      }}
+    >
+      <NumberInput
+        value={clamped}
+        onChange={apply}
+        disabled={disabled}
+        className="ui-input h-8 w-full min-w-0 pl-1.5 pr-5 text-xs text-center no-spinners"
+      />
+
+      <div className="absolute inset-y-0 right-0.5 flex w-4 flex-col items-center justify-center gap-0.5">
+        <button
+          type="button"
+          className="inline-flex h-3 w-3 items-center justify-center rounded hover:bg-white/10 disabled:opacity-50"
+          onClick={() => apply(clamped + 1)}
+          disabled={disabled || clamped >= max}
+          tabIndex={-1}
+          aria-label="Increase value"
+        >
+          <ChevronUp className="h-2.5 w-2.5" />
+        </button>
+        <button
+          type="button"
+          className="inline-flex h-3 w-3 items-center justify-center rounded hover:bg-white/10 disabled:opacity-50"
+          onClick={() => apply(clamped - 1)}
+          disabled={disabled || clamped <= min}
+          tabIndex={-1}
+          aria-label="Decrease value"
+        >
+          <ChevronDown className="h-2.5 w-2.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function DuplicatePanel({
   activeModelName,
+  layoutMode,
+  onLayoutModeChange,
   totalCopies,
   onTotalCopiesChange,
   spacingMm,
   onSpacingMmChange,
+  arrayCountX,
+  arrayCountY,
+  arrayCountZ,
+  onArrayCountXChange,
+  onArrayCountYChange,
+  onArrayCountZChange,
+  arrayGapX,
+  arrayGapY,
+  arrayGapZ,
+  onArrayGapXChange,
+  onArrayGapYChange,
+  onArrayGapZChange,
   onConfirm,
   previewCount,
   isApplying = false,
@@ -27,13 +117,33 @@ export function DuplicatePanel({
   const [expanded, setExpanded] = React.useState(true);
   const hasSelection = !!activeModelName;
 
+  const sanitizeNumber = React.useCallback((value: number, fallback: number) => {
+    return Number.isFinite(value) ? value : fallback;
+  }, []);
+
   const setClampedCopies = React.useCallback((value: number) => {
-    onTotalCopiesChange(Math.min(64, Math.max(1, Math.round(value))));
-  }, [onTotalCopiesChange]);
+    const next = sanitizeNumber(value, 1);
+    onTotalCopiesChange(Math.min(128, Math.max(1, Math.round(next))));
+  }, [onTotalCopiesChange, sanitizeNumber]);
 
   const setClampedSpacing = React.useCallback((value: number) => {
-    onSpacingMmChange(Math.min(120, Math.max(2, Math.round(value))));
-  }, [onSpacingMmChange]);
+    const next = sanitizeNumber(value, 0);
+    onSpacingMmChange(Math.min(120, Math.max(0, Math.round(next))));
+  }, [onSpacingMmChange, sanitizeNumber]);
+
+  const setClampedArrayCount = React.useCallback((setter: (value: number) => void, value: number) => {
+    const next = sanitizeNumber(value, 1);
+    setter(Math.min(32, Math.max(1, Math.round(next))));
+  }, [sanitizeNumber]);
+
+  const setClampedArrayGap = React.useCallback((setter: (value: number) => void, value: number) => {
+    const next = sanitizeNumber(value, 0);
+    setter(Math.min(120, Math.max(0, Math.round(next))));
+  }, [sanitizeNumber]);
+
+  const displayTotalCopies = Math.max(1, layoutMode === 'array'
+    ? (Math.max(1, Math.round(arrayCountX)) * Math.max(1, Math.round(arrayCountY)) * Math.max(1, Math.round(arrayCountZ)))
+    : Math.max(1, Math.round(totalCopies)));
 
   return (
     <Card>
@@ -80,62 +190,151 @@ export function DuplicatePanel({
           </div>
 
           <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-            <label className="ui-meta" style={{ color: 'var(--text-muted)' }}>Total copies</label>
-            <div className="mt-1 flex items-center gap-1">
-              <IconButton
-                className="!h-8 !w-8 !p-0"
-                onClick={() => setClampedCopies(totalCopies - 1)}
-                disabled={totalCopies <= 1 || isApplying}
-                title="Decrease total copies"
-              >
-                <Minus className="h-3.5 w-3.5" />
-              </IconButton>
-
-              <NumberInput
-                value={totalCopies}
-                onChange={setClampedCopies}
+            <div className="ui-meta mb-1" style={{ color: 'var(--text-muted)' }}>Layout mode</div>
+            <div className="grid grid-cols-2 gap-1">
+              <button
+                type="button"
+                className="ui-button ui-button-secondary !h-8 text-[11px]"
+                onClick={() => onLayoutModeChange('auto')}
                 disabled={isApplying}
-                className="ui-input h-8 flex-1 px-2 text-sm text-center no-spinners"
-              />
-
-              <IconButton
-                className="!h-8 !w-8 !p-0"
-                onClick={() => setClampedCopies(totalCopies + 1)}
-                disabled={totalCopies >= 64 || isApplying}
-                title="Increase total copies"
+                style={layoutMode === 'auto'
+                  ? {
+                      borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
+                      background: 'color-mix(in srgb, var(--accent), var(--surface-1) 85%)',
+                      color: 'var(--text-strong)',
+                    }
+                  : undefined}
               >
-                <Plus className="h-3.5 w-3.5" />
-              </IconButton>
+                Auto layout
+              </button>
+              <button
+                type="button"
+                className="ui-button ui-button-secondary !h-8 text-[11px]"
+                onClick={() => onLayoutModeChange('array')}
+                disabled={isApplying}
+                style={layoutMode === 'array'
+                  ? {
+                      borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
+                      background: 'color-mix(in srgb, var(--accent), var(--surface-1) 85%)',
+                      color: 'var(--text-strong)',
+                    }
+                  : undefined}
+              >
+                Array
+              </button>
             </div>
           </div>
 
+          {layoutMode === 'auto' ? (
+            <>
+              <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+                <label className="ui-meta" style={{ color: 'var(--text-muted)' }}>Total copies</label>
+                <div className="mt-1 flex items-center gap-1">
+                  <IconButton
+                    className="!h-8 !w-8 !p-0"
+                    onClick={() => setClampedCopies(totalCopies - 1)}
+                    disabled={totalCopies <= 1 || isApplying}
+                    title="Decrease total copies"
+                  >
+                    <Minus className="h-3.5 w-3.5" />
+                  </IconButton>
+
+                  <NumberInput
+                    value={totalCopies}
+                    onChange={setClampedCopies}
+                    onWheel={(e) => {
+                      if (isApplying) return;
+                      e.preventDefault();
+                      setClampedCopies(totalCopies + (e.deltaY < 0 ? 1 : -1));
+                    }}
+                    disabled={isApplying}
+                    className="ui-input h-8 flex-1 px-0 text-sm text-center tabular-nums font-semibold no-spinners"
+                  />
+
+                  <IconButton
+                    className="!h-8 !w-8 !p-0"
+                    onClick={() => setClampedCopies(totalCopies + 1)}
+                    disabled={totalCopies >= 128 || isApplying}
+                    title="Increase total copies"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                  </IconButton>
+                </div>
+              </div>
+
+              <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+                <label className="ui-meta" style={{ color: 'var(--text-muted)' }}>Arrange distance (mm)</label>
+                <div className="mt-1 flex items-center gap-1">
+                  <IconButton
+                    className="!h-8 !w-8 !p-0"
+                    onClick={() => setClampedSpacing(spacingMm - 1)}
+                    disabled={spacingMm <= 0 || isApplying}
+                    title="Decrease spacing"
+                  >
+                    <Minus className="h-3.5 w-3.5" />
+                  </IconButton>
+
+                  <NumberInput
+                    value={spacingMm}
+                    onChange={setClampedSpacing}
+                    onWheel={(e) => {
+                      if (isApplying) return;
+                      e.preventDefault();
+                      setClampedSpacing(spacingMm + (e.deltaY < 0 ? 1 : -1));
+                    }}
+                    disabled={isApplying}
+                    className="ui-input h-8 flex-1 px-0 text-sm text-center tabular-nums font-semibold no-spinners"
+                  />
+
+                  <IconButton
+                    className="!h-8 !w-8 !p-0"
+                    onClick={() => setClampedSpacing(spacingMm + 1)}
+                    disabled={spacingMm >= 120 || isApplying}
+                    title="Increase spacing"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                  </IconButton>
+                </div>
+              </div>
+            </>
+          ) : (
+            <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+              <div className="grid grid-cols-[24px_minmax(0,1fr)_minmax(0,1fr)] gap-1 items-center text-[10px] uppercase tracking-wide mb-1" style={{ color: 'var(--text-muted)' }}>
+                <span />
+                <span className="text-center">Count</span>
+                <span className="text-center">Gap</span>
+              </div>
+
+              {([
+                ['X', arrayCountX, onArrayCountXChange, arrayGapX, onArrayGapXChange],
+                ['Y', arrayCountY, onArrayCountYChange, arrayGapY, onArrayGapYChange],
+                ['Z', arrayCountZ, onArrayCountZChange, arrayGapZ, onArrayGapZChange],
+              ] as const).map(([axis, countValue, onCountChange, gapValue, onGapChange]) => (
+                <div key={axis} className="grid grid-cols-[24px_minmax(0,1fr)_minmax(0,1fr)] gap-1 items-center mb-1 last:mb-0 min-w-0">
+                  <span className="text-[11px] font-semibold" style={{ color: 'var(--text-muted)' }}>{axis}:</span>
+                  <MiniStepperField
+                    value={countValue}
+                    onChange={(next) => setClampedArrayCount(onCountChange, next)}
+                    min={1}
+                    max={32}
+                    disabled={isApplying}
+                  />
+                  <MiniStepperField
+                    value={gapValue}
+                    onChange={(next) => setClampedArrayGap(onGapChange, next)}
+                    min={0}
+                    max={120}
+                    disabled={isApplying}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+
           <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-            <label className="ui-meta" style={{ color: 'var(--text-muted)' }}>Arrange distance (mm)</label>
-            <div className="mt-1 flex items-center gap-1">
-              <IconButton
-                className="!h-8 !w-8 !p-0"
-                onClick={() => setClampedSpacing(spacingMm - 1)}
-                disabled={spacingMm <= 2 || isApplying}
-                title="Decrease spacing"
-              >
-                <Minus className="h-3.5 w-3.5" />
-              </IconButton>
-
-              <NumberInput
-                value={spacingMm}
-                onChange={setClampedSpacing}
-                disabled={isApplying}
-                className="ui-input h-8 flex-1 px-2 text-sm text-center no-spinners"
-              />
-
-              <IconButton
-                className="!h-8 !w-8 !p-0"
-                onClick={() => setClampedSpacing(spacingMm + 1)}
-                disabled={spacingMm >= 120 || isApplying}
-                title="Increase spacing"
-              >
-                <Plus className="h-3.5 w-3.5" />
-              </IconButton>
+            <label className="ui-meta" style={{ color: 'var(--text-muted)' }}>Total copies</label>
+            <div className="mt-0.5 text-center text-sm font-semibold tabular-nums" style={{ color: 'var(--text-strong)' }}>
+              {displayTotalCopies}
             </div>
           </div>
 
@@ -144,7 +343,7 @@ export function DuplicatePanel({
             variant="accent"
             size="sm"
             className="w-full !h-8 text-[11px]"
-            disabled={!hasSelection || totalCopies <= 1 || isApplying}
+            disabled={!hasSelection || previewCount <= 0 || isApplying}
             title={!hasSelection ? 'Select a model to duplicate' : 'Generate duplicates from preview'}
           >
             {isApplying ? (
@@ -153,7 +352,7 @@ export function DuplicatePanel({
                 Duplicating…
               </span>
             ) : (
-              `Confirm Duplicate (${Math.max(0, totalCopies - 1)} new)`
+              `Confirm Duplicate (${Math.max(0, previewCount)} new)`
             )}
           </Button>
         </div>

--- a/src/components/controls/DuplicatePanel.tsx
+++ b/src/components/controls/DuplicatePanel.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { CopyPlus, Loader2, Minus, Plus } from 'lucide-react';
+import { NumberInput } from '@/components/ui/NumberInput';
+import { Button, Card, CardHeader, IconButton } from '@/components/ui/primitives';
+
+interface DuplicatePanelProps {
+  activeModelName: string | null;
+  totalCopies: number;
+  onTotalCopiesChange: (value: number) => void;
+  spacingMm: number;
+  onSpacingMmChange: (value: number) => void;
+  onConfirm: () => void;
+  previewCount: number;
+  isApplying?: boolean;
+}
+
+export function DuplicatePanel({
+  activeModelName,
+  totalCopies,
+  onTotalCopiesChange,
+  spacingMm,
+  onSpacingMmChange,
+  onConfirm,
+  previewCount,
+  isApplying = false,
+}: DuplicatePanelProps) {
+  const [expanded, setExpanded] = React.useState(true);
+  const hasSelection = !!activeModelName;
+
+  const setClampedCopies = React.useCallback((value: number) => {
+    onTotalCopiesChange(Math.min(64, Math.max(1, Math.round(value))));
+  }, [onTotalCopiesChange]);
+
+  const setClampedSpacing = React.useCallback((value: number) => {
+    onSpacingMmChange(Math.min(120, Math.max(2, Math.round(value))));
+  }, [onSpacingMmChange]);
+
+  return (
+    <Card>
+      <CardHeader
+        left={(
+          <>
+            <IconButton
+              onClick={() => setExpanded((prev) => !prev)}
+              className="!p-0.5"
+              title={expanded ? 'Collapse card' : 'Expand card'}
+            >
+              <svg
+                className="w-3 h-3 transform transition-transform"
+                style={{ color: expanded ? 'var(--accent)' : 'var(--text-muted)' }}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                {expanded ? (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                ) : (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                )}
+              </svg>
+            </IconButton>
+            <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Duplicate</h3>
+          </>
+        )}
+        right={(
+          <div className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5" style={{ borderColor: 'var(--border-subtle)' }}>
+            <CopyPlus className="w-3 h-3" style={{ color: 'var(--accent)' }} />
+            <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>+{previewCount} preview</span>
+          </div>
+        )}
+      />
+
+      {expanded && (
+        <div className="px-2.5 pb-2.5 space-y-2">
+          <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+            <div className="ui-meta" style={{ color: 'var(--text-muted)' }}>Selected model</div>
+            <div className="mt-0.5 text-xs font-medium truncate" style={{ color: 'var(--text-strong)' }}>
+              {activeModelName ?? 'Select a model first'}
+            </div>
+          </div>
+
+          <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+            <label className="ui-meta" style={{ color: 'var(--text-muted)' }}>Total copies</label>
+            <div className="mt-1 flex items-center gap-1">
+              <IconButton
+                className="!h-8 !w-8 !p-0"
+                onClick={() => setClampedCopies(totalCopies - 1)}
+                disabled={totalCopies <= 1 || isApplying}
+                title="Decrease total copies"
+              >
+                <Minus className="h-3.5 w-3.5" />
+              </IconButton>
+
+              <NumberInput
+                value={totalCopies}
+                onChange={setClampedCopies}
+                disabled={isApplying}
+                className="ui-input h-8 flex-1 px-2 text-sm text-center no-spinners"
+              />
+
+              <IconButton
+                className="!h-8 !w-8 !p-0"
+                onClick={() => setClampedCopies(totalCopies + 1)}
+                disabled={totalCopies >= 64 || isApplying}
+                title="Increase total copies"
+              >
+                <Plus className="h-3.5 w-3.5" />
+              </IconButton>
+            </div>
+          </div>
+
+          <div className="rounded-md border p-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+            <label className="ui-meta" style={{ color: 'var(--text-muted)' }}>Arrange distance (mm)</label>
+            <div className="mt-1 flex items-center gap-1">
+              <IconButton
+                className="!h-8 !w-8 !p-0"
+                onClick={() => setClampedSpacing(spacingMm - 1)}
+                disabled={spacingMm <= 2 || isApplying}
+                title="Decrease spacing"
+              >
+                <Minus className="h-3.5 w-3.5" />
+              </IconButton>
+
+              <NumberInput
+                value={spacingMm}
+                onChange={setClampedSpacing}
+                disabled={isApplying}
+                className="ui-input h-8 flex-1 px-2 text-sm text-center no-spinners"
+              />
+
+              <IconButton
+                className="!h-8 !w-8 !p-0"
+                onClick={() => setClampedSpacing(spacingMm + 1)}
+                disabled={spacingMm >= 120 || isApplying}
+                title="Increase spacing"
+              >
+                <Plus className="h-3.5 w-3.5" />
+              </IconButton>
+            </div>
+          </div>
+
+          <Button
+            onClick={onConfirm}
+            variant="accent"
+            size="sm"
+            className="w-full !h-8 text-[11px]"
+            disabled={!hasSelection || totalCopies <= 1 || isApplying}
+            title={!hasSelection ? 'Select a model to duplicate' : 'Generate duplicates from preview'}
+          >
+            {isApplying ? (
+              <span className="inline-flex items-center gap-1.5">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Duplicating…
+              </span>
+            ) : (
+              `Confirm Duplicate (${Math.max(0, totalCopies - 1)} new)`
+            )}
+          </Button>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/components/controls/ModelManagerPanel.tsx
+++ b/src/components/controls/ModelManagerPanel.tsx
@@ -4,6 +4,7 @@ import {
   EyeOff,
   Trash2,
   Box,
+  AlertTriangle,
   Upload,
   FolderInput,
   Folder,
@@ -24,6 +25,7 @@ type GroupSelectMode = 'single' | 'add';
 
 interface ModelManagerPanelProps {
   models: LoadedModel[];
+  outsidePlateModelIds?: string[];
   activeModelId: string | null;
   selectedModelIds: string[];
   onSelect: (id: string, mode?: SelectMode) => void;
@@ -46,6 +48,7 @@ type GroupedEntry = {
   name: string;
   models: LoadedModel[];
   isGrouped: boolean;
+  isSystemGroup?: boolean;
 };
 
 type PanelContextMenuState = {
@@ -54,10 +57,14 @@ type PanelContextMenuState = {
   modelId?: string;
   groupId?: string;
   groupName?: string;
+  isSystemGroup?: boolean;
 };
+
+const OUTSIDE_PLATE_GROUP_ID = '__system_outside_plate__';
 
 export function ModelManagerPanel({
   models,
+  outsidePlateModelIds = [],
   activeModelId,
   selectedModelIds,
   onSelect,
@@ -83,9 +90,13 @@ export function ModelManagerPanel({
   const selectedSet = useMemo(() => new Set(selectedModelIds), [selectedModelIds]);
 
   const grouped = useMemo<GroupedEntry[]>(() => {
+    const outsidePlateSet = new Set(outsidePlateModelIds);
+    const outsideModels = models.filter((model) => outsidePlateSet.has(model.id));
+    const inPlateModels = models.filter((model) => !outsidePlateSet.has(model.id));
+
     const groupedMap = new Map<string, GroupedEntry>();
 
-    models.forEach((model) => {
+    inPlateModels.forEach((model) => {
       const key = model.groupId ?? `single-${model.id}`;
       const existing = groupedMap.get(key);
       if (existing) {
@@ -109,8 +120,20 @@ export function ModelManagerPanel({
       .sort((a, b) => {
         if (a.isGrouped !== b.isGrouped) return a.isGrouped ? -1 : 1;
         return a.name.localeCompare(b.name);
-      });
-  }, [models]);
+      })
+      .reduce<GroupedEntry[]>((acc, group) => {
+        acc.push(group);
+        return acc;
+      }, outsideModels.length > 0
+        ? [{
+            id: OUTSIDE_PLATE_GROUP_ID,
+            name: 'Outside Plate',
+            models: [...outsideModels].sort((a, b) => a.name.localeCompare(b.name)),
+            isGrouped: true,
+            isSystemGroup: true,
+          }]
+        : []);
+  }, [models, outsidePlateModelIds]);
 
   const contextModel = useMemo(() => {
     if (!contextMenu?.modelId) return null;
@@ -166,7 +189,7 @@ export function ModelManagerPanel({
   const selectFolder = (group: GroupedEntry, mode: GroupSelectMode) => {
     if (group.models.length === 0) return;
 
-    if (onSelectGroup && group.isGrouped) {
+    if (onSelectGroup && group.isGrouped && !group.isSystemGroup) {
       onSelectGroup(group.id, mode);
       return;
     }
@@ -321,7 +344,16 @@ export function ModelManagerPanel({
                 const showHeader = group.isGrouped;
 
                 return (
-                  <div key={group.id} className="space-y-1">
+                  <div
+                    key={group.id}
+                    className={showHeader ? 'space-y-1 rounded-md border p-1' : 'space-y-1'}
+                    style={showHeader
+                      ? {
+                          borderColor: 'color-mix(in srgb, var(--border-subtle), var(--accent) 14%)',
+                          background: 'color-mix(in srgb, var(--surface-1), var(--accent) 3%)',
+                        }
+                      : undefined}
+                  >
                     {showHeader && (
                       <div
                         className={`px-1.5 py-1 rounded border flex items-center gap-1.5 cursor-pointer transition-colors ${
@@ -346,6 +378,7 @@ export function ModelManagerPanel({
                             y: e.clientY,
                             groupId: group.id,
                             groupName: group.name,
+                            isSystemGroup: group.isSystemGroup,
                           });
                         }}
                       >
@@ -363,7 +396,9 @@ export function ModelManagerPanel({
                             : <ChevronDown className="w-3 h-3" style={{ color: 'var(--text-muted)' }} />}
                         </button>
 
-                        {isCollapsed
+                        {group.isSystemGroup ? (
+                          <AlertTriangle className="w-3.5 h-3.5" style={{ color: '#ff7c88' }} />
+                        ) : isCollapsed
                           ? <Folder className="w-3.5 h-3.5" style={{ color: 'var(--accent)' }} />
                           : <FolderOpen className="w-3.5 h-3.5" style={{ color: 'var(--accent)' }} />}
 
@@ -404,7 +439,11 @@ export function ModelManagerPanel({
                       </div>
                     )}
 
-                    {(!showHeader || !isCollapsed) && group.models.map((model) => {
+                    {(!showHeader || !isCollapsed) && (
+                      <div
+                        className={showHeader ? 'ml-1.5 space-y-1 pl-1' : 'space-y-1'}
+                      >
+                        {group.models.map((model) => {
                       const isActive = model.id === activeModelId;
                       const isSelected = selectedSet.has(model.id);
 
@@ -414,9 +453,14 @@ export function ModelManagerPanel({
                           className={`p-2 rounded border transition-colors flex items-center gap-2 cursor-pointer ${
                             isSelected
                               ? 'bg-blue-500/10 border-blue-500/50'
-                              : 'border-transparent hover:bg-neutral-700/70'
+                              : 'hover:bg-neutral-700/70'
                           }`}
-                          style={!isSelected ? { background: 'var(--surface-1)' } : undefined}
+                          style={!isSelected
+                            ? {
+                                background: 'var(--surface-1)',
+                                borderColor: 'var(--border-subtle)',
+                              }
+                            : undefined}
                           onClick={(e) => {
                             if (e.shiftKey) {
                               const anchorId = activeModelId ?? selectedModelIds[selectedModelIds.length - 1] ?? model.id;
@@ -497,6 +541,8 @@ export function ModelManagerPanel({
                         </div>
                       );
                     })}
+                      </div>
+                    )}
                   </div>
                 );
               })
@@ -575,10 +621,10 @@ export function ModelManagerPanel({
             <button
               type="button"
               className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium hover:bg-white/5"
-              style={{ color: contextMenu.groupId ? 'var(--text-strong)' : 'var(--text-muted)', opacity: contextMenu.groupId ? 1 : 0.6 }}
-              disabled={!contextMenu.groupId}
+              style={{ color: contextMenu.groupId && !contextMenu.isSystemGroup ? 'var(--text-strong)' : 'var(--text-muted)', opacity: contextMenu.groupId && !contextMenu.isSystemGroup ? 1 : 0.6 }}
+              disabled={!contextMenu.groupId || !!contextMenu.isSystemGroup}
               onClick={() => {
-                if (!contextMenu.groupId || !onRenameGroup) return;
+                if (!contextMenu.groupId || !onRenameGroup || contextMenu.isSystemGroup) return;
                 beginRenameGroup(contextMenu.groupId, contextMenu.groupName ?? contextGroup?.name ?? 'Group');
               }}
             >
@@ -589,10 +635,10 @@ export function ModelManagerPanel({
             <button
               type="button"
               className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium hover:bg-white/5"
-              style={{ color: contextMenu.groupId ? 'var(--text-strong)' : 'var(--text-muted)', opacity: contextMenu.groupId ? 1 : 0.6 }}
-              disabled={!contextMenu.groupId}
+              style={{ color: contextMenu.groupId && !contextMenu.isSystemGroup ? 'var(--text-strong)' : 'var(--text-muted)', opacity: contextMenu.groupId && !contextMenu.isSystemGroup ? 1 : 0.6 }}
+              disabled={!contextMenu.groupId || !!contextMenu.isSystemGroup}
               onClick={() => {
-                if (!contextMenu.groupId || !onUngroupGroup) return;
+                if (!contextMenu.groupId || !onUngroupGroup || contextMenu.isSystemGroup) return;
                 onUngroupGroup(contextMenu.groupId);
                 closeContextMenu();
               }}

--- a/src/components/controls/ModelManagerPanel.tsx
+++ b/src/components/controls/ModelManagerPanel.tsx
@@ -1,12 +1,37 @@
-import React, { useState } from 'react';
-import { Eye, EyeOff, Trash2, Box, Upload, FolderInput } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Eye,
+  EyeOff,
+  Trash2,
+  Box,
+  Upload,
+  FolderInput,
+  Folder,
+  FolderOpen,
+  ChevronRight,
+  ChevronDown,
+  Pencil,
+  FolderPlus,
+  FolderMinus,
+  PanelsTopLeft,
+} from 'lucide-react';
 import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import { Card, CardHeader, IconButton } from '@/components/ui/primitives';
+
+type SelectMode = 'single' | 'toggle' | 'add';
+
+type GroupSelectMode = 'single' | 'add';
 
 interface ModelManagerPanelProps {
   models: LoadedModel[];
   activeModelId: string | null;
-  onSelect: (id: string) => void;
+  selectedModelIds: string[];
+  onSelect: (id: string, mode?: SelectMode) => void;
+  onSelectGroup?: (groupId: string, mode?: GroupSelectMode) => void;
+  onGroupModels?: (modelIds: string[]) => void;
+  onUngroupModels?: (modelIds: string[]) => void;
+  onUngroupGroup?: (groupId: string) => void;
+  onRenameGroup?: (groupId: string, nextName: string) => void;
   onModelContextMenu?: (id: string, position: { x: number; y: number }) => void;
   onDelete: (id: string) => void;
   onVisibilityChange: (id: string, visible: boolean) => void;
@@ -15,10 +40,31 @@ interface ModelManagerPanelProps {
   dimmed?: boolean;
 }
 
+type GroupedEntry = {
+  id: string;
+  name: string;
+  models: LoadedModel[];
+  isGrouped: boolean;
+};
+
+type PanelContextMenuState = {
+  x: number;
+  y: number;
+  modelId?: string;
+  groupId?: string;
+  groupName?: string;
+};
+
 export function ModelManagerPanel({
   models,
   activeModelId,
+  selectedModelIds,
   onSelect,
+  onSelectGroup,
+  onGroupModels,
+  onUngroupModels,
+  onUngroupGroup,
+  onRenameGroup,
   onModelContextMenu,
   onDelete,
   onVisibilityChange,
@@ -27,6 +73,125 @@ export function ModelManagerPanel({
   dimmed = false,
 }: ModelManagerPanelProps) {
   const [expanded, setExpanded] = useState(true);
+  const [collapsedGroupIds, setCollapsedGroupIds] = useState<Record<string, boolean>>({});
+  const [renamingGroupId, setRenamingGroupId] = useState<string | null>(null);
+  const [renamingGroupName, setRenamingGroupName] = useState('');
+  const [contextMenu, setContextMenu] = useState<PanelContextMenuState | null>(null);
+
+  const selectedSet = useMemo(() => new Set(selectedModelIds), [selectedModelIds]);
+
+  const grouped = useMemo<GroupedEntry[]>(() => {
+    const groupedMap = new Map<string, GroupedEntry>();
+
+    models.forEach((model) => {
+      const key = model.groupId ?? `single-${model.id}`;
+      const existing = groupedMap.get(key);
+      if (existing) {
+        existing.models.push(model);
+        return;
+      }
+
+      groupedMap.set(key, {
+        id: key,
+        name: model.groupName ?? model.name,
+        models: [model],
+        isGrouped: !!model.groupId,
+      });
+    });
+
+    return Array.from(groupedMap.values())
+      .map((group) => ({
+        ...group,
+        models: [...group.models].sort((a, b) => a.name.localeCompare(b.name)),
+      }))
+      .sort((a, b) => {
+        if (a.isGrouped !== b.isGrouped) return a.isGrouped ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
+  }, [models]);
+
+  const contextModel = useMemo(() => {
+    if (!contextMenu?.modelId) return null;
+    return models.find((m) => m.id === contextMenu.modelId) ?? null;
+  }, [contextMenu?.modelId, models]);
+
+  const contextGroup = useMemo(() => {
+    if (!contextMenu?.groupId) return null;
+    return grouped.find((g) => g.id === contextMenu.groupId) ?? null;
+  }, [contextMenu?.groupId, grouped]);
+
+  const selectedGroupedCount = useMemo(() => {
+    if (selectedModelIds.length === 0) return 0;
+    const selected = models.filter((m) => selectedSet.has(m.id));
+    return selected.filter((m) => !!m.groupId).length;
+  }, [models, selectedModelIds.length, selectedSet]);
+
+  const closeContextMenu = () => setContextMenu(null);
+
+  const toggleGroupCollapsed = (groupId: string) => {
+    setCollapsedGroupIds((prev) => ({
+      ...prev,
+      [groupId]: !prev[groupId],
+    }));
+  };
+
+  const beginRenameGroup = (groupId: string, currentName: string) => {
+    setRenamingGroupId(groupId);
+    setRenamingGroupName(currentName);
+    closeContextMenu();
+  };
+
+  const cancelRenameGroup = () => {
+    setRenamingGroupId(null);
+    setRenamingGroupName('');
+  };
+
+  const commitRenameGroup = () => {
+    if (!renamingGroupId || !onRenameGroup) {
+      cancelRenameGroup();
+      return;
+    }
+
+    const trimmed = renamingGroupName.trim();
+    if (trimmed.length > 0) {
+      onRenameGroup(renamingGroupId, trimmed);
+    }
+    cancelRenameGroup();
+  };
+
+  const selectFolder = (group: GroupedEntry, mode: GroupSelectMode) => {
+    if (group.models.length === 0) return;
+
+    if (onSelectGroup && group.isGrouped) {
+      onSelectGroup(group.id, mode);
+      return;
+    }
+
+    group.models.forEach((model, index) => {
+      if (mode === 'single') {
+        onSelect(model.id, index === 0 ? 'single' : 'add');
+        return;
+      }
+      onSelect(model.id, 'add');
+    });
+  };
+
+  useEffect(() => {
+    if (!contextMenu) return;
+
+    const handlePointerDown = () => closeContextMenu();
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeContextMenu();
+    };
+
+    window.addEventListener('pointerdown', handlePointerDown);
+    window.addEventListener('keydown', handleEscape);
+
+    return () => {
+      window.removeEventListener('pointerdown', handlePointerDown);
+      window.removeEventListener('keydown', handleEscape);
+    };
+  }, [contextMenu]);
 
   return (
     <Card
@@ -144,66 +309,286 @@ export function ModelManagerPanel({
                 No models loaded
               </div>
             ) : (
-              models.map((model) => {
-                const isActive = model.id === activeModelId;
+              grouped.map((group) => {
+                const isCollapsed = group.isGrouped ? !!collapsedGroupIds[group.id] : false;
+                const selectedCount = group.models.filter((model) => selectedSet.has(model.id)).length;
+                const isGroupFullySelected = selectedCount > 0 && selectedCount === group.models.length;
+                const isGroupPartiallySelected = selectedCount > 0 && !isGroupFullySelected;
+                const showHeader = group.isGrouped;
+
                 return (
-                  <div
-                    key={model.id}
-                    className={`p-2 rounded border transition-colors flex items-center gap-2 cursor-pointer ${
-                      isActive
-                        ? 'bg-blue-500/10 border-blue-500/50'
-                        : 'border-transparent hover:bg-neutral-700/70'
-                    }`}
-                    style={!isActive ? { background: 'var(--surface-1)' } : undefined}
-                    onClick={() => onSelect(model.id)}
-                    onContextMenu={(e) => {
-                      if (!onModelContextMenu) return;
-                      e.preventDefault();
-                      e.stopPropagation();
-                      onModelContextMenu(model.id, { x: e.clientX, y: e.clientY });
-                    }}
-                  >
-                    {/* Icon */}
-                    <div className={`p-1 rounded ${isActive ? 'bg-blue-500/20 text-blue-300' : ''}`} style={!isActive ? { background: 'var(--surface-2)', color: 'var(--text-muted)' } : undefined}>
-                      <Box className="w-3.5 h-3.5" />
-                    </div>
-
-                    {/* Details */}
-                    <div className="flex-1 min-w-0">
-                      <div className={`text-xs font-medium truncate ${isActive ? 'text-blue-100' : ''}`} style={!isActive ? { color: 'var(--text-strong)' } : undefined}>
-                        {model.name}
-                      </div>
-                      <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
-                        {model.polygonCount.toLocaleString()} polys
-                      </div>
-                    </div>
-
-                    {/* Controls */}
-                    <div className="flex items-center gap-1">
-                      <IconButton
+                  <div key={group.id} className="space-y-1">
+                    {showHeader && (
+                      <div
+                        className={`px-1.5 py-1 rounded border flex items-center gap-1.5 cursor-pointer transition-colors ${
+                          isGroupFullySelected
+                            ? 'bg-blue-500/12 border-blue-500/45'
+                            : isGroupPartiallySelected
+                              ? 'bg-blue-500/8 border-blue-500/30'
+                              : 'hover:bg-neutral-700/60'
+                        }`}
+                        style={isGroupFullySelected || isGroupPartiallySelected
+                          ? undefined
+                          : { borderColor: 'var(--border-subtle)', background: 'var(--surface-2)' }}
                         onClick={(e) => {
-                          e.stopPropagation();
-                          onVisibilityChange(model.id, !model.visible);
+                          const mode: GroupSelectMode = (e.ctrlKey || e.metaKey || e.shiftKey) ? 'add' : 'single';
+                          selectFolder(group, mode);
                         }}
-                        className="!p-1.5"
-                        title={model.visible ? 'Hide' : 'Show'}
-                      >
-                        {model.visible ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
-                      </IconButton>
-                      <IconButton
-                        onClick={(e) => {
+                        onContextMenu={(e) => {
+                          e.preventDefault();
                           e.stopPropagation();
-                          onDelete(model.id);
+                          setContextMenu({
+                            x: e.clientX,
+                            y: e.clientY,
+                            groupId: group.id,
+                            groupName: group.name,
+                          });
                         }}
-                        className="!p-1.5 text-red-300 hover:text-red-200"
-                        title="Delete model"
                       >
-                        <Trash2 className="w-3.5 h-3.5" />
-                      </IconButton>
-                    </div>
+                        <button
+                          type="button"
+                          className="inline-flex items-center justify-center rounded p-0.5 hover:bg-black/20"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            toggleGroupCollapsed(group.id);
+                          }}
+                          title={isCollapsed ? 'Expand folder' : 'Collapse folder'}
+                        >
+                          {isCollapsed
+                            ? <ChevronRight className="w-3 h-3" style={{ color: 'var(--text-muted)' }} />
+                            : <ChevronDown className="w-3 h-3" style={{ color: 'var(--text-muted)' }} />}
+                        </button>
+
+                        {isCollapsed
+                          ? <Folder className="w-3.5 h-3.5" style={{ color: 'var(--accent)' }} />
+                          : <FolderOpen className="w-3.5 h-3.5" style={{ color: 'var(--accent)' }} />}
+
+                        {renamingGroupId === group.id ? (
+                          <input
+                            value={renamingGroupName}
+                            onChange={(e) => setRenamingGroupName(e.target.value)}
+                            onClick={(e) => e.stopPropagation()}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                e.preventDefault();
+                                commitRenameGroup();
+                              }
+                              if (e.key === 'Escape') {
+                                e.preventDefault();
+                                cancelRenameGroup();
+                              }
+                            }}
+                            onBlur={commitRenameGroup}
+                            autoFocus
+                            className="flex-1 min-w-0 rounded border px-1.5 py-0.5 text-[11px]"
+                            style={{
+                              borderColor: 'var(--border-subtle)',
+                              background: 'var(--surface-0)',
+                              color: 'var(--text-strong)',
+                            }}
+                            aria-label="Rename folder"
+                          />
+                        ) : (
+                          <span className="text-[10px] font-semibold uppercase tracking-wide truncate" style={{ color: 'var(--text-muted)' }}>
+                            {group.name}
+                          </span>
+                        )}
+
+                        <span className="ml-auto text-[10px] tabular-nums" style={{ color: 'var(--text-muted)' }}>
+                          {group.models.length}
+                        </span>
+                      </div>
+                    )}
+
+                    {(!showHeader || !isCollapsed) && group.models.map((model) => {
+                      const isActive = model.id === activeModelId;
+                      const isSelected = selectedSet.has(model.id);
+
+                      return (
+                        <div
+                          key={model.id}
+                          className={`p-2 rounded border transition-colors flex items-center gap-2 cursor-pointer ${
+                            isSelected
+                              ? 'bg-blue-500/10 border-blue-500/50'
+                              : 'border-transparent hover:bg-neutral-700/70'
+                          }`}
+                          style={!isSelected ? { background: 'var(--surface-1)' } : undefined}
+                          onClick={(e) => {
+                            const isToggle = e.ctrlKey || e.metaKey;
+                            const isAdd = e.shiftKey;
+                            onSelect(model.id, isToggle ? 'toggle' : isAdd ? 'add' : 'single');
+                          }}
+                          onContextMenu={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setContextMenu({
+                              x: e.clientX,
+                              y: e.clientY,
+                              modelId: model.id,
+                              groupId: model.groupId,
+                              groupName: model.groupName,
+                            });
+                          }}
+                        >
+                          <div className={`p-1 rounded ${isSelected ? 'bg-blue-500/20 text-blue-300' : ''}`} style={!isSelected ? { background: 'var(--surface-2)', color: 'var(--text-muted)' } : undefined}>
+                            <Box className="w-3.5 h-3.5" />
+                          </div>
+
+                          <div className="flex-1 min-w-0">
+                            <div className={`text-xs font-medium truncate ${isSelected ? 'text-blue-100' : ''}`} style={!isSelected ? { color: 'var(--text-strong)' } : undefined}>
+                              {model.name}
+                              {isActive && <span className="ml-1 text-[10px] uppercase" style={{ color: 'var(--accent)' }}>Active</span>}
+                            </div>
+                            <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                              {model.polygonCount.toLocaleString()} polys
+                            </div>
+                          </div>
+
+                          <div className="flex items-center gap-1">
+                            <IconButton
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onVisibilityChange(model.id, !model.visible);
+                              }}
+                              className="!p-1.5"
+                              title={model.visible ? 'Hide' : 'Show'}
+                            >
+                              {model.visible ? <Eye className="w-3.5 h-3.5" /> : <EyeOff className="w-3.5 h-3.5" />}
+                            </IconButton>
+                            <IconButton
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onDelete(model.id);
+                              }}
+                              className="!p-1.5 text-red-300 hover:text-red-200"
+                              title="Delete model"
+                            >
+                              <Trash2 className="w-3.5 h-3.5" />
+                            </IconButton>
+                          </div>
+                        </div>
+                      );
+                    })}
                   </div>
                 );
               })
+            )}
+          </div>
+        </div>
+      )}
+
+      {contextMenu && (
+        <div
+          className="fixed z-[130] w-52 rounded-lg border p-1.5 shadow-xl"
+          style={{
+            left: Math.max(8, Math.min(contextMenu.x, (typeof window !== 'undefined' ? window.innerWidth : 1920) - 216)),
+            top: Math.max(8, Math.min(contextMenu.y, (typeof window !== 'undefined' ? window.innerHeight : 1080) - 220)),
+            borderColor: 'var(--border-subtle)',
+            background: 'color-mix(in srgb, var(--surface-0), #000 12%)',
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          role="menu"
+          aria-label="Models context menu"
+        >
+          <div className="mb-1 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+            Models
+          </div>
+
+          <div className="space-y-0.5">
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium hover:bg-white/5"
+              style={{ color: selectedModelIds.length >= 2 ? 'var(--text-strong)' : 'var(--text-muted)', opacity: selectedModelIds.length >= 2 ? 1 : 0.6 }}
+              disabled={selectedModelIds.length < 2}
+              onClick={() => {
+                if (selectedModelIds.length < 2 || !onGroupModels) return;
+                onGroupModels(selectedModelIds);
+                closeContextMenu();
+              }}
+            >
+              <FolderPlus className="h-3.5 w-3.5" />
+              <span>Group Selected</span>
+            </button>
+
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium hover:bg-white/5"
+              style={{ color: selectedGroupedCount > 0 ? 'var(--text-strong)' : 'var(--text-muted)', opacity: selectedGroupedCount > 0 ? 1 : 0.6 }}
+              disabled={selectedGroupedCount === 0}
+              onClick={() => {
+                if (selectedGroupedCount === 0 || !onUngroupModels) return;
+                onUngroupModels(selectedModelIds);
+                closeContextMenu();
+              }}
+            >
+              <FolderMinus className="h-3.5 w-3.5" />
+              <span>Ungroup Selected</span>
+            </button>
+
+            <div className="my-1 h-px" style={{ background: 'var(--border-subtle)' }} />
+
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium hover:bg-white/5"
+              style={{ color: contextMenu.groupId ? 'var(--text-strong)' : 'var(--text-muted)', opacity: contextMenu.groupId ? 1 : 0.6 }}
+              disabled={!contextMenu.groupId}
+              onClick={() => {
+                if (!contextMenu.groupId) return;
+                const target = contextGroup ?? grouped.find((g) => g.id === contextMenu.groupId);
+                if (!target) return;
+                selectFolder(target, 'single');
+                closeContextMenu();
+              }}
+            >
+              <PanelsTopLeft className="h-3.5 w-3.5" />
+              <span>Select Folder</span>
+            </button>
+
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium hover:bg-white/5"
+              style={{ color: contextMenu.groupId ? 'var(--text-strong)' : 'var(--text-muted)', opacity: contextMenu.groupId ? 1 : 0.6 }}
+              disabled={!contextMenu.groupId}
+              onClick={() => {
+                if (!contextMenu.groupId || !onRenameGroup) return;
+                beginRenameGroup(contextMenu.groupId, contextMenu.groupName ?? contextGroup?.name ?? 'Group');
+              }}
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              <span>Rename Folder</span>
+            </button>
+
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium hover:bg-white/5"
+              style={{ color: contextMenu.groupId ? 'var(--text-strong)' : 'var(--text-muted)', opacity: contextMenu.groupId ? 1 : 0.6 }}
+              disabled={!contextMenu.groupId}
+              onClick={() => {
+                if (!contextMenu.groupId || !onUngroupGroup) return;
+                onUngroupGroup(contextMenu.groupId);
+                closeContextMenu();
+              }}
+            >
+              <FolderMinus className="h-3.5 w-3.5" />
+              <span>Ungroup Folder</span>
+            </button>
+
+            {contextModel && onModelContextMenu && (
+              <>
+                <div className="my-1 h-px" style={{ background: 'var(--border-subtle)' }} />
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium hover:bg-white/5"
+                  style={{ color: 'var(--text-strong)' }}
+                  onClick={() => {
+                    onModelContextMenu(contextModel.id, { x: contextMenu.x, y: contextMenu.y });
+                    closeContextMenu();
+                  }}
+                >
+                  <Box className="h-3.5 w-3.5" />
+                  <span>Model Actions…</span>
+                </button>
+              </>
             )}
           </div>
         </div>

--- a/src/components/controls/ModelManagerPanel.tsx
+++ b/src/components/controls/ModelManagerPanel.tsx
@@ -138,7 +138,7 @@ export function ModelManagerPanel({
             </div>
           </div>
 
-          <div className="space-y-1 max-h-48 overflow-y-auto custom-scrollbar">
+          <div className="space-y-1 overflow-y-auto custom-scrollbar pr-0.5 max-h-[min(68vh,calc(100vh-var(--topbar-height)-220px))]">
             {models.length === 0 ? (
               <div className="text-xs text-center py-2 italic" style={{ color: 'var(--text-muted)' }}>
                 No models loaded

--- a/src/components/controls/ModelManagerPanel.tsx
+++ b/src/components/controls/ModelManagerPanel.tsx
@@ -27,6 +27,7 @@ interface ModelManagerPanelProps {
   activeModelId: string | null;
   selectedModelIds: string[];
   onSelect: (id: string, mode?: SelectMode) => void;
+  onSelectRange?: (ids: string[], activeId: string, mode?: 'replace' | 'add') => void;
   onSelectGroup?: (groupId: string, mode?: GroupSelectMode) => void;
   onGroupModels?: (modelIds: string[]) => void;
   onUngroupModels?: (modelIds: string[]) => void;
@@ -60,6 +61,7 @@ export function ModelManagerPanel({
   activeModelId,
   selectedModelIds,
   onSelect,
+  onSelectRange,
   onSelectGroup,
   onGroupModels,
   onUngroupModels,
@@ -127,6 +129,8 @@ export function ModelManagerPanel({
   }, [models, selectedModelIds.length, selectedSet]);
 
   const closeContextMenu = () => setContextMenu(null);
+
+  const orderedModelIds = useMemo(() => grouped.flatMap((group) => group.models.map((model) => model.id)), [grouped]);
 
   const toggleGroupCollapsed = (groupId: string) => {
     setCollapsedGroupIds((prev) => ({
@@ -414,9 +418,33 @@ export function ModelManagerPanel({
                           }`}
                           style={!isSelected ? { background: 'var(--surface-1)' } : undefined}
                           onClick={(e) => {
+                            if (e.shiftKey) {
+                              const anchorId = activeModelId ?? selectedModelIds[selectedModelIds.length - 1] ?? model.id;
+                              const anchorIndex = orderedModelIds.indexOf(anchorId);
+                              const clickedIndex = orderedModelIds.indexOf(model.id);
+
+                              if (anchorIndex >= 0 && clickedIndex >= 0) {
+                                const start = Math.min(anchorIndex, clickedIndex);
+                                const end = Math.max(anchorIndex, clickedIndex);
+                                const rangeIds = orderedModelIds.slice(start, end + 1);
+                                const additive = e.ctrlKey || e.metaKey;
+
+                                if (onSelectRange) {
+                                  onSelectRange(rangeIds, model.id, additive ? 'add' : 'replace');
+                                } else {
+                                  if (additive) {
+                                    rangeIds.forEach((id) => onSelect(id, 'add'));
+                                  } else {
+                                    onSelect(model.id, 'single');
+                                    rangeIds.filter((id) => id !== model.id).forEach((id) => onSelect(id, 'add'));
+                                  }
+                                }
+                                return;
+                              }
+                            }
+
                             const isToggle = e.ctrlKey || e.metaKey;
-                            const isAdd = e.shiftKey;
-                            onSelect(model.id, isToggle ? 'toggle' : isAdd ? 'add' : 'single');
+                            onSelect(model.id, isToggle ? 'toggle' : 'single');
                           }}
                           onContextMenu={(e) => {
                             e.preventDefault();

--- a/src/components/controls/TransformToolbar.tsx
+++ b/src/components/controls/TransformToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Hand, Move3D, Paintbrush2 } from 'lucide-react';
+import { Hand, Move3D, Paintbrush2, LayoutGrid, CopyPlus } from 'lucide-react';
 import type { TransformMode } from '@/hooks/useModelTransform';
 
 interface TransformToolbarProps {
@@ -14,6 +14,8 @@ export function TransformToolbar({ mode, onModeChange }: TransformToolbarProps) 
     { mode: 'select', label: 'Select', icon: <Hand className="w-4 h-4" />, hint: 'Select and inspect model' },
     { mode: 'transform', label: 'Modify', icon: <Move3D className="w-4 h-4" />, hint: 'Move, rotate, and scale' },
     { mode: 'smoothing', label: 'Smooth', icon: <Paintbrush2 className="w-4 h-4" />, hint: 'Sculpt and smooth surface' },
+    { mode: 'arrange', label: 'Arrange', icon: <LayoutGrid className="w-4 h-4" />, hint: 'Auto-arrange models on plate' },
+    { mode: 'duplicate', label: 'Duplicate', icon: <CopyPlus className="w-4 h-4" />, hint: 'Preview and confirm copies' },
   ];
 
   const activeIndex = Math.max(0, buttons.findIndex((btn) => btn.mode === mode));
@@ -34,7 +36,7 @@ export function TransformToolbar({ mode, onModeChange }: TransformToolbarProps) 
       }}
     >
       <div
-        className="relative grid grid-cols-3 items-center rounded-full px-1 py-1"
+        className="relative grid grid-cols-5 items-center rounded-full px-1 py-1"
         style={{
           background: 'color-mix(in srgb, var(--surface-0), var(--surface-1) 50%)',
           backdropFilter: 'blur(12px)',
@@ -43,7 +45,7 @@ export function TransformToolbar({ mode, onModeChange }: TransformToolbarProps) 
         <div
           className="pointer-events-none absolute left-1 top-1 bottom-1 rounded-full transition-transform duration-300 ease-out"
           style={{
-            width: 'calc((100% - 8px) / 3)',
+            width: 'calc((100% - 8px) / 5)',
             transform: `translateX(${activeIndex * 100}%)`,
             background: 'var(--accent)',
             boxShadow: '0 2px 12px color-mix(in srgb, var(--accent), transparent 50%)',
@@ -60,7 +62,7 @@ export function TransformToolbar({ mode, onModeChange }: TransformToolbarProps) 
               onClick={() => handleModeClick(btn.mode)}
               onMouseEnter={() => setHoveredMode(btn.mode)}
               onMouseLeave={() => setHoveredMode((prev) => (prev === btn.mode ? null : prev))}
-              className={`relative z-[1] flex w-[108px] items-center justify-center gap-1.5 rounded-full px-3 py-2 text-[11px] font-semibold uppercase tracking-wider transition-all duration-200 active:scale-[0.98] ${
+              className={`relative z-[1] flex w-[98px] items-center justify-center gap-1.5 rounded-full px-3 py-2 text-[11px] font-semibold uppercase tracking-wider transition-all duration-200 active:scale-[0.98] ${
                 active
                   ? 'scale-[1.01]'
                   : 'hover:-translate-y-[1px] hover:shadow-[0_4px_14px_rgba(0,0,0,0.22)]'

--- a/src/components/scene/AxisLabels.tsx
+++ b/src/components/scene/AxisLabels.tsx
@@ -39,21 +39,21 @@ export function AxisLabels({ size = 100 }: { size?: number }) {
       {/* X axis - Red */}
       {xTexture && (
         <sprite position={[labelOffset, 0, 0]} scale={[8, 8, 1]} raycast={nullRaycast}>
-          <spriteMaterial map={xTexture} transparent sizeAttenuation={true} depthTest={false} depthWrite={false} toneMapped={false} />
+          <spriteMaterial map={xTexture} transparent sizeAttenuation={true} depthTest depthWrite={false} toneMapped={false} />
         </sprite>
       )}
       
       {/* Y axis - Green */}
       {yTexture && (
         <sprite position={[0, labelOffset, 0]} scale={[8, 8, 1]} raycast={nullRaycast}>
-          <spriteMaterial map={yTexture} transparent sizeAttenuation={true} depthTest={false} depthWrite={false} toneMapped={false} />
+          <spriteMaterial map={yTexture} transparent sizeAttenuation={true} depthTest depthWrite={false} toneMapped={false} />
         </sprite>
       )}
       
       {/* Z axis - Blue */}
       {zTexture && (
         <sprite position={[0, 0, labelOffset]} scale={[8, 8, 1]} raycast={nullRaycast}>
-          <spriteMaterial map={zTexture} transparent sizeAttenuation={true} depthTest={false} depthWrite={false} toneMapped={false} />
+          <spriteMaterial map={zTexture} transparent sizeAttenuation={true} depthTest depthWrite={false} toneMapped={false} />
         </sprite>
       )}
     </>

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -145,6 +145,7 @@ function CameraProjectionController({ mode }: { mode: CameraProjectionMode }) {
 export function SceneCanvas({
   models: modelsProp = [],
   activeModelId: activeModelIdProp,
+  selectedModelIds,
   // Legacy props kept for compatibility if needed
   geom,
   clipLower,
@@ -224,6 +225,7 @@ export function SceneCanvas({
 }: {
   models?: LoadedModel[];
   activeModelId?: string | null;
+  selectedModelIds?: string[];
   geom?: any;
   clipLower?: number | null;
   clipUpper?: number | null;
@@ -267,7 +269,7 @@ export function SceneCanvas({
   mode?: SupportMode;
   onSupportClick?: (hit: THREE.Intersection) => void;
   onSupportHover?: (hit: THREE.Intersection | null) => void;
-  onActiveModelChange?: (id: string | null) => void;
+  onActiveModelChange?: (id: string | null, options?: { selectionMode?: 'single' | 'toggle' | 'add' }) => void;
   trunkPlacementPreview?: SupportData | null;
   branchPlacementPreview?: SupportData | null;
   leafPlacementPreview?: SupportData | null;
@@ -673,6 +675,10 @@ export function SceneCanvas({
     return models.find((m) => m.id === activeModelId) ?? null;
   }, [models, activeModelId]);
 
+  const selectedModelIdSet = React.useMemo(() => {
+    return new Set(selectedModelIds ?? []);
+  }, [selectedModelIds]);
+
   const duplicatePreviewMeshOffset = React.useMemo(() => {
     if (!duplicatePreviewModel) return null;
     return new THREE.Vector3(
@@ -994,6 +1000,7 @@ export function SceneCanvas({
             <React.Suspense fallback={null}>
               {models.map((model) => {
                 const isActive = model.id === activeModelId;
+                const isSelectedModel = selectedModelIdSet.has(model.id);
                 // Use props.transform if active (for smooth drag), else model.transform
                 const transformToUse = isActive
                   ? (duplicateActivePreviewTransform ?? (transform ?? model.transform))
@@ -1042,7 +1049,7 @@ export function SceneCanvas({
                       blockSupportPlacement={isGizmoDragging || blockSupportPlacement}
                       suppressNextClickRef={suppressNextCanvasClickRef}
                       isSelected={
-                        isActive &&
+                        isSelectedModel &&
                         (
                           effectiveModelSelected && (selectionHighlightMode === 'tint' || selectionHighlightMode === 'spotlight')
                         )

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -201,6 +201,9 @@ export function SceneCanvas({
   blockSupportPlacement,
   supportsRef,
   ghostData,
+  duplicatePreviewModel,
+  duplicatePreviewTransforms,
+  duplicateActivePreviewTransform,
   isBranchPlacementActive,
   isLeafPlacementActive,
   isBracePlacementActive,
@@ -276,6 +279,17 @@ export function SceneCanvas({
   blockSupportPlacement?: boolean;
   supportsRef?: React.RefObject<THREE.Group | null>;
   ghostData?: any;
+  duplicatePreviewModel?: LoadedModel | null;
+  duplicatePreviewTransforms?: Array<{
+    position: THREE.Vector3;
+    rotation: THREE.Euler;
+    scale: THREE.Vector3;
+  }>;
+  duplicateActivePreviewTransform?: {
+    position: THREE.Vector3;
+    rotation: THREE.Euler;
+    scale: THREE.Vector3;
+  } | null;
   isBranchPlacementActive?: boolean;
   isLeafPlacementActive?: boolean;
   isBracePlacementActive?: boolean;
@@ -659,6 +673,15 @@ export function SceneCanvas({
     return models.find((m) => m.id === activeModelId) ?? null;
   }, [models, activeModelId]);
 
+  const duplicatePreviewMeshOffset = React.useMemo(() => {
+    if (!duplicatePreviewModel) return null;
+    return new THREE.Vector3(
+      -duplicatePreviewModel.geometry.center.x,
+      -duplicatePreviewModel.geometry.center.y,
+      -duplicatePreviewModel.geometry.center.z,
+    );
+  }, [duplicatePreviewModel]);
+
   const activeModelTransform = React.useMemo(() => {
     if (!activeModel) return null;
     if (transform && activeModelId === activeModel.id) return transform;
@@ -972,7 +995,9 @@ export function SceneCanvas({
               {models.map((model) => {
                 const isActive = model.id === activeModelId;
                 // Use props.transform if active (for smooth drag), else model.transform
-                const transformToUse = isActive && transform ? transform : model.transform;
+                const transformToUse = isActive
+                  ? (duplicateActivePreviewTransform ?? (transform ?? model.transform))
+                  : model.transform;
                 const dropOffsetZ = entryDropOffsets[model.id] ?? 0;
                 const animatedTransform = dropOffsetZ > 0
                   ? {
@@ -1063,6 +1088,36 @@ export function SceneCanvas({
                   </React.Fragment>
                 );
               })}
+
+              {duplicatePreviewModel
+                && duplicatePreviewMeshOffset
+                && (duplicatePreviewTransforms?.length ?? 0) > 0
+                ? duplicatePreviewTransforms!.map((previewTransform, index) => (
+                    <group
+                      key={`duplicate-preview-${index}`}
+                      position={previewTransform.position}
+                      rotation={previewTransform.rotation}
+                      scale={previewTransform.scale}
+                      raycast={() => null}
+                    >
+                      <mesh
+                        geometry={duplicatePreviewModel.geometry.geometry}
+                        position={duplicatePreviewMeshOffset}
+                        raycast={() => null}
+                        renderOrder={2}
+                      >
+                        <meshStandardMaterial
+                          color={duplicatePreviewModel.color ?? '#a3a3a3'}
+                          transparent
+                          opacity={0.22}
+                          roughness={0.5}
+                          metalness={0.02}
+                          depthWrite={false}
+                        />
+                      </mesh>
+                    </group>
+                  ))
+                : null}
 
               {activeBuildVolumeSettings?.enabled && buildVolumeBoxGeometry && buildVolumeEdgeGeometry && (
                 <group

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -142,6 +142,230 @@ function CameraProjectionController({ mode }: { mode: CameraProjectionMode }) {
   return null;
 }
 
+function CameraModeEntryFramingController({
+  runId,
+  restoreRunId,
+  target,
+  plateWidthMm,
+  plateDepthMm,
+}: {
+  runId: number;
+  restoreRunId: number;
+  target: THREE.Vector3;
+  plateWidthMm: number;
+  plateDepthMm: number;
+}) {
+  const { camera, controls, size } = useThree();
+
+  const activeRunIdRef = React.useRef<number | null>(null);
+  const completedFrameRunIdRef = React.useRef(0);
+  const completedRestoreRunIdRef = React.useRef(0);
+  const animatingRef = React.useRef(false);
+  const rafRef = React.useRef<number | null>(null);
+  const cameraSnapshotRef = React.useRef<{
+    position: THREE.Vector3;
+    target: THREE.Vector3;
+    zoom: number | null;
+  } | null>(null);
+
+  const cancelAnimation = React.useCallback(() => {
+    animatingRef.current = false;
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+  }, []);
+
+  const animateTo = React.useCallback((params: {
+    startPos: THREE.Vector3;
+    endPos: THREE.Vector3;
+    startTarget: THREE.Vector3;
+    endTarget: THREE.Vector3;
+    startZoom: number;
+    endZoom: number;
+    isOrthographic: boolean;
+    durationMs: number;
+    onComplete?: () => void;
+  }) => {
+    const {
+      startPos,
+      endPos,
+      startTarget,
+      endTarget,
+      startZoom,
+      endZoom,
+      isOrthographic,
+      durationMs,
+      onComplete,
+    } = params;
+
+    cancelAnimation();
+    animatingRef.current = true;
+
+    let startTime: number | null = null;
+    const orbit = controls as unknown as {
+      target: THREE.Vector3;
+      update: () => void;
+    };
+
+    const tick = (now: number) => {
+      if (!animatingRef.current) return;
+      if (startTime == null) startTime = now;
+
+      const t = Math.min(1, (now - startTime) / durationMs);
+      const eased = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+
+      camera.position.lerpVectors(startPos, endPos, eased);
+      orbit.target.lerpVectors(startTarget, endTarget, eased);
+
+      if (isOrthographic) {
+        const ortho = camera as THREE.OrthographicCamera;
+        ortho.zoom = THREE.MathUtils.lerp(startZoom, endZoom, eased);
+        ortho.updateProjectionMatrix();
+      }
+
+      orbit.update();
+
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        animatingRef.current = false;
+        rafRef.current = null;
+        onComplete?.();
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+  }, [camera, cancelAnimation, controls]);
+
+  React.useLayoutEffect(() => {
+    if (!runId) return;
+    if (completedFrameRunIdRef.current === runId) return;
+    if (activeRunIdRef.current === runId) return;
+    if (!controls || typeof controls !== 'object' || !('target' in controls) || !('update' in controls)) return;
+
+    const orbit = controls as unknown as {
+      target: THREE.Vector3;
+      update: () => void;
+    };
+
+    activeRunIdRef.current = runId;
+
+    const startPos = camera.position.clone();
+    const startTarget = orbit.target.clone();
+
+    cameraSnapshotRef.current = {
+      position: startPos.clone(),
+      target: startTarget.clone(),
+      zoom: camera instanceof THREE.OrthographicCamera ? camera.zoom : null,
+    };
+
+    const padding = 1.04;
+    const fov = camera instanceof THREE.PerspectiveCamera
+      ? THREE.MathUtils.degToRad(camera.fov)
+      : THREE.MathUtils.degToRad(50);
+    const aspect = size.width / Math.max(1, size.height);
+    const hFov = 2 * Math.atan(Math.tan(fov * 0.5) * aspect);
+    const minFov = Math.max(0.0001, Math.min(fov, hFov));
+
+    const halfDiagonal = 0.5 * Math.hypot(plateWidthMm, plateDepthMm) * padding;
+    const distance = Math.max(90, halfDiagonal / Math.sin(minFov * 0.5));
+  const viewDir = new THREE.Vector3(0, -0.52, 1).normalize(); // front-facing top-side birds-eye
+    const endTarget = target.clone().add(new THREE.Vector3(0, -plateDepthMm * 0.055, 0));
+    const endPos = endTarget.clone().addScaledVector(viewDir, distance);
+
+    const isOrthographic = camera instanceof THREE.OrthographicCamera;
+    const startZoom = isOrthographic ? (camera as THREE.OrthographicCamera).zoom : 1;
+    let endZoom = startZoom;
+
+    if (isOrthographic) {
+      const ortho = camera as THREE.OrthographicCamera;
+      const frustumHeight = Math.max(1e-6, ortho.top - ortho.bottom);
+      const requiredWorldHeight = Math.max(plateWidthMm, plateDepthMm) * padding;
+      endZoom = THREE.MathUtils.clamp(frustumHeight / Math.max(1e-6, requiredWorldHeight), 0.0001, 200);
+    }
+
+    animateTo({
+      startPos,
+      endPos,
+      startTarget,
+      endTarget,
+      startZoom,
+      endZoom,
+      isOrthographic,
+      durationMs: 700,
+      onComplete: () => {
+        activeRunIdRef.current = null;
+        completedFrameRunIdRef.current = runId;
+      },
+    });
+
+    return () => {
+      if (activeRunIdRef.current === runId && completedFrameRunIdRef.current !== runId) {
+        activeRunIdRef.current = null;
+      }
+    };
+  }, [animateTo, camera, controls, plateDepthMm, plateWidthMm, runId, size.height, size.width, target]);
+
+  React.useLayoutEffect(() => {
+    if (!restoreRunId) return;
+    if (completedRestoreRunIdRef.current === restoreRunId) return;
+    if (activeRunIdRef.current === restoreRunId) return;
+    if (!controls || typeof controls !== 'object' || !('target' in controls) || !('update' in controls)) return;
+
+    const snapshot = cameraSnapshotRef.current;
+    if (!snapshot) {
+      completedRestoreRunIdRef.current = restoreRunId;
+      return;
+    }
+
+    const orbit = controls as unknown as {
+      target: THREE.Vector3;
+      update: () => void;
+    };
+
+    activeRunIdRef.current = restoreRunId;
+
+    const isOrthographic = camera instanceof THREE.OrthographicCamera;
+    const startPos = camera.position.clone();
+    const endPos = snapshot.position.clone();
+    const startTarget = orbit.target.clone();
+    const endTarget = snapshot.target.clone();
+    const startZoom = isOrthographic ? (camera as THREE.OrthographicCamera).zoom : 1;
+    const endZoom = (isOrthographic && snapshot.zoom != null) ? snapshot.zoom : startZoom;
+
+    animateTo({
+      startPos,
+      endPos,
+      startTarget,
+      endTarget,
+      startZoom,
+      endZoom,
+      isOrthographic,
+      durationMs: 520,
+      onComplete: () => {
+        activeRunIdRef.current = null;
+        completedRestoreRunIdRef.current = restoreRunId;
+        cameraSnapshotRef.current = null;
+      },
+    });
+
+    return () => {
+      if (activeRunIdRef.current === restoreRunId && completedRestoreRunIdRef.current !== restoreRunId) {
+        activeRunIdRef.current = null;
+      }
+    };
+  }, [animateTo, camera, controls, restoreRunId]);
+
+  React.useEffect(() => {
+    return () => {
+      cancelAnimation();
+    };
+  }, [cancelAnimation]);
+
+  return null;
+}
+
 export function SceneCanvas({
   models: modelsProp = [],
   activeModelId: activeModelIdProp,
@@ -737,12 +961,33 @@ export function SceneCanvas({
   }, [computeModelWorldBounds, models]);
 
   const [entryDropOffsets, setEntryDropOffsets] = React.useState<Record<string, number>>({});
+  const [modeEntryFramingRunId, setModeEntryFramingRunId] = React.useState(0);
+  const [modeExitRestoreRunId, setModeExitRestoreRunId] = React.useState(0);
   const knownModelIdsRef = React.useRef<Set<string>>(new Set());
+  const prevTransformModeRef = React.useRef<TransformMode | undefined>(transformMode);
   const entryAnimRef = React.useRef<Record<string, { startMs: number; fromZ: number; skipBounce: boolean }>>({});
   const pendingEntryAnimRef = React.useRef<Record<string, { fromZ: number; runId: number; skipBounce: boolean }>>({});
   const isIntroAnimating = cameraIntroRunId > cameraIntroCompletedRunId;
   const isDropAnimating = Object.keys(entryDropOffsets).length > 0;
   const dynamicDpr = (isIntroAnimating || isDropAnimating) ? ([1, 1.5] as [number, number]) : ([1, 10] as [number, number]);
+
+  React.useEffect(() => {
+    const prevMode = prevTransformModeRef.current;
+    const prevIsPresentationMode = prevMode === 'arrange' || prevMode === 'duplicate';
+    const nextIsPresentationMode = transformMode === 'arrange' || transformMode === 'duplicate';
+    const enteringArrangeOrDuplicate = mode === 'prepare' && nextIsPresentationMode && !prevIsPresentationMode;
+    const leavingArrangeOrDuplicate = mode === 'prepare' && prevIsPresentationMode && !nextIsPresentationMode;
+
+    if (enteringArrangeOrDuplicate) {
+      setModeEntryFramingRunId((id) => id + 1);
+    }
+
+    if (leavingArrangeOrDuplicate) {
+      setModeExitRestoreRunId((id) => id + 1);
+    }
+
+    prevTransformModeRef.current = transformMode;
+  }, [mode, transformMode]);
 
   React.useEffect(() => {
     const currentIds = new Set(models.map((model) => model.id));
@@ -1485,6 +1730,13 @@ export function SceneCanvas({
           homePosition={defaultCamera.position}
           homeTarget={[buildVolumeCenterTarget.x, buildVolumeCenterTarget.y, buildVolumeCenterTarget.z]}
           homeFovDeg={defaultCamera.fov}
+        />
+        <CameraModeEntryFramingController
+          runId={modeEntryFramingRunId}
+          restoreRunId={modeExitRestoreRunId}
+          target={buildVolumeCenterTarget}
+          plateWidthMm={activeBuildVolumeSettings.widthMm}
+          plateDepthMm={activeBuildVolumeSettings.depthMm}
         />
         <CameraFocusController selectedIslandId={overlaySelectedIslandId ?? null} islandMarkers={islandMarkers ?? []} />
         {/* Selection outline effect - rendered by SelectionOutlineRenderer inside SelectionProvider */}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -205,6 +205,7 @@ export function SceneCanvas({
   duplicatePreviewModel,
   duplicatePreviewTransforms,
   duplicateActivePreviewTransform,
+  hideDuplicateSourceDuringApply,
   isBranchPlacementActive,
   isLeafPlacementActive,
   isBracePlacementActive,
@@ -292,6 +293,7 @@ export function SceneCanvas({
     rotation: THREE.Euler;
     scale: THREE.Vector3;
   } | null;
+  hideDuplicateSourceDuringApply?: boolean;
   isBranchPlacementActive?: boolean;
   isLeafPlacementActive?: boolean;
   isBracePlacementActive?: boolean;
@@ -1001,6 +1003,11 @@ export function SceneCanvas({
               {models.map((model) => {
                 const isActive = model.id === activeModelId;
                 const isSelectedModel = selectedModelIdSet.has(model.id);
+                const shouldHideDuplicateSourceModel = Boolean(
+                  hideDuplicateSourceDuringApply
+                  && duplicatePreviewModel
+                  && model.id === duplicatePreviewModel.id,
+                );
                 // Use props.transform if active (for smooth drag), else model.transform
                 const transformToUse = isActive
                   ? (duplicateActivePreviewTransform ?? (transform ?? model.transform))
@@ -1016,6 +1023,7 @@ export function SceneCanvas({
                 const showOutOfBoundsOverlay = !!activeBuildVolumeSettings?.enabled;
                 // Use per-model visibility
                 if (!model.visible) return null;
+                if (shouldHideDuplicateSourceModel) return null;
 
                 return (
                   <React.Fragment key={model.id}>
@@ -1124,6 +1132,37 @@ export function SceneCanvas({
                       </mesh>
                     </group>
                   ))
+                : null}
+
+              {hideDuplicateSourceDuringApply
+                && duplicatePreviewModel
+                && duplicatePreviewMeshOffset
+                && duplicateActivePreviewTransform
+                ? (
+                    <group
+                      key="duplicate-source-preview"
+                      position={duplicateActivePreviewTransform.position}
+                      rotation={duplicateActivePreviewTransform.rotation}
+                      scale={duplicateActivePreviewTransform.scale}
+                      raycast={() => null}
+                    >
+                      <mesh
+                        geometry={duplicatePreviewModel.geometry.geometry}
+                        position={duplicatePreviewMeshOffset}
+                        raycast={() => null}
+                        renderOrder={2}
+                      >
+                        <meshStandardMaterial
+                          color={duplicatePreviewModel.color ?? '#a3a3a3'}
+                          transparent
+                          opacity={0.22}
+                          roughness={0.5}
+                          metalness={0.02}
+                          depthWrite={false}
+                        />
+                      </mesh>
+                    </group>
+                  )
                 : null}
 
               {activeBuildVolumeSettings?.enabled && buildVolumeBoxGeometry && buildVolumeEdgeGeometry && (

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -367,21 +367,32 @@ function CameraModeEntryFramingController({
 }
 
 function SupportModeCameraRestoreController({
-  captureRunId,
-  restoreRunId,
+  capturePreSupportRunId,
+  restorePreSupportRunId,
+  captureSupportRunId,
+  restoreSupportRunId,
 }: {
-  captureRunId: number;
-  restoreRunId: number;
+  capturePreSupportRunId: number;
+  restorePreSupportRunId: number;
+  captureSupportRunId: number;
+  restoreSupportRunId: number;
 }) {
   const { camera, controls } = useThree();
 
-  const snapshotRef = React.useRef<{
+  const preSupportSnapshotRef = React.useRef<{
     position: THREE.Vector3;
     target: THREE.Vector3;
     zoom: number | null;
   } | null>(null);
-  const capturedRunIdRef = React.useRef(0);
-  const restoredRunIdRef = React.useRef(0);
+  const supportSnapshotRef = React.useRef<{
+    position: THREE.Vector3;
+    target: THREE.Vector3;
+    zoom: number | null;
+  } | null>(null);
+  const capturedPreSupportRunIdRef = React.useRef(0);
+  const restoredPreSupportRunIdRef = React.useRef(0);
+  const capturedSupportRunIdRef = React.useRef(0);
+  const restoredSupportRunIdRef = React.useRef(0);
   const activeRunIdRef = React.useRef<number | null>(null);
   const animatingRef = React.useRef(false);
   const rafRef = React.useRef<number | null>(null);
@@ -395,29 +406,44 @@ function SupportModeCameraRestoreController({
   }, []);
 
   React.useLayoutEffect(() => {
-    if (!captureRunId) return;
-    if (capturedRunIdRef.current === captureRunId) return;
+    if (!capturePreSupportRunId) return;
+    if (capturedPreSupportRunIdRef.current === capturePreSupportRunId) return;
     if (!controls || typeof controls !== 'object' || !('target' in controls)) return;
 
     const orbit = controls as unknown as { target: THREE.Vector3 };
-    snapshotRef.current = {
+    preSupportSnapshotRef.current = {
       position: camera.position.clone(),
       target: orbit.target.clone(),
       zoom: camera instanceof THREE.OrthographicCamera ? camera.zoom : null,
     };
 
-    capturedRunIdRef.current = captureRunId;
-  }, [camera, controls, captureRunId]);
+    capturedPreSupportRunIdRef.current = capturePreSupportRunId;
+  }, [camera, controls, capturePreSupportRunId]);
 
   React.useLayoutEffect(() => {
-    if (!restoreRunId) return;
-    if (restoredRunIdRef.current === restoreRunId) return;
-    if (activeRunIdRef.current === restoreRunId) return;
+    if (!captureSupportRunId) return;
+    if (capturedSupportRunIdRef.current === captureSupportRunId) return;
+    if (!controls || typeof controls !== 'object' || !('target' in controls)) return;
+
+    const orbit = controls as unknown as { target: THREE.Vector3 };
+    supportSnapshotRef.current = {
+      position: camera.position.clone(),
+      target: orbit.target.clone(),
+      zoom: camera instanceof THREE.OrthographicCamera ? camera.zoom : null,
+    };
+
+    capturedSupportRunIdRef.current = captureSupportRunId;
+  }, [camera, controls, captureSupportRunId]);
+
+  React.useLayoutEffect(() => {
+    if (!restorePreSupportRunId) return;
+    if (restoredPreSupportRunIdRef.current === restorePreSupportRunId) return;
+    if (activeRunIdRef.current === restorePreSupportRunId) return;
     if (!controls || typeof controls !== 'object' || !('target' in controls) || !('update' in controls)) return;
 
-    const snapshot = snapshotRef.current;
+    const snapshot = preSupportSnapshotRef.current;
     if (!snapshot) {
-      restoredRunIdRef.current = restoreRunId;
+      restoredPreSupportRunIdRef.current = restorePreSupportRunId;
       return;
     }
 
@@ -426,7 +452,7 @@ function SupportModeCameraRestoreController({
       update: () => void;
     };
 
-    activeRunIdRef.current = restoreRunId;
+    activeRunIdRef.current = restorePreSupportRunId;
     cancelAnimation();
     animatingRef.current = true;
 
@@ -465,19 +491,91 @@ function SupportModeCameraRestoreController({
         animatingRef.current = false;
         rafRef.current = null;
         activeRunIdRef.current = null;
-        restoredRunIdRef.current = restoreRunId;
-        snapshotRef.current = null;
+        restoredPreSupportRunIdRef.current = restorePreSupportRunId;
+        preSupportSnapshotRef.current = null;
       }
     };
 
     rafRef.current = requestAnimationFrame(tick);
 
     return () => {
-      if (activeRunIdRef.current === restoreRunId && restoredRunIdRef.current !== restoreRunId) {
+      if (
+        activeRunIdRef.current === restorePreSupportRunId
+        && restoredPreSupportRunIdRef.current !== restorePreSupportRunId
+      ) {
         activeRunIdRef.current = null;
       }
     };
-  }, [camera, cancelAnimation, controls, restoreRunId]);
+  }, [camera, cancelAnimation, controls, restorePreSupportRunId]);
+
+  React.useLayoutEffect(() => {
+    if (!restoreSupportRunId) return;
+    if (restoredSupportRunIdRef.current === restoreSupportRunId) return;
+    if (activeRunIdRef.current === restoreSupportRunId) return;
+    if (!controls || typeof controls !== 'object' || !('target' in controls) || !('update' in controls)) return;
+
+    const snapshot = supportSnapshotRef.current;
+    if (!snapshot) {
+      restoredSupportRunIdRef.current = restoreSupportRunId;
+      return;
+    }
+
+    const orbit = controls as unknown as {
+      target: THREE.Vector3;
+      update: () => void;
+    };
+
+    activeRunIdRef.current = restoreSupportRunId;
+    cancelAnimation();
+    animatingRef.current = true;
+
+    const isOrthographic = camera instanceof THREE.OrthographicCamera;
+    const startPos = camera.position.clone();
+    const endPos = snapshot.position.clone();
+    const startTarget = orbit.target.clone();
+    const endTarget = snapshot.target.clone();
+    const startZoom = isOrthographic ? (camera as THREE.OrthographicCamera).zoom : 1;
+    const endZoom = (isOrthographic && snapshot.zoom != null) ? snapshot.zoom : startZoom;
+
+    const duration = 560;
+    let startTime: number | null = null;
+
+    const tick = (now: number) => {
+      if (!animatingRef.current) return;
+      if (startTime == null) startTime = now;
+
+      const t = Math.min(1, (now - startTime) / duration);
+      const eased = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+
+      camera.position.lerpVectors(startPos, endPos, eased);
+      orbit.target.lerpVectors(startTarget, endTarget, eased);
+
+      if (isOrthographic) {
+        const ortho = camera as THREE.OrthographicCamera;
+        ortho.zoom = THREE.MathUtils.lerp(startZoom, endZoom, eased);
+        ortho.updateProjectionMatrix();
+      }
+
+      orbit.update();
+
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        animatingRef.current = false;
+        rafRef.current = null;
+        activeRunIdRef.current = null;
+        restoredSupportRunIdRef.current = restoreSupportRunId;
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (activeRunIdRef.current === restoreSupportRunId && restoredSupportRunIdRef.current !== restoreSupportRunId) {
+        activeRunIdRef.current = null;
+      }
+    };
+  }, [camera, cancelAnimation, controls, restoreSupportRunId]);
 
   React.useEffect(() => {
     return () => {
@@ -765,7 +863,10 @@ export function SceneCanvas({
   const [cameraIntroCompletedRunId, setCameraIntroCompletedRunId] = React.useState(0);
   const [supportEntryIntroRunId, setSupportEntryIntroRunId] = React.useState(0);
   const [supportEntryCaptureRunId, setSupportEntryCaptureRunId] = React.useState(0);
+  const [supportCameraCaptureRunId, setSupportCameraCaptureRunId] = React.useState(0);
+  const [supportCameraRestoreRunId, setSupportCameraRestoreRunId] = React.useState(0);
   const [supportExitRestoreRunId, setSupportExitRestoreRunId] = React.useState(0);
+  const hasSavedSupportCameraRef = React.useRef(false);
   const prevModeRef = React.useRef<SupportMode | undefined>(mode);
 
   const lastHoveredModelPointRef = React.useRef<THREE.Vector3 | null>(null);
@@ -1062,10 +1163,16 @@ export function SceneCanvas({
 
     if (enteringSupport && models.length > 0) {
       setSupportEntryCaptureRunId((id) => id + 1);
-      setSupportEntryIntroRunId((id) => id + 1);
+      if (hasSavedSupportCameraRef.current) {
+        setSupportCameraRestoreRunId((id) => id + 1);
+      } else {
+        setSupportEntryIntroRunId((id) => id + 1);
+      }
     }
 
     if (leavingSupport) {
+      setSupportCameraCaptureRunId((id) => id + 1);
+      hasSavedSupportCameraRef.current = true;
       setSupportExitRestoreRunId((id) => id + 1);
     }
 
@@ -1400,6 +1507,7 @@ export function SceneCanvas({
               {models.map((model) => {
                 const isActive = model.id === activeModelId;
                 const isSelectedModel = selectedModelIdSet.has(model.id);
+                const supportNonSelectedOpacity = mode === 'support' && !isSelectedModel ? 0.5 : undefined;
                 const shouldHideDuplicateSourceModel = Boolean(
                   hideDuplicateSourceDuringApply
                   && duplicatePreviewModel
@@ -1466,6 +1574,7 @@ export function SceneCanvas({
                       hoverTintColor={hoverTintColor}
                       hoverTintStrength={hoverTintStrength}
                       selectedTintStrength={selectedTintStrength}
+                      supportNonSelectedOpacity={supportNonSelectedOpacity}
                       showOutOfBoundsOverlay={showOutOfBoundsOverlay}
                       outOfBoundsMin={buildVolumeBounds?.min ?? null}
                       outOfBoundsMax={buildVolumeBounds?.max ?? null}
@@ -1898,8 +2007,10 @@ export function SceneCanvas({
           plateDepthMm={activeBuildVolumeSettings.depthMm}
         />
         <SupportModeCameraRestoreController
-          captureRunId={supportEntryCaptureRunId}
-          restoreRunId={supportExitRestoreRunId}
+          capturePreSupportRunId={supportEntryCaptureRunId}
+          restorePreSupportRunId={supportExitRestoreRunId}
+          captureSupportRunId={supportCameraCaptureRunId}
+          restoreSupportRunId={supportCameraRestoreRunId}
         />
         <CameraFocusController selectedIslandId={overlaySelectedIslandId ?? null} islandMarkers={islandMarkers ?? []} />
         {/* Selection outline effect - rendered by SelectionOutlineRenderer inside SelectionProvider */}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -659,6 +659,7 @@ export function SceneCanvas({
   duplicatePreviewModel,
   duplicatePreviewTransforms,
   duplicateActivePreviewTransform,
+  arrangeArrayPreviewItems,
   hideDuplicateSourceDuringApply,
   isBranchPlacementActive,
   isLeafPlacementActive,
@@ -747,6 +748,14 @@ export function SceneCanvas({
     rotation: THREE.Euler;
     scale: THREE.Vector3;
   } | null;
+  arrangeArrayPreviewItems?: Array<{
+    model: LoadedModel;
+    transform: {
+      position: THREE.Vector3;
+      rotation: THREE.Euler;
+      scale: THREE.Vector3;
+    };
+  }>;
   hideDuplicateSourceDuringApply?: boolean;
   isBranchPlacementActive?: boolean;
   isLeafPlacementActive?: boolean;
@@ -1686,6 +1695,42 @@ export function SceneCanvas({
                       </mesh>
                     </group>
                   )
+                : null}
+
+              {arrangeArrayPreviewItems && arrangeArrayPreviewItems.length > 0
+                ? arrangeArrayPreviewItems.map((item) => {
+                    const offset = new THREE.Vector3(
+                      -item.model.geometry.center.x,
+                      -item.model.geometry.center.y,
+                      -item.model.geometry.center.z,
+                    );
+
+                    return (
+                      <group
+                        key={`arrange-array-preview-${item.model.id}`}
+                        position={item.transform.position}
+                        rotation={item.transform.rotation}
+                        scale={item.transform.scale}
+                        raycast={() => null}
+                      >
+                        <mesh
+                          geometry={item.model.geometry.geometry}
+                          position={offset}
+                          raycast={() => null}
+                          renderOrder={2}
+                        >
+                          <meshStandardMaterial
+                            color={item.model.color ?? '#a3a3a3'}
+                            transparent
+                            opacity={0.22}
+                            roughness={0.5}
+                            metalness={0.02}
+                            depthWrite={false}
+                          />
+                        </mesh>
+                      </group>
+                    );
+                  })
                 : null}
 
               {activeBuildVolumeSettings?.enabled && buildVolumeBoxGeometry && buildVolumeEdgeGeometry && (

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -366,6 +366,128 @@ function CameraModeEntryFramingController({
   return null;
 }
 
+function SupportModeCameraRestoreController({
+  captureRunId,
+  restoreRunId,
+}: {
+  captureRunId: number;
+  restoreRunId: number;
+}) {
+  const { camera, controls } = useThree();
+
+  const snapshotRef = React.useRef<{
+    position: THREE.Vector3;
+    target: THREE.Vector3;
+    zoom: number | null;
+  } | null>(null);
+  const capturedRunIdRef = React.useRef(0);
+  const restoredRunIdRef = React.useRef(0);
+  const activeRunIdRef = React.useRef<number | null>(null);
+  const animatingRef = React.useRef(false);
+  const rafRef = React.useRef<number | null>(null);
+
+  const cancelAnimation = React.useCallback(() => {
+    animatingRef.current = false;
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+  }, []);
+
+  React.useLayoutEffect(() => {
+    if (!captureRunId) return;
+    if (capturedRunIdRef.current === captureRunId) return;
+    if (!controls || typeof controls !== 'object' || !('target' in controls)) return;
+
+    const orbit = controls as unknown as { target: THREE.Vector3 };
+    snapshotRef.current = {
+      position: camera.position.clone(),
+      target: orbit.target.clone(),
+      zoom: camera instanceof THREE.OrthographicCamera ? camera.zoom : null,
+    };
+
+    capturedRunIdRef.current = captureRunId;
+  }, [camera, controls, captureRunId]);
+
+  React.useLayoutEffect(() => {
+    if (!restoreRunId) return;
+    if (restoredRunIdRef.current === restoreRunId) return;
+    if (activeRunIdRef.current === restoreRunId) return;
+    if (!controls || typeof controls !== 'object' || !('target' in controls) || !('update' in controls)) return;
+
+    const snapshot = snapshotRef.current;
+    if (!snapshot) {
+      restoredRunIdRef.current = restoreRunId;
+      return;
+    }
+
+    const orbit = controls as unknown as {
+      target: THREE.Vector3;
+      update: () => void;
+    };
+
+    activeRunIdRef.current = restoreRunId;
+    cancelAnimation();
+    animatingRef.current = true;
+
+    const isOrthographic = camera instanceof THREE.OrthographicCamera;
+    const startPos = camera.position.clone();
+    const endPos = snapshot.position.clone();
+    const startTarget = orbit.target.clone();
+    const endTarget = snapshot.target.clone();
+    const startZoom = isOrthographic ? (camera as THREE.OrthographicCamera).zoom : 1;
+    const endZoom = (isOrthographic && snapshot.zoom != null) ? snapshot.zoom : startZoom;
+
+    const duration = 560;
+    let startTime: number | null = null;
+
+    const tick = (now: number) => {
+      if (!animatingRef.current) return;
+      if (startTime == null) startTime = now;
+
+      const t = Math.min(1, (now - startTime) / duration);
+      const eased = t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+
+      camera.position.lerpVectors(startPos, endPos, eased);
+      orbit.target.lerpVectors(startTarget, endTarget, eased);
+
+      if (isOrthographic) {
+        const ortho = camera as THREE.OrthographicCamera;
+        ortho.zoom = THREE.MathUtils.lerp(startZoom, endZoom, eased);
+        ortho.updateProjectionMatrix();
+      }
+
+      orbit.update();
+
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        animatingRef.current = false;
+        rafRef.current = null;
+        activeRunIdRef.current = null;
+        restoredRunIdRef.current = restoreRunId;
+        snapshotRef.current = null;
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (activeRunIdRef.current === restoreRunId && restoredRunIdRef.current !== restoreRunId) {
+        activeRunIdRef.current = null;
+      }
+    };
+  }, [camera, cancelAnimation, controls, restoreRunId]);
+
+  React.useEffect(() => {
+    return () => {
+      cancelAnimation();
+    };
+  }, [cancelAnimation]);
+
+  return null;
+}
+
 export function SceneCanvas({
   models: modelsProp = [],
   activeModelId: activeModelIdProp,
@@ -641,6 +763,10 @@ export function SceneCanvas({
   const { defaultCamera, orbitTarget, setOrbitTargetFromPoint, introBoundsSnapshot, cameraIntroRunId, cameraHomeResetRunId } =
     useStlLoadCameraIntro(models, buildVolumeCenterTarget);
   const [cameraIntroCompletedRunId, setCameraIntroCompletedRunId] = React.useState(0);
+  const [supportEntryIntroRunId, setSupportEntryIntroRunId] = React.useState(0);
+  const [supportEntryCaptureRunId, setSupportEntryCaptureRunId] = React.useState(0);
+  const [supportExitRestoreRunId, setSupportExitRestoreRunId] = React.useState(0);
+  const prevModeRef = React.useRef<SupportMode | undefined>(mode);
 
   const lastHoveredModelPointRef = React.useRef<THREE.Vector3 | null>(null);
   const onModelHoverPointChange = React.useCallback((point: THREE.Vector3 | null) => {
@@ -919,6 +1045,32 @@ export function SceneCanvas({
     if (transform && activeModelId === activeModel.id) return transform;
     return activeModel.transform;
   }, [activeModel, transform, activeModelId]);
+
+  const introControllerBounds = React.useMemo(() => {
+    if (mode === 'support' && activeModel) {
+      return computeModelWorldBounds(activeModel);
+    }
+    return introBoundsSnapshot;
+  }, [activeModel, computeModelWorldBounds, introBoundsSnapshot, mode]);
+
+  const introControllerRunId = cameraIntroRunId + supportEntryIntroRunId;
+
+  React.useEffect(() => {
+    const prevMode = prevModeRef.current;
+    const enteringSupport = mode === 'support' && prevMode !== 'support';
+    const leavingSupport = mode !== 'support' && prevMode === 'support';
+
+    if (enteringSupport && models.length > 0) {
+      setSupportEntryCaptureRunId((id) => id + 1);
+      setSupportEntryIntroRunId((id) => id + 1);
+    }
+
+    if (leavingSupport) {
+      setSupportExitRestoreRunId((id) => id + 1);
+    }
+
+    prevModeRef.current = mode;
+  }, [mode, models.length]);
 
   const selectedSpaceMousePivotPoint = React.useMemo(() => {
     if (!activeModel?.visible) return null;
@@ -1724,7 +1876,14 @@ export function SceneCanvas({
           onNavigationActiveChange={setSpaceMouseNavigationActive}
         />
         <CameraFocusHotkeyController hoverPointRef={lastHoveredModelPointRef} setOrbitTargetFromPoint={setOrbitTargetFromPoint} />
-        <CameraIntroController bounds={introBoundsSnapshot} runId={cameraIntroRunId} onComplete={setCameraIntroCompletedRunId} />
+        <CameraIntroController
+          bounds={introControllerBounds}
+          runId={introControllerRunId}
+          onComplete={setCameraIntroCompletedRunId}
+          mode={mode}
+          plateWidthMm={activeBuildVolumeSettings.widthMm}
+          plateDepthMm={activeBuildVolumeSettings.depthMm}
+        />
         <CameraHomeResetController
           runId={cameraHomeResetRunId}
           homePosition={defaultCamera.position}
@@ -1737,6 +1896,10 @@ export function SceneCanvas({
           target={buildVolumeCenterTarget}
           plateWidthMm={activeBuildVolumeSettings.widthMm}
           plateDepthMm={activeBuildVolumeSettings.depthMm}
+        />
+        <SupportModeCameraRestoreController
+          captureRunId={supportEntryCaptureRunId}
+          restoreRunId={supportExitRestoreRunId}
         />
         <CameraFocusController selectedIslandId={overlaySelectedIslandId ?? null} islandMarkers={islandMarkers ?? []} />
         {/* Selection outline effect - rendered by SelectionOutlineRenderer inside SelectionProvider */}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -405,6 +405,16 @@ function SupportModeCameraRestoreController({
     }
   }, []);
 
+  const ensureAboveTarget = React.useCallback((position: THREE.Vector3, target: THREE.Vector3) => {
+    const clamped = position.clone();
+    const horizontalDistance = Math.hypot(clamped.x - target.x, clamped.y - target.y);
+    const minVerticalClearance = Math.max(10, horizontalDistance * 0.22);
+    if (clamped.z < target.z + minVerticalClearance) {
+      clamped.z = target.z + minVerticalClearance;
+    }
+    return clamped;
+  }, []);
+
   React.useLayoutEffect(() => {
     if (!capturePreSupportRunId) return;
     if (capturedPreSupportRunIdRef.current === capturePreSupportRunId) return;
@@ -458,7 +468,7 @@ function SupportModeCameraRestoreController({
 
     const isOrthographic = camera instanceof THREE.OrthographicCamera;
     const startPos = camera.position.clone();
-    const endPos = snapshot.position.clone();
+    const endPos = ensureAboveTarget(snapshot.position.clone(), snapshot.target);
     const startTarget = orbit.target.clone();
     const endTarget = snapshot.target.clone();
     const startZoom = isOrthographic ? (camera as THREE.OrthographicCamera).zoom : 1;
@@ -575,7 +585,7 @@ function SupportModeCameraRestoreController({
         activeRunIdRef.current = null;
       }
     };
-  }, [camera, cancelAnimation, controls, restoreSupportRunId]);
+  }, [camera, cancelAnimation, controls, ensureAboveTarget, restoreSupportRunId]);
 
   React.useEffect(() => {
     return () => {
@@ -867,6 +877,7 @@ export function SceneCanvas({
   const [supportCameraRestoreRunId, setSupportCameraRestoreRunId] = React.useState(0);
   const [supportExitRestoreRunId, setSupportExitRestoreRunId] = React.useState(0);
   const hasSavedSupportCameraRef = React.useRef(false);
+  const savedSupportCameraModelIdRef = React.useRef<string | null>(null);
   const prevModeRef = React.useRef<SupportMode | undefined>(mode);
 
   const lastHoveredModelPointRef = React.useRef<THREE.Vector3 | null>(null);
@@ -1163,7 +1174,12 @@ export function SceneCanvas({
 
     if (enteringSupport && models.length > 0) {
       setSupportEntryCaptureRunId((id) => id + 1);
-      if (hasSavedSupportCameraRef.current) {
+      const canRestoreSavedSupportView =
+        hasSavedSupportCameraRef.current
+        && savedSupportCameraModelIdRef.current != null
+        && savedSupportCameraModelIdRef.current === activeModelId;
+
+      if (canRestoreSavedSupportView) {
         setSupportCameraRestoreRunId((id) => id + 1);
       } else {
         setSupportEntryIntroRunId((id) => id + 1);
@@ -1173,11 +1189,12 @@ export function SceneCanvas({
     if (leavingSupport) {
       setSupportCameraCaptureRunId((id) => id + 1);
       hasSavedSupportCameraRef.current = true;
+      savedSupportCameraModelIdRef.current = activeModelId ?? null;
       setSupportExitRestoreRunId((id) => id + 1);
     }
 
     prevModeRef.current = mode;
-  }, [mode, models.length]);
+  }, [activeModelId, mode, models.length]);
 
   const selectedSpaceMousePivotPoint = React.useMemo(() => {
     if (!activeModel?.visible) return null;

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -2132,14 +2132,16 @@ export function SceneCanvas({
 
       {activeBuildVolumeSettings?.enabled && activeBuildVolumeSettings.showViolationWarning && outOfBoundsModels.length > 0 && (
         <div
-          className="absolute left-3 top-3 z-40 rounded-md border px-3 py-2 text-xs"
+          className="absolute bottom-5 left-1/2 z-40 -translate-x-1/2 animate-pulse rounded-full border px-5 py-2 text-sm font-semibold shadow-lg"
           style={{
-            borderColor: 'color-mix(in srgb, #ff5b6f, var(--border-subtle) 30%)',
-            background: 'color-mix(in srgb, #ff5b6f, var(--surface-0) 88%)',
+            pointerEvents: 'none',
+            borderColor: 'color-mix(in srgb, #ff5b6f, var(--border-subtle) 42%)',
+            background: 'color-mix(in srgb, #ff5b6f, var(--surface-0) 90%)',
             color: 'var(--text-strong)',
           }}
           title={outOfBoundsModels.map((m) => m.name).join(', ')}
         >
+          <span style={{ marginRight: 6 }}>⚠</span>
           {outOfBoundsModels.length} model{outOfBoundsModels.length === 1 ? '' : 's'} out of build volume
         </div>
       )}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -2037,7 +2037,7 @@ export function SceneCanvas({
           onChange={handleOrbitChange}
           onEnd={handleOrbitEnd}
           target={orbitTarget}
-          mouseButtons={{ LEFT: undefined as unknown as THREE.MOUSE, MIDDLE: THREE.MOUSE.ROTATE, RIGHT: THREE.MOUSE.PAN }}
+          mouseButtons={{ LEFT: undefined as unknown as THREE.MOUSE, MIDDLE: THREE.MOUSE.PAN, RIGHT: THREE.MOUSE.ROTATE }}
         />
         <SpaceMouseController
           pivotPoint={selectedSpaceMousePivotPoint}

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect } from 'react';
 import * as THREE from 'three';
+import { useFrame, useThree } from '@react-three/fiber';
 import { usePicking } from '@/components/picking';
 import { MeshShaderMaterial, type MeshShaderType } from '@/features/shaders/mesh';
 import { OpaqueWireOverlayMaterial } from '@/features/shaders/mesh/opaqueWireMesh';
@@ -53,6 +54,7 @@ export function StlMesh({
   hoverTintColor,
   hoverTintStrength,
   selectedTintStrength,
+  supportNonSelectedOpacity,
   showOutOfBoundsOverlay,
   outOfBoundsMin,
   outOfBoundsMax,
@@ -97,6 +99,7 @@ export function StlMesh({
   hoverTintColor?: string;
   hoverTintStrength?: number;
   selectedTintStrength?: number;
+  supportNonSelectedOpacity?: number;
   showOutOfBoundsOverlay?: boolean;
   outOfBoundsMin?: THREE.Vector3 | null;
   outOfBoundsMax?: THREE.Vector3 | null;
@@ -106,8 +109,12 @@ export function StlMesh({
   // Note: This works because StlMesh is rendered inside PickingProvider
   const { hit } = usePicking(); // Import usePicking at top if not already used inside StlMesh
   const [isPointerHovered, setIsPointerHovered] = React.useState(false);
+  const { camera } = useThree();
 
   const smoothingScratchLocalPointRef = React.useRef(new THREE.Vector3());
+  const supportDimCameraLocalPointRef = React.useRef(new THREE.Vector3());
+  const supportDimWorldScaleRef = React.useRef(new THREE.Vector3());
+  const supportDimMaterialRef = React.useRef<THREE.MeshStandardMaterial | null>(null);
 
   // Build clipping planes for a band [clipLower, clipUpper] on Z axis
   // Clipping planes work in WORLD space
@@ -151,6 +158,13 @@ export function StlMesh({
     [centerOffset.x, centerOffset.y, centerOffset.z],
   );
 
+  const localGeometryBounds = React.useMemo(() => {
+    return (
+      geometry.boundingBox?.clone()
+      ?? new THREE.Box3().setFromBufferAttribute(geometry.getAttribute('position') as THREE.BufferAttribute)
+    );
+  }, [geometry]);
+
   // Internal ref for the mesh element to control raycasting
   const internalMeshRef = React.useRef<THREE.Mesh>(null);
 
@@ -180,6 +194,51 @@ export function StlMesh({
   const baseShaderType: MeshShaderType = shaderType === 'opaque_wire_mesh' ? 'soft_clay' : shaderType;
   const showOpaqueWireOverlay = shaderType === 'opaque_wire_mesh';
   const isHoveredModel = isPointerHovered || (hit.category === 'model' && hit.objectId === modelId);
+  const isSupportDimmed = typeof supportNonSelectedOpacity === 'number';
+  const dimmedBaseOpacity = isSupportDimmed
+    ? Math.min(0.95, Math.max(0.04, supportNonSelectedOpacity))
+    : null;
+  const dimmedInsideOpacity = isSupportDimmed
+    ? 0.0
+    : null;
+
+  useFrame(() => {
+    if (!isSupportDimmed) return;
+
+    const mesh = internalMeshRef.current;
+    const material = supportDimMaterialRef.current;
+    if (!mesh || !material || dimmedBaseOpacity == null || dimmedInsideOpacity == null) return;
+
+    const localPoint = supportDimCameraLocalPointRef.current;
+    localPoint.copy(camera.position);
+    mesh.worldToLocal(localPoint);
+
+    const localDistanceToBounds = localGeometryBounds.distanceToPoint(localPoint);
+    mesh.getWorldScale(supportDimWorldScaleRef.current);
+    const worldScale = supportDimWorldScaleRef.current;
+    const distanceScaleFactor = Math.max(
+      1e-6,
+      Math.max(Math.abs(worldScale.x), Math.abs(worldScale.y), Math.abs(worldScale.z)),
+    );
+    const distanceToBoundsMm = localDistanceToBounds * distanceScaleFactor;
+
+    // Fade non-selected support meshes out near the camera to keep line-of-sight clear.
+    // 0mm (inside/touching): fully culled. >= proximityFadeRangeMm: baseline opacity.
+    const proximityFadeRangeMm = 24;
+    const proximityT = THREE.MathUtils.clamp(1 - (distanceToBoundsMm / proximityFadeRangeMm), 0, 1);
+    const targetOpacity = THREE.MathUtils.lerp(dimmedBaseOpacity, dimmedInsideOpacity, proximityT);
+    const nextOpacity = THREE.MathUtils.lerp(material.opacity, targetOpacity, 0.18);
+
+    if (Math.abs(nextOpacity - material.opacity) > 0.0005) {
+      material.opacity = nextOpacity;
+    }
+
+    const shouldDepthWrite = nextOpacity > 0.2;
+    if (material.depthWrite !== shouldDepthWrite) {
+      material.depthWrite = shouldDepthWrite;
+      material.needsUpdate = true;
+    }
+  });
 
   const outOfBoundsMaterial = React.useMemo(() => {
     if (!showOutOfBoundsOverlay || !outOfBoundsMin || !outOfBoundsMax) return null;
@@ -259,6 +318,7 @@ export function StlMesh({
         userData={{ modelId }}
         geometry={geometry}
         position={meshLocalOffset}
+        renderOrder={isSupportDimmed ? 2 : 0}
         onClick={(e) => {
           console.log('[SceneCanvas] Mesh clicked, mode:', mode, 'id:', modelId);
 
@@ -388,6 +448,17 @@ export function StlMesh({
             metalness={0.02}
             clippingPlanes={planes}
             depthWrite={false}
+          />
+        ) : typeof supportNonSelectedOpacity === 'number' ? (
+          <meshStandardMaterial
+            ref={supportDimMaterialRef}
+            color={meshColor ?? '#c8c8ce'}
+            transparent
+            opacity={dimmedBaseOpacity ?? 0.5}
+            roughness={0.55}
+            metalness={0.02}
+            clippingPlanes={planes}
+            depthWrite
           />
         ) : (
           <MeshShaderMaterial

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -79,7 +79,7 @@ export function StlMesh({
   onSmoothingGeometryActivate?: (geometry: THREE.BufferGeometry | null) => void;
   onSupportClick?: (hit: THREE.Intersection) => void;
   onSupportHover?: (hit: THREE.Intersection | null) => void;
-  onActiveModelChange?: (id: string | null) => void;
+  onActiveModelChange?: (id: string | null, options?: { selectionMode?: 'single' | 'toggle' | 'add' }) => void;
   disableRaycast?: boolean;
   blockSupportPlacement?: boolean;
   suppressNextClickRef?: React.RefObject<boolean>;
@@ -274,7 +274,13 @@ export function StlMesh({
 
             // Update active model in parent state
             if (onActiveModelChange) {
-              onActiveModelChange(modelId);
+              const native = (e as unknown as { nativeEvent?: MouseEvent }).nativeEvent;
+              const selectionMode = native?.ctrlKey || native?.metaKey
+                ? 'toggle'
+                : native?.shiftKey
+                  ? 'add'
+                  : 'single';
+              onActiveModelChange(modelId, { selectionMode });
             }
           }
 

--- a/src/components/scene/camera/CameraIntroController.tsx
+++ b/src/components/scene/camera/CameraIntroController.tsx
@@ -9,6 +9,9 @@ type CameraIntroControllerProps = {
   runId: number;
   onComplete?: (runId: number) => void;
   preserveCurrentViewDirection?: boolean;
+  mode?: 'prepare' | 'analysis' | 'support' | 'export';
+  plateWidthMm?: number;
+  plateDepthMm?: number;
 };
 
 type OrbitLikeControls = {
@@ -22,7 +25,15 @@ function isOrbitLikeControls(value: unknown): value is OrbitLikeControls {
   return !!maybe.target && typeof maybe.update === 'function';
 }
 
-export function CameraIntroController({ bounds, runId, onComplete, preserveCurrentViewDirection = false }: CameraIntroControllerProps) {
+export function CameraIntroController({
+  bounds,
+  runId,
+  onComplete,
+  preserveCurrentViewDirection = false,
+  mode = 'prepare',
+  plateWidthMm,
+  plateDepthMm,
+}: CameraIntroControllerProps) {
   const { camera, controls, size } = useThree();
   const animatingRef = React.useRef(false);
   const activeRunIdRef = React.useRef<number>(0);
@@ -52,9 +63,27 @@ export function CameraIntroController({ bounds, runId, onComplete, preserveCurre
 
     const hFov = 2 * Math.atan(Math.tan(vFov * 0.5) * aspect);
     const minFov = Math.max(0.0001, Math.min(vFov, hFov));
-    const distance = (radius / Math.sin(minFov * 0.5)) * 1.2;
+    const modelDistance = (radius / Math.sin(minFov * 0.5));
 
-    const fallbackViewDir = new THREE.Vector3(-1, -1, 1).normalize();
+    const hasPlateDims = Number.isFinite(plateWidthMm) && Number.isFinite(plateDepthMm)
+      && (plateWidthMm ?? 0) > 0
+      && (plateDepthMm ?? 0) > 0;
+
+    const plateHalfDiagonal = hasPlateDims
+      ? 0.5 * Math.hypot(plateWidthMm as number, plateDepthMm as number)
+      : 0;
+    const plateDistance = hasPlateDims
+      ? (plateHalfDiagonal / Math.sin(minFov * 0.5))
+      : 0;
+
+    const yawRad = THREE.MathUtils.degToRad(20);
+    const baseDistance = mode === 'support'
+      ? modelDistance * 1.03
+      : Math.max(modelDistance * 0.95, plateDistance * 0.9);
+    const distance = mode === 'support'
+      ? modelDistance * 0.82
+      : baseDistance * 0.8;
+    const fallbackViewDir = new THREE.Vector3(-Math.sin(yawRad), -Math.cos(yawRad), 1).normalize();
     const currentViewVector = camera.position.clone().sub(orbitControls.target);
     const hasValidCurrentView = currentViewVector.lengthSq() > 1e-8;
     const viewDir = preserveCurrentViewDirection && hasValidCurrentView
@@ -124,7 +153,7 @@ export function CameraIntroController({ bounds, runId, onComplete, preserveCurre
         activeRunIdRef.current = 0;
       }
     };
-  }, [bounds, camera, controls, onComplete, preserveCurrentViewDirection, runId, size.height, size.width]);
+  }, [bounds, camera, controls, mode, onComplete, plateDepthMm, plateWidthMm, preserveCurrentViewDirection, runId, size.height, size.width]);
 
   return null;
 }

--- a/src/components/scene/camera/CameraIntroController.tsx
+++ b/src/components/scene/camera/CameraIntroController.tsx
@@ -77,19 +77,34 @@ export function CameraIntroController({
       : 0;
 
     const yawRad = THREE.MathUtils.degToRad(20);
-    const baseDistance = mode === 'support'
-      ? modelDistance * 1.03
-      : Math.max(modelDistance * 0.95, plateDistance * 0.9);
+    // Adaptive support framing: smaller models get a tighter fit, larger models get more margin.
+    const supportFitMargin = THREE.MathUtils.clamp(1.08 + (radius * 0.0012), 1.08, 1.26);
+    const prepareFitDistance = Math.max(modelDistance * 0.95, plateDistance * 0.9) * 0.8;
+    const supportFitDistance = modelDistance * supportFitMargin;
     const distance = mode === 'support'
-      ? modelDistance * 0.82
-      : baseDistance * 0.8;
+      ? supportFitDistance
+      : prepareFitDistance;
     const fallbackViewDir = new THREE.Vector3(-Math.sin(yawRad), -Math.cos(yawRad), 1).normalize();
     const currentViewVector = camera.position.clone().sub(orbitControls.target);
     const hasValidCurrentView = currentViewVector.lengthSq() > 1e-8;
     const viewDir = preserveCurrentViewDirection && hasValidCurrentView
       ? currentViewVector.normalize()
       : fallbackViewDir;
+
+    if (mode === 'support' && viewDir.z < 0.18) {
+      viewDir.z = Math.abs(viewDir.z) + 0.24;
+      viewDir.normalize();
+    }
+
     const endPos = center.clone().add(viewDir.clone().multiplyScalar(distance));
+
+    if (mode === 'support') {
+      const minVerticalClearance = Math.max(10, radius * 0.35);
+      if (endPos.z < center.z + minVerticalClearance) {
+        endPos.z = center.z + minVerticalClearance;
+      }
+    }
+
     const startPos = camera.position.clone();
     const startTarget = orbitControls.target.clone();
     const startZoom = isOrthographic ? (camera as THREE.OrthographicCamera).zoom : 1;

--- a/src/components/settings/HotkeysSettingsTab.tsx
+++ b/src/components/settings/HotkeysSettingsTab.tsx
@@ -112,6 +112,22 @@ export function HotkeysSettingsTab() {
             onCancel={() => setRecordingKey(null)}
           />
         ))}
+
+        {config.CANVAS && (
+          <div className="pt-1">
+            <div className="text-[11px] uppercase tracking-wide text-neutral-500 mb-1">Canvas Tools</div>
+            {Object.entries(config.CANVAS).map(([action, binding]) => (
+              <HotkeyRow
+                key={action}
+                label={binding.description}
+                binding={binding}
+                isRecording={recordingKey?.category === 'CANVAS' && recordingKey?.action === action}
+                onRecord={() => setRecordingKey({ category: 'CANVAS', action })}
+                onCancel={() => setRecordingKey(null)}
+              />
+            ))}
+          </div>
+        )}
       </section>
 
       {/* Supports Section */}

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -570,7 +570,7 @@ export function SettingsModal({
             </div>
           </div>
 
-          <div className="flex-1 min-h-0 overflow-y-auto p-4">
+          <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar p-4">
             <div className="mb-3 rounded-lg border px-3 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-1), transparent 8%)' }}>
               <div className="flex items-center gap-2">
                 <ActiveTabIcon className="h-4 w-4" style={{ color: activeTabColor }} />

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -41,6 +41,7 @@ import {
   getSavedWorkspaceCameraSettings,
   saveWorkspaceCameraSettings,
   type WorkspaceCameraDefaults,
+  type WorkspaceSelectionHighlightDefaults,
 } from '@/components/settings/workspaceCameraPreferences';
 import {
   DEFAULT_VIEW3D_SETTINGS,
@@ -163,6 +164,7 @@ export function SettingsModal({
   const [draftDebugPrimitivesPanelVisible, setDraftDebugPrimitivesPanelVisible] = useState<boolean>(() => debugPrimitivesPanelVisible);
   const [draftSpaceMouseSettings, setDraftSpaceMouseSettings] = useState<SpaceMouseSettings>(() => getSavedSpaceMouseSettings());
   const [draftWorkspaceCameraDefaults, setDraftWorkspaceCameraDefaults] = useState<WorkspaceCameraDefaults>(() => getSavedWorkspaceCameraSettings().defaults);
+  const [draftWorkspaceSelectionHighlightDefaults, setDraftWorkspaceSelectionHighlightDefaults] = useState<WorkspaceSelectionHighlightDefaults>(() => getSavedWorkspaceCameraSettings().selectionHighlightDefaults);
   const [draftView3dSettings, setDraftView3dSettings] = useState<View3DSettings>(() => view3dSettings ?? getSavedView3DSettings());
 
   const resetDraftFromProps = React.useCallback(() => {
@@ -186,6 +188,7 @@ export function SettingsModal({
     setDraftDebugPrimitivesPanelVisible(isDebugPrimitivesPanelVisibleEnabled());
     setDraftSpaceMouseSettings(getSavedSpaceMouseSettings());
     setDraftWorkspaceCameraDefaults(getSavedWorkspaceCameraSettings().defaults);
+    setDraftWorkspaceSelectionHighlightDefaults(getSavedWorkspaceCameraSettings().selectionHighlightDefaults);
     setDraftView3dSettings(view3dSettings ?? getSavedView3DSettings());
   }, [
     ambientIntensity,
@@ -242,6 +245,7 @@ export function SettingsModal({
     setDraftDebugPrimitivesPanelVisible(true);
     setDraftSpaceMouseSettings(DEFAULT_SPACEMOUSE_SETTINGS);
     setDraftWorkspaceCameraDefaults(DEFAULT_WORKSPACE_CAMERA_SETTINGS.defaults);
+    setDraftWorkspaceSelectionHighlightDefaults(DEFAULT_WORKSPACE_CAMERA_SETTINGS.selectionHighlightDefaults);
     setDraftView3dSettings(DEFAULT_VIEW3D_SETTINGS);
   }, []);
 
@@ -265,7 +269,10 @@ export function SettingsModal({
     setDebugPrimitivesPanelVisibleEnabled(draftDebugPrimitivesPanelVisible);
     saveSpaceMouseSettings(draftSpaceMouseSettings);
     saveCameraProjectionSettings({ mode: draftCameraProjectionMode });
-    saveWorkspaceCameraSettings({ defaults: draftWorkspaceCameraDefaults });
+    saveWorkspaceCameraSettings({
+      defaults: draftWorkspaceCameraDefaults,
+      selectionHighlightDefaults: draftWorkspaceSelectionHighlightDefaults,
+    });
     const normalized3dView = normalizeView3DSettings(draftView3dSettings);
     saveView3DSettings(normalized3dView);
     onView3dSettingsChange(normalized3dView);
@@ -298,6 +305,7 @@ export function SettingsModal({
     draftSpaceMouseSettings,
     draftCameraProjectionMode,
     draftWorkspaceCameraDefaults,
+    draftWorkspaceSelectionHighlightDefaults,
     draftView3dSettings,
     draftXrayOpacity,
     onAmbientIntensityChange,
@@ -404,6 +412,13 @@ export function SettingsModal({
 
   const handleWorkspaceCameraModeChange = React.useCallback((workspace: keyof WorkspaceCameraDefaults, mode: 'orthographic' | 'perspective') => {
     setDraftWorkspaceCameraDefaults((prev) => ({
+      ...prev,
+      [workspace]: mode,
+    }));
+  }, []);
+
+  const handleWorkspaceSelectionHighlightModeChange = React.useCallback((workspace: keyof WorkspaceSelectionHighlightDefaults, mode: SelectionHighlightMode) => {
+    setDraftWorkspaceSelectionHighlightDefaults((prev) => ({
       ...prev,
       [workspace]: mode,
     }));
@@ -601,6 +616,8 @@ export function SettingsModal({
                 <WorkspacesSettingsTab
                   workspaceCameraDefaults={draftWorkspaceCameraDefaults}
                   onWorkspaceCameraModeChange={handleWorkspaceCameraModeChange}
+                  workspaceSelectionHighlightDefaults={draftWorkspaceSelectionHighlightDefaults}
+                  onWorkspaceSelectionHighlightModeChange={handleWorkspaceSelectionHighlightModeChange}
                   view3dSettings={draftView3dSettings}
                   onView3dSettingsChange={setDraftView3dSettings}
                 />

--- a/src/components/settings/WorkspacesSettingsTab.tsx
+++ b/src/components/settings/WorkspacesSettingsTab.tsx
@@ -3,13 +3,19 @@
 import React from 'react';
 import type { SupportMode } from '@/supports/types';
 import type { CameraProjectionMode } from '@/components/settings/cameraProjectionPreferences';
-import type { WorkspaceCameraDefaults } from '@/components/settings/workspaceCameraPreferences';
+import type { SelectionHighlightMode } from '@/components/selection';
+import type {
+  WorkspaceCameraDefaults,
+  WorkspaceSelectionHighlightDefaults,
+} from '@/components/settings/workspaceCameraPreferences';
 import type { View3DSettings } from '@/components/settings/view3dPreferences';
 import { Layers3 } from 'lucide-react';
 
 interface WorkspacesSettingsTabProps {
   workspaceCameraDefaults: WorkspaceCameraDefaults;
   onWorkspaceCameraModeChange: (workspace: SupportMode, mode: CameraProjectionMode) => void;
+  workspaceSelectionHighlightDefaults: WorkspaceSelectionHighlightDefaults;
+  onWorkspaceSelectionHighlightModeChange: (workspace: SupportMode, mode: SelectionHighlightMode) => void;
   view3dSettings: View3DSettings;
   onView3dSettingsChange: (settings: View3DSettings) => void;
 }
@@ -24,6 +30,8 @@ const workspaceMeta: Array<{ key: SupportMode; label: string; hint: string }> = 
 export function WorkspacesSettingsTab({
   workspaceCameraDefaults,
   onWorkspaceCameraModeChange,
+  workspaceSelectionHighlightDefaults,
+  onWorkspaceSelectionHighlightModeChange,
   view3dSettings,
   onView3dSettingsChange,
 }: WorkspacesSettingsTabProps) {
@@ -344,6 +352,45 @@ export function WorkspacesSettingsTab({
               >
                 Perspective
               </button>
+            </div>
+
+            <div className="mt-3 text-xs font-semibold" style={{ color: 'var(--text-strong)' }}>
+              {workspaceMeta.find((w) => w.key === activeWorkspace)?.label} selection highlight
+            </div>
+            <div className="mt-0.5 text-[11px]" style={{ color: 'var(--text-muted)' }}>
+              Controls default selection emphasis when entering this workspace.
+            </div>
+
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+              {([
+                { key: 'tint', label: 'Mesh Tint' },
+                { key: 'spotlight', label: 'Spotlight' },
+                { key: 'fresnel', label: 'Fresnel' },
+                { key: 'none', label: 'None' },
+              ] as Array<{ key: SelectionHighlightMode; label: string }>).map((option) => {
+                const active = workspaceSelectionHighlightDefaults[activeWorkspace] === option.key;
+                return (
+                  <button
+                    key={option.key}
+                    type="button"
+                    onClick={() => onWorkspaceSelectionHighlightModeChange(activeWorkspace, option.key)}
+                    className="h-10 min-w-[120px] rounded-md border px-3 text-[12px] font-semibold uppercase tracking-wide transition-colors"
+                    style={active
+                      ? {
+                          borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
+                          background: 'color-mix(in srgb, var(--accent), var(--surface-0) 76%)',
+                          color: 'var(--accent-contrast)',
+                        }
+                      : {
+                          borderColor: 'var(--border-subtle)',
+                          background: 'var(--surface-1)',
+                          color: 'var(--text-muted)',
+                        }}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/src/components/settings/workspaceCameraPreferences.ts
+++ b/src/components/settings/workspaceCameraPreferences.ts
@@ -1,10 +1,13 @@
 import type { SupportMode } from '@/supports/types';
 import type { CameraProjectionMode } from '@/components/settings/cameraProjectionPreferences';
+import type { SelectionHighlightMode } from '@/components/selection';
 
 export type WorkspaceCameraDefaults = Record<SupportMode, CameraProjectionMode>;
+export type WorkspaceSelectionHighlightDefaults = Record<SupportMode, SelectionHighlightMode>;
 
 export type WorkspaceCameraSettings = {
   defaults: WorkspaceCameraDefaults;
+  selectionHighlightDefaults: WorkspaceSelectionHighlightDefaults;
 };
 
 export const WORKSPACE_CAMERA_SETTINGS_STORAGE_KEY = 'workspace-camera-settings';
@@ -17,10 +20,21 @@ export const DEFAULT_WORKSPACE_CAMERA_SETTINGS: WorkspaceCameraSettings = {
     support: 'perspective',
     export: 'orthographic',
   },
+  selectionHighlightDefaults: {
+    prepare: 'tint',
+    analysis: 'tint',
+    support: 'spotlight',
+    export: 'tint',
+  },
 };
 
 function normalizeMode(input: unknown): CameraProjectionMode {
   return input === 'perspective' ? 'perspective' : 'orthographic';
+}
+
+function normalizeSelectionHighlightMode(input: unknown): SelectionHighlightMode {
+  if (input === 'spotlight' || input === 'fresnel' || input === 'none') return input;
+  return 'tint';
 }
 
 export function normalizeWorkspaceCameraSettings(input: unknown): WorkspaceCameraSettings {
@@ -28,9 +42,11 @@ export function normalizeWorkspaceCameraSettings(input: unknown): WorkspaceCamer
 
   const candidate = input as Partial<WorkspaceCameraSettings> & {
     defaults?: Partial<Record<SupportMode, unknown>>;
+    selectionHighlightDefaults?: Partial<Record<SupportMode, unknown>>;
   };
 
   const defaults: Partial<Record<SupportMode, unknown>> = candidate.defaults ?? {};
+  const selectionHighlightDefaults: Partial<Record<SupportMode, unknown>> = candidate.selectionHighlightDefaults ?? {};
 
   return {
     defaults: {
@@ -38,6 +54,12 @@ export function normalizeWorkspaceCameraSettings(input: unknown): WorkspaceCamer
       analysis: normalizeMode(defaults.analysis),
       support: normalizeMode(defaults.support),
       export: normalizeMode(defaults.export),
+    },
+    selectionHighlightDefaults: {
+      prepare: normalizeSelectionHighlightMode(selectionHighlightDefaults.prepare),
+      analysis: normalizeSelectionHighlightMode(selectionHighlightDefaults.analysis),
+      support: normalizeSelectionHighlightMode(selectionHighlightDefaults.support),
+      export: normalizeSelectionHighlightMode(selectionHighlightDefaults.export),
     },
   };
 }

--- a/src/config/window-layouts.json
+++ b/src/config/window-layouts.json
@@ -88,6 +88,92 @@
       }
     },
     {
+      "id": "prepare-arrange",
+      "matchPanelIds": ["prepare-models", "prepare-arrange-panel"],
+      "order": [
+        "prepare-models",
+        "visual-settings",
+        "prepare-arrange-panel"
+      ],
+      "anchors": {
+        "visual-settings": {
+          "to": "prepare-models",
+          "side": "right-edge"
+        },
+        "prepare-arrange-panel": {
+          "to": "visual-settings",
+          "side": "left"
+        }
+      }
+    },
+    {
+      "id": "prepare-arrange-debug",
+      "matchPanelIds": ["prepare-models", "prepare-debug-primitives", "prepare-arrange-panel"],
+      "order": [
+        "prepare-models",
+        "prepare-debug-primitives",
+        "visual-settings",
+        "prepare-arrange-panel"
+      ],
+      "anchors": {
+        "prepare-debug-primitives": {
+          "to": "prepare-models",
+          "side": "below"
+        },
+        "visual-settings": {
+          "to": "prepare-models",
+          "side": "right-edge"
+        },
+        "prepare-arrange-panel": {
+          "to": "visual-settings",
+          "side": "left"
+        }
+      }
+    },
+    {
+      "id": "prepare-duplicate",
+      "matchPanelIds": ["prepare-models", "prepare-duplicate-panel"],
+      "order": [
+        "prepare-models",
+        "visual-settings",
+        "prepare-duplicate-panel"
+      ],
+      "anchors": {
+        "visual-settings": {
+          "to": "prepare-models",
+          "side": "right-edge"
+        },
+        "prepare-duplicate-panel": {
+          "to": "visual-settings",
+          "side": "left"
+        }
+      }
+    },
+    {
+      "id": "prepare-duplicate-debug",
+      "matchPanelIds": ["prepare-models", "prepare-debug-primitives", "prepare-duplicate-panel"],
+      "order": [
+        "prepare-models",
+        "prepare-debug-primitives",
+        "visual-settings",
+        "prepare-duplicate-panel"
+      ],
+      "anchors": {
+        "prepare-debug-primitives": {
+          "to": "prepare-models",
+          "side": "below"
+        },
+        "visual-settings": {
+          "to": "prepare-models",
+          "side": "right-edge"
+        },
+        "prepare-duplicate-panel": {
+          "to": "visual-settings",
+          "side": "left"
+        }
+      }
+    },
+    {
       "id": "analysis",
       "matchPanelIds": ["analysis-scan-card", "analysis-workflow"],
       "order": [

--- a/src/features/export/components/ExportPanel.tsx
+++ b/src/features/export/components/ExportPanel.tsx
@@ -20,6 +20,16 @@ type ToggleRowProps = {
   onChange: (checked: boolean) => void;
 };
 
+function normalizeExportBaseName(rawName: string | null | undefined): string {
+  const trimmed = (rawName ?? '').trim();
+  if (!trimmed) return 'MyPrint';
+
+  // Strip common source suffixes if present (including chained suffixes).
+  const withoutKnownExt = trimmed.replace(/(\.(stl|obj|3mf|lys|lychee|json))+$/i, '');
+  const cleaned = withoutKnownExt.replace(/[.\s]+$/g, '').trim();
+  return cleaned || 'MyPrint';
+}
+
 function ToggleRow({ label, hint, checked, onChange }: ToggleRowProps) {
   return (
     <label className="flex items-center justify-between gap-3 rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
@@ -51,7 +61,7 @@ export function ExportPanel({
   supportsRef,
 }: ExportPanelProps) {
   const [isExpanded, setIsExpanded] = useState(true);
-  const [filename, setFilename] = useState(activeModel?.name?.replace('.stl', '') || 'MyPrint');
+  const [filename, setFilename] = useState(() => normalizeExportBaseName(activeModel?.name));
   const [isExporting, setIsExporting] = useState(false);
 
   const [options, setOptions] = useState<ExportOptions>({
@@ -73,8 +83,7 @@ export function ExportPanel({
 
   useEffect(() => {
     if (!activeModel) return;
-    const baseName = activeModel.name.replace(/\.(stl|obj|3mf)$/i, '');
-    setFilename(baseName || 'MyPrint');
+    setFilename(normalizeExportBaseName(activeModel.name));
   }, [activeModel?.id]);
 
   const handleExport = async () => {

--- a/src/features/export/logic/ExportManager.ts
+++ b/src/features/export/logic/ExportManager.ts
@@ -37,6 +37,15 @@ export interface ExportOptions {
 }
 
 export class ExportManager {
+  private static normalizeExportFilenameBase(filename: string): string {
+    const trimmed = filename.trim();
+    if (!trimmed) return 'export';
+
+    const withoutKnownExt = trimmed.replace(/(\.(stl|obj|3mf|lys|lychee|json))+$/i, '');
+    const cleaned = withoutKnownExt.replace(/[.\s]+$/g, '').trim();
+    return cleaned || 'export';
+  }
+
   /**
    * Generates and downloads an STL file based on the current scene state.
    */
@@ -298,7 +307,8 @@ export class ExportManager {
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.download = filename.endsWith('.stl') ? filename : `${filename}.stl`;
+    const normalizedBaseName = this.normalizeExportFilenameBase(filename);
+    link.download = `${normalizedBaseName}.stl`;
     link.click();
     URL.revokeObjectURL(url);
   }

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -898,6 +898,20 @@ export function useSceneCollectionManager() {
     ));
   }, []);
 
+  const updateModelTransforms = useCallback((updates: Array<{ id: string; transform: ModelTransform }>) => {
+    if (updates.length === 0) return;
+
+    const updateMap = new Map<string, ModelTransform>();
+    updates.forEach((entry) => {
+      updateMap.set(entry.id, entry.transform);
+    });
+
+    setModels((prev) => prev.map((m) => {
+      const nextTransform = updateMap.get(m.id);
+      return nextTransform ? { ...m, transform: nextTransform } : m;
+    }));
+  }, []);
+
   const setModelVisibility = useCallback((id: string, visible: boolean) => {
     setModels(prev => prev.map(m =>
       m.id === id ? { ...m, visible } : m
@@ -982,6 +996,43 @@ export function useSceneCollectionManager() {
     setActiveModelId(id);
     return id;
   }, [cloneGeometryWithBounds, generateId, modelClipboard]);
+
+  const duplicateModelWithTransforms = useCallback((sourceId: string, transforms: ModelTransform[]) => {
+    if (transforms.length === 0) return [] as string[];
+
+    const source = models.find((m) => m.id === sourceId);
+    if (!source) return [] as string[];
+
+    const createdIds: string[] = [];
+
+    const newModels: LoadedModel[] = transforms.map((nextTransform, index) => {
+      const id = generateId();
+      createdIds.push(id);
+
+      return {
+        id,
+        name: `${source.name} Copy ${index + 1}`,
+        fileUrl: '',
+        fileSizeBytes: source.fileSizeBytes,
+        geometry: cloneGeometryWithBounds(source.geometry),
+        transform: {
+          position: nextTransform.position.clone(),
+          rotation: nextTransform.rotation.clone(),
+          scale: nextTransform.scale.clone(),
+        },
+        visible: source.visible,
+        color: source.color,
+        polygonCount: source.polygonCount,
+      };
+    });
+
+    setModels((prev) => [...prev, ...newModels]);
+    if (createdIds.length > 0) {
+      setActiveModelId(createdIds[0]);
+    }
+
+    return createdIds;
+  }, [cloneGeometryWithBounds, generateId, models]);
 
   // NEW: LYS Import (1-step)
   const lysImport = useLysImport();
@@ -1300,12 +1351,14 @@ export function useSceneCollectionManager() {
     loadFiles,
     onFileChange,
     updateModelTransform,
+    updateModelTransforms,
     setModelVisibility,
     renameModel,
     deleteModel,
     copyModel,
     cutModel,
     pasteModel,
+    duplicateModelWithTransforms,
     canPasteModel: modelClipboard !== null,
 
     // Scene settings

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -1207,35 +1207,138 @@ export function useSceneCollectionManager() {
     return id;
   }, [cloneGeometryWithBounds, deferAccelerateGeometry, generateId, modelClipboard]);
 
-  const pasteCopiedModelsAutoArrange = useCallback((spacingMm = 12) => {
+  const pasteCopiedModelsAutoArrange = useCallback((spacingMm = 5) => {
     if (modelClipboard.length === 0) return [] as string[];
 
     const entries = modelClipboard;
 
-    const maxWidth = Math.max(...entries.map((entry) => Math.max(2, Math.abs(entry.geometry.size.x * entry.transform.scale.x))));
-    const maxDepth = Math.max(...entries.map((entry) => Math.max(2, Math.abs(entry.geometry.size.y * entry.transform.scale.y))));
-    const stepX = maxWidth + spacingMm;
-    const stepY = maxDepth + spacingMm;
-
-    const count = entries.length;
-    const columns = Math.max(1, Math.ceil(Math.sqrt(count)));
-    const rows = Math.ceil(count / columns);
-
     const centerX = defaultImportCenterXY.x;
     const centerY = defaultImportCenterXY.y;
-    const startX = centerX - ((columns - 1) * stepX) * 0.5;
-    const startY = centerY - ((rows - 1) * stepY) * 0.5;
+
+    type Rect2D = { minX: number; maxX: number; minY: number; maxY: number };
+
+    const intersectsRect = (a: Rect2D, b: Rect2D) => {
+      return !(a.maxX <= b.minX || a.minX >= b.maxX || a.maxY <= b.minY || a.minY >= b.maxY);
+    };
+
+    const footprintFor = (size: THREE.Vector3, transform: ModelTransform) => {
+      const baseW = Math.max(2, Math.abs(size.x * transform.scale.x));
+      const baseD = Math.max(2, Math.abs(size.y * transform.scale.y));
+      const rz = transform.rotation.z;
+      const c = Math.abs(Math.cos(rz));
+      const s = Math.abs(Math.sin(rz));
+      return {
+        width: (baseW * c) + (baseD * s),
+        depth: (baseW * s) + (baseD * c),
+      };
+    };
+
+    const maxWidth = Math.max(...entries.map((entry) => footprintFor(entry.geometry.size, entry.transform).width));
+    const maxDepth = Math.max(...entries.map((entry) => footprintFor(entry.geometry.size, entry.transform).depth));
+    const stepX = Math.max(4, maxWidth + Math.max(0, spacingMm));
+    const stepY = Math.max(4, maxDepth + Math.max(0, spacingMm));
+
+    const blockedRects: Rect2D[] = models
+      .filter((model) => model.visible)
+      .map((model) => {
+        const { width, depth } = footprintFor(model.geometry.size, model.transform);
+        return {
+          minX: model.transform.position.x - (width * 0.5),
+          maxX: model.transform.position.x + (width * 0.5),
+          minY: model.transform.position.y - (depth * 0.5),
+          maxY: model.transform.position.y + (depth * 0.5),
+        };
+      });
+
+    const candidateCenters: Array<{ x: number; y: number; distSq: number }> = [];
+    const maxRing = 36;
+
+    for (let ring = 0; ring <= maxRing; ring += 1) {
+      if (ring === 0) {
+        candidateCenters.push({ x: centerX, y: centerY, distSq: 0 });
+        continue;
+      }
+
+      for (let gx = -ring; gx <= ring; gx += 1) {
+        const gyTop = ring;
+        const gyBottom = -ring;
+        const x = centerX + gx * stepX;
+
+        const yTop = centerY + gyTop * stepY;
+        const dxTop = x - centerX;
+        const dyTop = yTop - centerY;
+        candidateCenters.push({ x, y: yTop, distSq: (dxTop * dxTop) + (dyTop * dyTop) });
+
+        if (gyBottom !== gyTop) {
+          const yBottom = centerY + gyBottom * stepY;
+          const dxBottom = x - centerX;
+          const dyBottom = yBottom - centerY;
+          candidateCenters.push({ x, y: yBottom, distSq: (dxBottom * dxBottom) + (dyBottom * dyBottom) });
+        }
+      }
+
+      for (let gy = -ring + 1; gy <= ring - 1; gy += 1) {
+        const gxRight = ring;
+        const gxLeft = -ring;
+        const y = centerY + gy * stepY;
+
+        const xRight = centerX + gxRight * stepX;
+        const dxRight = xRight - centerX;
+        const dyRight = y - centerY;
+        candidateCenters.push({ x: xRight, y, distSq: (dxRight * dxRight) + (dyRight * dyRight) });
+
+        if (gxLeft !== gxRight) {
+          const xLeft = centerX + gxLeft * stepX;
+          const dxLeft = xLeft - centerX;
+          const dyLeft = y - centerY;
+          candidateCenters.push({ x: xLeft, y, distSq: (dxLeft * dxLeft) + (dyLeft * dyLeft) });
+        }
+      }
+    }
+
+    candidateCenters.sort((a, b) => a.distSq - b.distSq);
+
+    const assignedCenters: Array<{ x: number; y: number }> = entries.map((entry) => {
+      const { width, depth } = footprintFor(entry.geometry.size, entry.transform);
+
+      for (const candidate of candidateCenters) {
+        const rect: Rect2D = {
+          minX: candidate.x - (width * 0.5),
+          maxX: candidate.x + (width * 0.5),
+          minY: candidate.y - (depth * 0.5),
+          maxY: candidate.y + (depth * 0.5),
+        };
+
+        if (blockedRects.some((blocked) => intersectsRect(rect, blocked))) {
+          continue;
+        }
+
+        blockedRects.push(rect);
+        return { x: candidate.x, y: candidate.y };
+      }
+
+      // Fallback: if exhaustive candidates are blocked, place further to the right of center.
+      const fallbackX = centerX + (maxRing + 2 + blockedRects.length) * stepX;
+      const fallbackY = centerY;
+      blockedRects.push({
+        minX: fallbackX - (width * 0.5),
+        maxX: fallbackX + (width * 0.5),
+        minY: fallbackY - (depth * 0.5),
+        maxY: fallbackY + (depth * 0.5),
+      });
+      return { x: fallbackX, y: fallbackY };
+    });
 
     const createdIds: string[] = [];
     const pastedGeometries: GeometryWithBounds[] = [];
     const pastedModels: LoadedModel[] = entries.map((entry, index) => {
-      const col = index % columns;
-      const row = Math.floor(index / columns);
       const id = generateId();
       createdIds.push(id);
 
       const geometry = cloneGeometryWithBounds(entry.geometry, { accelerate: false });
       pastedGeometries.push(geometry);
+
+      const center = assignedCenters[index] ?? { x: centerX, y: centerY };
 
       return {
         id,
@@ -1244,7 +1347,7 @@ export function useSceneCollectionManager() {
         fileSizeBytes: entry.fileSizeBytes,
         geometry,
         transform: {
-          position: new THREE.Vector3(startX + col * stepX, startY + row * stepY, entry.transform.position.z),
+          position: new THREE.Vector3(center.x, center.y, entry.transform.position.z),
           rotation: entry.transform.rotation.clone(),
           scale: entry.transform.scale.clone(),
         },
@@ -1263,7 +1366,7 @@ export function useSceneCollectionManager() {
     deferAccelerateGeometry(pastedGeometries);
 
     return createdIds;
-  }, [cloneGeometryWithBounds, defaultImportCenterXY.x, defaultImportCenterXY.y, deferAccelerateGeometry, generateId, modelClipboard]);
+  }, [cloneGeometryWithBounds, defaultImportCenterXY.x, defaultImportCenterXY.y, deferAccelerateGeometry, generateId, modelClipboard, models]);
 
   const duplicateModelWithTransforms = useCallback((sourceId: string, transforms: ModelTransform[]) => {
     if (transforms.length === 0) return [] as string[];

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -1524,7 +1524,7 @@ export function useSceneCollectionManager() {
     return createdIds;
   }, [activeModelId, cloneGeometryWithBounds, defaultImportCenterXY.x, defaultImportCenterXY.y, deferAccelerateGeometry, generateId, modelClipboard, models, pushSceneSnapshotHistory, selectedModelIds, view3dSettings.depthMm, view3dSettings.originMode, view3dSettings.widthMm]);
 
-  const duplicateModelWithTransforms = useCallback((sourceId: string, transforms: ModelTransform[]) => {
+  const duplicateModelWithTransforms = useCallback((sourceId: string, transforms: ModelTransform[], sourceTransform?: ModelTransform | null) => {
     if (transforms.length === 0) return [] as string[];
 
     const source = models.find((m) => m.id === sourceId);
@@ -1566,11 +1566,20 @@ export function useSceneCollectionManager() {
 
     const withSourceGroup = models.map((model) => {
       if (model.id !== sourceId) return model;
-      if (model.groupId === resolvedGroupId && model.groupName === resolvedGroupName) return model;
+      const shouldUpdateGroup = model.groupId !== resolvedGroupId || model.groupName !== resolvedGroupName;
+      const shouldUpdateTransform = !!sourceTransform;
+      if (!shouldUpdateGroup && !shouldUpdateTransform) return model;
       return {
         ...model,
         groupId: resolvedGroupId,
         groupName: resolvedGroupName,
+        transform: sourceTransform
+          ? {
+              position: sourceTransform.position.clone(),
+              rotation: sourceTransform.rotation.clone(),
+              scale: sourceTransform.scale.clone(),
+            }
+          : model.transform,
       };
     });
 

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -16,6 +16,7 @@ import { useLysImport } from '@/components/lys-import/useLysImport';
 import { accelerateGeometry } from '@/utils/bvh';
 import type { MatcapVariant, MeshShaderType } from '@/features/shaders/mesh';
 import {
+  DEFAULT_VIEW3D_SETTINGS,
   getSavedView3DSettings,
   normalizeView3DSettings,
   saveView3DSettings,
@@ -432,13 +433,11 @@ export function useSceneCollectionManager() {
     [],
   );
 
-  const persistedAppearance = useMemo(() => readMeshAppearanceFromLocalStorage(), []);
-
   const [models, setModels] = useState<LoadedModel[]>([]);
   const [activeModelId, setActiveModelId] = useState<string | null>(null);
   const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
   const [modelClipboard, setModelClipboard] = useState<ModelClipboardEntry[]>([]);
-  const [recentOpenedFiles, setRecentOpenedFiles] = useState<RecentOpenedFileEntry[]>(() => readRecentOpenedFilesFromLocalStorage());
+  const [recentOpenedFiles, setRecentOpenedFiles] = useState<RecentOpenedFileEntry[]>([]);
   const [importProgress, setImportProgress] = useState<ImportProgressState>({
     active: false,
     type: null,
@@ -637,23 +636,44 @@ export function useSceneCollectionManager() {
   }, [isDebugModelName, models, tryRevokeObjectUrl]);
 
   // Lighting controls (Global)
-  const [ambientIntensity, setAmbientIntensity] = useState<number>(persistedAppearance?.ambientIntensity ?? DEFAULT_AMBIENT_INTENSITY);
-  const [directionalIntensity, setDirectionalIntensity] = useState<number>(persistedAppearance?.directionalIntensity ?? DEFAULT_DIRECTIONAL_INTENSITY);
-  const [materialRoughness, setMaterialRoughness] = useState<number>(persistedAppearance?.materialRoughness ?? DEFAULT_MATERIAL_ROUGHNESS);
+  const [ambientIntensity, setAmbientIntensity] = useState<number>(DEFAULT_AMBIENT_INTENSITY);
+  const [directionalIntensity, setDirectionalIntensity] = useState<number>(DEFAULT_DIRECTIONAL_INTENSITY);
+  const [materialRoughness, setMaterialRoughness] = useState<number>(DEFAULT_MATERIAL_ROUGHNESS);
 
   // Shader-specific settings (Global)
-  const [wireframeThicknessPx, setWireframeThicknessPx] = useState<number>(persistedAppearance?.wireframeThicknessPx ?? DEFAULT_WIREFRAME_THICKNESS_PX);
-  const [xrayOpacity, setXrayOpacity] = useState<number>(persistedAppearance?.xrayOpacity ?? DEFAULT_XRAY_OPACITY);
+  const [wireframeThicknessPx, setWireframeThicknessPx] = useState<number>(DEFAULT_WIREFRAME_THICKNESS_PX);
+  const [xrayOpacity, setXrayOpacity] = useState<number>(DEFAULT_XRAY_OPACITY);
 
   // Mesh shader selection (Global)
-  const [shaderType, setShaderType] = useState<MeshShaderType>(persistedAppearance?.shaderType ?? DEFAULT_SHADER_TYPE);
-  const [matcapVariant, setMatcapVariant] = useState<MatcapVariant>(persistedAppearance?.matcapVariant ?? DEFAULT_MATCAP_VARIANT);
-  const [flatUseVertexColors, setFlatUseVertexColors] = useState<boolean>(persistedAppearance?.flatUseVertexColors ?? DEFAULT_FLAT_USE_VERTEX_COLORS);
-  const [toonSteps, setToonSteps] = useState<number>(persistedAppearance?.toonSteps ?? DEFAULT_TOON_STEPS);
-  const [preferredMeshColor, setPreferredMeshColor] = useState<string>(persistedAppearance?.meshColor ?? DEFAULT_MESH_COLOR);
-  const [hoverTintStrength, setHoverTintStrength] = useState<number>(persistedAppearance?.hoverTintStrength ?? DEFAULT_HOVER_TINT_STRENGTH);
-  const [selectedTintStrength, setSelectedTintStrength] = useState<number>(persistedAppearance?.selectedTintStrength ?? DEFAULT_SELECTED_TINT_STRENGTH);
-  const [view3dSettings, setView3dSettingsState] = useState<View3DSettings>(() => getSavedView3DSettings());
+  const [shaderType, setShaderType] = useState<MeshShaderType>(DEFAULT_SHADER_TYPE);
+  const [matcapVariant, setMatcapVariant] = useState<MatcapVariant>(DEFAULT_MATCAP_VARIANT);
+  const [flatUseVertexColors, setFlatUseVertexColors] = useState<boolean>(DEFAULT_FLAT_USE_VERTEX_COLORS);
+  const [toonSteps, setToonSteps] = useState<number>(DEFAULT_TOON_STEPS);
+  const [preferredMeshColor, setPreferredMeshColor] = useState<string>(DEFAULT_MESH_COLOR);
+  const [hoverTintStrength, setHoverTintStrength] = useState<number>(DEFAULT_HOVER_TINT_STRENGTH);
+  const [selectedTintStrength, setSelectedTintStrength] = useState<number>(DEFAULT_SELECTED_TINT_STRENGTH);
+  const [view3dSettings, setView3dSettingsState] = useState<View3DSettings>(() => DEFAULT_VIEW3D_SETTINGS);
+
+  useEffect(() => {
+    const persistedAppearance = readMeshAppearanceFromLocalStorage();
+    if (persistedAppearance) {
+      setShaderType(persistedAppearance.shaderType);
+      setMatcapVariant(persistedAppearance.matcapVariant);
+      setFlatUseVertexColors(persistedAppearance.flatUseVertexColors);
+      setToonSteps(persistedAppearance.toonSteps);
+      setAmbientIntensity(persistedAppearance.ambientIntensity);
+      setDirectionalIntensity(persistedAppearance.directionalIntensity);
+      setMaterialRoughness(persistedAppearance.materialRoughness);
+      setWireframeThicknessPx(persistedAppearance.wireframeThicknessPx);
+      setXrayOpacity(persistedAppearance.xrayOpacity);
+      setPreferredMeshColor(persistedAppearance.meshColor);
+      setHoverTintStrength(persistedAppearance.hoverTintStrength);
+      setSelectedTintStrength(persistedAppearance.selectedTintStrength);
+    }
+
+    setRecentOpenedFiles(readRecentOpenedFilesFromLocalStorage());
+    setView3dSettingsState(getSavedView3DSettings());
+  }, []);
 
   const setView3dSettings = useCallback((next: View3DSettings) => {
     const normalized = normalizeView3DSettings(next);

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import { loadStlGeometry, processGeometry, type GeometryWithBounds } from '@/hooks/useStlGeometry';
@@ -392,6 +392,9 @@ export function useSceneCollectionManager() {
   });
 
   const isDebugModelName = useCallback((name: string) => name.startsWith('[Debug]'), []);
+  const deferredAccelerationQueueRef = useRef<THREE.BufferGeometry[]>([]);
+  const deferredAccelerationProcessingRef = useRef(false);
+  const deferredAccelerationPausedRef = useRef(false);
 
   const tryRevokeObjectUrl = useCallback((url: string) => {
     if (!url) return;
@@ -638,9 +641,11 @@ export function useSceneCollectionManager() {
   // Helper to generate IDs
   const generateId = () => crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).substring(2, 15);
 
-  const cloneGeometryWithBounds = useCallback((source: GeometryWithBounds): GeometryWithBounds => {
+  const cloneGeometryWithBounds = useCallback((source: GeometryWithBounds, options?: { accelerate?: boolean }): GeometryWithBounds => {
     const clonedGeometry = source.geometry.clone();
-    accelerateGeometry(clonedGeometry);
+    if (options?.accelerate ?? true) {
+      accelerateGeometry(clonedGeometry);
+    }
 
     return {
       geometry: clonedGeometry,
@@ -649,6 +654,60 @@ export function useSceneCollectionManager() {
       size: source.size.clone(),
     };
   }, []);
+
+  const processDeferredAccelerationQueue = useCallback(() => {
+    if (deferredAccelerationProcessingRef.current) return;
+    if (deferredAccelerationPausedRef.current) return;
+    if (deferredAccelerationQueueRef.current.length === 0) return;
+
+    deferredAccelerationProcessingRef.current = true;
+
+    const scheduleNext = (cb: () => void) => {
+      if (typeof window !== 'undefined' && typeof (window as any).requestIdleCallback === 'function') {
+        (window as any).requestIdleCallback(cb, { timeout: 120 });
+      } else {
+        setTimeout(cb, 16);
+      }
+    };
+
+    const step = () => {
+      if (deferredAccelerationPausedRef.current) {
+        deferredAccelerationProcessingRef.current = false;
+        return;
+      }
+
+      const geometry = deferredAccelerationQueueRef.current.shift();
+      if (!geometry) {
+        deferredAccelerationProcessingRef.current = false;
+        return;
+      }
+
+      accelerateGeometry(geometry);
+
+      if (deferredAccelerationQueueRef.current.length === 0) {
+        deferredAccelerationProcessingRef.current = false;
+        return;
+      }
+
+      scheduleNext(step);
+    };
+
+    scheduleNext(step);
+  }, []);
+
+  const deferAccelerateGeometry = useCallback((entries: GeometryWithBounds[]) => {
+    if (entries.length === 0) return;
+
+    deferredAccelerationQueueRef.current.push(...entries.map((entry) => entry.geometry));
+    processDeferredAccelerationQueue();
+  }, [processDeferredAccelerationQueue]);
+
+  const setBackgroundGeometryWorkPaused = useCallback((paused: boolean) => {
+    deferredAccelerationPausedRef.current = paused;
+    if (!paused) {
+      processDeferredAccelerationQueue();
+    }
+  }, [processDeferredAccelerationQueue]);
 
   const trackRecentOpenedFiles = useCallback((files: File[], kind: RecentOpenedFileKind) => {
     if (files.length === 0) return;
@@ -1071,7 +1130,7 @@ export function useSceneCollectionManager() {
         sourceId: source.id,
         name: source.name,
         fileSizeBytes: source.fileSizeBytes,
-        geometry: cloneGeometryWithBounds(source.geometry),
+        geometry: source.geometry,
         transform: {
           position: source.transform.position.clone(),
           rotation: source.transform.rotation.clone(),
@@ -1083,7 +1142,7 @@ export function useSceneCollectionManager() {
     ]);
 
     return true;
-  }, [cloneGeometryWithBounds, models]);
+  }, [models]);
 
   const copySelectedModels = useCallback((ids?: string[]) => {
     const idSet = new Set((ids && ids.length > 0) ? ids : selectedModelIds);
@@ -1096,7 +1155,7 @@ export function useSceneCollectionManager() {
       sourceId: source.id,
       name: source.name,
       fileSizeBytes: source.fileSizeBytes,
-      geometry: cloneGeometryWithBounds(source.geometry),
+      geometry: source.geometry,
       transform: {
         position: source.transform.position.clone(),
         rotation: source.transform.rotation.clone(),
@@ -1107,7 +1166,7 @@ export function useSceneCollectionManager() {
     })));
 
     return true;
-  }, [cloneGeometryWithBounds, models, selectedModelIds]);
+  }, [models, selectedModelIds]);
 
   const cutModel = useCallback((id: string) => {
     const copied = copyModel(id);
@@ -1121,13 +1180,15 @@ export function useSceneCollectionManager() {
 
     const first = modelClipboard[0];
 
+    const pastedGeometry = cloneGeometryWithBounds(first.geometry, { accelerate: false });
+
     const id = generateId();
     const pastedModel: LoadedModel = {
       id,
       name: `${first.name} Copy`,
       fileUrl: '',
       fileSizeBytes: first.fileSizeBytes,
-      geometry: cloneGeometryWithBounds(first.geometry),
+      geometry: pastedGeometry,
       transform: {
         position: first.transform.position.clone().add(new THREE.Vector3(6, 6, 0)),
         rotation: first.transform.rotation.clone(),
@@ -1141,8 +1202,10 @@ export function useSceneCollectionManager() {
     setModels((prev) => [...prev, pastedModel]);
     setActiveModelId(id);
     setSelectedModelIds([id]);
+
+    deferAccelerateGeometry([pastedGeometry]);
     return id;
-  }, [cloneGeometryWithBounds, generateId, modelClipboard]);
+  }, [cloneGeometryWithBounds, deferAccelerateGeometry, generateId, modelClipboard]);
 
   const pasteCopiedModelsAutoArrange = useCallback((spacingMm = 12) => {
     if (modelClipboard.length === 0) return [] as string[];
@@ -1164,18 +1227,22 @@ export function useSceneCollectionManager() {
     const startY = centerY - ((rows - 1) * stepY) * 0.5;
 
     const createdIds: string[] = [];
+    const pastedGeometries: GeometryWithBounds[] = [];
     const pastedModels: LoadedModel[] = entries.map((entry, index) => {
       const col = index % columns;
       const row = Math.floor(index / columns);
       const id = generateId();
       createdIds.push(id);
 
+      const geometry = cloneGeometryWithBounds(entry.geometry, { accelerate: false });
+      pastedGeometries.push(geometry);
+
       return {
         id,
         name: `${entry.name} Copy`,
         fileUrl: '',
         fileSizeBytes: entry.fileSizeBytes,
-        geometry: cloneGeometryWithBounds(entry.geometry),
+        geometry,
         transform: {
           position: new THREE.Vector3(startX + col * stepX, startY + row * stepY, entry.transform.position.z),
           rotation: entry.transform.rotation.clone(),
@@ -1193,8 +1260,10 @@ export function useSceneCollectionManager() {
       setSelectedModelIds(createdIds);
     }
 
+    deferAccelerateGeometry(pastedGeometries);
+
     return createdIds;
-  }, [cloneGeometryWithBounds, defaultImportCenterXY.x, defaultImportCenterXY.y, generateId, modelClipboard]);
+  }, [cloneGeometryWithBounds, defaultImportCenterXY.x, defaultImportCenterXY.y, deferAccelerateGeometry, generateId, modelClipboard]);
 
   const duplicateModelWithTransforms = useCallback((sourceId: string, transforms: ModelTransform[]) => {
     if (transforms.length === 0) return [] as string[];
@@ -1206,10 +1275,14 @@ export function useSceneCollectionManager() {
     const resolvedGroupName = source.groupName ?? source.name;
 
     const createdIds: string[] = [];
+    const duplicatedGeometries: GeometryWithBounds[] = [];
 
     const newModels: LoadedModel[] = transforms.map((nextTransform, index) => {
       const id = generateId();
       createdIds.push(id);
+
+      const geometry = cloneGeometryWithBounds(source.geometry, { accelerate: false });
+      duplicatedGeometries.push(geometry);
 
       return {
         id,
@@ -1218,7 +1291,7 @@ export function useSceneCollectionManager() {
         groupName: resolvedGroupName,
         fileUrl: '',
         fileSizeBytes: source.fileSizeBytes,
-        geometry: cloneGeometryWithBounds(source.geometry),
+        geometry,
         transform: {
           position: nextTransform.position.clone(),
           rotation: nextTransform.rotation.clone(),
@@ -1249,8 +1322,10 @@ export function useSceneCollectionManager() {
       setSelectedModelIds([sourceId, ...createdIds]);
     }
 
+    deferAccelerateGeometry(duplicatedGeometries);
+
     return createdIds;
-  }, [cloneGeometryWithBounds, generateId, models]);
+  }, [cloneGeometryWithBounds, deferAccelerateGeometry, generateId, models]);
 
   // NEW: LYS Import (1-step)
   const lysImport = useLysImport();
@@ -1590,6 +1665,7 @@ export function useSceneCollectionManager() {
     pasteModel,
     pasteCopiedModelsAutoArrange,
     duplicateModelWithTransforms,
+    setBackgroundGeometryWorkPaused,
     canPasteModel: modelClipboard.length > 0,
 
     // Scene settings

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -324,6 +324,8 @@ function generateRecentEntryId(): string {
 export interface LoadedModel {
   id: string;
   name: string;
+  groupId?: string;
+  groupName?: string;
   fileUrl: string;
   fileSizeBytes?: number;
   geometry: GeometryWithBounds;
@@ -377,6 +379,7 @@ export function useSceneCollectionManager() {
 
   const [models, setModels] = useState<LoadedModel[]>([]);
   const [activeModelId, setActiveModelId] = useState<string | null>(null);
+  const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
   const [modelClipboard, setModelClipboard] = useState<ModelClipboardEntry | null>(null);
   const [recentOpenedFiles, setRecentOpenedFiles] = useState<RecentOpenedFileEntry[]>(() => readRecentOpenedFilesFromLocalStorage());
   const [importProgress, setImportProgress] = useState<ImportProgressState>({
@@ -715,6 +718,31 @@ export function useSceneCollectionManager() {
     models.find(m => m.id === activeModelId) || null
     , [models, activeModelId]);
 
+  useEffect(() => {
+    const modelIdSet = new Set(models.map((m) => m.id));
+    setSelectedModelIds((prev) => prev.filter((id) => modelIdSet.has(id)));
+    if (activeModelId && !modelIdSet.has(activeModelId)) {
+      setActiveModelId(null);
+    }
+  }, [activeModelId, models]);
+
+  const selectModel = useCallback((id: string, mode: 'single' | 'toggle' | 'add' = 'single') => {
+    setActiveModelId(id);
+
+    setSelectedModelIds((prev) => {
+      if (mode === 'single') return [id];
+      if (mode === 'add') {
+        return prev.includes(id) ? prev : [...prev, id];
+      }
+      return prev.includes(id) ? prev.filter((sid) => sid !== id) : [...prev, id];
+    });
+  }, []);
+
+  const clearModelSelection = useCallback(() => {
+    setSelectedModelIds([]);
+    setActiveModelId(null);
+  }, []);
+
   // Clear support selection when switching away from support mode
   useEffect(() => {
     if (mode !== 'support') {
@@ -870,6 +898,7 @@ export function useSceneCollectionManager() {
         // If no active model, select the first new one
         if (!activeModelId) {
           setActiveModelId(newModels[0].id);
+          setSelectedModelIds([newModels[0].id]);
         }
       }
     } finally {
@@ -924,6 +953,91 @@ export function useSceneCollectionManager() {
     ));
   }, []);
 
+  const groupModels = useCallback((modelIds: string[], groupName?: string) => {
+    const ids = Array.from(new Set(modelIds));
+    if (ids.length === 0) return null;
+
+    let resolvedGroupId: string | null = null;
+    let resolvedGroupName: string | null = null;
+
+    setModels((prev) => {
+      const selected = prev.filter((model) => ids.includes(model.id));
+      if (selected.length === 0) return prev;
+
+      const commonGroupId = selected.every((model) => model.groupId && model.groupId === selected[0].groupId)
+        ? (selected[0].groupId ?? null)
+        : null;
+
+      resolvedGroupId = commonGroupId ?? `group-${generateId()}`;
+      const rawName = groupName?.trim();
+      resolvedGroupName = rawName && rawName.length > 0
+        ? rawName
+        : (selected.find((model) => model.groupName?.trim())?.groupName ?? selected[0].name);
+
+      return prev.map((model) => {
+        if (!ids.includes(model.id)) return model;
+        return {
+          ...model,
+          groupId: resolvedGroupId ?? undefined,
+          groupName: resolvedGroupName ?? undefined,
+        };
+      });
+    });
+
+    if (resolvedGroupId) {
+      setSelectedModelIds((prev) => {
+        const next = Array.from(new Set([...prev, ...ids]));
+        return next;
+      });
+      setActiveModelId((prev) => prev ?? ids[0] ?? null);
+    }
+
+    return resolvedGroupId;
+  }, []);
+
+  const ungroupModels = useCallback((modelIds: string[]) => {
+    const ids = new Set(modelIds);
+    if (ids.size === 0) return;
+
+    setModels((prev) => prev.map((model) => (
+      ids.has(model.id)
+        ? { ...model, groupId: undefined, groupName: undefined }
+        : model
+    )));
+  }, []);
+
+  const ungroupGroup = useCallback((groupId: string) => {
+    setModels((prev) => prev.map((model) => (
+      model.groupId === groupId
+        ? { ...model, groupId: undefined, groupName: undefined }
+        : model
+    )));
+  }, []);
+
+  const renameGroup = useCallback((groupId: string, nextName: string) => {
+    const trimmed = nextName.trim();
+    if (!trimmed) return;
+
+    setModels((prev) => prev.map((model) => (
+      model.groupId === groupId
+        ? { ...model, groupName: trimmed }
+        : model
+    )));
+  }, []);
+
+  const selectGroup = useCallback((groupId: string, mode: 'single' | 'add' = 'single') => {
+    const groupIds = models.filter((model) => model.groupId === groupId).map((model) => model.id);
+    if (groupIds.length === 0) return;
+
+    setActiveModelId(groupIds[0]);
+    setSelectedModelIds((prev) => {
+      if (mode === 'add') {
+        return Array.from(new Set([...prev, ...groupIds]));
+      }
+      return groupIds;
+    });
+  }, [models]);
+
   const deleteModel = useCallback((id: string) => {
     setModels(prev => {
       const model = prev.find(m => m.id === id);
@@ -937,6 +1051,8 @@ export function useSceneCollectionManager() {
     if (activeModelId === id) {
       setActiveModelId(null);
     }
+
+    setSelectedModelIds((prev) => prev.filter((sid) => sid !== id));
 
     // Clean up associated supports
     const supportState = getSnapshot();
@@ -994,6 +1110,7 @@ export function useSceneCollectionManager() {
 
     setModels((prev) => [...prev, pastedModel]);
     setActiveModelId(id);
+    setSelectedModelIds([id]);
     return id;
   }, [cloneGeometryWithBounds, generateId, modelClipboard]);
 
@@ -1002,6 +1119,9 @@ export function useSceneCollectionManager() {
 
     const source = models.find((m) => m.id === sourceId);
     if (!source) return [] as string[];
+
+    const resolvedGroupId = source.groupId ?? `group-${generateId()}`;
+    const resolvedGroupName = source.groupName ?? source.name;
 
     const createdIds: string[] = [];
 
@@ -1012,6 +1132,8 @@ export function useSceneCollectionManager() {
       return {
         id,
         name: `${source.name} Copy ${index + 1}`,
+        groupId: resolvedGroupId,
+        groupName: resolvedGroupName,
         fileUrl: '',
         fileSizeBytes: source.fileSizeBytes,
         geometry: cloneGeometryWithBounds(source.geometry),
@@ -1026,9 +1148,23 @@ export function useSceneCollectionManager() {
       };
     });
 
-    setModels((prev) => [...prev, ...newModels]);
+    setModels((prev) => {
+      const withSourceGroup = prev.map((model) => {
+        if (model.id !== sourceId) return model;
+        if (model.groupId === resolvedGroupId && model.groupName === resolvedGroupName) return model;
+        return {
+          ...model,
+          groupId: resolvedGroupId,
+          groupName: resolvedGroupName,
+        };
+      });
+
+      return [...withSourceGroup, ...newModels];
+    });
+
     if (createdIds.length > 0) {
       setActiveModelId(createdIds[0]);
+      setSelectedModelIds([sourceId, ...createdIds]);
     }
 
     return createdIds;
@@ -1092,6 +1228,7 @@ export function useSceneCollectionManager() {
 
         setModels(prev => [...prev, model]);
         setActiveModelId(model.id);
+        setSelectedModelIds([model.id]);
         console.log(`[SceneCollection] LYS Import successful: ${model.name}`);
       } else {
         const errorMessage = lysImport.error || 'LYS import failed before geometry could be produced.';
@@ -1203,6 +1340,7 @@ export function useSceneCollectionManager() {
 
     setModels(prev => [...prev, model]);
     setActiveModelId(result.modelId);
+    setSelectedModelIds([result.modelId]);
 
     console.log('[SceneCollection] Lychee import complete:', {
       modelId: result.modelId,
@@ -1328,6 +1466,10 @@ export function useSceneCollectionManager() {
     models,
     activeModelId,
     setActiveModelId,
+    selectedModelIds,
+    setSelectedModelIds,
+    selectModel,
+    clearModelSelection,
     activeModel,
 
     // Active Model Compatibility helpers
@@ -1354,6 +1496,11 @@ export function useSceneCollectionManager() {
     updateModelTransforms,
     setModelVisibility,
     renameModel,
+    groupModels,
+    ungroupModels,
+    ungroupGroup,
+    renameGroup,
+    selectGroup,
     deleteModel,
     copyModel,
     cutModel,

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -359,6 +359,7 @@ type ImportProgressState = {
 };
 
 type ModelClipboardEntry = {
+  sourceId: string;
   name: string;
   fileSizeBytes?: number;
   geometry: GeometryWithBounds;
@@ -380,7 +381,7 @@ export function useSceneCollectionManager() {
   const [models, setModels] = useState<LoadedModel[]>([]);
   const [activeModelId, setActiveModelId] = useState<string | null>(null);
   const [selectedModelIds, setSelectedModelIds] = useState<string[]>([]);
-  const [modelClipboard, setModelClipboard] = useState<ModelClipboardEntry | null>(null);
+  const [modelClipboard, setModelClipboard] = useState<ModelClipboardEntry[]>([]);
   const [recentOpenedFiles, setRecentOpenedFiles] = useState<RecentOpenedFileEntry[]>(() => readRecentOpenedFilesFromLocalStorage());
   const [importProgress, setImportProgress] = useState<ImportProgressState>({
     active: false,
@@ -1065,7 +1066,34 @@ export function useSceneCollectionManager() {
     const source = models.find((m) => m.id === id);
     if (!source) return false;
 
-    setModelClipboard({
+    setModelClipboard([
+      {
+        sourceId: source.id,
+        name: source.name,
+        fileSizeBytes: source.fileSizeBytes,
+        geometry: cloneGeometryWithBounds(source.geometry),
+        transform: {
+          position: source.transform.position.clone(),
+          rotation: source.transform.rotation.clone(),
+          scale: source.transform.scale.clone(),
+        },
+        color: source.color,
+        polygonCount: source.polygonCount,
+      },
+    ]);
+
+    return true;
+  }, [cloneGeometryWithBounds, models]);
+
+  const copySelectedModels = useCallback((ids?: string[]) => {
+    const idSet = new Set((ids && ids.length > 0) ? ids : selectedModelIds);
+    if (idSet.size === 0) return false;
+
+    const selected = models.filter((m) => idSet.has(m.id));
+    if (selected.length === 0) return false;
+
+    setModelClipboard(selected.map((source) => ({
+      sourceId: source.id,
       name: source.name,
       fileSizeBytes: source.fileSizeBytes,
       geometry: cloneGeometryWithBounds(source.geometry),
@@ -1076,10 +1104,10 @@ export function useSceneCollectionManager() {
       },
       color: source.color,
       polygonCount: source.polygonCount,
-    });
+    })));
 
     return true;
-  }, [cloneGeometryWithBounds, models]);
+  }, [cloneGeometryWithBounds, models, selectedModelIds]);
 
   const cutModel = useCallback((id: string) => {
     const copied = copyModel(id);
@@ -1089,23 +1117,25 @@ export function useSceneCollectionManager() {
   }, [copyModel, deleteModel]);
 
   const pasteModel = useCallback(() => {
-    if (!modelClipboard) return null;
+    if (modelClipboard.length === 0) return null;
+
+    const first = modelClipboard[0];
 
     const id = generateId();
     const pastedModel: LoadedModel = {
       id,
-      name: `${modelClipboard.name} Copy`,
+      name: `${first.name} Copy`,
       fileUrl: '',
-      fileSizeBytes: modelClipboard.fileSizeBytes,
-      geometry: cloneGeometryWithBounds(modelClipboard.geometry),
+      fileSizeBytes: first.fileSizeBytes,
+      geometry: cloneGeometryWithBounds(first.geometry),
       transform: {
-        position: modelClipboard.transform.position.clone().add(new THREE.Vector3(6, 6, 0)),
-        rotation: modelClipboard.transform.rotation.clone(),
-        scale: modelClipboard.transform.scale.clone(),
+        position: first.transform.position.clone().add(new THREE.Vector3(6, 6, 0)),
+        rotation: first.transform.rotation.clone(),
+        scale: first.transform.scale.clone(),
       },
       visible: true,
-      color: modelClipboard.color,
-      polygonCount: modelClipboard.polygonCount,
+      color: first.color,
+      polygonCount: first.polygonCount,
     };
 
     setModels((prev) => [...prev, pastedModel]);
@@ -1113,6 +1143,58 @@ export function useSceneCollectionManager() {
     setSelectedModelIds([id]);
     return id;
   }, [cloneGeometryWithBounds, generateId, modelClipboard]);
+
+  const pasteCopiedModelsAutoArrange = useCallback((spacingMm = 12) => {
+    if (modelClipboard.length === 0) return [] as string[];
+
+    const entries = modelClipboard;
+
+    const maxWidth = Math.max(...entries.map((entry) => Math.max(2, Math.abs(entry.geometry.size.x * entry.transform.scale.x))));
+    const maxDepth = Math.max(...entries.map((entry) => Math.max(2, Math.abs(entry.geometry.size.y * entry.transform.scale.y))));
+    const stepX = maxWidth + spacingMm;
+    const stepY = maxDepth + spacingMm;
+
+    const count = entries.length;
+    const columns = Math.max(1, Math.ceil(Math.sqrt(count)));
+    const rows = Math.ceil(count / columns);
+
+    const centerX = defaultImportCenterXY.x;
+    const centerY = defaultImportCenterXY.y;
+    const startX = centerX - ((columns - 1) * stepX) * 0.5;
+    const startY = centerY - ((rows - 1) * stepY) * 0.5;
+
+    const createdIds: string[] = [];
+    const pastedModels: LoadedModel[] = entries.map((entry, index) => {
+      const col = index % columns;
+      const row = Math.floor(index / columns);
+      const id = generateId();
+      createdIds.push(id);
+
+      return {
+        id,
+        name: `${entry.name} Copy`,
+        fileUrl: '',
+        fileSizeBytes: entry.fileSizeBytes,
+        geometry: cloneGeometryWithBounds(entry.geometry),
+        transform: {
+          position: new THREE.Vector3(startX + col * stepX, startY + row * stepY, entry.transform.position.z),
+          rotation: entry.transform.rotation.clone(),
+          scale: entry.transform.scale.clone(),
+        },
+        visible: true,
+        color: entry.color,
+        polygonCount: entry.polygonCount,
+      };
+    });
+
+    setModels((prev) => [...prev, ...pastedModels]);
+    if (createdIds.length > 0) {
+      setActiveModelId(createdIds[0]);
+      setSelectedModelIds(createdIds);
+    }
+
+    return createdIds;
+  }, [cloneGeometryWithBounds, defaultImportCenterXY.x, defaultImportCenterXY.y, generateId, modelClipboard]);
 
   const duplicateModelWithTransforms = useCallback((sourceId: string, transforms: ModelTransform[]) => {
     if (transforms.length === 0) return [] as string[];
@@ -1503,10 +1585,12 @@ export function useSceneCollectionManager() {
     selectGroup,
     deleteModel,
     copyModel,
+    copySelectedModels,
     cutModel,
     pasteModel,
+    pasteCopiedModelsAutoArrange,
     duplicateModelWithTransforms,
-    canPasteModel: modelClipboard !== null,
+    canPasteModel: modelClipboard.length > 0,
 
     // Scene settings
     ambientIntensity,

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -7,6 +7,8 @@ import { loadFromLychee } from '@/supports/state';
 import { getSettings } from '@/supports/Settings/state';
 import type { SelectionHighlightMode } from '@/components/selection';
 import { registerDeleteHandler } from '@/features/delete/deleteRegistry';
+import { pushHistory, registerHistoryHandler } from '@/history/historyStore';
+import type { HistoryAction, HistoryDirection } from '@/history/types';
 import type { ModelTransform } from '@/hooks/useModelTransform';
 import type { SupportMode } from '@/supports/types';
 import { useLycheeImport, type LycheeImportResult } from '@/components/lys-import/useLycheeImport';
@@ -55,6 +57,60 @@ const RECENT_OPENED_FILES_LIMIT = 10;
 const RECENT_FILES_DB_NAME = 'dragonfruit-recent-files';
 const RECENT_FILES_DB_VERSION = 1;
 const RECENT_FILES_STORE_NAME = 'files';
+const SCENE_MODELS_SNAPSHOT_APPLY = 'scene_models_snapshot_apply';
+const SCENE_HISTORY_MAX_SNAPSHOTS = 200;
+
+type SceneSnapshotPayload = { key: string };
+
+type SceneSnapshot = {
+  models: LoadedModel[];
+  activeModelId: string | null;
+  selectedModelIds: string[];
+};
+
+type SceneSnapshotPair = {
+  before: SceneSnapshot;
+  after: SceneSnapshot;
+};
+
+const sceneSnapshotRegistry = new Map<string, SceneSnapshotPair>();
+const sceneSnapshotOrder: string[] = [];
+
+function cloneTransform(transform: ModelTransform): ModelTransform {
+  return {
+    position: transform.position.clone(),
+    rotation: transform.rotation.clone(),
+    scale: transform.scale.clone(),
+  };
+}
+
+function cloneLoadedModel(model: LoadedModel): LoadedModel {
+  return {
+    ...model,
+    transform: cloneTransform(model.transform),
+  };
+}
+
+function captureSceneSnapshot(models: LoadedModel[], activeModelId: string | null, selectedModelIds: string[]): SceneSnapshot {
+  return {
+    models: models.map(cloneLoadedModel),
+    activeModelId,
+    selectedModelIds: [...selectedModelIds],
+  };
+}
+
+function storeSceneSnapshotPair(pair: SceneSnapshotPair): string {
+  const key = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  sceneSnapshotRegistry.set(key, pair);
+  sceneSnapshotOrder.push(key);
+
+  while (sceneSnapshotOrder.length > SCENE_HISTORY_MAX_SNAPSHOTS) {
+    const removed = sceneSnapshotOrder.shift();
+    if (removed) sceneSnapshotRegistry.delete(removed);
+  }
+
+  return key;
+}
 
 export type RecentOpenedFileKind = 'mesh' | 'scene';
 
@@ -638,6 +694,40 @@ export function useSceneCollectionManager() {
   const [mode, setMode] = useState<SupportMode>('prepare');
   const [selectionHighlightMode, setSelectionHighlightMode] = useState<SelectionHighlightMode>('spotlight');
 
+  const applySceneSnapshot = useCallback((snapshot: SceneSnapshot) => {
+    setModels(snapshot.models.map(cloneLoadedModel));
+    setActiveModelId(snapshot.activeModelId);
+    setSelectedModelIds([...snapshot.selectedModelIds]);
+  }, []);
+
+  useEffect(() => {
+    const unregisterSceneModelsHistory = registerHistoryHandler(
+      SCENE_MODELS_SNAPSHOT_APPLY,
+      (action: HistoryAction, direction: HistoryDirection) => {
+        const payload = action.payload as SceneSnapshotPayload | undefined;
+        if (!payload?.key) return false;
+
+        const pair = sceneSnapshotRegistry.get(payload.key);
+        if (!pair) return false;
+
+        applySceneSnapshot(direction === 'undo' ? pair.before : pair.after);
+        return true;
+      },
+    );
+
+    return () => {
+      unregisterSceneModelsHistory();
+    };
+  }, [applySceneSnapshot]);
+
+  const pushSceneSnapshotHistory = useCallback((before: SceneSnapshot, after: SceneSnapshot) => {
+    const key = storeSceneSnapshotPair({ before, after });
+    pushHistory({
+      type: SCENE_MODELS_SNAPSHOT_APPLY,
+      payload: { key } satisfies SceneSnapshotPayload,
+    });
+  }, []);
+
   // Helper to generate IDs
   const generateId = () => crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).substring(2, 15);
 
@@ -990,16 +1080,23 @@ export function useSceneCollectionManager() {
   const updateModelTransforms = useCallback((updates: Array<{ id: string; transform: ModelTransform }>) => {
     if (updates.length === 0) return;
 
+    const before = captureSceneSnapshot(models, activeModelId, selectedModelIds);
+
     const updateMap = new Map<string, ModelTransform>();
     updates.forEach((entry) => {
       updateMap.set(entry.id, entry.transform);
     });
 
-    setModels((prev) => prev.map((m) => {
+    const nextModels = models.map((m) => {
       const nextTransform = updateMap.get(m.id);
       return nextTransform ? { ...m, transform: nextTransform } : m;
-    }));
-  }, []);
+    });
+
+    setModels(nextModels);
+
+    const after = captureSceneSnapshot(nextModels, activeModelId, selectedModelIds);
+    pushSceneSnapshotHistory(before, after);
+  }, [activeModelId, models, pushSceneSnapshotHistory, selectedModelIds]);
 
   const setModelVisibility = useCallback((id: string, visible: boolean) => {
     setModels(prev => prev.map(m =>
@@ -1098,28 +1195,42 @@ export function useSceneCollectionManager() {
     });
   }, [models]);
 
-  const deleteModel = useCallback((id: string) => {
-    setModels(prev => {
-      const model = prev.find(m => m.id === id);
-      if (model) {
-        tryRevokeObjectUrl(model.fileUrl);
-      }
-      const newModels = prev.filter(m => m.id !== id);
-      return newModels;
+  const deleteModels = useCallback((idsInput: string[]) => {
+    const ids = new Set(idsInput);
+    if (ids.size === 0) return;
+
+    const existing = models.filter((m) => ids.has(m.id));
+    if (existing.length === 0) return;
+
+    const before = captureSceneSnapshot(models, activeModelId, selectedModelIds);
+
+    existing.forEach((model) => {
+      tryRevokeObjectUrl(model.fileUrl);
     });
 
-    if (activeModelId === id) {
-      setActiveModelId(null);
-    }
+    const nextModels = models.filter((m) => !ids.has(m.id));
+    const nextActiveModelId = activeModelId && ids.has(activeModelId) ? null : activeModelId;
+    const nextSelectedModelIds = selectedModelIds.filter((sid) => !ids.has(sid));
 
-    setSelectedModelIds((prev) => prev.filter((sid) => sid !== id));
+    setModels(nextModels);
+    setActiveModelId(nextActiveModelId);
+    setSelectedModelIds(nextSelectedModelIds);
 
-    // Clean up associated supports
+    const after = captureSceneSnapshot(nextModels, nextActiveModelId, nextSelectedModelIds);
+    pushSceneSnapshotHistory(before, after);
+
+    // Clean up associated supports.
     const supportState = getSnapshot();
-    const removedSupports = deleteSupportsForModel(supportState, id);
-    console.log(`[SceneCollection] Deleted model ${id} and ${removedSupports} associated supports.`);
+    let totalRemovedSupports = 0;
+    ids.forEach((id) => {
+      totalRemovedSupports += deleteSupportsForModel(supportState, id);
+    });
+    console.log(`[SceneCollection] Deleted ${ids.size} model(s) and ${totalRemovedSupports} associated supports.`);
+  }, [activeModelId, models, pushSceneSnapshotHistory, selectedModelIds, tryRevokeObjectUrl]);
 
-  }, [activeModelId]);
+  const deleteModel = useCallback((id: string) => {
+    deleteModels([id]);
+  }, [deleteModels]);
 
   const copyModel = useCallback((id: string) => {
     const source = models.find((m) => m.id === id);
@@ -1178,6 +1289,8 @@ export function useSceneCollectionManager() {
   const pasteModel = useCallback(() => {
     if (modelClipboard.length === 0) return null;
 
+    const before = captureSceneSnapshot(models, activeModelId, selectedModelIds);
+
     const first = modelClipboard[0];
 
     const pastedGeometry = cloneGeometryWithBounds(first.geometry, { accelerate: false });
@@ -1199,16 +1312,22 @@ export function useSceneCollectionManager() {
       polygonCount: first.polygonCount,
     };
 
-    setModels((prev) => [...prev, pastedModel]);
+    const nextModels = [...models, pastedModel];
+    setModels(nextModels);
     setActiveModelId(id);
     setSelectedModelIds([id]);
 
+    const after = captureSceneSnapshot(nextModels, id, [id]);
+    pushSceneSnapshotHistory(before, after);
+
     deferAccelerateGeometry([pastedGeometry]);
     return id;
-  }, [cloneGeometryWithBounds, deferAccelerateGeometry, generateId, modelClipboard]);
+  }, [activeModelId, cloneGeometryWithBounds, deferAccelerateGeometry, generateId, modelClipboard, models, pushSceneSnapshotHistory, selectedModelIds]);
 
   const pasteCopiedModelsAutoArrange = useCallback((spacingMm = 5) => {
     if (modelClipboard.length === 0) return [] as string[];
+
+    const before = captureSceneSnapshot(models, activeModelId, selectedModelIds);
 
     const entries = modelClipboard;
 
@@ -1390,22 +1509,28 @@ export function useSceneCollectionManager() {
       };
     });
 
-    setModels((prev) => [...prev, ...pastedModels]);
+    const nextModels = [...models, ...pastedModels];
+    setModels(nextModels);
     if (createdIds.length > 0) {
       setActiveModelId(createdIds[0]);
       setSelectedModelIds(createdIds);
+
+      const after = captureSceneSnapshot(nextModels, createdIds[0], createdIds);
+      pushSceneSnapshotHistory(before, after);
     }
 
     deferAccelerateGeometry(pastedGeometries);
 
     return createdIds;
-  }, [cloneGeometryWithBounds, defaultImportCenterXY.x, defaultImportCenterXY.y, deferAccelerateGeometry, generateId, modelClipboard, models, view3dSettings.depthMm, view3dSettings.originMode, view3dSettings.widthMm]);
+  }, [activeModelId, cloneGeometryWithBounds, defaultImportCenterXY.x, defaultImportCenterXY.y, deferAccelerateGeometry, generateId, modelClipboard, models, pushSceneSnapshotHistory, selectedModelIds, view3dSettings.depthMm, view3dSettings.originMode, view3dSettings.widthMm]);
 
   const duplicateModelWithTransforms = useCallback((sourceId: string, transforms: ModelTransform[]) => {
     if (transforms.length === 0) return [] as string[];
 
     const source = models.find((m) => m.id === sourceId);
     if (!source) return [] as string[];
+
+    const before = captureSceneSnapshot(models, activeModelId, selectedModelIds);
 
     const resolvedGroupId = source.groupId ?? `group-${generateId()}`;
     const resolvedGroupName = source.groupName ?? source.name;
@@ -1439,29 +1564,32 @@ export function useSceneCollectionManager() {
       };
     });
 
-    setModels((prev) => {
-      const withSourceGroup = prev.map((model) => {
-        if (model.id !== sourceId) return model;
-        if (model.groupId === resolvedGroupId && model.groupName === resolvedGroupName) return model;
-        return {
-          ...model,
-          groupId: resolvedGroupId,
-          groupName: resolvedGroupName,
-        };
-      });
-
-      return [...withSourceGroup, ...newModels];
+    const withSourceGroup = models.map((model) => {
+      if (model.id !== sourceId) return model;
+      if (model.groupId === resolvedGroupId && model.groupName === resolvedGroupName) return model;
+      return {
+        ...model,
+        groupId: resolvedGroupId,
+        groupName: resolvedGroupName,
+      };
     });
+
+    const nextModels = [...withSourceGroup, ...newModels];
+    setModels(nextModels);
 
     if (createdIds.length > 0) {
       setActiveModelId(createdIds[0]);
       setSelectedModelIds([sourceId, ...createdIds]);
+
+      const nextSelected = [sourceId, ...createdIds];
+      const after = captureSceneSnapshot(nextModels, createdIds[0], nextSelected);
+      pushSceneSnapshotHistory(before, after);
     }
 
     deferAccelerateGeometry(duplicatedGeometries);
 
     return createdIds;
-  }, [cloneGeometryWithBounds, deferAccelerateGeometry, generateId, models]);
+  }, [activeModelId, cloneGeometryWithBounds, deferAccelerateGeometry, generateId, models, pushSceneSnapshotHistory, selectedModelIds]);
 
   // NEW: LYS Import (1-step)
   const lysImport = useLysImport();
@@ -1794,6 +1922,7 @@ export function useSceneCollectionManager() {
     ungroupGroup,
     renameGroup,
     selectGroup,
+    deleteModels,
     deleteModel,
     copyModel,
     copySelectedModels,

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -1214,12 +1214,23 @@ export function useSceneCollectionManager() {
 
     const centerX = defaultImportCenterXY.x;
     const centerY = defaultImportCenterXY.y;
+    const minX = view3dSettings.originMode === 'front_left' ? 0 : -view3dSettings.widthMm * 0.5;
+    const maxX = minX + view3dSettings.widthMm;
+    const minY = view3dSettings.originMode === 'front_left' ? 0 : -view3dSettings.depthMm * 0.5;
+    const maxY = minY + view3dSettings.depthMm;
 
     type Rect2D = { minX: number; maxX: number; minY: number; maxY: number };
 
     const intersectsRect = (a: Rect2D, b: Rect2D) => {
       return !(a.maxX <= b.minX || a.minX >= b.maxX || a.maxY <= b.minY || a.minY >= b.maxY);
     };
+
+    const isRectInsidePlate = (rect: Rect2D) => (
+      rect.minX >= minX
+      && rect.maxX <= maxX
+      && rect.minY >= minY
+      && rect.maxY <= maxY
+    );
 
     const footprintFor = (size: THREE.Vector3, transform: ModelTransform) => {
       const baseW = Math.max(2, Math.abs(size.x * transform.scale.x));
@@ -1251,7 +1262,13 @@ export function useSceneCollectionManager() {
       });
 
     const candidateCenters: Array<{ x: number; y: number; distSq: number }> = [];
-    const maxRing = 36;
+    const halfSpanX = Math.max(Math.abs(centerX - minX), Math.abs(maxX - centerX));
+    const halfSpanY = Math.max(Math.abs(centerY - minY), Math.abs(maxY - centerY));
+    const inPlateRingX = Math.ceil(halfSpanX / stepX) + 2;
+    const inPlateRingY = Math.ceil(halfSpanY / stepY) + 2;
+    const maxInPlateRing = Math.max(inPlateRingX, inPlateRingY);
+    const outsideRings = 12;
+    const maxRing = maxInPlateRing + outsideRings;
 
     for (let ring = 0; ring <= maxRing; ring += 1) {
       if (ring === 0) {
@@ -1301,13 +1318,29 @@ export function useSceneCollectionManager() {
     const assignedCenters: Array<{ x: number; y: number }> = entries.map((entry) => {
       const { width, depth } = footprintFor(entry.geometry.size, entry.transform);
 
+      const makeRectAt = (x: number, y: number): Rect2D => ({
+        minX: x - (width * 0.5),
+        maxX: x + (width * 0.5),
+        minY: y - (depth * 0.5),
+        maxY: y + (depth * 0.5),
+      });
+
+      // Pass 1: exhaust all valid in-plate positions first.
       for (const candidate of candidateCenters) {
-        const rect: Rect2D = {
-          minX: candidate.x - (width * 0.5),
-          maxX: candidate.x + (width * 0.5),
-          minY: candidate.y - (depth * 0.5),
-          maxY: candidate.y + (depth * 0.5),
-        };
+        const rect = makeRectAt(candidate.x, candidate.y);
+        if (!isRectInsidePlate(rect)) continue;
+
+        if (blockedRects.some((blocked) => intersectsRect(rect, blocked))) {
+          continue;
+        }
+
+        blockedRects.push(rect);
+        return { x: candidate.x, y: candidate.y };
+      }
+
+      // Pass 2: if in-plate is full, allow outside placements.
+      for (const candidate of candidateCenters) {
+        const rect = makeRectAt(candidate.x, candidate.y);
 
         if (blockedRects.some((blocked) => intersectsRect(rect, blocked))) {
           continue;
@@ -1366,7 +1399,7 @@ export function useSceneCollectionManager() {
     deferAccelerateGeometry(pastedGeometries);
 
     return createdIds;
-  }, [cloneGeometryWithBounds, defaultImportCenterXY.x, defaultImportCenterXY.y, deferAccelerateGeometry, generateId, modelClipboard, models]);
+  }, [cloneGeometryWithBounds, defaultImportCenterXY.x, defaultImportCenterXY.y, deferAccelerateGeometry, generateId, modelClipboard, models, view3dSettings.depthMm, view3dSettings.originMode, view3dSettings.widthMm]);
 
   const duplicateModelWithTransforms = useCallback((sourceId: string, transforms: ModelTransform[]) => {
     if (transforms.length === 0) return [] as string[];

--- a/src/hooks/useModelTransform.ts
+++ b/src/hooks/useModelTransform.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import * as THREE from 'three';
 
-export type TransformMode = 'select' | 'transform' | 'smoothing';
+export type TransformMode = 'select' | 'transform' | 'smoothing' | 'arrange' | 'duplicate';
 
 export interface ModelTransform {
   position: THREE.Vector3;

--- a/src/hotkeys/hotkeyConfig.ts
+++ b/src/hotkeys/hotkeyConfig.ts
@@ -70,6 +70,28 @@ export const DEFAULT_KEYBINDINGS: HotkeyConfig = {
             description: 'Toggle camera projection (Orthographic / Perspective)'
         }
     },
+    CANVAS: {
+        TOOL_SELECT: {
+            key: 'q',
+            description: 'Switch canvas tool to Select'
+        },
+        TOOL_MODIFY: {
+            key: 'm',
+            description: 'Switch canvas tool to Modify'
+        },
+        TOOL_SMOOTH: {
+            key: 's',
+            description: 'Switch canvas tool to Smooth'
+        },
+        TOOL_ARRANGE: {
+            key: 'a',
+            description: 'Switch canvas tool to Arrange'
+        },
+        TOOL_DUPLICATE: {
+            key: 'd',
+            description: 'Switch canvas tool to Duplicate'
+        }
+    },
     PRESETS: {
         APPLY_DETAIL: {
             key: '1',

--- a/src/hotkeys/usePrepareTransformHotkeys.ts
+++ b/src/hotkeys/usePrepareTransformHotkeys.ts
@@ -6,7 +6,9 @@ import { matchesConfiguredHotkeyDown } from './hotkeyConfig';
 type UsePrepareTransformHotkeysParams = {
   appMode: 'prepare' | 'analysis' | 'support' | 'export';
   hasModels: boolean;
+  transformMode: TransformMode;
   setTransformMode: (mode: TransformMode) => void;
+  onArrangeAll: () => void;
 };
 
 function isEditableElement(target: EventTarget | null): boolean {
@@ -22,7 +24,9 @@ function isEditableElement(target: EventTarget | null): boolean {
 export function usePrepareTransformHotkeys({
   appMode,
   hasModels,
+  transformMode,
   setTransformMode,
+  onArrangeAll,
 }: UsePrepareTransformHotkeysParams) {
   const { getHotkey } = useHotkeyConfig();
   const selectKey = getHotkey('CANVAS', 'TOOL_SELECT');
@@ -58,7 +62,11 @@ export function usePrepareTransformHotkeys({
 
       if (matchesConfiguredHotkeyDown(event, { key: arrangeKey.key, modifier: arrangeKey.modifier })) {
         event.preventDefault();
-        setTransformMode('arrange');
+        if (transformMode === 'arrange') {
+          onArrangeAll();
+        } else {
+          setTransformMode('arrange');
+        }
         return;
       }
 
@@ -73,7 +81,9 @@ export function usePrepareTransformHotkeys({
   }, [
     appMode,
     hasModels,
+    transformMode,
     setTransformMode,
+    onArrangeAll,
     selectKey,
     modifyKey,
     smoothKey,

--- a/src/hotkeys/usePrepareTransformHotkeys.ts
+++ b/src/hotkeys/usePrepareTransformHotkeys.ts
@@ -1,0 +1,83 @@
+import { useEffect } from 'react';
+import type { TransformMode } from '@/hooks/useModelTransform';
+import { useHotkeyConfig } from './HotkeyContext';
+import { matchesConfiguredHotkeyDown } from './hotkeyConfig';
+
+type UsePrepareTransformHotkeysParams = {
+  appMode: 'prepare' | 'analysis' | 'support' | 'export';
+  hasModels: boolean;
+  setTransformMode: (mode: TransformMode) => void;
+};
+
+function isEditableElement(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+
+  return Boolean(target.closest('input, textarea, select, [contenteditable="true"]'));
+}
+
+export function usePrepareTransformHotkeys({
+  appMode,
+  hasModels,
+  setTransformMode,
+}: UsePrepareTransformHotkeysParams) {
+  const { getHotkey } = useHotkeyConfig();
+  const selectKey = getHotkey('CANVAS', 'TOOL_SELECT');
+  const modifyKey = getHotkey('CANVAS', 'TOOL_MODIFY');
+  const smoothKey = getHotkey('CANVAS', 'TOOL_SMOOTH');
+  const arrangeKey = getHotkey('CANVAS', 'TOOL_ARRANGE');
+  const duplicateKey = getHotkey('CANVAS', 'TOOL_DUPLICATE');
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (appMode !== 'prepare') return;
+      if (!hasModels) return;
+      if (event.repeat) return;
+      if (isEditableElement(event.target)) return;
+
+      if (matchesConfiguredHotkeyDown(event, { key: selectKey.key, modifier: selectKey.modifier })) {
+        event.preventDefault();
+        setTransformMode('select');
+        return;
+      }
+
+      if (matchesConfiguredHotkeyDown(event, { key: modifyKey.key, modifier: modifyKey.modifier })) {
+        event.preventDefault();
+        setTransformMode('transform');
+        return;
+      }
+
+      if (matchesConfiguredHotkeyDown(event, { key: smoothKey.key, modifier: smoothKey.modifier })) {
+        event.preventDefault();
+        setTransformMode('smoothing');
+        return;
+      }
+
+      if (matchesConfiguredHotkeyDown(event, { key: arrangeKey.key, modifier: arrangeKey.modifier })) {
+        event.preventDefault();
+        setTransformMode('arrange');
+        return;
+      }
+
+      if (matchesConfiguredHotkeyDown(event, { key: duplicateKey.key, modifier: duplicateKey.modifier })) {
+        event.preventDefault();
+        setTransformMode('duplicate');
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
+  }, [
+    appMode,
+    hasModels,
+    setTransformMode,
+    selectKey,
+    modifyKey,
+    smoothKey,
+    arrangeKey,
+    duplicateKey,
+  ]);
+}

--- a/src/hotkeys/useUndoRedoHotkeys.ts
+++ b/src/hotkeys/useUndoRedoHotkeys.ts
@@ -16,7 +16,16 @@ export function useUndoRedoHotkeys() {
       if (isTextInput(event.target)) return;
       const isMeta = event.metaKey || event.ctrlKey;
       if (!isMeta) return;
-      if (event.key.toLowerCase() !== UNIVERSAL_HOTKEYS.UNDO.key) return;
+      const key = event.key.toLowerCase();
+
+      // Windows/Linux-friendly redo shortcut.
+      if (key === 'y') {
+        event.preventDefault();
+        redo();
+        return;
+      }
+
+      if (key !== UNIVERSAL_HOTKEYS.UNDO.key) return;
 
       event.preventDefault();
       if (event.shiftKey) {

--- a/src/supports/Settings/AnatomyPreview/AnatomyPreviewCameraLogic.ts
+++ b/src/supports/Settings/AnatomyPreview/AnatomyPreviewCameraLogic.ts
@@ -1,6 +1,12 @@
 import type { SupportKind } from '../supportKindState';
 import type { CameraFocusState } from './AnatomyPreviewCameraTypes';
-import { getSupportTargetFocusState, SUPPORT_HOME_FOCUS_STATE, TRUNK_HOME_FOCUS_STATE } from './PreviewTypes/Trunk/camera';
+import {
+    getStickTargetFocusState,
+    getSupportTargetFocusState,
+    getTwigTargetFocusState,
+    SUPPORT_HOME_FOCUS_STATE,
+    TRUNK_HOME_FOCUS_STATE,
+} from './PreviewTypes/Trunk/camera';
 import { getRaftTargetFocusState, RAFT_HOME_FOCUS_STATE } from './PreviewTypes/Raft/camera';
 import { getGridTargetFocusState } from './PreviewTypes/Grid/camera';
 
@@ -12,6 +18,8 @@ export { RAFT_HOME_FOCUS_STATE };
 export function getTargetFocusState(kind: SupportKind, key: string | null): CameraFocusState {
     if (kind === 'raft') return getRaftTargetFocusState(key);
     if (kind === 'grid') return getGridTargetFocusState(key);
+    if (kind === 'stick') return getStickTargetFocusState(key);
+    if (kind === 'twig') return getTwigTargetFocusState(key);
     if (kind === 'trunk' && !key) return TRUNK_HOME_FOCUS_STATE;
     return getSupportTargetFocusState(key);
 }

--- a/src/supports/Settings/AnatomyPreview/PreviewTypes/Grid/camera.ts
+++ b/src/supports/Settings/AnatomyPreview/PreviewTypes/Grid/camera.ts
@@ -1,6 +1,7 @@
 export const GRID_HOME_FOCUS_STATE = {
-    position: [22.3, -41.73, 25.19] as [number, number, number],
-    target: [-1.27, 3.34, 4.56] as [number, number, number],
+    // Slightly raised framing target so the grid preview content sits lower in the viewport.
+    position: [22.3, -41.73, 26.8] as [number, number, number],
+    target: [-1.27, 3.34, 0.0] as [number, number, number],
     zoom: 11.98
 };
 

--- a/src/supports/Settings/AnatomyPreview/PreviewTypes/Trunk/camera.ts
+++ b/src/supports/Settings/AnatomyPreview/PreviewTypes/Trunk/camera.ts
@@ -13,6 +13,18 @@ export const TRUNK_HOME_FOCUS_STATE: CameraFocusState = {
     zoom: 30,
 };
 
+export const STICK_HOME_FOCUS_STATE: CameraFocusState = {
+    position: [0, -49.53, 10],
+    target: [0, 0, 9.2],
+    zoom: 23,
+};
+
+export const TWIG_HOME_FOCUS_STATE: CameraFocusState = {
+    position: [0, -49.53, 10],
+    target: [0, 0, 9.2],
+    zoom: 23,
+};
+
 export const TIP_FOCUS_STATE: CameraFocusState = {
     position: [1.66, -49.25, 10],
     target: [1.66, 0.28, 14.9],
@@ -55,4 +67,13 @@ export const SUPPORT_CAMERA_FOCUS_MAP: Record<string, CameraFocusState> = {
 export function getSupportTargetFocusState(key: string | null): CameraFocusState {
     if (!key) return SUPPORT_HOME_FOCUS_STATE;
     return SUPPORT_CAMERA_FOCUS_MAP[key] || SUPPORT_HOME_FOCUS_STATE;
+}
+
+export function getStickTargetFocusState(_key: string | null): CameraFocusState {
+    // Stick preview has dual contact points and should avoid aggressive parameter-specific zoom jumps.
+    return STICK_HOME_FOCUS_STATE;
+}
+
+export function getTwigTargetFocusState(_key: string | null): CameraFocusState {
+    return TWIG_HOME_FOCUS_STATE;
 }

--- a/src/supports/Settings/AnatomyPreview/SupportAnatomyPreviewCanvas.tsx
+++ b/src/supports/Settings/AnatomyPreview/SupportAnatomyPreviewCanvas.tsx
@@ -443,6 +443,7 @@ function PreviewContent({
 
         // --- Dynamic Zoom Logic for Tip Contact Diameter Only ---
         const isContactDiameterFocus = previewState.activeSettingKey === 'tip.contactDiameterMm';
+        const isStickLikeKind = activeKind === 'stick' || activeKind === 'twig';
 
         // Strict scope: ONLY 'tip.contactDiameterMm' triggers dynamic zoom
         // Previously we checked startsWith('tip.'), which caused snapback on other tip settings
@@ -456,8 +457,8 @@ function PreviewContent({
             const diam = liveConfigRef.current.tipContactDiameterMm;
             const minDia = 0.12;
             const maxDia = 1.0;
-            const maxZoom = 140; // Zoom for small diameter
-            const minZoom = 35;  // Zoom for large diameter
+            const maxZoom = isStickLikeKind ? 38 : 140; // Zoom for small diameter
+            const minZoom = isStickLikeKind ? 24 : 35;  // Zoom for large diameter
 
             if (diam <= minDia) {
                 finalZoom = maxZoom;
@@ -471,39 +472,41 @@ function PreviewContent({
                 finalZoom = maxZoom + t * (minZoom - maxZoom);
             }
 
-            const internalAngle = Math.abs(liveConfigRef.current.coneAngleDeg);
-            const angleRad = THREE.MathUtils.degToRad(internalAngle);
+            if (!isStickLikeKind) {
+                const internalAngle = Math.abs(liveConfigRef.current.coneAngleDeg);
+                const angleRad = THREE.MathUtils.degToRad(internalAngle);
 
-            const nx = Math.cos(angleRad);
-            const nz = Math.sin(angleRad);
+                const nx = Math.cos(angleRad);
+                const nz = Math.sin(angleRad);
 
-            const tipNormal = { x: -nx, y: 0, z: -nz };
+                const tipNormal = { x: -nx, y: 0, z: -nz };
 
-            const tipProfile: SupportTipProfile = {
-                type: 'disk',
-                contactDiameterMm: liveConfigRef.current.tipContactDiameterMm,
-                bodyDiameterMm: settings.shaft.diameterMm,
-                lengthMm: liveConfigRef.current.tipLengthMm,
-                penetrationMm: settings.tip.penetrationMm,
-                diskThicknessMm: settings.tip.diskThicknessMm ?? 0.1,
-                maxStandoffMm: settings.tip.maxStandoffMm ?? 1.5,
-                standoffAngleThreshold: settings.tip.standoffAngleThreshold ?? (Math.PI / 4),
-            };
+                const tipProfile: SupportTipProfile = {
+                    type: 'disk',
+                    contactDiameterMm: liveConfigRef.current.tipContactDiameterMm,
+                    bodyDiameterMm: settings.shaft.diameterMm,
+                    lengthMm: liveConfigRef.current.tipLengthMm,
+                    penetrationMm: settings.tip.penetrationMm,
+                    diskThicknessMm: settings.tip.diskThicknessMm ?? 0.1,
+                    maxStandoffMm: settings.tip.maxStandoffMm ?? 1.5,
+                    standoffAngleThreshold: settings.tip.standoffAngleThreshold ?? (Math.PI / 4),
+                };
 
-            const coneAngleMode = settings.tip.coneAngleMode ?? 'normal';
-            const adaptiveConeAngleOffsetDeg = settings.tip.adaptiveConeAngleOffsetDeg ?? 30;
+                const coneAngleMode = settings.tip.coneAngleMode ?? 'normal';
+                const adaptiveConeAngleOffsetDeg = settings.tip.adaptiveConeAngleOffsetDeg ?? 30;
 
-            const { coneAxis } = resolveConeAxisPolicy({
-                surfaceNormal: tipNormal,
-                coneAngleMode,
-                adaptiveConeAngleOffsetDeg,
-            });
+                const { coneAxis } = resolveConeAxisPolicy({
+                    surfaceNormal: tipNormal,
+                    coneAngleMode,
+                    adaptiveConeAngleOffsetDeg,
+                });
 
-            const diskThickness = calculateDiskThickness(tipNormal, coneAxis, tipProfile);
-            const tipX = -(tipNormal.x * diskThickness + coneAxis.x * tipProfile.lengthMm);
-            const dx = tipX - targetFocus.target[0];
+                const diskThickness = calculateDiskThickness(tipNormal, coneAxis, tipProfile);
+                const tipX = -(tipNormal.x * diskThickness + coneAxis.x * tipProfile.lengthMm);
+                const dx = tipX - targetFocus.target[0];
 
-            finalPosition[0] = targetFocus.position[0] + dx;
+                finalPosition[0] = targetFocus.position[0] + dx;
+            }
         }
 
         // --- Dynamic Zoom/Target Logic for Tip Length/Angle ---
@@ -512,7 +515,7 @@ function PreviewContent({
         // We clone here because we might modify it
         let finalTarget = [...targetFocus.target] as [number, number, number];
 
-        if (isContactDiameterFocus) {
+        if (isContactDiameterFocus && !isStickLikeKind) {
             const dx = finalPosition[0] - targetFocus.position[0];
             finalTarget[0] = targetFocus.target[0] + dx;
         }

--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -307,14 +307,12 @@ export function SupportSidebar() {
                     </div>
                 ) : activeKind === 'grid' ? (
                     <div className="space-y-2.5">
-                        <div className="flex gap-2.5">
-                            {renderPreviewBox('h-auto min-h-[220px]', 'flex-1 min-w-0')}
-                            <div className="flex-1 min-w-0 rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-                                <GridSettingsCard
-                                    grid={settings.grid}
-                                    onChange={(partial) => updateGridSettings(partial)}
-                                />
-                            </div>
+                        {renderPreviewBox('h-[212px]')}
+                        <div className="rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+                            <GridSettingsCard
+                                grid={settings.grid}
+                                onChange={(partial) => updateGridSettings(partial)}
+                            />
                         </div>
                     </div>
                 ) : (

--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -317,10 +317,16 @@ export function SupportSidebar() {
                     </div>
                 ) : (
                     <div className="space-y-2.5">
-                        <div className="flex gap-2.5">
-                            {renderPreviewBox('h-auto min-h-[340px]', 'flex-1 min-w-0')}
+                        <div className={activeKind === 'stick' ? 'space-y-2.5' : 'flex gap-2.5'}>
+                            {renderPreviewBox(
+                                activeKind === 'stick' ? 'h-[212px]' : 'h-auto min-h-[340px]',
+                                activeKind === 'stick' ? 'w-full' : 'flex-1 min-w-0'
+                            )}
 
-                            <div className="flex-1 min-w-0 rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+                            <div
+                                className={activeKind === 'stick' ? 'w-full rounded-md border p-2.5' : 'flex-1 min-w-0 rounded-md border p-2.5'}
+                                style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+                            >
                             <div className="space-y-2">
                                 <div className="text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
                                     Support Geometry


### PR DESCRIPTION
## Buckle up, it's another big one!

With this PR, we're introducing several Workspace (Canvas) Improvements, including:

### Multi-Select and Model Grouping
<img width="310" height="447" alt="image" src="https://github.com/user-attachments/assets/86c6e5d8-94a9-4873-8d9d-0eb192ee819c" />

**It is now possible to select multiple models at once, and even group them in the Models list!**

### Arrange
<img width="306" height="403" alt="image" src="https://github.com/user-attachments/assets/c6a64e6d-51b2-45d8-acb7-1ae9c521605d" />

**The new Arrange tool allows to select multiple models or model groups, and arrange them. Either using automatic mode, or using a manually set matrix size.**

### Duplicate
<img width="1696" height="1260" alt="image" src="https://github.com/user-attachments/assets/608a9483-2b03-4899-8dac-f871de4b278e" />

**The new Duplication tool allows us to easily visualize and duplicate models, which will automatically group them. Ghost Previews, spooky!**

## Other Workspace Improvements
- Spotlight mode for Supports, Mesh Tint for other workspaces, configurable.
- Copy Pasting Models is now allowed.
- Use CTRL-A to select all models and mass delete!
- Out-of-Bounds models will now be marked as such in the Models list!
- New keybinds for all Canvas Tools
- Auto-Zoom to active model in Support workspace
- Culling for inactive models in Support workspace

### New Keybinds
| Function Name | Key |
|------------------|-----|
| Select                | Q   |
| Modify              | M   |
| Smooth            | S     |
| Arrange            | A    |
| Duplicate          | D   |

### Enjoy! 👻 