### PR TITLE
Feature: Auto-bracing v2 (MST, Mesh Clearance, X-Patterns)

### DIFF
--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -14,6 +14,7 @@ import type { SupportMode } from '@/supports/types';
 import { useLycheeImport, type LycheeImportResult } from '@/components/lys-import/useLycheeImport';
 import { useLysImport } from '@/components/lys-import/useLysImport';
 import { accelerateGeometry, disposeGeometryBVH } from '@/utils/bvh';
+import { registerMeshForAutoBrace, unregisterMeshForAutoBrace } from '@/supports/autoBracing/meshGeometryStore';
 import type { MatcapVariant, MeshShaderType } from '@/features/shaders/mesh';
 import {
   DEFAULT_VIEW3D_SETTINGS,
@@ -1945,6 +1946,24 @@ export function useSceneCollectionManager() {
 
     trackedGeometriesRef.current = next;
   }, [modelClipboard, models]);
+
+  // Sync model geometries into the auto-brace mesh store so clearance checks can access them.
+  useEffect(() => {
+    const currentIds = new Set(models.map((m) => m.id));
+    for (const model of models) {
+      const matrix = new THREE.Matrix4().compose(
+        model.transform.position,
+        new THREE.Quaternion().setFromEuler(model.transform.rotation),
+        model.transform.scale,
+      );
+      registerMeshForAutoBrace(model.id, model.geometry.geometry, matrix);
+    }
+    return () => {
+      for (const id of currentIds) {
+        unregisterMeshForAutoBrace(id);
+      }
+    };
+  }, [models]);
 
   useEffect(() => {
     return () => {

--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useSyncExternalStore } from 'react';
 import { Save, RotateCcw } from 'lucide-react';
 import { usePresetHotkeys } from '@/hotkeys/usePresetHotkeys';
 import {
@@ -14,6 +14,8 @@ import {
     updateShaftProfile,
     updateRootsProfile,
     updateJointProfile,
+    updateGridSettings,
+    updateAutoBracingSettings,
 } from './state';
 import { checkPresetDrift } from './presets';
 import { createDefaultSettings } from './types';
@@ -26,6 +28,8 @@ import {
 import { Button } from '@/components/ui/primitives';
 import { NumberInput } from '@/components/ui/NumberInput';
 import { SupportAnatomyPreviewSlot } from './AnatomyPreview/SupportAnatomyPreviewSlot';
+import { AutoBracingSettingsCard } from '../autoBracing/AutoBracingSettingsCard';
+import { runAutoBracing } from '../autoBracing/autoBrace';
 import { setAnatomyPreviewActiveSettingKey, setAnatomyPreviewShowTuner, subscribeToAnatomyPreviewState, getAnatomyPreviewState } from './AnatomyPreview/previewState';
 import {
     getSupportKindSnapshot,
@@ -38,7 +42,6 @@ import {
     setRaftSettings,
     updateRaftSettings,
 } from '../Rafts/Crenelated/RaftState';
-import { updateGridSettings } from './state';
 import { DEFAULT_RAFT_SETTINGS } from '../Rafts/Crenelated/RaftDefaults';
 
 /**
@@ -49,8 +52,9 @@ import { DEFAULT_RAFT_SETTINGS } from '../Rafts/Crenelated/RaftDefaults';
  */
 export function SupportSidebar() {
     usePresetHotkeys();
-    const [settings, setLocalSettings] = useState(() => getSettings());
+    const settings = useSyncExternalStore(subscribeToSettings, getSettings, getSettings);
     const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'error'>('idle');
+    const [autoBraceStatus, setAutoBraceStatus] = useState<{ kind: 'success' | 'warning' | 'error'; message: string } | null>(null);
     const [baseViewportScale, setBaseViewportScale] = useState(1);
     const [appliedCompactScale, setAppliedCompactScale] = useState(1);
     const [isCompactLayout, setIsCompactLayout] = useState(false);
@@ -126,12 +130,10 @@ export function SupportSidebar() {
             console.error('[SupportSidebar] Failed to load raft settings:', err);
         }
 
-        setLocalSettings(getSettings());
+        checkPresetDrift(getSettings());
 
         const unsubscribeSettings = subscribeToSettings(() => {
-            const current = getSettings();
-            setLocalSettings(current);
-            checkPresetDrift(current);
+            checkPresetDrift(getSettings());
         });
         return () => {
             unsubscribeSettings();
@@ -230,6 +232,26 @@ export function SupportSidebar() {
         setAnatomyPreviewActiveSettingKey(null);
     }, []);
 
+    const handleAutoBrace = React.useCallback(() => {
+        try {
+            const result = runAutoBracing();
+            if (!result.changed) {
+                setAutoBraceStatus({ kind: 'warning', message: result.message });
+            } else if (result.underQualifiedSupportCount > 0) {
+                setAutoBraceStatus({ kind: 'warning', message: result.message });
+            } else {
+                setAutoBraceStatus({ kind: 'success', message: result.message });
+            }
+        } catch (err) {
+            console.error('[SupportSidebar] Auto Brace failed:', err);
+            setAutoBraceStatus({ kind: 'error', message: 'Auto Brace failed. Check console for details.' });
+        }
+
+        window.setTimeout(() => {
+            setAutoBraceStatus(null);
+        }, 2800);
+    }, []);
+
     const getInputProps = (key: string, baseClass: string) => {
         const isActive = activeKey === key;
         if (isActive) {
@@ -315,16 +337,28 @@ export function SupportSidebar() {
                             />
                         </div>
                     </div>
+                ) : activeKind === 'stick' ? (
+                    <div className="space-y-2.5">
+                        {renderPreviewBox('h-[240px]')}
+                        <div className="rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+                            <AutoBracingSettingsCard
+                                settings={settings.autoBracing}
+                                onChange={(partial) => updateAutoBracingSettings(partial)}
+                                onAutoBrace={handleAutoBrace}
+                                status={autoBraceStatus}
+                            />
+                        </div>
+                    </div>
                 ) : (
                     <div className="space-y-2.5">
-                        <div className={activeKind === 'stick' ? 'space-y-2.5' : 'flex gap-2.5'}>
+                        <div className="flex gap-2.5">
                             {renderPreviewBox(
-                                activeKind === 'stick' ? 'h-[212px]' : 'h-auto min-h-[340px]',
-                                activeKind === 'stick' ? 'w-full' : 'flex-1 min-w-0'
+                                'h-auto min-h-[340px]',
+                                'flex-1 min-w-0'
                             )}
 
                             <div
-                                className={activeKind === 'stick' ? 'w-full rounded-md border p-2.5' : 'flex-1 min-w-0 rounded-md border p-2.5'}
+                                className="flex-1 min-w-0 rounded-md border p-2.5"
                                 style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
                             >
                             <div className="space-y-2">
@@ -345,7 +379,7 @@ export function SupportSidebar() {
                                         />
                                     </div>
 
-                                    {(activeKind === 'trunk' || activeKind === 'branch' || activeKind === 'leaf' || activeKind === 'stick') && (
+                                    {(activeKind === 'trunk' || activeKind === 'branch' || activeKind === 'leaf') && (
                                         <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('tip.lengthMm')}>
                                             <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Contact cone length</div>
                                             <NumberInput
@@ -359,7 +393,7 @@ export function SupportSidebar() {
                                         </div>
                                     )}
 
-                                    {(activeKind === 'trunk' || activeKind === 'branch' || activeKind === 'leaf' || activeKind === 'stick') && (
+                                    {(activeKind === 'trunk' || activeKind === 'branch' || activeKind === 'leaf') && (
                                         <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('tip.coneAngleMode')}>
                                             <div
                                                 className={
@@ -403,10 +437,10 @@ export function SupportSidebar() {
                                         </div>
                                     )}
 
-                                    {(activeKind === 'trunk' || activeKind === 'branch' || activeKind === 'stick') && (
+                                    {(activeKind === 'trunk' || activeKind === 'branch') && (
                                         <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('shaft.diameterMm')}>
                                             <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>
-                                                {activeKind === 'stick' ? 'Stick diameter' : 'Trunk diameter'}
+                                                Trunk diameter
                                             </div>
                                             <NumberInput
                                                 value={settings.shaft.diameterMm}

--- a/src/supports/Settings/components/SupportKindTabs.tsx
+++ b/src/supports/Settings/components/SupportKindTabs.tsx
@@ -14,7 +14,7 @@ const TABS: TabDef[] = [
     { kind: 'trunk', label: 'Trunk', icon: Pickaxe },
     { kind: 'raft', label: 'Raft', icon: Sailboat },
     { kind: 'grid', label: 'Grid', icon: Grid3X3 },
-    { kind: 'stick', label: 'Stick', icon: WandSparkles },
+    { kind: 'stick', label: 'Bracing', icon: WandSparkles },
 ];
 
 export function SupportKindTabs({

--- a/src/supports/Settings/index.ts
+++ b/src/supports/Settings/index.ts
@@ -15,6 +15,7 @@ export type {
     PresetCollection,
 } from './types';
 export { createDefaultSettings } from './types';
+export type { AutoBracingSettings, AutoBracingPattern } from '../autoBracing/settings';
 
 // State
 export {
@@ -26,6 +27,7 @@ export {
     getJointProfile,
     getGridSettings,
     getMeshToMeshSettings,
+    getAutoBracingSettings,
     setSettings,
     updateTipProfile,
     updateShaftProfile,
@@ -34,6 +36,7 @@ export {
     updateJointProfile,
     updateGridSettings,
     updateMeshToMeshSettings,
+    updateAutoBracingSettings,
     subscribeToSettings,
     getSettingsSnapshot,
 } from './state';

--- a/src/supports/Settings/presets.ts
+++ b/src/supports/Settings/presets.ts
@@ -6,6 +6,7 @@
 
 import { SupportPreset, PresetCollection, SupportSettings, createDefaultSettings } from './types';
 import { getSettings, setSettings } from './state';
+import { createDefaultAutoBracingSettings } from '../autoBracing/settings';
 
 // --- Built-in Presets ---
 
@@ -60,6 +61,7 @@ const DETAIL_PRESET: SupportPreset = {
         meshToMesh: {
             stickVsTwigCutoffMm: 5.0,
         },
+        autoBracing: createDefaultAutoBracingSettings(),
     },
 };
 
@@ -124,6 +126,7 @@ const ANCHOR_PRESET: SupportPreset = {
         meshToMesh: {
             stickVsTwigCutoffMm: 5.0,
         },
+        autoBracing: createDefaultAutoBracingSettings(),
     },
 };
 
@@ -330,6 +333,10 @@ export function setActivePreset(id: string | null): void {
             adaptiveConeAngleOffsetDeg: current.tip.adaptiveConeAngleOffsetDeg,
             coneAngleDeg: current.tip.coneAngleDeg,
         },
+        // Preserve current Auto Bracing settings
+        autoBracing: {
+            ...current.autoBracing,
+        },
     });
 
     savePresetsToStorage();
@@ -360,7 +367,10 @@ export function savePreset(id: string): void {
             coneAngleMode: existingPreset.settings.tip.coneAngleMode,
             adaptiveConeAngleOffsetDeg: existingPreset.settings.tip.adaptiveConeAngleOffsetDeg,
             coneAngleDeg: existingPreset.settings.tip.coneAngleDeg,
-        }
+        },
+        autoBracing: {
+            ...existingPreset.settings.autoBracing,
+        },
     };
 
     presets.byId[id] = {

--- a/src/supports/Settings/state.ts
+++ b/src/supports/Settings/state.ts
@@ -6,6 +6,10 @@
  */
 
 import { SupportSettings, createDefaultSettings } from './types';
+import {
+    applyAutoBracingSettingsPatch,
+    normalizeAutoBracingSettings,
+} from '../autoBracing/settings';
 
 // --- Store ---
 
@@ -36,6 +40,11 @@ function mergeWithDefaults(settings: SupportSettings): SupportSettings {
         attachSearchStepMm: coerceNumber((mergedGridRaw as any).attachSearchStepMm, defaults.grid.attachSearchStepMm),
     };
 
+    const mergedAutoBracing = normalizeAutoBracingSettings({
+        ...defaults.autoBracing,
+        ...((settings as any).autoBracing ?? {}),
+    });
+
     return {
         ...defaults,
         ...settings,
@@ -46,6 +55,7 @@ function mergeWithDefaults(settings: SupportSettings): SupportSettings {
         joint: { ...defaults.joint, ...settings.joint },
         grid: mergedGrid,
         meshToMesh: { ...defaults.meshToMesh, ...(settings as any).meshToMesh },
+        autoBracing: mergedAutoBracing,
     };
 }
 
@@ -94,6 +104,10 @@ export function getGridSettings() {
 
 export function getMeshToMeshSettings() {
     return currentSettings.meshToMesh;
+}
+
+export function getAutoBracingSettings() {
+    return currentSettings.autoBracing;
 }
 
 // --- Setters ---
@@ -155,6 +169,14 @@ export function updateMeshToMeshSettings(meshToMesh: Partial<SupportSettings['me
     currentSettings = {
         ...currentSettings,
         meshToMesh: { ...currentSettings.meshToMesh, ...meshToMesh },
+    };
+    notify();
+}
+
+export function updateAutoBracingSettings(autoBracing: Partial<SupportSettings['autoBracing']>): void {
+    currentSettings = {
+        ...currentSettings,
+        autoBracing: applyAutoBracingSettingsPatch(currentSettings.autoBracing, autoBracing),
     };
     notify();
 }

--- a/src/supports/Settings/types.ts
+++ b/src/supports/Settings/types.ts
@@ -32,6 +32,10 @@ import {
     DEFAULT_GRID_ATTACH_SEARCH_STEP_MM,
     DEFAULT_MESH_TO_MESH_STICK_VS_TWIG_CUTOFF_MM,
 } from './defaults';
+import {
+    createDefaultAutoBracingSettings,
+    type AutoBracingSettings,
+} from '../autoBracing/settings';
 
 // --- Profile Types ---
 
@@ -107,6 +111,7 @@ export interface SupportSettings {
     joint: JointProfile;
     grid: GridSettings;
     meshToMesh: MeshToMeshSettings;
+    autoBracing: AutoBracingSettings;
 }
 
 // --- Default Factory ---
@@ -164,6 +169,7 @@ export function createDefaultSettings(): SupportSettings {
         meshToMesh: {
             stickVsTwigCutoffMm: DEFAULT_MESH_TO_MESH_STICK_VS_TWIG_CUTOFF_MM,
         },
+        autoBracing: createDefaultAutoBracingSettings(),
     };
 }
 

--- a/src/supports/SupportRenderer.tsx
+++ b/src/supports/SupportRenderer.tsx
@@ -21,6 +21,7 @@ import { BezierGizmoManager } from './Curves/BezierGizmo/BezierGizmoManager';
 import { SupportMode } from './types';
 import { useJointCreationState } from './SupportPrimitives/Joint/jointCreationState';
 import { useSupportHistoryHandlers } from './history/useSupportHistoryHandlers';
+import { subscribeToSettings, getSettingsSnapshot } from './Settings/state';
 
 interface SupportRendererProps {
     mode?: SupportMode;
@@ -31,6 +32,7 @@ interface SupportRendererProps {
 
 export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ mode, hidePlateContactPrimitives = false, clipLower, clipUpper }, ref) => {
     const state = useSyncExternalStore(subscribe, getSnapshot);
+    const settings = useSyncExternalStore(subscribeToSettings, getSettingsSnapshot, getSettingsSnapshot);
     const supportBraceState = useSupportBraceStoreState();
     const { isActive: isJointCreationActive } = useJointCreationState();
     const { altActive: braceAltActive } = useBracePlacementState();
@@ -276,6 +278,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                         showKnots={showKnots}
                         suppressHover={suppressHover}
                         isInteractable={isInteractable}
+                        debugSectionColors={settings.autoBracing.debugSectionColorsEnabled}
                     />
                 );
             })}

--- a/src/supports/SupportTypes/Brace/BraceRenderer.tsx
+++ b/src/supports/SupportTypes/Brace/BraceRenderer.tsx
@@ -9,6 +9,12 @@ import { BezierRenderer } from '../../Renderers/BezierRenderer';
 import { usePicking } from '@/components/picking';
 import { setSelectedId } from '../../state';
 
+const DEBUG_SECTION_COLORS: Record<string, string> = {
+    top: '#00e5ff',
+    middle: '#76ff03',
+    bottom: '#ff6d00',
+};
+
 interface BraceRendererProps {
     brace: Brace;
     startKnot: Knot;
@@ -19,6 +25,7 @@ interface BraceRendererProps {
     isHovered?: boolean;
     suppressHover?: boolean;
     isInteractable?: boolean;
+    debugSectionColors?: boolean;
 }
 
 export function BraceRenderer({
@@ -31,10 +38,15 @@ export function BraceRenderer({
     isHovered: propHovered,
     suppressHover,
     isInteractable = true,
+    debugSectionColors = false,
 }: BraceRendererProps) {
     const segmentId = `braceSegment:${brace.id}`;
 
     const isBezierSelected = !!isSelected && brace.curve?.type === 'bezier';
+
+    const debugColor = debugSectionColors && brace.debugSection
+        ? DEBUG_SECTION_COLORS[brace.debugSection] ?? '#ff8800'
+        : null;
 
     const { pickRef, visuals } = useHighlight({
         id: brace.id,
@@ -42,7 +54,7 @@ export function BraceRenderer({
         isSelected,
         suppressHover,
         externalHover: propHovered,
-        baseColor: dimNonSelected && !isSelected ? '#666666' : '#ff8800',
+        baseColor: debugColor ?? (dimNonSelected && !isSelected ? '#666666' : '#ff8800'),
         selectedColor: '#80fffd',
     });
 

--- a/src/supports/__tests__/autoBraceGeneration.test.ts
+++ b/src/supports/__tests__/autoBraceGeneration.test.ts
@@ -1,0 +1,429 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildAutoBracedSnapshot } from '../autoBracing/autoBrace';
+import { createDefaultAutoBracingSettings } from '../autoBracing/settings';
+import type { Roots, SupportState, Trunk } from '../types';
+
+function createRoot(id: string, modelId: string, x: number, y = 0): Roots {
+    return {
+        id,
+        modelId,
+        transform: {
+            pos: { x, y, z: 0 },
+            rot: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        diameter: 3,
+        diskHeight: 0.5,
+        coneHeight: 0.5,
+    };
+}
+
+function createTrunk(id: string, modelId: string, rootId: string, segmentId: string, x: number, y = 0, topZ = 4): Trunk {
+    return {
+        id,
+        modelId,
+        rootId,
+        segments: [
+            {
+                id: segmentId,
+                diameter: 1,
+                topJoint: {
+                    id: `joint-${id}`,
+                    pos: { x, y, z: topZ },
+                    diameter: 1.2,
+                },
+            },
+        ],
+    };
+}
+
+function createEmptySnapshot(): SupportState {
+    return {
+        roots: {},
+        trunks: {},
+        branches: {},
+        leaves: {},
+        twigs: {},
+        sticks: {},
+        braces: {},
+        knots: {},
+        selectedId: null,
+        selectedCategory: null,
+        hoveredId: null,
+        hoveredCategory: 'none',
+        interactionWarning: null,
+    };
+}
+
+test('buildAutoBracedSnapshot replaces old braces and generates braces with valid angles', () => {
+    const snapshot = createEmptySnapshot();
+    const modelId = 'model-a';
+
+    // Stagger heights so adjacent top-tier anchors have ~45° angle between them.
+    // topOffsetFromTopMm default = 2.0, so anchor for trunk of height H is at H - 2.
+    // For a 45° angle between adjacent supports spaced 2mm apart horizontally,
+    // we need |dz| ≈ horizontal distance. Spacing = 2mm, so height diff = 2mm.
+    // Heights: 6, 8, 10 → anchors at 4, 6, 8 → dz=2 between adjacent, dx=2 → 45°.
+    const rootA = createRoot('root-a', modelId, 0);
+    const rootB = createRoot('root-b', modelId, 2);
+    const rootC = createRoot('root-c', modelId, 4);
+
+    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 6);
+    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 2, 0, 8);
+    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 4, 0, 10);
+
+    snapshot.roots[rootA.id] = rootA;
+    snapshot.roots[rootB.id] = rootB;
+    snapshot.roots[rootC.id] = rootC;
+
+    snapshot.trunks[trunkA.id] = trunkA;
+    snapshot.trunks[trunkB.id] = trunkB;
+    snapshot.trunks[trunkC.id] = trunkC;
+
+    snapshot.knots['k-old-a'] = {
+        id: 'k-old-a',
+        parentShaftId: 'seg-a',
+        t: 0.5,
+        pos: { x: 0, y: 0, z: 3 },
+        diameter: 1.1,
+    };
+    snapshot.knots['k-old-b'] = {
+        id: 'k-old-b',
+        parentShaftId: 'seg-b',
+        t: 0.5,
+        pos: { x: 2, y: 0, z: 4 },
+        diameter: 1.1,
+    };
+
+    snapshot.braces['brace-old'] = {
+        id: 'brace-old',
+        modelId,
+        startKnotId: 'k-old-a',
+        endKnotId: 'k-old-b',
+        profile: { diameter: 0.9 },
+    };
+
+    const settings = createDefaultAutoBracingSettings();
+    const result = buildAutoBracedSnapshot(snapshot, settings);
+
+    assert.equal(result.removedBraceCount, 1);
+    assert.equal(result.skippedSupportCount, 0);
+    assert.equal(result.changed, true);
+
+    assert.equal(result.snapshot.braces['brace-old'], undefined);
+    assert.equal(result.snapshot.knots['k-old-a'], undefined);
+    assert.equal(result.snapshot.knots['k-old-b'], undefined);
+
+    for (const brace of Object.values(result.snapshot.braces)) {
+        assert.equal(brace.profile.diameter, settings.braceDiameterMm);
+    }
+});
+
+test('buildAutoBracedSnapshot leaves state unchanged when fewer than 3 supports qualify', () => {
+    const snapshot = createEmptySnapshot();
+    const modelId = 'model-b';
+
+    const rootA = createRoot('root-a', modelId, -2);
+    const rootB = createRoot('root-b', modelId, 2);
+
+    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', -2);
+    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 2);
+
+    snapshot.roots[rootA.id] = rootA;
+    snapshot.roots[rootB.id] = rootB;
+    snapshot.trunks[trunkA.id] = trunkA;
+    snapshot.trunks[trunkB.id] = trunkB;
+
+    const settings = createDefaultAutoBracingSettings();
+    const result = buildAutoBracedSnapshot(snapshot, settings);
+
+    assert.equal(result.generatedBraceCount, 0);
+    assert.equal(result.removedBraceCount, 0);
+    assert.equal(result.changed, false);
+    assert.equal(result.skippedSupportCount, 2);
+    assert.equal(result.underQualifiedSupportCount, 0);
+    assert.equal(Object.keys(result.snapshot.braces).length, 0);
+    assert.equal(Object.keys(result.snapshot.knots).length, 0);
+});
+
+test('buildAutoBracedSnapshot reports qualified anchors when braces span two distinct axes', () => {
+    const snapshot = createEmptySnapshot();
+    const modelId = 'model-c';
+
+    // 4 supports in a 2x2 grid, staggered heights so all adjacent pairs produce 45° angles.
+    // Grid spacing = 4mm, height step = 4mm → atan2(4,4) = 45° for all adjacent pairs.
+    // Heights: A=6, B=10, C=10, D=14 → top anchors: A=4, B=8, C=8, D=12
+    // A↔B: dz=4, dx=4 → 45°; A↔C: dz=4, dy=4 → 45°; B↔D: dz=4, dy=4 → 45°; C↔D: dz=4, dx=4 → 45°
+    // Support A gets braces from +X direction (A↔B) and +Y direction (A↔C) → two distinct axes → qualified.
+    const rootA = createRoot('root-a', modelId, 0, 0);
+    const rootB = createRoot('root-b', modelId, 4, 0);
+    const rootC = createRoot('root-c', modelId, 0, 4);
+    const rootD = createRoot('root-d', modelId, 4, 4);
+
+    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 6);
+    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 4, 0, 10);
+    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 0, 4, 10);
+    const trunkD = createTrunk('trunk-d', modelId, rootD.id, 'seg-d', 4, 4, 14);
+
+    snapshot.roots[rootA.id] = rootA;
+    snapshot.roots[rootB.id] = rootB;
+    snapshot.roots[rootC.id] = rootC;
+    snapshot.roots[rootD.id] = rootD;
+
+    snapshot.trunks[trunkA.id] = trunkA;
+    snapshot.trunks[trunkB.id] = trunkB;
+    snapshot.trunks[trunkC.id] = trunkC;
+    snapshot.trunks[trunkD.id] = trunkD;
+
+    const settings = createDefaultAutoBracingSettings();
+    const result = buildAutoBracedSnapshot(snapshot, settings);
+
+    assert.ok(result.generatedBraceCount >= 2, `Expected at least 2 braces, got ${result.generatedBraceCount}`);
+    assert.ok(
+        result.underQualifiedSupportCount < 4,
+        `Expected fewer than 4 under-qualified supports, got ${result.underQualifiedSupportCount}`,
+    );
+});
+
+test('buildAutoBracedSnapshot is deterministic: same input produces identical output', () => {
+    const snapshot = createEmptySnapshot();
+    const modelId = 'model-det';
+
+    for (let i = 0; i < 5; i += 1) {
+        const root = createRoot(`root-${i}`, modelId, i * 3);
+        const trunk = createTrunk(`trunk-${i}`, modelId, root.id, `seg-${i}`, i * 3, 0, 20);
+        snapshot.roots[root.id] = root;
+        snapshot.trunks[trunk.id] = trunk;
+    }
+
+    const settings = createDefaultAutoBracingSettings();
+    const result1 = buildAutoBracedSnapshot(snapshot, settings);
+    const result2 = buildAutoBracedSnapshot(snapshot, settings);
+
+    assert.equal(result1.generatedBraceCount, result2.generatedBraceCount);
+    assert.equal(result1.underQualifiedSupportCount, result2.underQualifiedSupportCount);
+
+    const braceIds1 = Object.keys(result1.snapshot.braces).sort();
+    const braceIds2 = Object.keys(result2.snapshot.braces).sort();
+    assert.deepEqual(braceIds1, braceIds2);
+});
+
+test('buildAutoBracedSnapshot produces only top-section braces for short supports', () => {
+    const snapshot = createEmptySnapshot();
+    const modelId = 'model-short';
+
+    // Height = 5mm. topOffset=2mm, bottomOffset=2mm. minHeightForBottom = 2+2+2 = 6mm.
+    // 5mm < 6mm → bottom section NOT active. Only top braces expected.
+    const rootA = createRoot('root-a', modelId, 0);
+    const rootB = createRoot('root-b', modelId, 4);
+    const rootC = createRoot('root-c', modelId, 8);
+
+    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 5);
+    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 4, 0, 5);
+    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 8, 0, 5);
+
+    snapshot.roots[rootA.id] = rootA;
+    snapshot.roots[rootB.id] = rootB;
+    snapshot.roots[rootC.id] = rootC;
+    snapshot.trunks[trunkA.id] = trunkA;
+    snapshot.trunks[trunkB.id] = trunkB;
+    snapshot.trunks[trunkC.id] = trunkC;
+
+    const settings = createDefaultAutoBracingSettings();
+    const result = buildAutoBracedSnapshot(snapshot, settings);
+
+    assert.ok(result.generatedBraceCount > 0, 'Should generate top-section braces');
+
+    for (const brace of Object.values(result.snapshot.braces)) {
+        assert.equal(brace.debugSection, 'top', `Expected top section, got ${brace.debugSection}`);
+    }
+});
+
+test('buildAutoBracedSnapshot produces top and bottom braces for medium-height supports', () => {
+    const snapshot = createEmptySnapshot();
+    const modelId = 'model-medium';
+
+    // Height = 10mm. topOffset=2mm, bottomOffset=2mm. minHeightForBottom = 6mm.
+    // 10mm >= 6mm → bottom section active. minHeightForMiddle = 2+2+4 = 8mm.
+    // centerZ = 5mm. topSearchBound = 10-2-1 = 7mm. 5 <= 7 → middle active too.
+    // Use height=8mm to be at the boundary: minHeightForMiddle=8mm, 8>=8 → middle just active.
+    // Use height=7mm: 7 < 8 → middle NOT active. Only top+bottom.
+    const rootA = createRoot('root-a', modelId, 0);
+    const rootB = createRoot('root-b', modelId, 4);
+    const rootC = createRoot('root-c', modelId, 8);
+
+    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 7);
+    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 4, 0, 7);
+    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 8, 0, 7);
+
+    snapshot.roots[rootA.id] = rootA;
+    snapshot.roots[rootB.id] = rootB;
+    snapshot.roots[rootC.id] = rootC;
+    snapshot.trunks[trunkA.id] = trunkA;
+    snapshot.trunks[trunkB.id] = trunkB;
+    snapshot.trunks[trunkC.id] = trunkC;
+
+    const settings = createDefaultAutoBracingSettings();
+    const result = buildAutoBracedSnapshot(snapshot, settings);
+
+    const sections = new Set(Object.values(result.snapshot.braces).map((b) => b.debugSection));
+    assert.ok(sections.has('top'), 'Expected top section braces');
+    assert.ok(sections.has('bottom'), 'Expected bottom section braces');
+    assert.ok(!sections.has('middle'), 'Should not have middle section braces at this height');
+});
+
+test('buildAutoBracedSnapshot produces top, bottom, and middle braces for tall supports', () => {
+    const snapshot = createEmptySnapshot();
+    const modelId = 'model-tall';
+
+    // Height = 20mm. minHeightForMiddle = 8mm. 20 >= 8 → all three sections active.
+    const rootA = createRoot('root-a', modelId, 0);
+    const rootB = createRoot('root-b', modelId, 4);
+    const rootC = createRoot('root-c', modelId, 8);
+
+    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 20);
+    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 4, 0, 20);
+    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 8, 0, 20);
+
+    snapshot.roots[rootA.id] = rootA;
+    snapshot.roots[rootB.id] = rootB;
+    snapshot.roots[rootC.id] = rootC;
+    snapshot.trunks[trunkA.id] = trunkA;
+    snapshot.trunks[trunkB.id] = trunkB;
+    snapshot.trunks[trunkC.id] = trunkC;
+
+    const settings = createDefaultAutoBracingSettings();
+    const result = buildAutoBracedSnapshot(snapshot, settings);
+
+    const sections = new Set(Object.values(result.snapshot.braces).map((b) => b.debugSection));
+    assert.ok(sections.has('top'), 'Expected top section braces');
+    assert.ok(sections.has('bottom'), 'Expected bottom section braces');
+    assert.ok(sections.has('middle'), 'Expected middle section braces for tall supports');
+});
+
+test('buildAutoBracedSnapshot crossDiagonal produces mirror slope vs singleDiagonal', () => {
+    const makeSnapshot = () => {
+        const snapshot = createEmptySnapshot();
+        const modelId = 'model-pattern';
+        const rootA = createRoot('root-a', modelId, 0);
+        const rootB = createRoot('root-b', modelId, 4);
+        const rootC = createRoot('root-c', modelId, 8);
+        const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 20);
+        const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 4, 0, 20);
+        const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 8, 0, 20);
+        snapshot.roots[rootA.id] = rootA;
+        snapshot.roots[rootB.id] = rootB;
+        snapshot.roots[rootC.id] = rootC;
+        snapshot.trunks[trunkA.id] = trunkA;
+        snapshot.trunks[trunkB.id] = trunkB;
+        snapshot.trunks[trunkC.id] = trunkC;
+        return snapshot;
+    };
+
+    const singleSettings = { ...createDefaultAutoBracingSettings(), topPattern: 'singleDiagonal' as const };
+    const crossSettings = { ...createDefaultAutoBracingSettings(), topPattern: 'crossDiagonal' as const };
+
+    const singleResult = buildAutoBracedSnapshot(makeSnapshot(), singleSettings);
+    const crossResult = buildAutoBracedSnapshot(makeSnapshot(), crossSettings);
+
+    assert.ok(singleResult.generatedBraceCount > 0, 'singleDiagonal should generate braces');
+    assert.ok(crossResult.generatedBraceCount > 0, 'crossDiagonal should generate braces');
+
+    // Extract dz signs for top braces: singleDiagonal and crossDiagonal should have opposite slopes
+    const getTopBraceDzSigns = (result: ReturnType<typeof buildAutoBracedSnapshot>) =>
+        Object.values(result.snapshot.braces)
+            .filter((b) => b.debugSection === 'top')
+            .map((b) => {
+                const sk = result.snapshot.knots[b.startKnotId];
+                const ek = result.snapshot.knots[b.endKnotId];
+                if (!sk || !ek) return 0;
+                return Math.sign(ek.pos.z - sk.pos.z);
+            });
+
+    const singleSigns = getTopBraceDzSigns(singleResult);
+    const crossSigns = getTopBraceDzSigns(crossResult);
+
+    // crossDiagonal produces both diagonals (X), so more braces than singleDiagonal
+    assert.ok(
+        crossResult.generatedBraceCount > singleResult.generatedBraceCount,
+        `crossDiagonal (${crossResult.generatedBraceCount}) should produce more braces than singleDiagonal (${singleResult.generatedBraceCount})`,
+    );
+
+    // crossDiagonal should contain both slope directions (positive and negative dz)
+    const hasPositive = crossSigns.some((s) => s > 0);
+    const hasNegative = crossSigns.some((s) => s < 0);
+    assert.ok(hasPositive && hasNegative, 'crossDiagonal should have braces going both up and down (X pattern)');
+});
+
+test('buildAutoBracedSnapshot rejects pairs whose brace length exceeds maxBraceLengthMm', () => {
+    const snapshot = createEmptySnapshot();
+    const modelId = 'model-long';
+
+    // Supports spaced 15mm apart horizontally. maxBraceLengthMm = 10mm filters on hDist,
+    // so 15mm > 10mm → all pairs rejected.
+    const rootA = createRoot('root-a', modelId, -15);
+    const rootB = createRoot('root-b', modelId, 0);
+    const rootC = createRoot('root-c', modelId, 15);
+
+    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', -15, 0, 30);
+    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 0, 0, 30);
+    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 15, 0, 30);
+
+    snapshot.roots[rootA.id] = rootA;
+    snapshot.roots[rootB.id] = rootB;
+    snapshot.roots[rootC.id] = rootC;
+    snapshot.trunks[trunkA.id] = trunkA;
+    snapshot.trunks[trunkB.id] = trunkB;
+    snapshot.trunks[trunkC.id] = trunkC;
+
+    const settings = createDefaultAutoBracingSettings();
+    const result = buildAutoBracedSnapshot(snapshot, settings);
+
+    assert.equal(result.generatedBraceCount, 0, 'Pairs exceeding maxBraceLengthMm should be rejected');
+    assert.equal(result.changed, false);
+});
+
+test('buildAutoBracedSnapshot places braces at ~45 degrees even when supports are same height', () => {
+    const snapshot = createEmptySnapshot();
+    const modelId = 'model-d';
+
+    // All supports at same height. The new algorithm derives dz = horizontal distance
+    // to achieve 45°, so braces should still be generated with correct angle.
+    const rootA = createRoot('root-a', modelId, -4);
+    const rootB = createRoot('root-b', modelId, 0);
+    const rootC = createRoot('root-c', modelId, 4);
+
+    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', -4, 0, 20);
+    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 0, 0, 20);
+    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 4, 0, 20);
+
+    snapshot.roots[rootA.id] = rootA;
+    snapshot.roots[rootB.id] = rootB;
+    snapshot.roots[rootC.id] = rootC;
+    snapshot.trunks[trunkA.id] = trunkA;
+    snapshot.trunks[trunkB.id] = trunkB;
+    snapshot.trunks[trunkC.id] = trunkC;
+
+    const settings = createDefaultAutoBracingSettings();
+    const result = buildAutoBracedSnapshot(snapshot, settings);
+
+    assert.ok(result.generatedBraceCount > 0, 'Should generate braces at 45° even with same-height supports');
+
+    // Verify each generated brace is within 20° of 45°
+    for (const brace of Object.values(result.snapshot.braces)) {
+        const sk = result.snapshot.knots[brace.startKnotId];
+        const ek = result.snapshot.knots[brace.endKnotId];
+        if (!sk || !ek) continue;
+        const dx = ek.pos.x - sk.pos.x;
+        const dy = ek.pos.y - sk.pos.y;
+        const dz = Math.abs(ek.pos.z - sk.pos.z);
+        const hDist = Math.sqrt(dx * dx + dy * dy);
+        if (hDist < 0.001) continue;
+        const angleDeg = Math.atan2(dz, hDist) * (180 / Math.PI);
+        assert.ok(
+            Math.abs(angleDeg - 45) <= 20,
+            `Brace angle ${angleDeg.toFixed(1)}° deviates more than 20° from 45°`,
+        );
+    }
+});

--- a/src/supports/__tests__/autoBracingSettings.test.ts
+++ b/src/supports/__tests__/autoBracingSettings.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    AUTO_BRACING_CONSTRAINTS,
+    applyAutoBracingSettingsPatch,
+    createDefaultAutoBracingSettings,
+    normalizeAutoBracingSettings,
+} from '../autoBracing/settings';
+
+test('auto-bracing defaults are created from the SSOT constraint defaults', () => {
+    const settings = createDefaultAutoBracingSettings();
+
+    assert.equal(settings.braceDiameterMm, AUTO_BRACING_CONSTRAINTS.braceDiameterMm.defaultValue);
+    assert.equal(settings.maxGroupSize, AUTO_BRACING_CONSTRAINTS.maxGroupSize.defaultValue);
+    assert.equal(settings.topOffsetFromTopMm, AUTO_BRACING_CONSTRAINTS.topOffsetFromTopMm.defaultValue);
+    assert.equal(settings.middleRepeatIntervalMm, AUTO_BRACING_CONSTRAINTS.middleRepeatIntervalMm.defaultValue);
+    assert.equal(settings.bottomOffsetFromBottomMm, AUTO_BRACING_CONSTRAINTS.bottomOffsetFromBottomMm.defaultValue);
+    assert.equal(settings.topPattern, 'singleDiagonal');
+    assert.equal(settings.middlePattern, 'singleDiagonal');
+    assert.equal(settings.bottomPattern, 'singleDiagonal');
+    assert.equal(settings.debugSectionColorsEnabled, false);
+});
+
+test('normalizeAutoBracingSettings clamps numeric values and restores invalid patterns', () => {
+    const normalized = normalizeAutoBracingSettings({
+        braceDiameterMm: -5,
+        maxGroupSize: 42,
+        topPattern: 'invalid-pattern' as any,
+        topOffsetFromTopMm: 999,
+        middlePattern: 'crossDiagonal',
+        middleRepeatIntervalMm: -1,
+        bottomPattern: 'invalid-pattern' as any,
+        bottomOffsetFromBottomMm: 999,
+        debugSectionColorsEnabled: 'yes' as any,
+    });
+
+    assert.equal(normalized.braceDiameterMm, AUTO_BRACING_CONSTRAINTS.braceDiameterMm.min);
+    assert.equal(normalized.maxGroupSize, AUTO_BRACING_CONSTRAINTS.maxGroupSize.max);
+    assert.equal(normalized.topPattern, 'singleDiagonal');
+    assert.equal(normalized.topOffsetFromTopMm, AUTO_BRACING_CONSTRAINTS.topOffsetFromTopMm.max);
+    assert.equal(normalized.middlePattern, 'crossDiagonal');
+    assert.equal(normalized.middleRepeatIntervalMm, AUTO_BRACING_CONSTRAINTS.middleRepeatIntervalMm.min);
+    assert.equal(normalized.bottomPattern, 'singleDiagonal');
+    assert.equal(normalized.bottomOffsetFromBottomMm, AUTO_BRACING_CONSTRAINTS.bottomOffsetFromBottomMm.max);
+    assert.equal(normalized.debugSectionColorsEnabled, false);
+});
+
+test('applyAutoBracingSettingsPatch keeps untouched fields and normalizes patched values', () => {
+    const base = createDefaultAutoBracingSettings();
+    const patched = applyAutoBracingSettingsPatch(base, {
+        maxGroupSize: 8.8,
+        topPattern: 'crossDiagonal',
+        debugSectionColorsEnabled: true,
+    });
+
+    assert.equal(patched.maxGroupSize, 9);
+    assert.equal(patched.topPattern, 'crossDiagonal');
+    assert.equal(patched.debugSectionColorsEnabled, true);
+    assert.equal(patched.bottomPattern, base.bottomPattern);
+    assert.equal(patched.braceDiameterMm, base.braceDiameterMm);
+});

--- a/src/supports/autoBracing/AutoBracingSettingsCard.tsx
+++ b/src/supports/autoBracing/AutoBracingSettingsCard.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import React from 'react';
+import { NumberInput } from '@/components/ui/NumberInput';
+import { Button } from '@/components/ui/primitives';
+import {
+    AUTO_BRACING_CONSTRAINTS,
+    AUTO_BRACING_HARD_RULES,
+    AUTO_BRACING_PATTERN_OPTIONS,
+    type AutoBracingSettings,
+    type AutoBracingPattern,
+} from './settings';
+
+interface AutoBracingSettingsCardProps {
+    settings: AutoBracingSettings;
+    onChange: (patch: Partial<AutoBracingSettings>) => void;
+    onAutoBrace: () => void;
+    status?: {
+        kind: 'success' | 'warning' | 'error';
+        message: string;
+    } | null;
+}
+
+const compactInputClass = 'ui-input w-full h-[36px] px-3 py-2 text-base no-spinners';
+
+export function AutoBracingSettingsCard({
+    settings,
+    onChange,
+    onAutoBrace,
+    status,
+}: AutoBracingSettingsCardProps) {
+    const renderPatternSelect = (
+        label: string,
+        value: AutoBracingPattern,
+        onPatternChange: (pattern: AutoBracingPattern) => void,
+    ) => {
+        return (
+            <label className="space-y-1 min-w-0">
+                <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>{label}</div>
+                <select
+                    value={value}
+                    onChange={(event) => onPatternChange(event.target.value as AutoBracingPattern)}
+                    className="ui-input w-full h-[36px] px-3 py-2 text-base"
+                >
+                    {AUTO_BRACING_PATTERN_OPTIONS.map((pattern) => (
+                        <option key={pattern} value={pattern}>
+                            {pattern === 'singleDiagonal' ? 'Single diagonal' : 'Cross diagonal'}
+                        </option>
+                    ))}
+                </select>
+            </label>
+        );
+    };
+
+    return (
+        <div className="space-y-3">
+            <div className="text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+                Auto Bracing
+            </div>
+
+            <div className="grid grid-cols-2 gap-1.5">
+                <label className="space-y-1 min-w-0">
+                    <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Brace diameter (mm)</div>
+                    <NumberInput
+                        value={settings.braceDiameterMm}
+                        onChange={(value) => onChange({ braceDiameterMm: value })}
+                        className={compactInputClass}
+                    />
+                </label>
+
+                <label className="space-y-1 min-w-0">
+                    <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Max group size</div>
+                    <NumberInput
+                        value={settings.maxGroupSize}
+                        onChange={(value) => onChange({ maxGroupSize: value })}
+                        className={compactInputClass}
+                    />
+                </label>
+            </div>
+
+            <div className="grid grid-cols-2 gap-1.5">
+                {renderPatternSelect('Top pattern', settings.topPattern, (topPattern) => onChange({ topPattern }))}
+                <label className="space-y-1 min-w-0">
+                    <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Top offset from top (mm)</div>
+                    <NumberInput
+                        value={settings.topOffsetFromTopMm}
+                        onChange={(value) => onChange({ topOffsetFromTopMm: value })}
+                        className={compactInputClass}
+                    />
+                </label>
+            </div>
+
+            <div className="grid grid-cols-2 gap-1.5">
+                {renderPatternSelect('Middle pattern', settings.middlePattern, (middlePattern) => onChange({ middlePattern }))}
+                <label className="space-y-1 min-w-0">
+                    <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Middle repeat interval (mm)</div>
+                    <NumberInput
+                        value={settings.middleRepeatIntervalMm}
+                        onChange={(value) => onChange({ middleRepeatIntervalMm: value })}
+                        className={compactInputClass}
+                    />
+                </label>
+            </div>
+
+            <div className="grid grid-cols-2 gap-1.5">
+                {renderPatternSelect('Bottom pattern', settings.bottomPattern, (bottomPattern) => onChange({ bottomPattern }))}
+                <label className="space-y-1 min-w-0">
+                    <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Bottom offset from bottom (mm)</div>
+                    <NumberInput
+                        value={settings.bottomOffsetFromBottomMm}
+                        onChange={(value) => onChange({ bottomOffsetFromBottomMm: value })}
+                        className={compactInputClass}
+                    />
+                </label>
+            </div>
+
+            <label className="flex items-center justify-between rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-0), transparent 8%)' }}>
+                <span className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Show section debug colors</span>
+                <input
+                    type="checkbox"
+                    checked={settings.debugSectionColorsEnabled}
+                    onChange={(event) => onChange({ debugSectionColorsEnabled: event.target.checked })}
+                    className="ui-checkbox"
+                />
+            </label>
+
+            <div className="rounded-md border px-2.5 py-2 text-[10px] leading-tight" style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-0), transparent 6%)', color: 'var(--text-muted)' }}>
+                <div>Fixed rules: {AUTO_BRACING_HARD_RULES.braceAngleDeg}° brace angle, minimum group size {AUTO_BRACING_HARD_RULES.minGroupSize}, and {AUTO_BRACING_HARD_RULES.minAxisSeparationDeg}° minimum axis separation.</div>
+                <div className="mt-1">Value limits: diameter {AUTO_BRACING_CONSTRAINTS.braceDiameterMm.min}–{AUTO_BRACING_CONSTRAINTS.braceDiameterMm.max} mm, group size {AUTO_BRACING_CONSTRAINTS.maxGroupSize.min}–{AUTO_BRACING_CONSTRAINTS.maxGroupSize.max}.</div>
+            </div>
+
+            {status && (
+                <div
+                    className="rounded-md border px-2.5 py-2 text-[10px] leading-tight"
+                    style={{
+                        borderColor:
+                            status.kind === 'success'
+                                ? '#34d399'
+                                : status.kind === 'warning'
+                                    ? '#f59e0b'
+                                    : '#f87171',
+                        color:
+                            status.kind === 'success'
+                                ? '#34d399'
+                                : status.kind === 'warning'
+                                    ? '#f59e0b'
+                                    : '#f87171',
+                        background: 'color-mix(in srgb, var(--surface-0), transparent 6%)',
+                    }}
+                >
+                    {status.message}
+                </div>
+            )}
+
+            <Button
+                type="button"
+                onClick={onAutoBrace}
+                variant="primary"
+                size="sm"
+                className="w-full !h-10 !text-[12px] !font-semibold"
+            >
+                Auto Brace
+            </Button>
+        </div>
+    );
+}

--- a/src/supports/autoBracing/autoBrace.ts
+++ b/src/supports/autoBracing/autoBrace.ts
@@ -1,0 +1,1081 @@
+import * as THREE from 'three';
+import { pushHistory } from '@/history/historyStore';
+import { getSettings } from '../Settings/state';
+import { getAllMeshEntriesForAutoBrace } from './meshGeometryStore';
+import {
+    SUPPORT_AUTO_BRACE_REPLACE,
+    type SupportReplaceStatePayload,
+} from '../history/actionTypes';
+import { getSnapshot, setSnapshot } from '../state';
+import {
+    calculateKnotPositionOnSegmentFromT,
+    getTrunkSegmentEndpoints,
+} from '../SupportPrimitives/Knot/knotUtils';
+import { JOINT_DIAMETER_OFFSET_MM } from '../constants';
+import type {
+    Brace,
+    Branch,
+    Knot,
+    Segment,
+    SupportState,
+    Trunk,
+    Vec3,
+} from '../types';
+import {
+    AUTO_BRACING_HARD_RULES,
+    normalizeAutoBracingSettings,
+    type AutoBracingPattern,
+    type AutoBracingSettings,
+} from './settings';
+
+type SupportKind = 'trunk' | 'branch';
+type SectionKey = 'top' | 'bottom' | 'middle';
+
+const MESH_CLEARANCE_MM = 1.0;
+const BRACE_CLEARANCE_SAMPLE_COUNT = 12;
+
+/**
+ * Returns true if the brace centerline from posA to posB maintains at least
+ * MESH_CLEARANCE_MM + braceDiameterMm/2 clearance from all registered mesh surfaces.
+ * Samples points along the brace, transforms to local mesh space, and queries BVH.
+ * The BVH closestPointToPoint returns distance in local space; we convert to world
+ * space using the mesh's uniform scale factor.
+ */
+function bracePassesMeshClearance(posA: Vec3, posB: Vec3, modelId: string, braceDiameterMm: number): boolean {
+    const minClearance = MESH_CLEARANCE_MM + braceDiameterMm / 2;
+    const meshEntries = getAllMeshEntriesForAutoBrace();
+
+    const entry = meshEntries.get(modelId);
+    if (!entry) return true;
+
+    const bvh = (entry.geometry as any).boundsTree;
+    if (!bvh) return true;
+
+    const inverseMatrix = entry.transform.clone().invert();
+
+    // Extract world-space scale to convert local distances back to world distances.
+    const scaleVec = new THREE.Vector3();
+    entry.transform.decompose(new THREE.Vector3(), new THREE.Quaternion(), scaleVec);
+    const worldScale = (scaleVec.x + scaleVec.y + scaleVec.z) / 3;
+
+    const ax = posA.x, ay = posA.y, az = posA.z;
+    const bx = posB.x, by = posB.y, bz = posB.z;
+    const resultTarget: { point?: THREE.Vector3; distance?: number } = {};
+
+    for (let i = 0; i <= BRACE_CLEARANCE_SAMPLE_COUNT; i++) {
+        const t = i / BRACE_CLEARANCE_SAMPLE_COUNT;
+        const worldPoint = new THREE.Vector3(
+            ax + (bx - ax) * t,
+            ay + (by - ay) * t,
+            az + (bz - az) * t,
+        );
+        const localPoint = worldPoint.clone().applyMatrix4(inverseMatrix);
+        const result = bvh.closestPointToPoint(localPoint, resultTarget);
+        if (!result) continue;
+
+        // result.distance is in local space; multiply by worldScale to get world mm
+        const worldDist = (result.distance as number) * worldScale;
+        if (worldDist < minClearance) return false;
+    }
+
+    return true;
+}
+
+type SegmentSample = {
+    segmentId: string;
+    segment: Segment;
+    start: Vec3;
+    end: Vec3;
+    diameterMm: number;
+};
+
+type SupportSample = {
+    supportId: string;
+    supportKind: SupportKind;
+    modelId: string;
+    segments: SegmentSample[];
+    topReferenceZ: number;
+    bottomReferenceZ: number;
+    sortAnchor: Vec3;
+};
+
+type SectionHeights = {
+    top: number[];
+    bottom: number[];
+    middle: number[];
+};
+
+type AnchorPoint = {
+    supportId: string;
+    modelId: string;
+    segmentId: string;
+    t: number;
+    pos: Vec3;
+    hostDiameterMm: number;
+};
+
+type AnchorCandidate = {
+    segment: SegmentSample;
+    t: number;
+    pos: Vec3;
+    score: number;
+};
+
+type AnchorSpec = {
+    section: 'top' | 'middle';
+    anchorZ: number;
+};
+
+export interface AutoBraceResult {
+    generatedBraceCount: number;
+    removedBraceCount: number;
+    skippedSupportCount: number;
+    underQualifiedSupportCount: number;
+    changed: boolean;
+    message: string;
+}
+
+type BuildSnapshotResult = AutoBraceResult & {
+    snapshot: SupportState;
+};
+
+const ANCHOR_Z_TOLERANCE_MM = 0.3;
+
+function clamp(value: number, min: number, max: number): number {
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
+}
+
+function sortSupports(a: SupportSample, b: SupportSample): number {
+    if (a.modelId !== b.modelId) return a.modelId.localeCompare(b.modelId);
+    if (a.sortAnchor.x !== b.sortAnchor.x) return a.sortAnchor.x - b.sortAnchor.x;
+    if (a.sortAnchor.y !== b.sortAnchor.y) return a.sortAnchor.y - b.sortAnchor.y;
+    if (a.sortAnchor.z !== b.sortAnchor.z) return a.sortAnchor.z - b.sortAnchor.z;
+    if (a.supportKind !== b.supportKind) return a.supportKind.localeCompare(b.supportKind);
+    return a.supportId.localeCompare(b.supportId);
+}
+
+function createUniqueIdFactory(prefix: string, existingIds: Set<string>) {
+    let index = 1;
+    return () => {
+        while (true) {
+            const id = `${prefix}-${index}`;
+            index += 1;
+            if (!existingIds.has(id)) {
+                existingIds.add(id);
+                return id;
+            }
+        }
+    };
+}
+
+function collectSegmentExtrema(segments: SegmentSample[]): { topReferenceZ: number; bottomReferenceZ: number; sortAnchor: Vec3 } {
+    let topPoint: Vec3 | null = null;
+    let bottomPoint: Vec3 | null = null;
+
+    for (const segment of segments) {
+        const points = [segment.start, segment.end];
+        for (const point of points) {
+            if (!topPoint || point.z > topPoint.z) topPoint = point;
+            if (!bottomPoint || point.z < bottomPoint.z) bottomPoint = point;
+        }
+    }
+
+    if (!topPoint || !bottomPoint) {
+        return {
+            topReferenceZ: 0,
+            bottomReferenceZ: 0,
+            sortAnchor: { x: 0, y: 0, z: 0 },
+        };
+    }
+
+    return {
+        topReferenceZ: topPoint.z,
+        bottomReferenceZ: bottomPoint.z,
+        sortAnchor: topPoint,
+    };
+}
+
+function buildSupportSamples(snapshot: SupportState): SupportSample[] {
+    const supports: SupportSample[] = [];
+
+    for (const trunk of Object.values(snapshot.trunks)) {
+        const root = snapshot.roots[trunk.rootId];
+        if (!root) continue;
+
+        const segments: SegmentSample[] = [];
+        trunk.segments.forEach((segment, segmentIndex) => {
+            const endpoints = getTrunkSegmentEndpoints(trunk, segment, segmentIndex, root);
+            if (!endpoints) return;
+            segments.push({
+                segmentId: segment.id,
+                segment,
+                start: endpoints.start,
+                end: endpoints.end,
+                diameterMm: segment.diameter,
+            });
+        });
+
+        if (segments.length === 0) continue;
+
+        const extrema = collectSegmentExtrema(segments);
+        supports.push({
+            supportId: trunk.id,
+            supportKind: 'trunk',
+            modelId: trunk.modelId,
+            segments,
+            topReferenceZ: extrema.topReferenceZ,
+            bottomReferenceZ: extrema.bottomReferenceZ,
+            sortAnchor: extrema.sortAnchor,
+        });
+    }
+
+    // Branches are excluded from auto-bracing for now — separate logic TBD.
+
+    supports.sort(sortSupports);
+    return supports;
+}
+
+type PairPlacementResult = { anchorA: AnchorPoint; anchorB: AnchorPoint };
+
+function validateCandidate(
+    anchorA: AnchorPoint,
+    anchorB: AnchorPoint,
+): boolean {
+    const dx = anchorB.pos.x - anchorA.pos.x;
+    const dy = anchorB.pos.y - anchorA.pos.y;
+    const dz = Math.abs(anchorB.pos.z - anchorA.pos.z);
+    const hDist = Math.sqrt(dx * dx + dy * dy);
+    if (hDist < 0.001) return false;
+
+    const angleDeg = Math.abs(Math.atan2(dz, hDist) * (180 / Math.PI));
+    const deviation = Math.abs(angleDeg - AUTO_BRACING_HARD_RULES.braceAngleDeg);
+    if (deviation > 20) return false;
+
+    // Filter on horizontal distance — maxBraceLengthMm controls how far apart two supports
+    // can be and still be braced. At 45°, 3D length = hDist×√2, but hDist is the more
+    // intuitive limit (neighbor spacing in XY).
+    return hDist <= AUTO_BRACING_HARD_RULES.maxBraceLengthMm;
+}
+
+/**
+ * Compute the dz needed for a 45\u00b0 brace between two supports.
+ * Uses bottom-of-shaft positions as the stable horizontal reference.
+ */
+function computeDzFor45(supportA: SupportSample, supportB: SupportSample): number | null {
+    const baseA = resolveAnchorAtZ(supportA, supportA.bottomReferenceZ);
+    const baseB = resolveAnchorAtZ(supportB, supportB.bottomReferenceZ);
+    if (!baseA || !baseB) return null;
+
+    const hDist = Math.sqrt(
+        (baseA.pos.x - baseB.pos.x) ** 2 +
+        (baseA.pos.y - baseB.pos.y) ** 2,
+    );
+    return hDist < 0.001 ? null : hDist;
+}
+
+/**
+ * For bottom/middle: searchStart is the LOW point, high = searchStart + dz.
+ * For top: searchStart is the HIGH point, low = searchStart - dz.
+ * Returns { lowZ, highZ } for a given support and section.
+ */
+function sectionLowHighZ(
+    searchStart: number,
+    dz: number,
+    sectionKey: SectionKey,
+): { lowZ: number; highZ: number } {
+    if (sectionKey === 'top') {
+        return { lowZ: searchStart - dz, highZ: searchStart };
+    }
+    return { lowZ: searchStart, highZ: searchStart + dz };
+}
+
+/**
+ * Primary diagonal: A-knot LOW, B-knot HIGH.
+ * singleDiagonal places only this brace.
+ */
+function resolvePairPlacement(
+    supportA: SupportSample,
+    supportB: SupportSample,
+    sectionKey: SectionKey,
+    settings: AutoBracingSettings,
+): PairPlacementResult | null {
+    const dz = computeDzFor45(supportA, supportB);
+    if (dz === null) return null;
+
+    const ssA = sectionSearchStart(supportA, sectionKey, settings);
+    const ssB = sectionSearchStart(supportB, sectionKey, settings);
+    if (ssA === null || ssB === null) return null;
+
+    // Use the lower of the two search starts as the shared reference.
+    // This anchors the brace to the shorter support's section Z so both
+    // primary and mirror span the same Z range regardless of height difference.
+    const ref = Math.min(ssA, ssB);
+    const { lowZ, highZ } = sectionLowHighZ(ref, dz, sectionKey);
+
+    const anchorA = resolveAnchorAtZ(supportA, lowZ);
+    const anchorB = resolveAnchorAtZ(supportB, highZ);
+    if (!anchorA || !anchorB) return null;
+    if (!validateCandidate(anchorA, anchorB)) return null;
+    if (anchorB.pos.z - anchorA.pos.z < 0.1) return null;
+
+    return { anchorA, anchorB };
+}
+
+/**
+ * Mirror diagonal: A-knot HIGH, B-knot LOW.
+ * crossDiagonal places this in addition to the primary, forming the X.
+ * Uses the same shared reference Z as resolvePairPlacement so both braces
+ * span the identical Z range — producing a clean symmetric X.
+ */
+function resolveMirrorPlacement(
+    supportA: SupportSample,
+    supportB: SupportSample,
+    sectionKey: SectionKey,
+    settings: AutoBracingSettings,
+): PairPlacementResult | null {
+    const dz = computeDzFor45(supportA, supportB);
+    if (dz === null) return null;
+
+    const ssA = sectionSearchStart(supportA, sectionKey, settings);
+    const ssB = sectionSearchStart(supportB, sectionKey, settings);
+    if (ssA === null || ssB === null) return null;
+
+    // Same shared reference as primary — anchored to the shorter support's section Z.
+    const ref = Math.min(ssA, ssB);
+    const { lowZ, highZ } = sectionLowHighZ(ref, dz, sectionKey);
+
+    // Mirror: A gets HIGH, B gets LOW (opposite of primary)
+    const anchorA = resolveAnchorAtZ(supportA, highZ);
+    const anchorB = resolveAnchorAtZ(supportB, lowZ);
+    if (!anchorA || !anchorB) return null;
+    if (!validateCandidate(anchorA, anchorB)) return null;
+    if (anchorA.pos.z - anchorB.pos.z < 0.1) return null;
+
+    return { anchorA, anchorB };
+}
+
+/**
+ * Returns the highest Z to start searching for a brace placement on a support
+ * for the given section. Returns null if the section is not active for this support.
+ */
+function sectionSearchStart(
+    support: SupportSample,
+    sectionKey: SectionKey,
+    settings: AutoBracingSettings,
+): number | null {
+    const effectiveHeight = support.topReferenceZ - support.bottomReferenceZ;
+
+    if (sectionKey === 'top') {
+        // Top section is always active. Search starts just below the top reference.
+        const z = support.topReferenceZ - settings.topOffsetFromTopMm;
+        return clamp(z, support.bottomReferenceZ, support.topReferenceZ);
+    }
+
+    if (sectionKey === 'bottom') {
+        // Bottom section requires enough height to fit both top and bottom offsets
+        // with a minimum gap between them (TBD from calibration, using 2mm for now).
+        const minHeightForBottom = settings.topOffsetFromTopMm + settings.bottomOffsetFromBottomMm + 2.0;
+        if (effectiveHeight < minHeightForBottom) return null;
+        const z = support.bottomReferenceZ + settings.bottomOffsetFromBottomMm;
+        return clamp(z, support.bottomReferenceZ, support.topReferenceZ);
+    }
+
+    if (sectionKey === 'middle') {
+        // Middle section requires enough height for top + bottom + at least one middle tier
+        // with clearance from both ends (TBD from calibration, using 4mm for now).
+        const minHeightForMiddle = settings.topOffsetFromTopMm + settings.bottomOffsetFromBottomMm + 4.0;
+        if (effectiveHeight < minHeightForMiddle) return null;
+        // Middle starts at the center of effective height
+        const centerZ = (support.topReferenceZ + support.bottomReferenceZ) / 2;
+        return centerZ;
+    }
+
+    return null;
+}
+
+/**
+ * Returns all Z search starts for middle section repeats on a support.
+ * First middle is at center, then repeats upward at middleRepeatIntervalMm.
+ */
+function middleSectionSearchStarts(
+    support: SupportSample,
+    settings: AutoBracingSettings,
+): number[] {
+    const firstZ = sectionSearchStart(support, 'middle', settings);
+    if (firstZ === null) return [];
+
+    const topSearchBound = support.topReferenceZ - settings.topOffsetFromTopMm - 1.0;
+    const results: number[] = [firstZ];
+    const intervalMm = Math.max(0.5, settings.middleRepeatIntervalMm);
+    let nextZ = firstZ + intervalMm;
+
+    while (nextZ <= topSearchBound) {
+        results.push(nextZ);
+        nextZ += intervalMm;
+    }
+
+    return results;
+}
+
+function resolveAnchorAtZ(support: SupportSample, targetZ: number): AnchorPoint | null {
+    const EPSILON = 0.000001;
+
+    let best: AnchorCandidate | null = null;
+
+    const createCandidate = (segment: SegmentSample, t: number): AnchorCandidate => {
+        const clampedT = clamp(t, 0, 1);
+        const pos = calculateKnotPositionOnSegmentFromT(segment.start, segment.end, segment.segment, clampedT);
+        return {
+            segment,
+            t: clampedT,
+            pos,
+            score: Math.abs(pos.z - targetZ),
+        };
+    };
+
+    const pickBetterCandidate = (
+        current: AnchorCandidate | null,
+        candidate: AnchorCandidate,
+    ): AnchorCandidate => {
+        if (!current) return candidate;
+
+        if (candidate.score < current.score - EPSILON) {
+            return candidate;
+        }
+
+        if (Math.abs(candidate.score - current.score) <= EPSILON) {
+            if (candidate.segment.segmentId < current.segment.segmentId) {
+                return candidate;
+            }
+
+            if (
+                candidate.segment.segmentId === current.segment.segmentId
+                && candidate.t < current.t
+            ) {
+                return candidate;
+            }
+        }
+
+        return current;
+    };
+
+    for (const segment of support.segments) {
+        const dz = segment.end.z - segment.start.z;
+        const minZ = Math.min(segment.start.z, segment.end.z);
+        const maxZ = Math.max(segment.start.z, segment.end.z);
+
+        if (Math.abs(dz) <= EPSILON) {
+            continue;
+        }
+
+        if (targetZ < minZ - EPSILON || targetZ > maxZ + EPSILON) {
+            continue;
+        }
+
+        const t = (targetZ - segment.start.z) / dz;
+        best = pickBetterCandidate(best, createCandidate(segment, t));
+    }
+
+    if (!best) {
+        for (const segment of support.segments) {
+            best = pickBetterCandidate(best, createCandidate(segment, 0));
+            best = pickBetterCandidate(best, createCandidate(segment, 1));
+        }
+    }
+
+    if (!best) return null;
+
+    return {
+        supportId: support.supportId,
+        modelId: support.modelId,
+        segmentId: best.segment.segmentId,
+        t: best.t,
+        pos: best.pos,
+        hostDiameterMm: best.segment.diameterMm,
+    };
+}
+
+function buildGroupPairs(group: SupportSample[], pattern: AutoBracingPattern): Array<[SupportSample, SupportSample]> {
+    if (group.length < 2) return [];
+
+    const pairs: Array<[SupportSample, SupportSample]> = [];
+    const pairKeys = new Set<string>();
+
+    const addPair = (a: SupportSample, b: SupportSample) => {
+        const minId = a.supportId < b.supportId ? a.supportId : b.supportId;
+        const maxId = a.supportId < b.supportId ? b.supportId : a.supportId;
+        const key = `${minId}:${maxId}`;
+        if (pairKeys.has(key)) return;
+        pairKeys.add(key);
+        pairs.push([a, b]);
+    };
+
+    // Build MST using Kruskal's algorithm: sort all candidate edges by distance,
+    // add each edge only if it connects two previously unconnected components.
+    // This guarantees the minimum set of connections with no redundant long diagonals.
+
+    // Generate all candidate edges
+    type Edge = { a: SupportSample; b: SupportSample; distSq: number };
+    const edges: Edge[] = [];
+    for (let i = 0; i < group.length; i += 1) {
+        for (let j = i + 1; j < group.length; j += 1) {
+            const a = group[i];
+            const b = group[j];
+            const dx = b.sortAnchor.x - a.sortAnchor.x;
+            const dy = b.sortAnchor.y - a.sortAnchor.y;
+            edges.push({ a, b, distSq: dx * dx + dy * dy });
+        }
+    }
+    edges.sort((x, y) => x.distSq - y.distSq);
+
+    // Union-Find
+    const parent = new Map<string, string>();
+    const find = (id: string): string => {
+        if (parent.get(id) !== id) parent.set(id, find(parent.get(id)!));
+        return parent.get(id)!;
+    };
+    const union = (a: string, b: string) => { parent.set(find(a), find(b)); };
+    for (const s of group) parent.set(s.supportId, s.supportId);
+
+    // Add shortest edges that connect new components (MST)
+    for (const { a, b } of edges) {
+        if (find(a.supportId) !== find(b.supportId)) {
+            addPair(a, b);
+            union(a.supportId, b.supportId);
+        }
+    }
+
+    // Second-axis pass: for each support that only has connections along one axis direction,
+    // find its nearest neighbor in a sufficiently different direction and add that pair.
+    // This ensures every support gets two-axis bracing, not just a 1D chain.
+    const minSepDeg = AUTO_BRACING_HARD_RULES.minAxisSeparationDeg;
+
+    const getAxisAngle = (a: SupportSample, b: SupportSample): number => {
+        const dx = b.sortAnchor.x - a.sortAnchor.x;
+        const dy = b.sortAnchor.y - a.sortAnchor.y;
+        return normalizeAxisAngleRad(Math.atan2(dy, dx));
+    };
+
+    // Build adjacency from current pairs
+    const pairNeighbors = new Map<string, SupportSample[]>();
+    for (const s of group) pairNeighbors.set(s.supportId, []);
+    for (const [a, b] of pairs) {
+        pairNeighbors.get(a.supportId)!.push(b);
+        pairNeighbors.get(b.supportId)!.push(a);
+    }
+
+    const hasTwoAxes = (s: SupportSample): boolean => {
+        const neighbors = pairNeighbors.get(s.supportId) ?? [];
+        if (neighbors.length < 2) return false;
+        const firstAxis = getAxisAngle(s, neighbors[0]);
+        return neighbors.slice(1).some(
+            (n) => axisSeparationDeg(firstAxis, getAxisAngle(s, n)) >= minSepDeg,
+        );
+    };
+
+    for (const s of group) {
+        if (hasTwoAxes(s)) continue;
+
+        const currentNeighbors = pairNeighbors.get(s.supportId) ?? [];
+        const existingAxes = currentNeighbors.map((n) => getAxisAngle(s, n));
+
+        // Find nearest candidate that provides a new axis
+        for (const { a, b } of edges) {
+            const candidate = a.supportId === s.supportId ? b : b.supportId === s.supportId ? a : null;
+            if (!candidate) continue;
+
+            const candidateAxis = getAxisAngle(s, candidate);
+            const isNewAxis = existingAxes.every(
+                (ax) => axisSeparationDeg(ax, candidateAxis) >= minSepDeg,
+            );
+            if (!isNewAxis) continue;
+
+            addPair(s, candidate);
+            pairNeighbors.get(s.supportId)!.push(candidate);
+            pairNeighbors.get(candidate.supportId)!.push(s);
+            existingAxes.push(candidateAxis);
+            break; // edges are sorted by distance, so first valid is nearest
+        }
+    }
+
+    return pairs;
+}
+
+function partitionSupportsIntoGroups(
+    supports: SupportSample[],
+    minGroupSize: number,
+    maxGroupSize: number,
+): SupportSample[][] {
+    if (supports.length < minGroupSize) return [];
+
+    const supportDistanceSq = (a: SupportSample, b: SupportSample): number => {
+        const dx = a.sortAnchor.x - b.sortAnchor.x;
+        const dy = a.sortAnchor.y - b.sortAnchor.y;
+        const dz = a.sortAnchor.z - b.sortAnchor.z;
+        return dx * dx + dy * dy + dz * dz;
+    };
+
+    const pickNextNearestIndex = (
+        group: SupportSample[],
+        candidates: SupportSample[],
+    ): number => {
+        let bestIndex = 0;
+        let bestDistSq = Number.POSITIVE_INFINITY;
+
+        for (let i = 0; i < candidates.length; i += 1) {
+            const candidate = candidates[i];
+
+            let nearestDistSq = Number.POSITIVE_INFINITY;
+            for (const current of group) {
+                const distSq = supportDistanceSq(current, candidate);
+                if (distSq < nearestDistSq) {
+                    nearestDistSq = distSq;
+                }
+            }
+
+            if (nearestDistSq < bestDistSq - 0.000001) {
+                bestDistSq = nearestDistSq;
+                bestIndex = i;
+                continue;
+            }
+
+            if (Math.abs(nearestDistSq - bestDistSq) <= 0.000001) {
+                const currentBest = candidates[bestIndex];
+                if (sortSupports(candidate, currentBest) < 0) {
+                    bestIndex = i;
+                }
+            }
+        }
+
+        return bestIndex;
+    };
+
+    const remaining = [...supports].sort(sortSupports);
+    const groups: SupportSample[][] = [];
+
+    while (remaining.length > 0) {
+        const seed = remaining.shift();
+        if (!seed) break;
+
+        const group: SupportSample[] = [seed];
+
+        while (group.length < maxGroupSize && remaining.length > 0) {
+            const nextIndex = pickNextNearestIndex(group, remaining);
+            const [next] = remaining.splice(nextIndex, 1);
+            group.push(next);
+        }
+
+        groups.push(group);
+    }
+
+    if (groups.length > 1) {
+        const lastGroup = groups[groups.length - 1];
+        if (lastGroup.length < minGroupSize) {
+            const previousGroup = groups[groups.length - 2];
+
+            while (lastGroup.length < minGroupSize && previousGroup.length > minGroupSize) {
+                const moved = previousGroup.pop();
+                if (!moved) break;
+                lastGroup.unshift(moved);
+            }
+
+            if (lastGroup.length < minGroupSize) {
+                previousGroup.push(...lastGroup);
+                groups.pop();
+            }
+        }
+    }
+
+    return groups.filter((group) => group.length >= minGroupSize);
+}
+
+function selectionExists(snapshot: SupportState, selectedId: string): boolean {
+    if (snapshot.roots[selectedId]) return true;
+    if (snapshot.trunks[selectedId]) return true;
+    if (snapshot.branches[selectedId]) return true;
+    if (snapshot.leaves[selectedId]) return true;
+    if (snapshot.twigs[selectedId]) return true;
+    if (snapshot.sticks[selectedId]) return true;
+    if (snapshot.braces[selectedId]) return true;
+    if (snapshot.knots[selectedId]) return true;
+
+    if (selectedId.startsWith('braceSegment:')) {
+        const braceId = selectedId.slice('braceSegment:'.length);
+        return Boolean(snapshot.braces[braceId]);
+    }
+
+    return false;
+}
+
+function clearMissingSelection(snapshot: SupportState): SupportState {
+    if (!snapshot.selectedId) return snapshot;
+    if (selectionExists(snapshot, snapshot.selectedId)) return snapshot;
+
+    return {
+        ...snapshot,
+        selectedId: null,
+        selectedCategory: null,
+    };
+}
+
+function clearExistingBraceData(snapshot: SupportState): { snapshot: SupportState; removedBraceCount: number } {
+    const braceKnotIds = new Set<string>();
+    for (const brace of Object.values(snapshot.braces)) {
+        braceKnotIds.add(brace.startKnotId);
+        braceKnotIds.add(brace.endKnotId);
+    }
+
+    const preservedKnotIds = new Set<string>();
+    for (const branch of Object.values(snapshot.branches)) {
+        preservedKnotIds.add(branch.parentKnotId);
+    }
+    for (const leaf of Object.values(snapshot.leaves)) {
+        preservedKnotIds.add(leaf.parentKnotId);
+    }
+
+    const nextKnots: Record<string, Knot> = {};
+    for (const [knotId, knot] of Object.entries(snapshot.knots)) {
+        if (braceKnotIds.has(knotId) && !preservedKnotIds.has(knotId)) {
+            continue;
+        }
+        nextKnots[knotId] = knot;
+    }
+
+    return {
+        snapshot: {
+            ...snapshot,
+            braces: {},
+            knots: nextKnots,
+        },
+        removedBraceCount: Object.keys(snapshot.braces).length,
+    };
+}
+
+function normalizeAxisAngleRad(angleRad: number): number {
+    const pi = Math.PI;
+    let normalized = angleRad % pi;
+    if (normalized < 0) normalized += pi;
+    return normalized;
+}
+
+function axisSeparationDeg(aRad: number, bRad: number): number {
+    const diff = Math.abs(aRad - bRad);
+    const wrapped = Math.min(diff, Math.PI - diff);
+    return (wrapped * 180) / Math.PI;
+}
+
+function hasTwoDistinctAxes(angles: number[], minSeparationDeg: number): boolean {
+    if (angles.length < 2) return false;
+
+    for (let i = 0; i < angles.length; i += 1) {
+        for (let j = i + 1; j < angles.length; j += 1) {
+            if (axisSeparationDeg(angles[i], angles[j]) >= minSeparationDeg) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+function evaluateAnchorQualification(args: {
+    snapshot: SupportState;
+    supportSamples: SupportSample[];
+    anchorSpecBySupportId: Map<string, AnchorSpec>;
+}): { underQualifiedSupportCount: number } {
+    const { snapshot, supportSamples, anchorSpecBySupportId } = args;
+
+    const supportIdBySegmentId = new Map<string, string>();
+    for (const support of supportSamples) {
+        for (const segment of support.segments) {
+            supportIdBySegmentId.set(segment.segmentId, support.supportId);
+        }
+    }
+
+    const axisAnglesBySupportId = new Map<string, number[]>();
+    const axisMergeToleranceDeg = 2;
+
+    const addAxisAngle = (supportId: string, angleRad: number) => {
+        const normalized = normalizeAxisAngleRad(angleRad);
+        const list = axisAnglesBySupportId.get(supportId) ?? [];
+
+        const alreadyPresent = list.some((existing) => axisSeparationDeg(existing, normalized) <= axisMergeToleranceDeg);
+        if (!alreadyPresent) {
+            list.push(normalized);
+        }
+
+        axisAnglesBySupportId.set(supportId, list);
+    };
+
+    const registerAxisFromEndpoint = (endpointKnot: Knot, otherKnot: Knot, braceSection: SectionKey) => {
+        const supportId = supportIdBySegmentId.get(endpointKnot.parentShaftId);
+        if (!supportId) return;
+
+        const anchorSpec = anchorSpecBySupportId.get(supportId);
+        if (!anchorSpec) return;
+
+        // Only count braces from the anchor section for this support.
+        if (braceSection !== anchorSpec.section) return;
+
+        const dx = otherKnot.pos.x - endpointKnot.pos.x;
+        const dy = otherKnot.pos.y - endpointKnot.pos.y;
+        const lenSq = dx * dx + dy * dy;
+        if (lenSq <= 0.000001) return;
+
+        addAxisAngle(supportId, Math.atan2(dy, dx));
+    };
+
+    for (const brace of Object.values(snapshot.braces)) {
+        const startKnot = snapshot.knots[brace.startKnotId];
+        const endKnot = snapshot.knots[brace.endKnotId];
+        if (!startKnot || !endKnot) continue;
+
+        const braceSection = (brace.debugSection ?? 'top') as SectionKey;
+        registerAxisFromEndpoint(startKnot, endKnot, braceSection);
+        registerAxisFromEndpoint(endKnot, startKnot, braceSection);
+    }
+
+    let underQualifiedSupportCount = 0;
+    for (const support of supportSamples) {
+        if (!anchorSpecBySupportId.has(support.supportId)) continue;
+
+        const axisAngles = axisAnglesBySupportId.get(support.supportId) ?? [];
+        const qualified = hasTwoDistinctAxes(axisAngles, AUTO_BRACING_HARD_RULES.minAxisSeparationDeg);
+        if (!qualified) {
+            underQualifiedSupportCount += 1;
+        }
+    }
+
+    return { underQualifiedSupportCount };
+}
+
+export function buildAutoBracedSnapshot(
+    snapshot: SupportState,
+    inputSettings: AutoBracingSettings,
+): BuildSnapshotResult {
+    const settings = normalizeAutoBracingSettings(inputSettings);
+    const supportSamples = buildSupportSamples(snapshot);
+
+    const byModel = new Map<string, SupportSample[]>();
+    for (const support of supportSamples) {
+        if (!byModel.has(support.modelId)) {
+            byModel.set(support.modelId, []);
+        }
+        byModel.get(support.modelId)!.push(support);
+    }
+
+    const groupedSupports: SupportSample[][] = [];
+    for (const supportsForModel of byModel.values()) {
+        supportsForModel.sort(sortSupports);
+        const groups = partitionSupportsIntoGroups(
+            supportsForModel,
+            AUTO_BRACING_HARD_RULES.minGroupSize,
+            settings.maxGroupSize,
+        );
+        groupedSupports.push(...groups);
+    }
+
+    const groupedSupportIds = new Set<string>();
+    groupedSupports.forEach((group) => {
+        group.forEach((support) => groupedSupportIds.add(support.supportId));
+    });
+
+    const cleared = clearExistingBraceData(snapshot);
+    let nextSnapshot = cleared.snapshot;
+
+    const braceIdSet = new Set<string>(Object.keys(nextSnapshot.braces));
+    const knotIdSet = new Set<string>(Object.keys(nextSnapshot.knots));
+    const createBraceId = createUniqueIdFactory('auto-brace', braceIdSet);
+    const createKnotId = createUniqueIdFactory('auto-brace-knot', knotIdSet);
+
+    const generatedBraces: Record<string, Brace> = {};
+    const generatedKnots: Record<string, Knot> = {};
+    const anchorSpecBySupportId = new Map<string, AnchorSpec>();
+
+    const sectionOrder: SectionKey[] = ['top', 'bottom', 'middle'];
+
+    // Track the highest placed knot Z per support per section for qualification anchor.
+    // Key: supportId, Value: { section, highestZ }
+    const placedAnchorZBySupportId = new Map<string, { section: SectionKey; highestZ: number }>();
+
+    const updatePlacedAnchor = (supportId: string, sectionKey: SectionKey, knotZ: number) => {
+        const existing = placedAnchorZBySupportId.get(supportId);
+        // Qualification anchor rule: top-most middle if present, else top.
+        // Middle always wins over top. Within same section, prefer highest Z.
+        if (!existing) {
+            placedAnchorZBySupportId.set(supportId, { section: sectionKey, highestZ: knotZ });
+            return;
+        }
+        const sectionPriority = (s: SectionKey) => s === 'middle' ? 2 : s === 'top' ? 1 : 0;
+        if (sectionPriority(sectionKey) > sectionPriority(existing.section)) {
+            placedAnchorZBySupportId.set(supportId, { section: sectionKey, highestZ: knotZ });
+        } else if (sectionKey === existing.section && knotZ > existing.highestZ) {
+            placedAnchorZBySupportId.set(supportId, { section: sectionKey, highestZ: knotZ });
+        }
+    };
+
+    const placeBrace = (anchorA: AnchorPoint, anchorB: AnchorPoint, sectionKey: SectionKey) => {
+        if (anchorA.modelId !== anchorB.modelId) return;
+        if (anchorA.segmentId === anchorB.segmentId && Math.abs(anchorA.t - anchorB.t) < 0.0001) return;
+        if (!bracePassesMeshClearance(anchorA.pos, anchorB.pos, anchorA.modelId, settings.braceDiameterMm)) return;
+
+        const startKnotId = createKnotId();
+        const endKnotId = createKnotId();
+        const braceId = createBraceId();
+
+        generatedKnots[startKnotId] = {
+            id: startKnotId,
+            parentShaftId: anchorA.segmentId,
+            t: anchorA.t,
+            pos: anchorA.pos,
+            diameter: Math.max(0.001, anchorA.hostDiameterMm) + JOINT_DIAMETER_OFFSET_MM,
+        };
+        generatedKnots[endKnotId] = {
+            id: endKnotId,
+            parentShaftId: anchorB.segmentId,
+            t: anchorB.t,
+            pos: anchorB.pos,
+            diameter: Math.max(0.001, anchorB.hostDiameterMm) + JOINT_DIAMETER_OFFSET_MM,
+        };
+        generatedBraces[braceId] = {
+            id: braceId,
+            modelId: anchorA.modelId,
+            startKnotId,
+            endKnotId,
+            profile: { diameter: settings.braceDiameterMm },
+            debugSection: sectionKey,
+        };
+
+        updatePlacedAnchor(anchorA.supportId, sectionKey, anchorA.pos.z);
+        updatePlacedAnchor(anchorB.supportId, sectionKey, anchorB.pos.z);
+    };
+
+    for (const group of groupedSupports) {
+
+        for (const sectionKey of sectionOrder) {
+            const sectionPattern = sectionKey === 'top'
+                ? settings.topPattern
+                : sectionKey === 'bottom'
+                    ? settings.bottomPattern
+                    : settings.middlePattern;
+
+            const pairs = buildGroupPairs(group, sectionPattern);
+
+            const placePair = (supportA: SupportSample, supportB: SupportSample, sk: SectionKey) => {
+                const primary = resolvePairPlacement(supportA, supportB, sk, settings);
+                if (primary) placeBrace(primary.anchorA, primary.anchorB, sk);
+
+                if (sectionPattern === 'crossDiagonal') {
+                    const mirror = resolveMirrorPlacement(supportA, supportB, sk, settings);
+                    if (mirror) placeBrace(mirror.anchorA, mirror.anchorB, sk);
+                }
+            };
+
+            if (sectionKey === 'middle') {
+                for (const [supportA, supportB] of pairs) {
+                    const middleStartsA = middleSectionSearchStarts(supportA, settings);
+                    const middleStartsB = middleSectionSearchStarts(supportB, settings);
+                    const tierCount = Math.max(middleStartsA.length, middleStartsB.length);
+                    for (let tierIndex = 0; tierIndex < tierCount; tierIndex += 1) {
+                        placePair(supportA, supportB, 'middle');
+                    }
+                }
+            } else {
+                for (const [supportA, supportB] of pairs) {
+                    placePair(supportA, supportB, sectionKey);
+                }
+            }
+        }
+    }
+
+    // Build anchorSpecBySupportId using sectionSearchStart as the anchor Z.
+    // We can't use placed.highestZ because the shared-ref approach intentionally
+    // places knots at the shorter support's Z, not each support's own section Z.
+    for (const [supportId, placed] of placedAnchorZBySupportId.entries()) {
+        const support = supportSamples.find((s) => s.supportId === supportId);
+        const qualSection: 'top' | 'middle' = placed.section === 'bottom' ? 'top' : placed.section;
+        const anchorZ = support
+            ? (sectionSearchStart(support, qualSection, settings) ?? placed.highestZ)
+            : placed.highestZ;
+        anchorSpecBySupportId.set(supportId, { section: qualSection, anchorZ });
+    }
+
+    nextSnapshot = clearMissingSelection({
+        ...nextSnapshot,
+        knots: {
+            ...nextSnapshot.knots,
+            ...generatedKnots,
+        },
+        braces: {
+            ...generatedBraces,
+        },
+    });
+
+    const qualification = evaluateAnchorQualification({
+        snapshot: nextSnapshot,
+        supportSamples,
+        anchorSpecBySupportId,
+    });
+
+    const generatedBraceCount = Object.keys(generatedBraces).length;
+    const skippedSupportCount = supportSamples.length - groupedSupportIds.size;
+    const underQualifiedSupportCount = qualification.underQualifiedSupportCount;
+    const changed = cleared.removedBraceCount > 0 || generatedBraceCount > 0;
+
+    const message = !changed
+        ? 'No eligible supports were found for Auto Brace.'
+        : underQualifiedSupportCount > 0
+            ? `Auto Brace complete: generated ${generatedBraceCount} brace(s), removed ${cleared.removedBraceCount} previous brace(s), ${underQualifiedSupportCount} support(s) remain under-qualified at the anchor section.`
+            : `Auto Brace complete: generated ${generatedBraceCount} brace(s), removed ${cleared.removedBraceCount} previous brace(s).`;
+
+    return {
+        snapshot: nextSnapshot,
+        generatedBraceCount,
+        removedBraceCount: cleared.removedBraceCount,
+        skippedSupportCount,
+        underQualifiedSupportCount,
+        changed,
+        message,
+    };
+}
+
+export function runAutoBracing(): AutoBraceResult {
+    const before = structuredClone(getSnapshot());
+    const activeSettings = normalizeAutoBracingSettings(getSettings().autoBracing);
+    const built = buildAutoBracedSnapshot(before, activeSettings);
+
+    if (!built.changed) {
+        return {
+            generatedBraceCount: built.generatedBraceCount,
+            removedBraceCount: built.removedBraceCount,
+            skippedSupportCount: built.skippedSupportCount,
+            underQualifiedSupportCount: built.underQualifiedSupportCount,
+            changed: false,
+            message: built.message,
+        };
+    }
+
+    const after = structuredClone(built.snapshot);
+    setSnapshot(after);
+
+    const payload: SupportReplaceStatePayload = {
+        before,
+        after,
+    };
+
+    pushHistory({
+        type: SUPPORT_AUTO_BRACE_REPLACE,
+        payload,
+    });
+
+    return {
+        generatedBraceCount: built.generatedBraceCount,
+        removedBraceCount: built.removedBraceCount,
+        skippedSupportCount: built.skippedSupportCount,
+        underQualifiedSupportCount: built.underQualifiedSupportCount,
+        changed: true,
+        message: built.message,
+    };
+}

--- a/src/supports/autoBracing/index.ts
+++ b/src/supports/autoBracing/index.ts
@@ -1,0 +1,19 @@
+export {
+    AUTO_BRACING_CONSTRAINTS,
+    AUTO_BRACING_HARD_RULES,
+    AUTO_BRACING_PATTERN_OPTIONS,
+    createDefaultAutoBracingSettings,
+    normalizeAutoBracingSettings,
+    applyAutoBracingSettingsPatch,
+} from './settings';
+
+export type { AutoBracingSettings, AutoBracingPattern } from './settings';
+
+export { AutoBracingSettingsCard } from './AutoBracingSettingsCard';
+
+export {
+    buildAutoBracedSnapshot,
+    runAutoBracing,
+} from './autoBrace';
+
+export type { AutoBraceResult } from './autoBrace';

--- a/src/supports/autoBracing/meshGeometryStore.ts
+++ b/src/supports/autoBracing/meshGeometryStore.ts
@@ -1,0 +1,29 @@
+import * as THREE from 'three';
+
+/**
+ * Module-level store for model mesh geometries used by auto-bracing clearance checks.
+ * Keyed by modelId. Registered by the scene manager when models load/unload.
+ */
+
+type MeshEntry = {
+    geometry: THREE.BufferGeometry;
+    transform: THREE.Matrix4;
+};
+
+const meshEntries = new Map<string, MeshEntry>();
+
+export function registerMeshForAutoBrace(modelId: string, geometry: THREE.BufferGeometry, transform: THREE.Matrix4): void {
+    meshEntries.set(modelId, { geometry, transform });
+}
+
+export function unregisterMeshForAutoBrace(modelId: string): void {
+    meshEntries.delete(modelId);
+}
+
+export function getMeshEntryForAutoBrace(modelId: string): MeshEntry | undefined {
+    return meshEntries.get(modelId);
+}
+
+export function getAllMeshEntriesForAutoBrace(): Map<string, MeshEntry> {
+    return meshEntries;
+}

--- a/src/supports/autoBracing/settings.ts
+++ b/src/supports/autoBracing/settings.ts
@@ -1,0 +1,132 @@
+export type AutoBracingPattern = 'singleDiagonal' | 'crossDiagonal';
+
+export interface AutoBracingSettings {
+    braceDiameterMm: number;
+    maxGroupSize: number;
+    topPattern: AutoBracingPattern;
+    topOffsetFromTopMm: number;
+    middlePattern: AutoBracingPattern;
+    middleRepeatIntervalMm: number;
+    bottomPattern: AutoBracingPattern;
+    bottomOffsetFromBottomMm: number;
+    debugSectionColorsEnabled: boolean;
+}
+
+type NumericConstraint = {
+    min: number;
+    max: number;
+    step: number;
+    defaultValue: number;
+    integer?: boolean;
+};
+
+type NumericAutoBracingSettingKey =
+    | 'braceDiameterMm'
+    | 'maxGroupSize'
+    | 'topOffsetFromTopMm'
+    | 'middleRepeatIntervalMm'
+    | 'bottomOffsetFromBottomMm';
+
+export const AUTO_BRACING_PATTERN_OPTIONS: readonly AutoBracingPattern[] = [
+    'singleDiagonal',
+    'crossDiagonal',
+];
+
+export const AUTO_BRACING_CONSTRAINTS = {
+    braceDiameterMm: { min: 0.5, max: 2.0, step: 0.05, defaultValue: 0.7 },
+    maxGroupSize: { min: 3, max: 10, step: 1, defaultValue: 10, integer: true },
+    topOffsetFromTopMm: { min: 0.1, max: 25, step: 0.1, defaultValue: 2.0 },
+    middleRepeatIntervalMm: { min: 0.1, max: 25, step: 0.1, defaultValue: 3.0 },
+    bottomOffsetFromBottomMm: { min: 0.1, max: 25, step: 0.1, defaultValue: 2.0 },
+} satisfies Record<NumericAutoBracingSettingKey, NumericConstraint>;
+
+export const AUTO_BRACING_HARD_RULES = {
+    braceAngleDeg: 45,
+    maxBraceLengthMm: 10,
+    minGroupSize: 3,
+    minAxisSeparationDeg: 20,
+    supportBraceMeshClearanceMm: 0.5,
+    minHeightForBottomSectionMm: 0,
+    minHeightForFirstMiddleTierMm: 0,
+    firstMiddleMinClearanceFromTopBottomMm: 0,
+    middleTierRepeatMinClearanceMm: 0,
+    sectionActivationOrder: ['top', 'bottom', 'middle'] as const,
+    qualificationAnchorSectionRule: 'top-most-middle-if-present-else-top' as const,
+};
+
+function precisionFromStep(step: number): number {
+    const text = String(step);
+    const parts = text.split('.');
+    return parts[1] ? parts[1].length : 0;
+}
+
+function clampNumeric(value: unknown, constraint: NumericConstraint): number {
+    const raw = typeof value === 'number' && Number.isFinite(value)
+        ? value
+        : constraint.defaultValue;
+
+    const clamped = Math.min(constraint.max, Math.max(constraint.min, raw));
+
+    if (constraint.integer) {
+        return Math.round(clamped);
+    }
+
+    const stepsFromMin = Math.round((clamped - constraint.min) / constraint.step);
+    const stepped = constraint.min + stepsFromMin * constraint.step;
+    const precision = Math.max(0, precisionFromStep(constraint.step));
+    const rounded = Number(stepped.toFixed(precision));
+
+    return Math.min(constraint.max, Math.max(constraint.min, rounded));
+}
+
+function normalizePattern(value: unknown, fallback: AutoBracingPattern): AutoBracingPattern {
+    if (value === 'singleDiagonal' || value === 'crossDiagonal') {
+        return value;
+    }
+    return fallback;
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+    return typeof value === 'boolean' ? value : fallback;
+}
+
+export function createDefaultAutoBracingSettings(): AutoBracingSettings {
+    return {
+        braceDiameterMm: AUTO_BRACING_CONSTRAINTS.braceDiameterMm.defaultValue,
+        maxGroupSize: AUTO_BRACING_CONSTRAINTS.maxGroupSize.defaultValue,
+        topPattern: 'singleDiagonal',
+        topOffsetFromTopMm: AUTO_BRACING_CONSTRAINTS.topOffsetFromTopMm.defaultValue,
+        middlePattern: 'singleDiagonal',
+        middleRepeatIntervalMm: AUTO_BRACING_CONSTRAINTS.middleRepeatIntervalMm.defaultValue,
+        bottomPattern: 'singleDiagonal',
+        bottomOffsetFromBottomMm: AUTO_BRACING_CONSTRAINTS.bottomOffsetFromBottomMm.defaultValue,
+        debugSectionColorsEnabled: false,
+    };
+}
+
+export function normalizeAutoBracingSettings(input?: Partial<AutoBracingSettings> | null): AutoBracingSettings {
+    const defaults = createDefaultAutoBracingSettings();
+    const source = input ?? defaults;
+
+    return {
+        braceDiameterMm: clampNumeric(source.braceDiameterMm, AUTO_BRACING_CONSTRAINTS.braceDiameterMm),
+        maxGroupSize: clampNumeric(source.maxGroupSize, AUTO_BRACING_CONSTRAINTS.maxGroupSize),
+        topPattern: normalizePattern(source.topPattern, defaults.topPattern),
+        topOffsetFromTopMm: clampNumeric(source.topOffsetFromTopMm, AUTO_BRACING_CONSTRAINTS.topOffsetFromTopMm),
+        middlePattern: normalizePattern(source.middlePattern, defaults.middlePattern),
+        middleRepeatIntervalMm: clampNumeric(source.middleRepeatIntervalMm, AUTO_BRACING_CONSTRAINTS.middleRepeatIntervalMm),
+        bottomPattern: normalizePattern(source.bottomPattern, defaults.bottomPattern),
+        bottomOffsetFromBottomMm: clampNumeric(source.bottomOffsetFromBottomMm, AUTO_BRACING_CONSTRAINTS.bottomOffsetFromBottomMm),
+        debugSectionColorsEnabled: normalizeBoolean(source.debugSectionColorsEnabled, defaults.debugSectionColorsEnabled),
+    };
+}
+
+export function applyAutoBracingSettingsPatch(
+    current: AutoBracingSettings,
+    patch: Partial<AutoBracingSettings>,
+): AutoBracingSettings {
+    return normalizeAutoBracingSettings({
+        ...current,
+        ...patch,
+    });
+}

--- a/src/supports/history/actionTypes.ts
+++ b/src/supports/history/actionTypes.ts
@@ -25,6 +25,7 @@ export const SUPPORT_ADD_SUPPORT_BRACE = 'support:add-support-brace' as const;
 export const SUPPORT_REMOVE_SUPPORT_BRACE = 'support:remove-support-brace' as const;
 
 export const SUPPORT_REPLACE_TRUNK = 'support:replace-trunk' as const;
+export const SUPPORT_AUTO_BRACE_REPLACE = 'support:auto-brace-replace' as const;
 
 export type SupportHistoryActionType =
   | typeof SUPPORT_ADD_TRUNK
@@ -43,7 +44,8 @@ export type SupportHistoryActionType =
   | typeof SUPPORT_REMOVE_BRACE
   | typeof SUPPORT_ADD_SUPPORT_BRACE
   | typeof SUPPORT_REMOVE_SUPPORT_BRACE
-  | typeof SUPPORT_REPLACE_TRUNK;
+  | typeof SUPPORT_REPLACE_TRUNK
+  | typeof SUPPORT_AUTO_BRACE_REPLACE;
 
 export interface SupportTrunkPayload {
   trunk: Trunk;
@@ -118,6 +120,11 @@ export interface SupportSupportBracePayload {
 }
 
 export interface SupportReplaceTrunkPayload {
+  before: SupportState;
+  after: SupportState;
+}
+
+export interface SupportReplaceStatePayload {
   before: SupportState;
   after: SupportState;
 }

--- a/src/supports/history/useSupportHistoryHandlers.ts
+++ b/src/supports/history/useSupportHistoryHandlers.ts
@@ -18,6 +18,7 @@ import {
   SUPPORT_ADD_SUPPORT_BRACE,
   SUPPORT_REMOVE_SUPPORT_BRACE,
   SUPPORT_REPLACE_TRUNK,
+  SUPPORT_AUTO_BRACE_REPLACE,
   SupportLeafPayload,
   SupportBranchPayload,
   SupportTwigPayload,
@@ -28,6 +29,7 @@ import {
   SupportTrunkUpdatePayload,
   SupportBranchUpdatePayload,
   SupportReplaceTrunkPayload,
+  SupportReplaceStatePayload,
   SupportSupportBracePayload,
 } from './actionTypes';
 import { addKnot, addLeaf, addRoot, addTrunk, addBranch, addTwig, addStick, addBrace, removeLeaf, removeTrunk, removeBranch, removeTwig, removeStick, removeBrace, removeKnotById, removeRootById, updateTrunk, updateBranch, updateKnot, setSnapshot } from '../state';
@@ -257,6 +259,16 @@ export function useSupportHistoryHandlers() {
       }),
       registerHistoryHandler(SUPPORT_REPLACE_TRUNK, (action, direction) => {
         const payload = action.payload as SupportReplaceTrunkPayload | undefined;
+        if (!payload?.before || !payload?.after) return false;
+        if (direction === 'undo') {
+          setSnapshot(payload.before);
+        } else {
+          setSnapshot(payload.after);
+        }
+        return true;
+      }),
+      registerHistoryHandler(SUPPORT_AUTO_BRACE_REPLACE, (action, direction) => {
+        const payload = action.payload as SupportReplaceStatePayload | undefined;
         if (!payload?.before || !payload?.after) return false;
         if (direction === 'undo') {
           setSnapshot(payload.before);

--- a/src/supports/types.ts
+++ b/src/supports/types.ts
@@ -179,6 +179,7 @@ export interface Brace extends SupportEntity {
     profile: {
         diameter: number;
     };
+    debugSection?: 'top' | 'bottom' | 'middle';
 }
 
 // --- Collection State ---


### PR DESCRIPTION
## What changed
- Implemented Kruskal's Minimum Spanning Tree (MST) for pair building to avoid redundant diagonals.
- Added a second-axis pass to ensure supports get multi-directional bracing.
- Added mesh clearance checks using BVH closest-point queries to prevent braces from intersecting the model mesh.
- Ensured cross-diagonals form proper X-patterns.
- Excluded branches from auto-bracing.

## Why it changed
To fix issues with redundant braces, braces clipping through the model mesh, and missing secondary axes for support lines.

## How to test
1. Run \
pm test\ to ensure all 16 auto-bracing tests pass.
2. Use the UI to generate auto-braces and visually inspect mesh clearance and cross-diagonal generation.