### PR TITLE
feat(auto-bracing): Generative fallback braces and root rendering

### DIFF
--- a/src/components/lys-import/converter/convertLycheeData.ts
+++ b/src/components/lys-import/converter/convertLycheeData.ts
@@ -185,8 +185,9 @@ export function convertLycheeData(data: LycheeData, settings: SupportSettings, m
         const supportType = (s as any)?.type;
         // Lychee can encode single-parent support braces as either type 1 or type 0.
         const isSupportBraceSourceType = !Number.isFinite(supportType) || supportType === 1 || supportType === 0;
+        const isObjectTouching = s.isBaseTip === true;
 
-        if (hasExplicitSingleParentHint && baseIsGrounded && isSupportBraceSourceType && !isMiniSupport(s)) {
+        if (hasExplicitSingleParentHint && baseIsGrounded && isSupportBraceSourceType && !isMiniSupport(s) && !isObjectTouching) {
           supportBraceCandidates.push({ id, s, parentIds });
         } else {
           branchCandidates.push({ id, s, parentIds });

--- a/src/supports/SupportRenderer.tsx
+++ b/src/supports/SupportRenderer.tsx
@@ -32,6 +32,7 @@ import { getFinalSocketPosition } from './SupportPrimitives/ContactCone/contactC
 import { calculateDiskThickness } from './SupportPrimitives/ContactDisk/contactDiskUtils';
 import { getRaftSettings, subscribeToRaftStore } from './Rafts/Crenelated/RaftState';
 import { JOINT_DIAMETER_OFFSET_MM } from './constants';
+import { DEBUG_SECTION_COLORS as AUTO_BRACING_DEBUG_SECTION_COLORS } from './autoBracing/settings';
 
 interface SupportRendererProps {
     mode?: SupportMode;
@@ -1598,7 +1599,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
     }, [supportBraceState.supportBraces, supportBraceShaftsBySupport, selectedSupportBraceIds, restrictToActiveModel, activeModelId, applyDropToVec3Like]);
 
     const sceneBatchedBraceShaftGroups = useMemo(() => {
-        const grouped = new Map<string, { modelId?: string; shafts: InstancedShaft[] }>();
+        const grouped = new Map<string, { modelId?: string; debugSection?: 'initial' | 'repeating' | null; shafts: InstancedShaft[] }>();
+
+        const sectionColorsEnabled = !!settings.autoBracing.debugSectionColorsEnabled;
+        const splitByDebugSection = sectionColorsEnabled && !dimNonSelected;
 
         for (const brace of Object.values(state.braces)) {
             if (!isModelVisible(brace.modelId, brace.id)) continue;
@@ -1608,8 +1612,12 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             if (selectedBraceIds.has(brace.id)) continue;
 
             const modelKey = shaftSet.modelId ?? '__unassigned__';
+            const debugSection = splitByDebugSection
+                ? (brace.debugSection ?? null)
+                : null;
+            const groupKey = debugSection ? `${modelKey}:${debugSection}` : modelKey;
 
-            const existing = grouped.get(modelKey);
+            const existing = grouped.get(groupKey);
             if (existing) {
                 existing.shafts.push(...shaftSet.shafts.map((shaft) => ({
                     ...shaft,
@@ -1617,8 +1625,9 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                     end: applyDropToVec3Like(shaft.end, shaft.modelId),
                 })));
             } else {
-                grouped.set(modelKey, {
+                grouped.set(groupKey, {
                     modelId: shaftSet.modelId,
+                    debugSection,
                     shafts: shaftSet.shafts.map((shaft) => ({
                         ...shaft,
                         start: applyDropToVec3Like(shaft.start, shaft.modelId),
@@ -1629,7 +1638,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
         }
 
         return Array.from(grouped.values());
-    }, [state.braces, braceShaftsBySupport, selectedBraceIds, restrictToActiveModel, activeModelId, applyDropToVec3Like]);
+    }, [state.braces, braceShaftsBySupport, selectedBraceIds, restrictToActiveModel, activeModelId, applyDropToVec3Like, settings.autoBracing.debugSectionColorsEnabled, dimNonSelected]);
 
     const sceneBatchedTrunkShaftGroups = useMemo(() => {
         const grouped = new Map<string, { modelId?: string; shafts: InstancedShaft[] }>();
@@ -1735,6 +1744,67 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
         resolveSceneSupportColor,
         applyDropToVec3Like,
         selectedTrunkIds,
+        restrictToActiveModel,
+        activeModelId,
+    ]);
+
+    const sceneBatchedSupportBraceRootGroups = useMemo(() => {
+        if (hidePlateContactPrimitivesEffective) return [] as Array<{ color: string; roots: InstancedRoot[] }>;
+
+        const grouped = new Map<string, InstancedRoot[]>();
+        const hasSolidBottom = raftSettings.bottomMode === 'solid';
+        const raftThickness = raftSettings.thickness ?? 0;
+
+        for (const supportBrace of Object.values(supportBraceState.supportBraces)) {
+            if (!isModelVisible(supportBrace.modelId, supportBrace.id)) continue;
+            if (selectedSupportBraceIds.has(supportBrace.id)) continue;
+
+            const root = supportBraceState.roots[supportBrace.rootId];
+            if (!root) continue;
+
+            const shaftDiameter = Math.max(
+                0.001,
+                supportBrace.segments[0]?.diameter ?? supportBrace.profile.bodyDiameterMm,
+            );
+            const topRadius = shaftDiameter / 2;
+            const bottomRadius = Math.max(0.001, root.diameter / 2);
+            const effectiveDiskHeight = hasSolidBottom ? 0.05 : Math.max(0.001, root.diskHeight);
+            const verticalOffset = hasSolidBottom ? Math.max(raftThickness - effectiveDiskHeight, 0) : 0;
+
+            const color = resolveSceneSupportColor(supportBrace.modelId, supportBrace.id);
+            const rootsForColor = grouped.get(color) ?? [];
+            rootsForColor.push({
+                id: root.id,
+                supportId: supportBrace.id,
+                modelId: supportBrace.modelId,
+                basePos: applyDropToVec3Like({
+                    x: root.transform.pos.x,
+                    y: root.transform.pos.y,
+                    z: root.transform.pos.z + verticalOffset,
+                }, supportBrace.modelId),
+                bottomRadius,
+                topRadius,
+                effectiveDiskHeight,
+                coneHeight: Math.max(0, root.coneHeight),
+            });
+
+            if (rootsForColor.length > 0) {
+                grouped.set(color, rootsForColor);
+            }
+        }
+
+        return Array.from(grouped.entries()).map(([color, roots]) => ({ color, roots }));
+    }, [
+        hidePlateContactPrimitivesEffective,
+        raftSettings.bottomMode,
+        raftSettings.thickness,
+        supportBraceState.supportBraces,
+        supportBraceState.roots,
+        selectedSupportBraceIds,
+        dimNonSelected,
+        resolveBaseColor,
+        resolveSceneSupportColor,
+        applyDropToVec3Like,
         restrictToActiveModel,
         activeModelId,
     ]);
@@ -2251,6 +2321,19 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 />
             ))}
 
+            {sceneBatchedSupportBraceRootGroups.map((group) => (
+                <InstancedRootsGroup
+                    key={`scene-support-brace-root-batch:${group.color}:${group.roots.length}`}
+                    roots={group.roots}
+                    color={group.color}
+                    transparent={ghostTransparent}
+                    opacity={ghostOpacityClamped}
+                    onRootClick={isPointerInteractable ? handleSceneBatchedRootClick : undefined}
+                    onRootPointerMove={isPointerInteractable ? handleSceneBatchedRootPointerMove : undefined}
+                    onRootPointerOut={isPointerInteractable ? handleSceneBatchedShaftPointerOut : undefined}
+                />
+            ))}
+
             {sceneBatchedContactConeGroups.map((group) => (
                 <InstancedContactConeGroup
                     key={`scene-cone-batch:${group.color}:${group.cones.length}`}
@@ -2529,10 +2612,16 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
             {/* Render Braces */}
             {sceneBatchedBraceShaftGroups.map((group) => (
-                <group key={`scene-brace-batch:${group.modelId ?? 'none'}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
+                <group key={`scene-brace-batch:${group.modelId ?? 'none'}:${group.debugSection ?? 'none'}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
                     <InstancedShaftGroup
                         shafts={group.shafts}
-                        color={dimNonSelected ? '#666666' : resolveBaseColor(group.modelId)}
+                        color={
+                            dimNonSelected
+                                ? '#666666'
+                                : (settings.autoBracing.debugSectionColorsEnabled && group.debugSection
+                                    ? AUTO_BRACING_DEBUG_SECTION_COLORS[group.debugSection]
+                                    : resolveBaseColor(group.modelId))
+                        }
                         transparent={ghostTransparent}
                         opacity={ghostOpacityClamped}
                         radialSegments={sceneBatchedShaftRadialSegments}

--- a/src/supports/SupportTypes/Brace/BraceRenderer.tsx
+++ b/src/supports/SupportTypes/Brace/BraceRenderer.tsx
@@ -10,9 +10,8 @@ import { BezierRenderer } from '../../Renderers/BezierRenderer';
 import { setSelectedId } from '../../state';
 
 const DEBUG_SECTION_COLORS: Record<string, string> = {
-    top: '#00e5ff',
-    middle: '#76ff03',
-    bottom: '#ff6d00',
+    initial: '#00ff00',
+    repeating: '#00e5ff',
 };
 
 interface BraceRendererProps {

--- a/src/supports/__tests__/autoBraceGeneration.test.ts
+++ b/src/supports/__tests__/autoBraceGeneration.test.ts
@@ -60,17 +60,16 @@ test('buildAutoBracedSnapshot replaces old braces and generates braces with vali
     const snapshot = createEmptySnapshot();
     const modelId = 'model-a';
 
-    // Stagger heights so adjacent top-tier anchors have ~45° angle between them.
-    // topOffsetFromTopMm default = 2.0, so anchor for trunk of height H is at H - 2.
-    // For a 45° angle between adjacent supports spaced 2mm apart horizontally,
-    // we need |dz| ≈ horizontal distance. Spacing = 2mm, so height diff = 2mm.
-    // Heights: 6, 8, 10 → anchors at 4, 6, 8 → dz=2 between adjacent, dx=2 → 45°.
+    // Ladder Model 2.0: Braces are at fixed Z levels (Initial + Repeating)
+    // Initial at 2.0mm. Repeating at 2+10=12.0mm.
+    // For 45°, dz = hDist. 
+    // If adjacent supports are 2mm apart, dz = 2mm.
     const rootA = createRoot('root-a', modelId, 0);
     const rootB = createRoot('root-b', modelId, 2);
     const rootC = createRoot('root-c', modelId, 4);
 
-    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 6);
-    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 2, 0, 8);
+    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 10);
+    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 2, 0, 10);
     const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 4, 0, 10);
 
     snapshot.roots[rootA.id] = rootA;
@@ -86,13 +85,6 @@ test('buildAutoBracedSnapshot replaces old braces and generates braces with vali
         parentShaftId: 'seg-a',
         t: 0.5,
         pos: { x: 0, y: 0, z: 3 },
-        diameter: 1.1,
-    };
-    snapshot.knots['k-old-b'] = {
-        id: 'k-old-b',
-        parentShaftId: 'seg-b',
-        t: 0.5,
-        pos: { x: 2, y: 0, z: 4 },
         diameter: 1.1,
     };
 
@@ -113,10 +105,14 @@ test('buildAutoBracedSnapshot replaces old braces and generates braces with vali
 
     assert.equal(result.snapshot.braces['brace-old'], undefined);
     assert.equal(result.snapshot.knots['k-old-a'], undefined);
-    assert.equal(result.snapshot.knots['k-old-b'], undefined);
 
     for (const brace of Object.values(result.snapshot.braces)) {
         assert.equal(brace.profile.diameter, settings.braceDiameterMm);
+        const sk = result.snapshot.knots[brace.startKnotId]!;
+        const ek = result.snapshot.knots[brace.endKnotId]!;
+        const hDist = Math.sqrt((ek.pos.x - sk.pos.x) ** 2 + (ek.pos.y - sk.pos.y) ** 2);
+        const dz = Math.abs(ek.pos.z - sk.pos.z);
+        assert.ok(Math.abs(dz - hDist) < 0.1, `Expected 45 deg (dz=hDist), got dz=${dz}, hDist=${hDist}`);
     }
 });
 
@@ -127,8 +123,8 @@ test('buildAutoBracedSnapshot leaves state unchanged when fewer than 3 supports 
     const rootA = createRoot('root-a', modelId, -2);
     const rootB = createRoot('root-b', modelId, 2);
 
-    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', -2);
-    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 2);
+    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', -2, 0, 10);
+    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 2, 0, 10);
 
     snapshot.roots[rootA.id] = rootA;
     snapshot.roots[rootB.id] = rootB;
@@ -142,120 +138,51 @@ test('buildAutoBracedSnapshot leaves state unchanged when fewer than 3 supports 
     assert.equal(result.removedBraceCount, 0);
     assert.equal(result.changed, false);
     assert.equal(result.skippedSupportCount, 2);
-    assert.equal(result.underQualifiedSupportCount, 0);
-    assert.equal(Object.keys(result.snapshot.braces).length, 0);
-    assert.equal(Object.keys(result.snapshot.knots).length, 0);
 });
 
-test('buildAutoBracedSnapshot reports qualified anchors when braces span two distinct axes', () => {
+test('buildAutoBracedSnapshot isolated grouping respects min/max limits', () => {
     const snapshot = createEmptySnapshot();
-    const modelId = 'model-c';
+    const modelId = 'model-group';
 
-    // 4 supports in a 2x2 grid, staggered heights so all adjacent pairs produce 45° angles.
-    // Grid spacing = 4mm, height step = 4mm → atan2(4,4) = 45° for all adjacent pairs.
-    // Heights: A=6, B=10, C=10, D=14 → top anchors: A=4, B=8, C=8, D=12
-    // A↔B: dz=4, dx=4 → 45°; A↔C: dz=4, dy=4 → 45°; B↔D: dz=4, dy=4 → 45°; C↔D: dz=4, dx=4 → 45°
-    // Support A gets braces from +X direction (A↔B) and +Y direction (A↔C) → two distinct axes → qualified.
-    const rootA = createRoot('root-a', modelId, 0, 0);
-    const rootB = createRoot('root-b', modelId, 4, 0);
-    const rootC = createRoot('root-c', modelId, 0, 4);
-    const rootD = createRoot('root-d', modelId, 4, 4);
-
-    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 6);
-    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 4, 0, 10);
-    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 0, 4, 10);
-    const trunkD = createTrunk('trunk-d', modelId, rootD.id, 'seg-d', 4, 4, 14);
-
-    snapshot.roots[rootA.id] = rootA;
-    snapshot.roots[rootB.id] = rootB;
-    snapshot.roots[rootC.id] = rootC;
-    snapshot.roots[rootD.id] = rootD;
-
-    snapshot.trunks[trunkA.id] = trunkA;
-    snapshot.trunks[trunkB.id] = trunkB;
-    snapshot.trunks[trunkC.id] = trunkC;
-    snapshot.trunks[trunkD.id] = trunkD;
-
-    const settings = createDefaultAutoBracingSettings();
-    const result = buildAutoBracedSnapshot(snapshot, settings);
-
-    assert.ok(result.generatedBraceCount >= 2, `Expected at least 2 braces, got ${result.generatedBraceCount}`);
-    assert.ok(
-        result.underQualifiedSupportCount < 4,
-        `Expected fewer than 4 under-qualified supports, got ${result.underQualifiedSupportCount}`,
-    );
-});
-
-test('buildAutoBracedSnapshot is deterministic: same input produces identical output', () => {
-    const snapshot = createEmptySnapshot();
-    const modelId = 'model-det';
-
-    for (let i = 0; i < 5; i += 1) {
-        const root = createRoot(`root-${i}`, modelId, i * 3);
-        const trunk = createTrunk(`trunk-${i}`, modelId, root.id, `seg-${i}`, i * 3, 0, 20);
+    // 10 supports. Max group size = 5. Should form exactly two groups of 5.
+    for (let i = 0; i < 10; i++) {
+        const root = createRoot(`root-${i}`, modelId, i * 2, 0);
+        const trunk = createTrunk(`trunk-${i}`, modelId, root.id, `seg-${i}`, i * 2, 0, 10);
         snapshot.roots[root.id] = root;
         snapshot.trunks[trunk.id] = trunk;
     }
 
-    const settings = createDefaultAutoBracingSettings();
-    const result1 = buildAutoBracedSnapshot(snapshot, settings);
-    const result2 = buildAutoBracedSnapshot(snapshot, settings);
-
-    assert.equal(result1.generatedBraceCount, result2.generatedBraceCount);
-    assert.equal(result1.underQualifiedSupportCount, result2.underQualifiedSupportCount);
-
-    const braceIds1 = Object.keys(result1.snapshot.braces).sort();
-    const braceIds2 = Object.keys(result2.snapshot.braces).sort();
-    assert.deepEqual(braceIds1, braceIds2);
-});
-
-test('buildAutoBracedSnapshot produces only top-section braces for short supports', () => {
-    const snapshot = createEmptySnapshot();
-    const modelId = 'model-short';
-
-    // Height = 5mm. topOffset=2mm, bottomOffset=2mm. minHeightForBottom = 2+2+2 = 6mm.
-    // 5mm < 6mm → bottom section NOT active. Only top braces expected.
-    const rootA = createRoot('root-a', modelId, 0);
-    const rootB = createRoot('root-b', modelId, 4);
-    const rootC = createRoot('root-c', modelId, 8);
-
-    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 5);
-    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 4, 0, 5);
-    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 8, 0, 5);
-
-    snapshot.roots[rootA.id] = rootA;
-    snapshot.roots[rootB.id] = rootB;
-    snapshot.roots[rootC.id] = rootC;
-    snapshot.trunks[trunkA.id] = trunkA;
-    snapshot.trunks[trunkB.id] = trunkB;
-    snapshot.trunks[trunkC.id] = trunkC;
-
-    const settings = createDefaultAutoBracingSettings();
+    const settings = { ...createDefaultAutoBracingSettings(), maxGroupSize: 5 };
     const result = buildAutoBracedSnapshot(snapshot, settings);
 
-    assert.ok(result.generatedBraceCount > 0, 'Should generate top-section braces');
-
+    // Braces never cross groups. Verify no brace connects trunk-4 (end of group 1) to trunk-5 (start of group 2).
     for (const brace of Object.values(result.snapshot.braces)) {
-        assert.equal(brace.debugSection, 'top', `Expected top section, got ${brace.debugSection}`);
+        const sk = result.snapshot.knots[brace.startKnotId]!;
+        const ek = result.snapshot.knots[brace.endKnotId]!;
+
+        const idA = sk.parentShaftId.replace('seg-trunk-', '');
+        const idB = ek.parentShaftId.replace('seg-trunk-', '');
+        const groupA = Math.floor(parseInt(idA) / 5);
+        const groupB = Math.floor(parseInt(idB) / 5);
+        assert.equal(groupA, groupB, `Brace ${brace.id} crosses group boundary! ${idA} and ${idB}`);
     }
 });
 
-test('buildAutoBracedSnapshot produces top and bottom braces for medium-height supports', () => {
+test('buildAutoBracedSnapshot termination respects support height', () => {
     const snapshot = createEmptySnapshot();
-    const modelId = 'model-medium';
+    const modelId = 'model-term';
 
-    // Height = 10mm. topOffset=2mm, bottomOffset=2mm. minHeightForBottom = 6mm.
-    // 10mm >= 6mm → bottom section active. minHeightForMiddle = 2+2+4 = 8mm.
-    // centerZ = 5mm. topSearchBound = 10-2-1 = 7mm. 5 <= 7 → middle active too.
-    // Use height=8mm to be at the boundary: minHeightForMiddle=8mm, 8>=8 → middle just active.
-    // Use height=7mm: 7 < 8 → middle NOT active. Only top+bottom.
-    const rootA = createRoot('root-a', modelId, 0);
-    const rootB = createRoot('root-b', modelId, 4);
-    const rootC = createRoot('root-c', modelId, 8);
+    // Support A is tall (10mm). Support B is short (1mm).
+    // Initial brace at 2.0mm. hDist = 2mm.
+    // If A is low (2mm) and B is high (2+2=4mm), B top reference (1mm) < 4mm -> REJECTED.
+    // If B is low (2mm) and A is high (4mm), B top reference (1mm) < 2mm -> REJECTED.
+    const rootA = createRoot('root-a', modelId, 0, 0);
+    const rootB = createRoot('root-b', modelId, 2, 0);
+    const rootC = createRoot('root-c', modelId, 4, 0);
 
-    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 7);
-    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 4, 0, 7);
-    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 8, 0, 7);
+    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 10);
+    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 2, 0, 1);
+    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 4, 0, 10);
 
     snapshot.roots[rootA.id] = rootA;
     snapshot.roots[rootB.id] = rootB;
@@ -267,163 +194,50 @@ test('buildAutoBracedSnapshot produces top and bottom braces for medium-height s
     const settings = createDefaultAutoBracingSettings();
     const result = buildAutoBracedSnapshot(snapshot, settings);
 
-    const sections = new Set(Object.values(result.snapshot.braces).map((b) => b.debugSection));
-    assert.ok(sections.has('top'), 'Expected top section braces');
-    assert.ok(sections.has('bottom'), 'Expected bottom section braces');
-    assert.ok(!sections.has('middle'), 'Should not have middle section braces at this height');
-});
-
-test('buildAutoBracedSnapshot produces top, bottom, and middle braces for tall supports', () => {
-    const snapshot = createEmptySnapshot();
-    const modelId = 'model-tall';
-
-    // Height = 20mm. minHeightForMiddle = 8mm. 20 >= 8 → all three sections active.
-    const rootA = createRoot('root-a', modelId, 0);
-    const rootB = createRoot('root-b', modelId, 4);
-    const rootC = createRoot('root-c', modelId, 8);
-
-    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 20);
-    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 4, 0, 20);
-    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 8, 0, 20);
-
-    snapshot.roots[rootA.id] = rootA;
-    snapshot.roots[rootB.id] = rootB;
-    snapshot.roots[rootC.id] = rootC;
-    snapshot.trunks[trunkA.id] = trunkA;
-    snapshot.trunks[trunkB.id] = trunkB;
-    snapshot.trunks[trunkC.id] = trunkC;
-
-    const settings = createDefaultAutoBracingSettings();
-    const result = buildAutoBracedSnapshot(snapshot, settings);
-
-    const sections = new Set(Object.values(result.snapshot.braces).map((b) => b.debugSection));
-    assert.ok(sections.has('top'), 'Expected top section braces');
-    assert.ok(sections.has('bottom'), 'Expected bottom section braces');
-    assert.ok(sections.has('middle'), 'Expected middle section braces for tall supports');
-});
-
-test('buildAutoBracedSnapshot crossDiagonal produces mirror slope vs singleDiagonal', () => {
-    const makeSnapshot = () => {
-        const snapshot = createEmptySnapshot();
-        const modelId = 'model-pattern';
-        const rootA = createRoot('root-a', modelId, 0);
-        const rootB = createRoot('root-b', modelId, 4);
-        const rootC = createRoot('root-c', modelId, 8);
-        const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', 0, 0, 20);
-        const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 4, 0, 20);
-        const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 8, 0, 20);
-        snapshot.roots[rootA.id] = rootA;
-        snapshot.roots[rootB.id] = rootB;
-        snapshot.roots[rootC.id] = rootC;
-        snapshot.trunks[trunkA.id] = trunkA;
-        snapshot.trunks[trunkB.id] = trunkB;
-        snapshot.trunks[trunkC.id] = trunkC;
-        return snapshot;
-    };
-
-    const singleSettings = { ...createDefaultAutoBracingSettings(), topPattern: 'singleDiagonal' as const };
-    const crossSettings = { ...createDefaultAutoBracingSettings(), topPattern: 'crossDiagonal' as const };
-
-    const singleResult = buildAutoBracedSnapshot(makeSnapshot(), singleSettings);
-    const crossResult = buildAutoBracedSnapshot(makeSnapshot(), crossSettings);
-
-    assert.ok(singleResult.generatedBraceCount > 0, 'singleDiagonal should generate braces');
-    assert.ok(crossResult.generatedBraceCount > 0, 'crossDiagonal should generate braces');
-
-    // Extract dz signs for top braces: singleDiagonal and crossDiagonal should have opposite slopes
-    const getTopBraceDzSigns = (result: ReturnType<typeof buildAutoBracedSnapshot>) =>
-        Object.values(result.snapshot.braces)
-            .filter((b) => b.debugSection === 'top')
-            .map((b) => {
-                const sk = result.snapshot.knots[b.startKnotId];
-                const ek = result.snapshot.knots[b.endKnotId];
-                if (!sk || !ek) return 0;
-                return Math.sign(ek.pos.z - sk.pos.z);
-            });
-
-    const singleSigns = getTopBraceDzSigns(singleResult);
-    const crossSigns = getTopBraceDzSigns(crossResult);
-
-    // crossDiagonal produces both diagonals (X), so more braces than singleDiagonal
-    assert.ok(
-        crossResult.generatedBraceCount > singleResult.generatedBraceCount,
-        `crossDiagonal (${crossResult.generatedBraceCount}) should produce more braces than singleDiagonal (${singleResult.generatedBraceCount})`,
-    );
-
-    // crossDiagonal should contain both slope directions (positive and negative dz)
-    const hasPositive = crossSigns.some((s) => s > 0);
-    const hasNegative = crossSigns.some((s) => s < 0);
-    assert.ok(hasPositive && hasNegative, 'crossDiagonal should have braces going both up and down (X pattern)');
-});
-
-test('buildAutoBracedSnapshot rejects pairs whose brace length exceeds maxBraceLengthMm', () => {
-    const snapshot = createEmptySnapshot();
-    const modelId = 'model-long';
-
-    // Supports spaced 15mm apart horizontally. maxBraceLengthMm = 10mm filters on hDist,
-    // so 15mm > 10mm → all pairs rejected.
-    const rootA = createRoot('root-a', modelId, -15);
-    const rootB = createRoot('root-b', modelId, 0);
-    const rootC = createRoot('root-c', modelId, 15);
-
-    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', -15, 0, 30);
-    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 0, 0, 30);
-    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 15, 0, 30);
-
-    snapshot.roots[rootA.id] = rootA;
-    snapshot.roots[rootB.id] = rootB;
-    snapshot.roots[rootC.id] = rootC;
-    snapshot.trunks[trunkA.id] = trunkA;
-    snapshot.trunks[trunkB.id] = trunkB;
-    snapshot.trunks[trunkC.id] = trunkC;
-
-    const settings = createDefaultAutoBracingSettings();
-    const result = buildAutoBracedSnapshot(snapshot, settings);
-
-    assert.equal(result.generatedBraceCount, 0, 'Pairs exceeding maxBraceLengthMm should be rejected');
-    assert.equal(result.changed, false);
-});
-
-test('buildAutoBracedSnapshot places braces at ~45 degrees even when supports are same height', () => {
-    const snapshot = createEmptySnapshot();
-    const modelId = 'model-d';
-
-    // All supports at same height. The new algorithm derives dz = horizontal distance
-    // to achieve 45°, so braces should still be generated with correct angle.
-    const rootA = createRoot('root-a', modelId, -4);
-    const rootB = createRoot('root-b', modelId, 0);
-    const rootC = createRoot('root-c', modelId, 4);
-
-    const trunkA = createTrunk('trunk-a', modelId, rootA.id, 'seg-a', -4, 0, 20);
-    const trunkB = createTrunk('trunk-b', modelId, rootB.id, 'seg-b', 0, 0, 20);
-    const trunkC = createTrunk('trunk-c', modelId, rootC.id, 'seg-c', 4, 0, 20);
-
-    snapshot.roots[rootA.id] = rootA;
-    snapshot.roots[rootB.id] = rootB;
-    snapshot.roots[rootC.id] = rootC;
-    snapshot.trunks[trunkA.id] = trunkA;
-    snapshot.trunks[trunkB.id] = trunkB;
-    snapshot.trunks[trunkC.id] = trunkC;
-
-    const settings = createDefaultAutoBracingSettings();
-    const result = buildAutoBracedSnapshot(snapshot, settings);
-
-    assert.ok(result.generatedBraceCount > 0, 'Should generate braces at 45° even with same-height supports');
-
-    // Verify each generated brace is within 20° of 45°
+    // trunk-b should have NO braces attached to it.
     for (const brace of Object.values(result.snapshot.braces)) {
-        const sk = result.snapshot.knots[brace.startKnotId];
-        const ek = result.snapshot.knots[brace.endKnotId];
-        if (!sk || !ek) continue;
-        const dx = ek.pos.x - sk.pos.x;
-        const dy = ek.pos.y - sk.pos.y;
-        const dz = Math.abs(ek.pos.z - sk.pos.z);
-        const hDist = Math.sqrt(dx * dx + dy * dy);
-        if (hDist < 0.001) continue;
-        const angleDeg = Math.atan2(dz, hDist) * (180 / Math.PI);
-        assert.ok(
-            Math.abs(angleDeg - 45) <= 20,
-            `Brace angle ${angleDeg.toFixed(1)}° deviates more than 20° from 45°`,
-        );
+        const sk = result.snapshot.knots[brace.startKnotId]!;
+        const ek = result.snapshot.knots[brace.endKnotId]!;
+        assert.notEqual(sk.parentShaftId, 'seg-b');
+        assert.notEqual(ek.parentShaftId, 'seg-b');
     }
+});
+
+test('buildAutoBracedSnapshot respects maxBraceLengthMm during grouping', () => {
+    const snapshot = createEmptySnapshot();
+    const modelId = 'model-dist-group';
+
+    // 2 supports close (5mm), 3rd support far (20mm).
+    // Max bracing distance = 6mm (treated as horizontal span).
+    // 1 and 2 should group. 3 should be isolated.
+    const root1 = createRoot('root-1', modelId, 0, 0);
+    const root2 = createRoot('root-2', modelId, 5, 0); // 5mm gap
+    const root3 = createRoot('root-3', modelId, 25, 0); // 20mm gap
+
+    const trunk1 = createTrunk('trunk-1', modelId, root1.id, 'seg-1', 0, 0, 10);
+    const trunk2 = createTrunk('trunk-2', modelId, root2.id, 'seg-2', 5, 0, 10);
+    const trunk3 = createTrunk('trunk-3', modelId, root3.id, 'seg-3', 25, 0, 10);
+
+    snapshot.roots[root1.id] = root1;
+    snapshot.roots[root2.id] = root2;
+    snapshot.roots[root3.id] = root3;
+    snapshot.trunks[trunk1.id] = trunk1;
+    snapshot.trunks[trunk2.id] = trunk2;
+    snapshot.trunks[trunk3.id] = trunk3;
+
+    const settings = { ...createDefaultAutoBracingSettings(), maxBraceLengthMm: 6, minGroupSize: 2 };
+    const result = buildAutoBracedSnapshot(snapshot, settings);
+
+    // trunk-1 and trunk-2 should have a brace. trunk-3 should have NONE.
+    let hasBrace3 = false;
+    let hasBrace1_2 = false;
+    for (const brace of Object.values(result.snapshot.braces)) {
+        const sk = result.snapshot.knots[brace.startKnotId]!;
+        const ek = result.snapshot.knots[brace.endKnotId]!;
+        if (sk.parentShaftId === 'seg-3' || ek.parentShaftId === 'seg-3') hasBrace3 = true;
+        if ((sk.parentShaftId === 'seg-1' && ek.parentShaftId === 'seg-2') ||
+            (sk.parentShaftId === 'seg-2' && ek.parentShaftId === 'seg-1')) hasBrace1_2 = true;
+    }
+    assert.equal(hasBrace1_2, true, 'Trunk 1 and 2 should be braced (5mm gap < 6mm limit)');
+    assert.equal(hasBrace3, false, 'Trunk 3 should not be braced as it is too far from the group');
 });

--- a/src/supports/autoBracing/AutoBracingSettingsCard.tsx
+++ b/src/supports/autoBracing/AutoBracingSettingsCard.tsx
@@ -53,65 +53,71 @@ export function AutoBracingSettingsCard({
     };
 
     return (
-        <div className="space-y-3">
+        <div className="space-y-4">
             <div className="text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-                Auto Bracing
+                Auto Bracing (Ladder Model)
             </div>
 
-            <div className="grid grid-cols-2 gap-1.5">
-                <label className="space-y-1 min-w-0">
-                    <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Brace diameter (mm)</div>
-                    <NumberInput
-                        value={settings.braceDiameterMm}
-                        onChange={(value) => onChange({ braceDiameterMm: value })}
-                        className={compactInputClass}
-                    />
-                </label>
+            <div className="space-y-3">
+                {/* Global Settings */}
+                <div className="grid grid-cols-2 gap-1.5">
+                    <label className="space-y-1 min-w-0">
+                        <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Brace diameter (mm)</div>
+                        <NumberInput
+                            value={settings.braceDiameterMm}
+                            onChange={(value) => onChange({ braceDiameterMm: value })}
+                            className={compactInputClass}
+                        />
+                    </label>
+                    <label className="space-y-1 min-w-0">
+                        <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Max group size (supports)</div>
+                        <NumberInput
+                            value={settings.maxGroupSize}
+                            onChange={(value) => onChange({ maxGroupSize: value })}
+                            className={compactInputClass}
+                        />
+                    </label>
+                </div>
 
-                <label className="space-y-1 min-w-0">
-                    <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Max group size</div>
-                    <NumberInput
-                        value={settings.maxGroupSize}
-                        onChange={(value) => onChange({ maxGroupSize: value })}
-                        className={compactInputClass}
-                    />
-                </label>
-            </div>
+                {/* Initial Pattern Settings */}
+                <div className="grid grid-cols-2 gap-1.5">
+                    {renderPatternSelect('Initial pattern', settings.initialPattern, (initialPattern) => onChange({ initialPattern }))}
+                    <label className="space-y-1 min-w-0">
+                        <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Initial distance from Z=0 (mm)</div>
+                        <NumberInput
+                            value={settings.initialDistanceMm}
+                            onChange={(value) => onChange({ initialDistanceMm: value })}
+                            className={compactInputClass}
+                        />
+                    </label>
+                </div>
 
-            <div className="grid grid-cols-2 gap-1.5">
-                {renderPatternSelect('Top pattern', settings.topPattern, (topPattern) => onChange({ topPattern }))}
-                <label className="space-y-1 min-w-0">
-                    <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Top offset from top (mm)</div>
-                    <NumberInput
-                        value={settings.topOffsetFromTopMm}
-                        onChange={(value) => onChange({ topOffsetFromTopMm: value })}
-                        className={compactInputClass}
-                    />
-                </label>
-            </div>
+                {/* Repeating Pattern Settings */}
+                <div className="grid grid-cols-2 gap-1.5">
+                    {renderPatternSelect('Repeating pattern', settings.repeatingPattern, (repeatingPattern) => onChange({ repeatingPattern }))}
+                    <label className="space-y-1 min-w-0">
+                        <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Repeat interval (mm)</div>
+                        <NumberInput
+                            value={settings.patternIntervalMm}
+                            onChange={(value) => onChange({ patternIntervalMm: value })}
+                            className={compactInputClass}
+                        />
+                    </label>
+                </div>
 
-            <div className="grid grid-cols-2 gap-1.5">
-                {renderPatternSelect('Middle pattern', settings.middlePattern, (middlePattern) => onChange({ middlePattern }))}
-                <label className="space-y-1 min-w-0">
-                    <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Middle repeat interval (mm)</div>
-                    <NumberInput
-                        value={settings.middleRepeatIntervalMm}
-                        onChange={(value) => onChange({ middleRepeatIntervalMm: value })}
-                        className={compactInputClass}
-                    />
-                </label>
-            </div>
+                <div className="h-px w-full" style={{ background: 'var(--border-subtle)' }} />
 
-            <div className="grid grid-cols-2 gap-1.5">
-                {renderPatternSelect('Bottom pattern', settings.bottomPattern, (bottomPattern) => onChange({ bottomPattern }))}
-                <label className="space-y-1 min-w-0">
-                    <div className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Bottom offset from bottom (mm)</div>
-                    <NumberInput
-                        value={settings.bottomOffsetFromBottomMm}
-                        onChange={(value) => onChange({ bottomOffsetFromBottomMm: value })}
-                        className={compactInputClass}
-                    />
-                </label>
+                {/* Tuning Settings */}
+                <div className="grid grid-cols-1 gap-1.5">
+                    <label className="space-y-1 min-w-0">
+                        <div className="text-[10px] font-medium" style={{ color: 'var(--text-secondary)' }}>Max bracing distance (mm) - Tuning</div>
+                        <NumberInput
+                            value={settings.maxBraceLengthMm}
+                            onChange={(value) => onChange({ maxBraceLengthMm: value })}
+                            className={compactInputClass}
+                        />
+                    </label>
+                </div>
             </div>
 
             <label className="flex items-center justify-between rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-0), transparent 8%)' }}>
@@ -125,8 +131,8 @@ export function AutoBracingSettingsCard({
             </label>
 
             <div className="rounded-md border px-2.5 py-2 text-[10px] leading-tight" style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-0), transparent 6%)', color: 'var(--text-muted)' }}>
-                <div>Fixed rules: {AUTO_BRACING_HARD_RULES.braceAngleDeg}° brace angle, minimum group size {AUTO_BRACING_HARD_RULES.minGroupSize}, and {AUTO_BRACING_HARD_RULES.minAxisSeparationDeg}° minimum axis separation.</div>
-                <div className="mt-1">Value limits: diameter {AUTO_BRACING_CONSTRAINTS.braceDiameterMm.min}–{AUTO_BRACING_CONSTRAINTS.braceDiameterMm.max} mm, group size {AUTO_BRACING_CONSTRAINTS.maxGroupSize.min}–{AUTO_BRACING_CONSTRAINTS.maxGroupSize.max}.</div>
+                <div>Fixed rules: {AUTO_BRACING_HARD_RULES.braceAngleDeg}° brace angle, min group size {AUTO_BRACING_HARD_RULES.minGroupSize}, and {AUTO_BRACING_HARD_RULES.minAxisSeparationDeg}° min axis separation.</div>
+                <div className="mt-1">Value limits: dia {AUTO_BRACING_CONSTRAINTS.braceDiameterMm.min}–{AUTO_BRACING_CONSTRAINTS.braceDiameterMm.max}, dist {AUTO_BRACING_CONSTRAINTS.maxBraceLengthMm.min}–{AUTO_BRACING_CONSTRAINTS.maxBraceLengthMm.max} mm.</div>
             </div>
 
             {status && (

--- a/src/supports/autoBracing/autoBrace.ts
+++ b/src/supports/autoBracing/autoBrace.ts
@@ -13,6 +13,8 @@ import {
     getBranchSegmentEndpoints,
 } from '../SupportPrimitives/Knot/knotUtils';
 import { JOINT_DIAMETER_OFFSET_MM } from '../constants';
+import { getSupportBraceSnapshot, setSupportBraceSnapshot } from '../SupportTypes/SupportBrace/supportBraceStore';
+import type { SupportBraceState } from '../SupportTypes/SupportBrace/types';
 import type {
     Brace,
     Branch,
@@ -28,10 +30,12 @@ import {
     type AutoBracingPattern,
     type AutoBracingSettings,
 } from './settings';
+import { generateRequiredSupportBraces } from './generativeBracing';
 
 const EPS = 0.000001;
+const SQRT2 = Math.SQRT2;
 
-type SupportKind = 'trunk' | 'branch';
+type SupportKind = 'trunk' | 'branch' | 'supportBrace';
 
 const BRACE_CLEARANCE_SAMPLE_COUNT = 12;
 
@@ -70,6 +74,10 @@ function bracePassesMeshClearance(posA: Vec3, posB: Vec3, modelId: string, brace
     return true;
 }
 
+function maxHorizontalRunFromBraceLen(maxBraceLenMm: number): number {
+    return maxBraceLenMm / SQRT2;
+}
+
 type SegmentSample = {
     segmentId: string;
     segment: Segment;
@@ -86,6 +94,7 @@ type SupportSample = {
     topReferenceZ: number;
     bottomReferenceZ: number;
     sortAnchor: Vec3;
+    hostSegmentId?: string;
 };
 
 type AnchorPoint = {
@@ -190,6 +199,51 @@ function buildSupportSamples(snapshot: SupportState): SupportSample[] {
     return supports;
 }
 
+function buildSupportBraceSamples(supportBraceState: SupportBraceState): SupportSample[] {
+    const supports: SupportSample[] = [];
+
+    for (const supportBrace of Object.values(supportBraceState.supportBraces)) {
+        const root = supportBraceState.roots[supportBrace.rootId];
+        const hostKnot = supportBraceState.knots[supportBrace.hostKnotId];
+        if (!root || !hostKnot) continue;
+
+        const basePos = new THREE.Vector3(root.transform.pos.x, root.transform.pos.y, root.transform.pos.z);
+        const rootTopZ = root.diskHeight + root.coneHeight;
+        let currentStart = basePos.clone().add(new THREE.Vector3(0, 0, rootTopZ));
+
+        const segments: SegmentSample[] = [];
+        supportBrace.segments.forEach((seg) => {
+            const endPoint = seg.topJoint
+                ? new THREE.Vector3(seg.topJoint.pos.x, seg.topJoint.pos.y, seg.topJoint.pos.z)
+                : new THREE.Vector3(hostKnot.pos.x, hostKnot.pos.y, hostKnot.pos.z);
+
+            segments.push({
+                segmentId: seg.id,
+                segment: seg,
+                start: { x: currentStart.x, y: currentStart.y, z: currentStart.z },
+                end: { x: endPoint.x, y: endPoint.y, z: endPoint.z },
+                diameterMm: seg.diameter,
+            });
+
+            currentStart = endPoint;
+        });
+
+        if (segments.length === 0) continue;
+        const ex = collectSegmentExtrema(segments);
+        supports.push({
+            supportId: supportBrace.id,
+            supportKind: 'supportBrace',
+            modelId: supportBrace.modelId,
+            segments,
+            ...ex,
+            hostSegmentId: supportBrace.hostSegmentId,
+        });
+    }
+
+    supports.sort(sortSupports);
+    return supports;
+}
+
 function resolveAnchorAtZ(support: SupportSample, targetZ: number): AnchorPoint | null {
     let best: AnchorCandidate | null = null;
 
@@ -233,8 +287,33 @@ function axisSeparationDeg(aRad: number, bRad: number): number {
 
 type Edge = { a: SupportSample; b: SupportSample; hDist: number; angleRad: number };
 
+const SUPPORT_BRACE_MAX_EDGES_PER_TRUNK = 3;
+const SUPPORT_BRACE_MAX_EDGES_PER_SUPPORT_BRACE = 2;
+
+function referenceZForDistance(a: SupportSample, b: SupportSample): number {
+    const low = Math.max(a.bottomReferenceZ, b.bottomReferenceZ);
+    const high = Math.min(a.topReferenceZ, b.topReferenceZ);
+    if (high > low + 0.001) return (low + high) / 2;
+    return Math.min(a.topReferenceZ, b.topReferenceZ);
+}
+
+function horizontalDistanceAtZ(a: SupportSample, b: SupportSample, z: number): { hDist: number; angleRad: number } | null {
+    const aAnchor = resolveAnchorAtZ(a, z);
+    const bAnchor = resolveAnchorAtZ(b, z);
+    const aPos = aAnchor?.pos ?? a.sortAnchor;
+    const bPos = bAnchor?.pos ?? b.sortAnchor;
+
+    const dx = bPos.x - aPos.x;
+    const dy = bPos.y - aPos.y;
+    const hDist = Math.sqrt(dx * dx + dy * dy);
+    if (hDist < 0.000001) return null;
+    return { hDist, angleRad: normalizeAxisAngleRad(Math.atan2(dy, dx)) };
+}
+
 function buildGroupPairs(group: SupportSample[], maxLen: number): Edge[] {
     if (group.length < 2) return [];
+
+    const maxRun = maxHorizontalRunFromBraceLen(maxLen);
 
     const edges: Edge[] = [];
     for (let i = 0; i < group.length; i++) {
@@ -243,7 +322,7 @@ function buildGroupPairs(group: SupportSample[], maxLen: number): Edge[] {
             const dx = b.sortAnchor.x - a.sortAnchor.x;
             const dy = b.sortAnchor.y - a.sortAnchor.y;
             const hDist = Math.sqrt(dx * dx + dy * dy);
-            if (hDist < 0.001 || hDist > maxLen) continue;
+            if (hDist < 0.001 || hDist > maxRun) continue;
             edges.push({ a, b, hDist, angleRad: normalizeAxisAngleRad(Math.atan2(dy, dx)) });
         }
     }
@@ -325,9 +404,26 @@ function buildGroupPairs(group: SupportSample[], maxLen: number): Edge[] {
     return result;
 }
 
-function partitionSupportsIntoGroups(supports: SupportSample[], max: number, maxDist: number): SupportSample[][] {
+function partitionSupportsIntoGroups(
+    supports: SupportSample[],
+    max: number,
+    maxBraceLen: number,
+    weightBySupportId?: Map<string, number>,
+): SupportSample[][] {
     const min = AUTO_BRACING_HARD_RULES.minGroupSize;
-    if (supports.length < min) return [];
+    
+    const maxRun = maxHorizontalRunFromBraceLen(maxBraceLen);
+    const weightOf = (s: SupportSample) => weightBySupportId?.get(s.supportId) ?? 1;
+    const groupWeight = (items: SupportSample[]) => items.reduce((sum, item) => sum + weightOf(item), 0);
+
+    // If total weight is less than min, we can still brace them if there's enough elements in the end, 
+    // but the strict "skip everything if < min" rule is handled later after support braces are mixed in.
+    if (groupWeight(supports) < min && supports.length > 0 && groupWeight(supports) === supports.length) {
+        // If it's pure trunks and still below min, we can bail. But if weight > length, it means it has support braces, so we should try to keep it.
+        if (groupWeight(supports) < min) {
+             return [];
+        }
+    }
 
     const remaining = [...supports].sort(sortSupports);
     const groups: SupportSample[][] = [];
@@ -335,50 +431,194 @@ function partitionSupportsIntoGroups(supports: SupportSample[], max: number, max
     while (remaining.length > 0) {
         const seed = remaining.shift()!;
         const group = [seed];
-        while (group.length < max && remaining.length > 0) {
-            let bestIdx = -1, bestDist = Infinity;
+        let currentWeight = weightOf(seed);
+
+        while (currentWeight < max && remaining.length > 0) {
+            let bestIdx = -1;
+            let bestDist = Infinity;
+
             for (let i = 0; i < remaining.length; i++) {
+                const candidate = remaining[i];
+                const candidateWeight = weightOf(candidate);
+                if (currentWeight + candidateWeight > max) continue;
+
                 for (const g of group) {
-                    const d = Math.sqrt((g.sortAnchor.x - remaining[i].sortAnchor.x) ** 2 + (g.sortAnchor.y - remaining[i].sortAnchor.y) ** 2);
-                    if (d < bestDist) { bestDist = d; bestIdx = i; }
+                    const d = Math.sqrt(
+                        (g.sortAnchor.x - candidate.sortAnchor.x) ** 2
+                        + (g.sortAnchor.y - candidate.sortAnchor.y) ** 2,
+                    );
+                    if (d < bestDist) {
+                        bestDist = d;
+                        bestIdx = i;
+                    }
                 }
             }
-            if (bestDist > maxDist) break;
-            group.push(remaining.splice(bestIdx, 1)[0]);
+
+            if (bestIdx === -1) break;
+            if (bestDist > maxRun) break;
+
+            const chosen = remaining.splice(bestIdx, 1)[0];
+            group.push(chosen);
+            currentWeight += weightOf(chosen);
         }
         groups.push(group);
     }
     // Cleanup small tail groups
     if (groups.length > 1) {
         const last = groups[groups.length - 1];
-        if (last.length < min) {
+        if (groupWeight(last) < min) {
             const prev = groups[groups.length - 2];
-            if (prev.length + last.length <= max) {
+            if (groupWeight(prev) + groupWeight(last) <= max) {
                 prev.push(...last);
                 groups.pop();
             } else {
-                while (last.length < min && prev.length > min) last.unshift(prev.pop()!);
-                if (last.length < min) { prev.push(...last); groups.pop(); }
+                while (groupWeight(last) < min && groupWeight(prev) > min) {
+                    const moved = prev[prev.length - 1];
+                    if (!moved) break;
+                    if (groupWeight(last) + weightOf(moved) > max) break;
+                    last.unshift(prev.pop()!);
+                }
+                if (groupWeight(last) < min && groupWeight(prev) + groupWeight(last) <= max) {
+                    prev.push(...last);
+                    groups.pop();
+                }
             }
         }
     }
-    return groups.filter(g => g.length >= min);
+    return groups.filter(g => groupWeight(g) >= min); 
 }
 
 export function buildAutoBracedSnapshot(snapshot: SupportState, inputSettings: AutoBracingSettings): BuildSnapshotResult {
     const settings = normalizeAutoBracingSettings(inputSettings);
-    const supportSamples = buildSupportSamples(snapshot).filter(s => s.supportKind === 'trunk');
+    const maxRun = maxHorizontalRunFromBraceLen(settings.maxBraceLengthMm);
+    const trunkSamples = buildSupportSamples(snapshot).filter(s => s.supportKind === 'trunk');
+
+    let supportBraceState = getSupportBraceSnapshot();
+
+    // -- PRELIMINARY PAIRING PASS (To detect trunks needing generative fallback) --
+    const tempByModel = new Map<string, SupportSample[]>();
+    for (const s of trunkSamples) {
+        if (!tempByModel.has(s.modelId)) tempByModel.set(s.modelId, []);
+        tempByModel.get(s.modelId)!.push(s);
+    }
+    
+    const existingTrunkEdges: Array<{ a: string; b: string; angleRad: number }> = [];
+    for (const list of tempByModel.values()) {
+        // Evaluate physical pairing across the ENTIRE model first.
+        // If a trunk can physically reach another trunk, it is not "isolated", 
+        // even if it ultimately gets placed in a different group later.
+        const pairs = buildGroupPairs(list, settings.maxBraceLengthMm);
+        for (const edge of pairs) {
+            existingTrunkEdges.push({
+                a: edge.a.supportId,
+                b: edge.b.supportId,
+                angleRad: edge.angleRad
+            });
+        }
+    }
+
+    // -- GENERATIVE PHASE --
+    // Only generate Support Braces if a tall trunk failed to find 2-axis bracing
+    // amongst the existing trunks in the preliminary pass.
+    const generatedSupportBraces = generateRequiredSupportBraces(snapshot, supportBraceState, settings, existingTrunkEdges);
+    
+    let generatedSupportBraceCount = 0;
+    if (generatedSupportBraces.length > 0) {
+        const nextSupportBraces = { ...supportBraceState.supportBraces };
+        const nextRoots = { ...supportBraceState.roots };
+        const nextKnots = { ...supportBraceState.knots };
+
+        for (const build of generatedSupportBraces) {
+            // Ensure the generated support brace explicitly tracks its host to guarantee grouping
+            build.supportBrace.hostSegmentId = build.supportBrace.hostSegmentId || build.hostKnot.parentShaftId;
+            nextSupportBraces[build.supportBrace.id] = build.supportBrace;
+            nextRoots[build.root.id] = build.root;
+            nextKnots[build.hostKnot.id] = build.hostKnot;
+        }
+
+        supportBraceState = {
+            ...supportBraceState,
+            supportBraces: nextSupportBraces,
+            roots: nextRoots,
+            knots: nextKnots
+        };
+        
+        // Update the global store so they exist in the app
+        setSupportBraceSnapshot(supportBraceState);
+        generatedSupportBraceCount = generatedSupportBraces.length;
+    }
+    // -- END GENERATIVE PHASE --
+
+    const supportBraceSamples = buildSupportBraceSamples(supportBraceState);
+
+    const segmentOwnerTrunkId = new Map<string, string>();
+    for (const trunk of Object.values(snapshot.trunks)) {
+        for (const seg of trunk.segments) {
+            segmentOwnerTrunkId.set(seg.id, trunk.id);
+        }
+    }
+
+    const assignedTrunkIdBySupportBraceId = new Map<string, string>();
+    const supportBracesByTrunkId = new Map<string, SupportSample[]>();
+
+    const findNearestTrunkId = (sb: SupportSample): string | null => {
+        let bestId: string | null = null;
+        let bestDist = Infinity;
+        for (const trunk of trunkSamples) {
+            if (trunk.modelId !== sb.modelId) continue;
+            const zRef = referenceZForDistance(trunk, sb);
+            const d = horizontalDistanceAtZ(trunk, sb, zRef);
+            if (!d) continue;
+            if (d.hDist < bestDist) {
+                bestDist = d.hDist;
+                bestId = trunk.supportId;
+            }
+        }
+        if (!bestId) return null;
+        if (bestDist > maxRun + EPS) return null;
+        return bestId;
+    };
+
+    for (const sb of supportBraceSamples) {
+        const hostSegmentId = sb.hostSegmentId;
+        const hostTrunkId = hostSegmentId ? (segmentOwnerTrunkId.get(hostSegmentId) ?? null) : null;
+
+        const assignedTrunkId = hostTrunkId ?? findNearestTrunkId(sb);
+        if (!assignedTrunkId) continue;
+
+        assignedTrunkIdBySupportBraceId.set(sb.supportId, assignedTrunkId);
+        const list = supportBracesByTrunkId.get(assignedTrunkId) ?? [];
+        list.push(sb);
+        supportBracesByTrunkId.set(assignedTrunkId, list);
+    }
+
+    const weightByTrunkId = new Map<string, number>();
+    for (const trunk of trunkSamples) {
+        const count = supportBracesByTrunkId.get(trunk.supportId)?.length ?? 0;
+        weightByTrunkId.set(trunk.supportId, 1 + count);
+    }
+
     const byModel = new Map<string, SupportSample[]>();
-    for (const s of supportSamples) {
+    for (const s of trunkSamples) {
         if (!byModel.has(s.modelId)) byModel.set(s.modelId, []);
         byModel.get(s.modelId)!.push(s);
     }
 
     const groupedSupports: SupportSample[][] = [];
-    for (const list of byModel.values()) groupedSupports.push(...partitionSupportsIntoGroups(list, settings.maxGroupSize, settings.maxBraceLengthMm));
+    for (const list of byModel.values()) {
+        const trunkGroups = partitionSupportsIntoGroups(list, settings.maxGroupSize, settings.maxBraceLengthMm, weightByTrunkId);
+        for (const g of trunkGroups) {
+            const members: SupportSample[] = [...g];
+            for (const trunk of g) {
+                const sbs = supportBracesByTrunkId.get(trunk.supportId);
+                if (sbs && sbs.length > 0) members.push(...sbs);
+            }
+            groupedSupports.push(members);
+        }
+    }
 
     const groupedIds = new Set<string>();
-    groupedSupports.forEach(g => g.forEach(s => groupedIds.add(s.supportId)));
+    groupedSupports.forEach(g => g.forEach(s => { if (s.supportKind === 'trunk') groupedIds.add(s.supportId); }));
 
     const braceKnotIds = new Set<string>();
     for (const b of Object.values(snapshot.braces)) { braceKnotIds.add(b.startKnotId); braceKnotIds.add(b.endKnotId); }
@@ -399,9 +639,172 @@ export function buildAutoBracedSnapshot(snapshot: SupportState, inputSettings: A
     const generatedBraces: Record<string, Brace> = {};
     const generatedKnots: Record<string, Knot> = {};
 
-    for (const group of groupedSupports) {
-        const pairs = buildGroupPairs(group, settings.maxBraceLengthMm);
-        const maxZ = Math.max(...group.map(s => s.topReferenceZ));
+    for (let groupIndex = 0; groupIndex < groupedSupports.length; groupIndex += 1) {
+        const groupMembers = groupedSupports[groupIndex];
+        const groupTrunks = groupMembers.filter((s) => s.supportKind === 'trunk');
+        const pairs = buildGroupPairs(groupTrunks, settings.maxBraceLengthMm);
+        const extra = groupMembers.filter((s) => s.supportKind === 'supportBrace');
+        if (extra.length > 0 && groupTrunks.length > 0) {
+            const supportBraceCandidateEdges: Edge[] = [];
+            for (const sb of extra) {
+                for (const trunk of groupTrunks) {
+                    const zRef = referenceZForDistance(trunk, sb);
+                    const d = horizontalDistanceAtZ(trunk, sb, zRef);
+                    if (!d) continue;
+                    if (d.hDist > maxRun + EPS) continue;
+                    supportBraceCandidateEdges.push({
+                        a: trunk,
+                        b: sb,
+                        hDist: d.hDist,
+                        angleRad: d.angleRad,
+                    });
+                }
+            }
+
+            // Also check for support braces near each other (like 2 generated braces on an isolated trunk)
+            for (let i = 0; i < extra.length; i++) {
+                for (let j = i + 1; j < extra.length; j++) {
+                    const sb1 = extra[i];
+                    const sb2 = extra[j];
+                    const zRef = referenceZForDistance(sb1, sb2);
+                    const d = horizontalDistanceAtZ(sb1, sb2, zRef);
+                    if (!d) continue;
+                    if (d.hDist > maxRun + EPS) continue;
+                    // For the sake of the graph, we inject this as an edge, keeping the structure generic
+                    // We'll treat sb1 as 'a' (like a pseudo-trunk for this connection)
+                    supportBraceCandidateEdges.push({
+                        a: sb1,
+                        b: sb2,
+                        hDist: d.hDist,
+                        angleRad: d.angleRad,
+                    });
+                }
+            }
+
+            const edgeId = (e: Edge) => [e.a.supportId, e.b.supportId].sort().join(':');
+            const existingEdgeIds = new Set(pairs.map(edgeId));
+            const trunkEdgeCount = new Map<string, number>();
+            const supportBraceEdgeCount = new Map<string, number>();
+
+            const inc = (map: Map<string, number>, key: string) => {
+                map.set(key, (map.get(key) ?? 0) + 1);
+            };
+
+            const canTake = (trunkId: string, sbId: string) => {
+                const tCount = trunkEdgeCount.get(trunkId) ?? 0;
+                const sbCount = supportBraceEdgeCount.get(sbId) ?? 0;
+                return tCount < SUPPORT_BRACE_MAX_EDGES_PER_TRUNK && sbCount < SUPPORT_BRACE_MAX_EDGES_PER_SUPPORT_BRACE;
+            };
+
+            const addEdge = (e: Edge) => {
+                pairs.push(e);
+                existingEdgeIds.add(edgeId(e));
+                inc(trunkEdgeCount, e.a.supportId);
+                inc(supportBraceEdgeCount, e.b.supportId);
+            };
+
+            for (const sb of extra) {
+                const candidates = supportBraceCandidateEdges
+                    .filter((e) => e.b.supportId === sb.supportId)
+                    .sort((x, y) => x.hDist - y.hDist);
+
+                let chosen: Edge | null = null;
+                const assignedHostTrunkId = assignedTrunkIdBySupportBraceId.get(sb.supportId) ?? null;
+                if (assignedHostTrunkId) {
+                    for (const cand of candidates) {
+                        if (cand.a.supportId !== assignedHostTrunkId) continue;
+                        if (existingEdgeIds.has(edgeId(cand))) continue;
+                        if (canTake(cand.a.supportId, cand.b.supportId)) {
+                            chosen = cand;
+                            break;
+                        }
+                    }
+                }
+
+                if (!chosen && assignedHostTrunkId) {
+                    for (const cand of candidates) {
+                        if (cand.a.supportId !== assignedHostTrunkId) continue;
+                        if (existingEdgeIds.has(edgeId(cand))) continue;
+                        chosen = cand;
+                        break;
+                    }
+                }
+
+                if (!chosen) {
+                    for (const cand of candidates) {
+                        if (existingEdgeIds.has(edgeId(cand))) continue;
+                        if (canTake(cand.a.supportId, cand.b.supportId)) {
+                            chosen = cand;
+                            break;
+                        }
+                    }
+                }
+
+                if (!chosen) {
+                    for (const cand of candidates) {
+                        if (existingEdgeIds.has(edgeId(cand))) continue;
+                        chosen = cand;
+                        break;
+                    }
+                }
+
+                if (chosen) {
+                    addEdge(chosen);
+                }
+            }
+
+            for (const trunk of groupTrunks) {
+                const axes: number[] = [];
+                for (const e of pairs) {
+                    if (e.a.supportId === trunk.supportId || e.b.supportId === trunk.supportId) {
+                        axes.push(e.angleRad);
+                    }
+                }
+
+                let qualified = false;
+                for (let i = 0; i < axes.length; i++) {
+                    for (let j = i + 1; j < axes.length; j++) {
+                        if (axisSeparationDeg(axes[i], axes[j]) >= AUTO_BRACING_HARD_RULES.minAxisSeparationDeg) {
+                            qualified = true;
+                            break;
+                        }
+                    }
+                    if (qualified) break;
+                }
+                if (qualified) continue;
+
+                let bestCandidate: Edge | null = null;
+                let bestScore = -1;
+
+                for (const cand of supportBraceCandidateEdges) {
+                    if (cand.a.supportId !== trunk.supportId) continue;
+                    if (existingEdgeIds.has(edgeId(cand))) continue;
+
+                    if (!canTake(cand.a.supportId, cand.b.supportId)) continue;
+
+                    if (axes.length === 0) {
+                        bestCandidate = cand;
+                        break;
+                    }
+
+                    for (const existing of axes) {
+                        const sep = axisSeparationDeg(existing, cand.angleRad);
+                        if (sep >= AUTO_BRACING_HARD_RULES.minAxisSeparationDeg) {
+                            const score = 90 - Math.abs(90 - sep);
+                            if (score > bestScore) {
+                                bestScore = score;
+                                bestCandidate = cand;
+                            }
+                        }
+                    }
+                }
+
+                if (bestCandidate) {
+                    addEdge(bestCandidate);
+                }
+            }
+        }
+        const maxZ = Math.max(...groupTrunks.map(s => s.topReferenceZ));
 
         const ladder: number[] = [settings.initialDistanceMm];
         let curr = settings.initialDistanceMm + settings.patternIntervalMm;
@@ -411,15 +814,47 @@ export function buildAutoBracedSnapshot(snapshot: SupportState, inputSettings: A
             const isInitial = tierIndex === 0;
             const pattern = isInitial ? settings.initialPattern : settings.repeatingPattern;
             for (const edge of pairs) {
-                const dz = edge.hDist; // 45 degrees: dz = dx
-
-                // Termination: If the brace would end above or at the support tip, skip this tier for this pair.
-                if (anchorZ + dz >= edge.a.topReferenceZ - 0.1 || anchorZ + dz >= edge.b.topReferenceZ - 0.1) continue;
-
                 const place = (lowS: SupportSample, highS: SupportSample, section: 'initial' | 'repeating') => {
                     const lowAnchor = resolveAnchorAtZ(lowS, anchorZ);
-                    const highAnchor = resolveAnchorAtZ(highS, anchorZ + dz);
-                    if (!lowAnchor || !highAnchor) return;
+                    if (!lowAnchor) return;
+
+                    const sameTierAnchor = resolveAnchorAtZ(highS, anchorZ);
+                    if (!sameTierAnchor) return;
+
+                    let dzGuess = Math.sqrt(
+                        (sameTierAnchor.pos.x - lowAnchor.pos.x) ** 2
+                        + (sameTierAnchor.pos.y - lowAnchor.pos.y) ** 2,
+                    );
+                    if (dzGuess < EPS) return;
+
+                    let highAnchor: AnchorPoint | null = null;
+                    for (let iter = 0; iter < 3; iter++) {
+                        highAnchor = resolveAnchorAtZ(highS, anchorZ + dzGuess);
+                        if (!highAnchor) return;
+                        const hDist = Math.sqrt(
+                            (highAnchor.pos.x - lowAnchor.pos.x) ** 2
+                            + (highAnchor.pos.y - lowAnchor.pos.y) ** 2,
+                        );
+                        if (Math.abs(hDist - dzGuess) < 0.01) {
+                            dzGuess = hDist;
+                            break;
+                        }
+                        dzGuess = hDist;
+                        if (dzGuess < EPS) return;
+                    }
+
+                    if (dzGuess > maxRun + EPS) return;
+
+                    if (anchorZ + dzGuess >= lowS.topReferenceZ - 0.1 || anchorZ + dzGuess >= highS.topReferenceZ - 0.1) return;
+
+                    highAnchor = resolveAnchorAtZ(highS, anchorZ + dzGuess);
+                    if (!highAnchor) return;
+
+                    const dx = highAnchor.pos.x - lowAnchor.pos.x;
+                    const dy = highAnchor.pos.y - lowAnchor.pos.y;
+                    const dz = highAnchor.pos.z - lowAnchor.pos.z;
+                    const braceLen = Math.sqrt(dx * dx + dy * dy + dz * dz);
+                    if (braceLen > settings.maxBraceLengthMm + EPS) return;
 
                     if (!bracePassesMeshClearance(lowAnchor.pos, highAnchor.pos, lowAnchor.modelId, settings.braceDiameterMm)) return;
 
@@ -446,7 +881,7 @@ export function buildAutoBracedSnapshot(snapshot: SupportState, inputSettings: A
         snapshot: nextSnapshot,
         generatedBraceCount,
         removedBraceCount,
-        skippedSupportCount: supportSamples.length - groupedIds.size,
+        skippedSupportCount: trunkSamples.length - groupedIds.size,
         changed,
         message: changed
             ? `Auto Brace complete: generated ${generatedBraceCount} brace(s), removed ${removedBraceCount} legacy brace(s).`

--- a/src/supports/autoBracing/autoBrace.ts
+++ b/src/supports/autoBracing/autoBrace.ts
@@ -10,6 +10,7 @@ import { getSnapshot, setSnapshot } from '../state';
 import {
     calculateKnotPositionOnSegmentFromT,
     getTrunkSegmentEndpoints,
+    getBranchSegmentEndpoints,
 } from '../SupportPrimitives/Knot/knotUtils';
 import { JOINT_DIAMETER_OFFSET_MM } from '../constants';
 import type {
@@ -28,21 +29,17 @@ import {
     type AutoBracingSettings,
 } from './settings';
 
-type SupportKind = 'trunk' | 'branch';
-type SectionKey = 'top' | 'bottom' | 'middle';
+const EPS = 0.000001;
 
-const MESH_CLEARANCE_MM = 1.0;
+type SupportKind = 'trunk' | 'branch';
+
 const BRACE_CLEARANCE_SAMPLE_COUNT = 12;
 
 /**
- * Returns true if the brace centerline from posA to posB maintains at least
- * MESH_CLEARANCE_MM + braceDiameterMm/2 clearance from all registered mesh surfaces.
- * Samples points along the brace, transforms to local mesh space, and queries BVH.
- * The BVH closestPointToPoint returns distance in local space; we convert to world
- * space using the mesh's uniform scale factor.
+ * Returns true if the brace centerline from posA to posB maintains clearance.
  */
 function bracePassesMeshClearance(posA: Vec3, posB: Vec3, modelId: string, braceDiameterMm: number): boolean {
-    const minClearance = MESH_CLEARANCE_MM + braceDiameterMm / 2;
+    const minClearance = AUTO_BRACING_HARD_RULES.supportBraceMeshClearanceMm + braceDiameterMm / 2;
     const meshEntries = getAllMeshEntriesForAutoBrace();
 
     const entry = meshEntries.get(modelId);
@@ -52,8 +49,6 @@ function bracePassesMeshClearance(posA: Vec3, posB: Vec3, modelId: string, brace
     if (!bvh) return true;
 
     const inverseMatrix = entry.transform.clone().invert();
-
-    // Extract world-space scale to convert local distances back to world distances.
     const scaleVec = new THREE.Vector3();
     entry.transform.decompose(new THREE.Vector3(), new THREE.Quaternion(), scaleVec);
     const worldScale = (scaleVec.x + scaleVec.y + scaleVec.z) / 3;
@@ -64,20 +59,14 @@ function bracePassesMeshClearance(posA: Vec3, posB: Vec3, modelId: string, brace
 
     for (let i = 0; i <= BRACE_CLEARANCE_SAMPLE_COUNT; i++) {
         const t = i / BRACE_CLEARANCE_SAMPLE_COUNT;
-        const worldPoint = new THREE.Vector3(
-            ax + (bx - ax) * t,
-            ay + (by - ay) * t,
-            az + (bz - az) * t,
-        );
+        const worldPoint = new THREE.Vector3(ax + (bx - ax) * t, ay + (by - ay) * t, az + (bz - az) * t);
         const localPoint = worldPoint.clone().applyMatrix4(inverseMatrix);
         const result = bvh.closestPointToPoint(localPoint, resultTarget);
         if (!result) continue;
 
-        // result.distance is in local space; multiply by worldScale to get world mm
         const worldDist = (result.distance as number) * worldScale;
         if (worldDist < minClearance) return false;
     }
-
     return true;
 }
 
@@ -99,12 +88,6 @@ type SupportSample = {
     sortAnchor: Vec3;
 };
 
-type SectionHeights = {
-    top: number[];
-    bottom: number[];
-    middle: number[];
-};
-
 type AnchorPoint = {
     supportId: string;
     modelId: string;
@@ -121,38 +104,22 @@ type AnchorCandidate = {
     score: number;
 };
 
-type AnchorSpec = {
-    section: 'top' | 'middle';
-    anchorZ: number;
-};
-
 export interface AutoBraceResult {
     generatedBraceCount: number;
     removedBraceCount: number;
     skippedSupportCount: number;
-    underQualifiedSupportCount: number;
     changed: boolean;
     message: string;
 }
 
-type BuildSnapshotResult = AutoBraceResult & {
-    snapshot: SupportState;
-};
-
-const ANCHOR_Z_TOLERANCE_MM = 0.3;
-
 function clamp(value: number, min: number, max: number): number {
-    if (value < min) return min;
-    if (value > max) return max;
-    return value;
+    return Math.min(max, Math.max(min, value));
 }
 
 function sortSupports(a: SupportSample, b: SupportSample): number {
     if (a.modelId !== b.modelId) return a.modelId.localeCompare(b.modelId);
     if (a.sortAnchor.x !== b.sortAnchor.x) return a.sortAnchor.x - b.sortAnchor.x;
     if (a.sortAnchor.y !== b.sortAnchor.y) return a.sortAnchor.y - b.sortAnchor.y;
-    if (a.sortAnchor.z !== b.sortAnchor.z) return a.sortAnchor.z - b.sortAnchor.z;
-    if (a.supportKind !== b.supportKind) return a.supportKind.localeCompare(b.supportKind);
     return a.supportId.localeCompare(b.supportId);
 }
 
@@ -175,318 +142,74 @@ function collectSegmentExtrema(segments: SegmentSample[]): { topReferenceZ: numb
     let bottomPoint: Vec3 | null = null;
 
     for (const segment of segments) {
-        const points = [segment.start, segment.end];
-        for (const point of points) {
+        for (const point of [segment.start, segment.end]) {
             if (!topPoint || point.z > topPoint.z) topPoint = point;
             if (!bottomPoint || point.z < bottomPoint.z) bottomPoint = point;
         }
     }
 
-    if (!topPoint || !bottomPoint) {
-        return {
-            topReferenceZ: 0,
-            bottomReferenceZ: 0,
-            sortAnchor: { x: 0, y: 0, z: 0 },
-        };
-    }
-
     return {
-        topReferenceZ: topPoint.z,
-        bottomReferenceZ: bottomPoint.z,
-        sortAnchor: topPoint,
+        topReferenceZ: topPoint?.z ?? 0,
+        bottomReferenceZ: bottomPoint?.z ?? 0,
+        sortAnchor: topPoint ?? { x: 0, y: 0, z: 0 },
     };
 }
 
 function buildSupportSamples(snapshot: SupportState): SupportSample[] {
     const supports: SupportSample[] = [];
 
+    // Process Trunks
     for (const trunk of Object.values(snapshot.trunks)) {
         const root = snapshot.roots[trunk.rootId];
         if (!root) continue;
-
         const segments: SegmentSample[] = [];
-        trunk.segments.forEach((segment, segmentIndex) => {
-            const endpoints = getTrunkSegmentEndpoints(trunk, segment, segmentIndex, root);
-            if (!endpoints) return;
-            segments.push({
-                segmentId: segment.id,
-                segment,
-                start: endpoints.start,
-                end: endpoints.end,
-                diameterMm: segment.diameter,
-            });
+        trunk.segments.forEach((seg, idx) => {
+            const ep = getTrunkSegmentEndpoints(trunk, seg, idx, root);
+            if (ep) segments.push({ segmentId: seg.id, segment: seg, start: ep.start, end: ep.end, diameterMm: seg.diameter });
         });
-
         if (segments.length === 0) continue;
-
-        const extrema = collectSegmentExtrema(segments);
-        supports.push({
-            supportId: trunk.id,
-            supportKind: 'trunk',
-            modelId: trunk.modelId,
-            segments,
-            topReferenceZ: extrema.topReferenceZ,
-            bottomReferenceZ: extrema.bottomReferenceZ,
-            sortAnchor: extrema.sortAnchor,
-        });
+        const ex = collectSegmentExtrema(segments);
+        supports.push({ supportId: trunk.id, supportKind: 'trunk', modelId: trunk.modelId, segments, ...ex });
     }
 
-    // Branches are excluded from auto-bracing for now — separate logic TBD.
+    // Process Branches
+    for (const branch of Object.values(snapshot.branches)) {
+        const knot = snapshot.knots[branch.parentKnotId];
+        if (!knot) continue;
+        const segments: SegmentSample[] = [];
+        branch.segments.forEach((seg, idx) => {
+            const ep = getBranchSegmentEndpoints(branch, seg, idx, knot);
+            if (ep) segments.push({ segmentId: seg.id, segment: seg, start: ep.start, end: ep.end, diameterMm: seg.diameter });
+        });
+        if (segments.length === 0) continue;
+        const ex = collectSegmentExtrema(segments);
+        supports.push({ supportId: branch.id, supportKind: 'branch', modelId: branch.modelId, segments, ...ex });
+    }
 
     supports.sort(sortSupports);
     return supports;
 }
 
-type PairPlacementResult = { anchorA: AnchorPoint; anchorB: AnchorPoint };
-
-function validateCandidate(
-    anchorA: AnchorPoint,
-    anchorB: AnchorPoint,
-): boolean {
-    const dx = anchorB.pos.x - anchorA.pos.x;
-    const dy = anchorB.pos.y - anchorA.pos.y;
-    const dz = Math.abs(anchorB.pos.z - anchorA.pos.z);
-    const hDist = Math.sqrt(dx * dx + dy * dy);
-    if (hDist < 0.001) return false;
-
-    const angleDeg = Math.abs(Math.atan2(dz, hDist) * (180 / Math.PI));
-    const deviation = Math.abs(angleDeg - AUTO_BRACING_HARD_RULES.braceAngleDeg);
-    if (deviation > 20) return false;
-
-    // Filter on horizontal distance — maxBraceLengthMm controls how far apart two supports
-    // can be and still be braced. At 45°, 3D length = hDist×√2, but hDist is the more
-    // intuitive limit (neighbor spacing in XY).
-    return hDist <= AUTO_BRACING_HARD_RULES.maxBraceLengthMm;
-}
-
-/**
- * Compute the dz needed for a 45\u00b0 brace between two supports.
- * Uses bottom-of-shaft positions as the stable horizontal reference.
- */
-function computeDzFor45(supportA: SupportSample, supportB: SupportSample): number | null {
-    const baseA = resolveAnchorAtZ(supportA, supportA.bottomReferenceZ);
-    const baseB = resolveAnchorAtZ(supportB, supportB.bottomReferenceZ);
-    if (!baseA || !baseB) return null;
-
-    const hDist = Math.sqrt(
-        (baseA.pos.x - baseB.pos.x) ** 2 +
-        (baseA.pos.y - baseB.pos.y) ** 2,
-    );
-    return hDist < 0.001 ? null : hDist;
-}
-
-/**
- * For bottom/middle: searchStart is the LOW point, high = searchStart + dz.
- * For top: searchStart is the HIGH point, low = searchStart - dz.
- * Returns { lowZ, highZ } for a given support and section.
- */
-function sectionLowHighZ(
-    searchStart: number,
-    dz: number,
-    sectionKey: SectionKey,
-): { lowZ: number; highZ: number } {
-    if (sectionKey === 'top') {
-        return { lowZ: searchStart - dz, highZ: searchStart };
-    }
-    return { lowZ: searchStart, highZ: searchStart + dz };
-}
-
-/**
- * Primary diagonal: A-knot LOW, B-knot HIGH.
- * singleDiagonal places only this brace.
- */
-function resolvePairPlacement(
-    supportA: SupportSample,
-    supportB: SupportSample,
-    sectionKey: SectionKey,
-    settings: AutoBracingSettings,
-): PairPlacementResult | null {
-    const dz = computeDzFor45(supportA, supportB);
-    if (dz === null) return null;
-
-    const ssA = sectionSearchStart(supportA, sectionKey, settings);
-    const ssB = sectionSearchStart(supportB, sectionKey, settings);
-    if (ssA === null || ssB === null) return null;
-
-    // Use the lower of the two search starts as the shared reference.
-    // This anchors the brace to the shorter support's section Z so both
-    // primary and mirror span the same Z range regardless of height difference.
-    const ref = Math.min(ssA, ssB);
-    const { lowZ, highZ } = sectionLowHighZ(ref, dz, sectionKey);
-
-    const anchorA = resolveAnchorAtZ(supportA, lowZ);
-    const anchorB = resolveAnchorAtZ(supportB, highZ);
-    if (!anchorA || !anchorB) return null;
-    if (!validateCandidate(anchorA, anchorB)) return null;
-    if (anchorB.pos.z - anchorA.pos.z < 0.1) return null;
-
-    return { anchorA, anchorB };
-}
-
-/**
- * Mirror diagonal: A-knot HIGH, B-knot LOW.
- * crossDiagonal places this in addition to the primary, forming the X.
- * Uses the same shared reference Z as resolvePairPlacement so both braces
- * span the identical Z range — producing a clean symmetric X.
- */
-function resolveMirrorPlacement(
-    supportA: SupportSample,
-    supportB: SupportSample,
-    sectionKey: SectionKey,
-    settings: AutoBracingSettings,
-): PairPlacementResult | null {
-    const dz = computeDzFor45(supportA, supportB);
-    if (dz === null) return null;
-
-    const ssA = sectionSearchStart(supportA, sectionKey, settings);
-    const ssB = sectionSearchStart(supportB, sectionKey, settings);
-    if (ssA === null || ssB === null) return null;
-
-    // Same shared reference as primary — anchored to the shorter support's section Z.
-    const ref = Math.min(ssA, ssB);
-    const { lowZ, highZ } = sectionLowHighZ(ref, dz, sectionKey);
-
-    // Mirror: A gets HIGH, B gets LOW (opposite of primary)
-    const anchorA = resolveAnchorAtZ(supportA, highZ);
-    const anchorB = resolveAnchorAtZ(supportB, lowZ);
-    if (!anchorA || !anchorB) return null;
-    if (!validateCandidate(anchorA, anchorB)) return null;
-    if (anchorA.pos.z - anchorB.pos.z < 0.1) return null;
-
-    return { anchorA, anchorB };
-}
-
-/**
- * Returns the highest Z to start searching for a brace placement on a support
- * for the given section. Returns null if the section is not active for this support.
- */
-function sectionSearchStart(
-    support: SupportSample,
-    sectionKey: SectionKey,
-    settings: AutoBracingSettings,
-): number | null {
-    const effectiveHeight = support.topReferenceZ - support.bottomReferenceZ;
-
-    if (sectionKey === 'top') {
-        // Top section is always active. Search starts just below the top reference.
-        const z = support.topReferenceZ - settings.topOffsetFromTopMm;
-        return clamp(z, support.bottomReferenceZ, support.topReferenceZ);
-    }
-
-    if (sectionKey === 'bottom') {
-        // Bottom section requires enough height to fit both top and bottom offsets
-        // with a minimum gap between them (TBD from calibration, using 2mm for now).
-        const minHeightForBottom = settings.topOffsetFromTopMm + settings.bottomOffsetFromBottomMm + 2.0;
-        if (effectiveHeight < minHeightForBottom) return null;
-        const z = support.bottomReferenceZ + settings.bottomOffsetFromBottomMm;
-        return clamp(z, support.bottomReferenceZ, support.topReferenceZ);
-    }
-
-    if (sectionKey === 'middle') {
-        // Middle section requires enough height for top + bottom + at least one middle tier
-        // with clearance from both ends (TBD from calibration, using 4mm for now).
-        const minHeightForMiddle = settings.topOffsetFromTopMm + settings.bottomOffsetFromBottomMm + 4.0;
-        if (effectiveHeight < minHeightForMiddle) return null;
-        // Middle starts at the center of effective height
-        const centerZ = (support.topReferenceZ + support.bottomReferenceZ) / 2;
-        return centerZ;
-    }
-
-    return null;
-}
-
-/**
- * Returns all Z search starts for middle section repeats on a support.
- * First middle is at center, then repeats upward at middleRepeatIntervalMm.
- */
-function middleSectionSearchStarts(
-    support: SupportSample,
-    settings: AutoBracingSettings,
-): number[] {
-    const firstZ = sectionSearchStart(support, 'middle', settings);
-    if (firstZ === null) return [];
-
-    const topSearchBound = support.topReferenceZ - settings.topOffsetFromTopMm - 1.0;
-    const results: number[] = [firstZ];
-    const intervalMm = Math.max(0.5, settings.middleRepeatIntervalMm);
-    let nextZ = firstZ + intervalMm;
-
-    while (nextZ <= topSearchBound) {
-        results.push(nextZ);
-        nextZ += intervalMm;
-    }
-
-    return results;
-}
-
 function resolveAnchorAtZ(support: SupportSample, targetZ: number): AnchorPoint | null {
-    const EPSILON = 0.000001;
-
     let best: AnchorCandidate | null = null;
 
-    const createCandidate = (segment: SegmentSample, t: number): AnchorCandidate => {
-        const clampedT = clamp(t, 0, 1);
-        const pos = calculateKnotPositionOnSegmentFromT(segment.start, segment.end, segment.segment, clampedT);
-        return {
-            segment,
-            t: clampedT,
-            pos,
-            score: Math.abs(pos.z - targetZ),
-        };
-    };
-
-    const pickBetterCandidate = (
-        current: AnchorCandidate | null,
-        candidate: AnchorCandidate,
-    ): AnchorCandidate => {
-        if (!current) return candidate;
-
-        if (candidate.score < current.score - EPSILON) {
-            return candidate;
-        }
-
-        if (Math.abs(candidate.score - current.score) <= EPSILON) {
-            if (candidate.segment.segmentId < current.segment.segmentId) {
-                return candidate;
-            }
-
-            if (
-                candidate.segment.segmentId === current.segment.segmentId
-                && candidate.t < current.t
-            ) {
-                return candidate;
-            }
-        }
-
-        return current;
-    };
-
     for (const segment of support.segments) {
-        const dz = segment.end.z - segment.start.z;
         const minZ = Math.min(segment.start.z, segment.end.z);
         const maxZ = Math.max(segment.start.z, segment.end.z);
+        if (targetZ < minZ - EPS || targetZ > maxZ + EPS) continue;
 
-        if (Math.abs(dz) <= EPSILON) {
-            continue;
-        }
+        const dz = segment.end.z - segment.start.z;
+        const t = Math.abs(dz) < EPS ? 0 : (targetZ - segment.start.z) / dz;
+        const clampedT = clamp(t, 0, 1);
+        const pos = calculateKnotPositionOnSegmentFromT(segment.start, segment.end, segment.segment, clampedT);
+        const score = Math.abs(pos.z - targetZ);
 
-        if (targetZ < minZ - EPSILON || targetZ > maxZ + EPSILON) {
-            continue;
-        }
-
-        const t = (targetZ - segment.start.z) / dz;
-        best = pickBetterCandidate(best, createCandidate(segment, t));
-    }
-
-    if (!best) {
-        for (const segment of support.segments) {
-            best = pickBetterCandidate(best, createCandidate(segment, 0));
-            best = pickBetterCandidate(best, createCandidate(segment, 1));
+        if (!best || score < best.score - EPS) {
+            best = { segment, t: clampedT, pos, score };
         }
     }
 
     if (!best) return null;
-
     return {
         supportId: support.supportId,
         modelId: support.modelId,
@@ -497,585 +220,248 @@ function resolveAnchorAtZ(support: SupportSample, targetZ: number): AnchorPoint 
     };
 }
 
-function buildGroupPairs(group: SupportSample[], pattern: AutoBracingPattern): Array<[SupportSample, SupportSample]> {
-    if (group.length < 2) return [];
-
-    const pairs: Array<[SupportSample, SupportSample]> = [];
-    const pairKeys = new Set<string>();
-
-    const addPair = (a: SupportSample, b: SupportSample) => {
-        const minId = a.supportId < b.supportId ? a.supportId : b.supportId;
-        const maxId = a.supportId < b.supportId ? b.supportId : a.supportId;
-        const key = `${minId}:${maxId}`;
-        if (pairKeys.has(key)) return;
-        pairKeys.add(key);
-        pairs.push([a, b]);
-    };
-
-    // Build MST using Kruskal's algorithm: sort all candidate edges by distance,
-    // add each edge only if it connects two previously unconnected components.
-    // This guarantees the minimum set of connections with no redundant long diagonals.
-
-    // Generate all candidate edges
-    type Edge = { a: SupportSample; b: SupportSample; distSq: number };
-    const edges: Edge[] = [];
-    for (let i = 0; i < group.length; i += 1) {
-        for (let j = i + 1; j < group.length; j += 1) {
-            const a = group[i];
-            const b = group[j];
-            const dx = b.sortAnchor.x - a.sortAnchor.x;
-            const dy = b.sortAnchor.y - a.sortAnchor.y;
-            edges.push({ a, b, distSq: dx * dx + dy * dy });
-        }
-    }
-    edges.sort((x, y) => x.distSq - y.distSq);
-
-    // Union-Find
-    const parent = new Map<string, string>();
-    const find = (id: string): string => {
-        if (parent.get(id) !== id) parent.set(id, find(parent.get(id)!));
-        return parent.get(id)!;
-    };
-    const union = (a: string, b: string) => { parent.set(find(a), find(b)); };
-    for (const s of group) parent.set(s.supportId, s.supportId);
-
-    // Add shortest edges that connect new components (MST)
-    for (const { a, b } of edges) {
-        if (find(a.supportId) !== find(b.supportId)) {
-            addPair(a, b);
-            union(a.supportId, b.supportId);
-        }
-    }
-
-    // Second-axis pass: for each support that only has connections along one axis direction,
-    // find its nearest neighbor in a sufficiently different direction and add that pair.
-    // This ensures every support gets two-axis bracing, not just a 1D chain.
-    const minSepDeg = AUTO_BRACING_HARD_RULES.minAxisSeparationDeg;
-
-    const getAxisAngle = (a: SupportSample, b: SupportSample): number => {
-        const dx = b.sortAnchor.x - a.sortAnchor.x;
-        const dy = b.sortAnchor.y - a.sortAnchor.y;
-        return normalizeAxisAngleRad(Math.atan2(dy, dx));
-    };
-
-    // Build adjacency from current pairs
-    const pairNeighbors = new Map<string, SupportSample[]>();
-    for (const s of group) pairNeighbors.set(s.supportId, []);
-    for (const [a, b] of pairs) {
-        pairNeighbors.get(a.supportId)!.push(b);
-        pairNeighbors.get(b.supportId)!.push(a);
-    }
-
-    const hasTwoAxes = (s: SupportSample): boolean => {
-        const neighbors = pairNeighbors.get(s.supportId) ?? [];
-        if (neighbors.length < 2) return false;
-        const firstAxis = getAxisAngle(s, neighbors[0]);
-        return neighbors.slice(1).some(
-            (n) => axisSeparationDeg(firstAxis, getAxisAngle(s, n)) >= minSepDeg,
-        );
-    };
-
-    for (const s of group) {
-        if (hasTwoAxes(s)) continue;
-
-        const currentNeighbors = pairNeighbors.get(s.supportId) ?? [];
-        const existingAxes = currentNeighbors.map((n) => getAxisAngle(s, n));
-
-        // Find nearest candidate that provides a new axis
-        for (const { a, b } of edges) {
-            const candidate = a.supportId === s.supportId ? b : b.supportId === s.supportId ? a : null;
-            if (!candidate) continue;
-
-            const candidateAxis = getAxisAngle(s, candidate);
-            const isNewAxis = existingAxes.every(
-                (ax) => axisSeparationDeg(ax, candidateAxis) >= minSepDeg,
-            );
-            if (!isNewAxis) continue;
-
-            addPair(s, candidate);
-            pairNeighbors.get(s.supportId)!.push(candidate);
-            pairNeighbors.get(candidate.supportId)!.push(s);
-            existingAxes.push(candidateAxis);
-            break; // edges are sorted by distance, so first valid is nearest
-        }
-    }
-
-    return pairs;
+function normalizeAxisAngleRad(angleRad: number): number {
+    let n = angleRad % Math.PI;
+    if (n < 0) n += Math.PI;
+    return n;
 }
 
-function partitionSupportsIntoGroups(
-    supports: SupportSample[],
-    minGroupSize: number,
-    maxGroupSize: number,
-): SupportSample[][] {
-    if (supports.length < minGroupSize) return [];
+function axisSeparationDeg(aRad: number, bRad: number): number {
+    const diff = Math.abs(aRad - bRad);
+    return (Math.min(diff, Math.PI - diff) * 180) / Math.PI;
+}
 
-    const supportDistanceSq = (a: SupportSample, b: SupportSample): number => {
-        const dx = a.sortAnchor.x - b.sortAnchor.x;
-        const dy = a.sortAnchor.y - b.sortAnchor.y;
-        const dz = a.sortAnchor.z - b.sortAnchor.z;
-        return dx * dx + dy * dy + dz * dz;
-    };
+type Edge = { a: SupportSample; b: SupportSample; hDist: number; angleRad: number };
 
-    const pickNextNearestIndex = (
-        group: SupportSample[],
-        candidates: SupportSample[],
-    ): number => {
-        let bestIndex = 0;
-        let bestDistSq = Number.POSITIVE_INFINITY;
+function buildGroupPairs(group: SupportSample[], maxLen: number): Edge[] {
+    if (group.length < 2) return [];
 
-        for (let i = 0; i < candidates.length; i += 1) {
-            const candidate = candidates[i];
+    const edges: Edge[] = [];
+    for (let i = 0; i < group.length; i++) {
+        for (let j = i + 1; j < group.length; j++) {
+            const a = group[i], b = group[j];
+            const dx = b.sortAnchor.x - a.sortAnchor.x;
+            const dy = b.sortAnchor.y - a.sortAnchor.y;
+            const hDist = Math.sqrt(dx * dx + dy * dy);
+            if (hDist < 0.001 || hDist > maxLen) continue;
+            edges.push({ a, b, hDist, angleRad: normalizeAxisAngleRad(Math.atan2(dy, dx)) });
+        }
+    }
+    edges.sort((x, y) => x.hDist - y.hDist);
 
-            let nearestDistSq = Number.POSITIVE_INFINITY;
-            for (const current of group) {
-                const distSq = supportDistanceSq(current, candidate);
-                if (distSq < nearestDistSq) {
-                    nearestDistSq = distSq;
+    const result: Edge[] = [];
+    const adjacency = new Map<string, Edge[]>();
+    for (const s of group) adjacency.set(s.supportId, []);
+
+    // 1. Minimum Spanning Tree (MST)
+    const parent = new Map<string, string>();
+    const find = (id: string): string => (parent.get(id) === id ? id : find(parent.get(id)!));
+    for (const s of group) parent.set(s.supportId, s.supportId);
+
+    const addedSet = new Set<string>();
+    const getEdgeId = (e: Edge) => [e.a.supportId, e.b.supportId].sort().join(':');
+
+    for (const e of edges) {
+        if (find(e.a.supportId) !== find(e.b.supportId)) {
+            result.push(e);
+            addedSet.add(getEdgeId(e));
+            parent.set(find(e.a.supportId), find(e.b.supportId));
+            adjacency.get(e.a.supportId)!.push(e);
+            adjacency.get(e.b.supportId)!.push(e);
+        }
+    }
+
+    // 2. Two-Axis Priority (90/50 rule)
+    for (const s of group) {
+        const currentEdges = adjacency.get(s.supportId)!;
+        const axes = currentEdges.map(e => e.angleRad);
+
+        const isQualified = () => {
+            for (let i = 0; i < axes.length; i++) {
+                for (let j = i + 1; j < axes.length; j++) {
+                    if (axisSeparationDeg(axes[i], axes[j]) >= AUTO_BRACING_HARD_RULES.minAxisSeparationDeg) return true;
                 }
             }
+            return false;
+        };
 
-            if (nearestDistSq < bestDistSq - 0.000001) {
-                bestDistSq = nearestDistSq;
-                bestIndex = i;
-                continue;
-            }
+        if (isQualified()) continue;
 
-            if (Math.abs(nearestDistSq - bestDistSq) <= 0.000001) {
-                const currentBest = candidates[bestIndex];
-                if (sortSupports(candidate, currentBest) < 0) {
-                    bestIndex = i;
+        // Find nearest best axial fallback
+        let bestCandidate: Edge | null = null;
+        let bestScore = -1; // Higher is better (closer to 90)
+
+        for (const e of edges) {
+            if (addedSet.has(getEdgeId(e))) continue;
+            const other = e.a.supportId === s.supportId ? e.b : e.b.supportId === s.supportId ? e.a : null;
+            if (!other) continue;
+
+            // Rule: Skip if they already share a braced neighbor to reduce redundancy
+            const nA = adjacency.get(s.supportId)!.map(oe => oe.a.supportId === s.supportId ? oe.b.supportId : oe.a.supportId);
+            const nB = adjacency.get(other.supportId)!.map(oe => oe.a.supportId === other.supportId ? oe.b.supportId : oe.a.supportId);
+            const setA = new Set(nA);
+            if (nB.some(id => setA.has(id))) continue;
+
+            for (const existing of axes) {
+                const sep = axisSeparationDeg(existing, e.angleRad);
+                if (sep >= AUTO_BRACING_HARD_RULES.minAxisSeparationDeg) {
+                    const score = 90 - Math.abs(90 - sep);
+                    if (score > bestScore) {
+                        bestScore = score;
+                        bestCandidate = e;
+                    }
                 }
             }
         }
 
-        return bestIndex;
-    };
+        if (bestCandidate) {
+            result.push(bestCandidate);
+            addedSet.add(getEdgeId(bestCandidate));
+            adjacency.get(s.supportId)!.push(bestCandidate);
+            adjacency.get(bestCandidate.a.supportId === s.supportId ? bestCandidate.b.supportId : bestCandidate.a.supportId)!.push(bestCandidate);
+        }
+    }
+
+    return result;
+}
+
+function partitionSupportsIntoGroups(supports: SupportSample[], max: number, maxDist: number): SupportSample[][] {
+    const min = AUTO_BRACING_HARD_RULES.minGroupSize;
+    if (supports.length < min) return [];
 
     const remaining = [...supports].sort(sortSupports);
     const groups: SupportSample[][] = [];
 
     while (remaining.length > 0) {
-        const seed = remaining.shift();
-        if (!seed) break;
-
-        const group: SupportSample[] = [seed];
-
-        while (group.length < maxGroupSize && remaining.length > 0) {
-            const nextIndex = pickNextNearestIndex(group, remaining);
-            const [next] = remaining.splice(nextIndex, 1);
-            group.push(next);
+        const seed = remaining.shift()!;
+        const group = [seed];
+        while (group.length < max && remaining.length > 0) {
+            let bestIdx = -1, bestDist = Infinity;
+            for (let i = 0; i < remaining.length; i++) {
+                for (const g of group) {
+                    const d = Math.sqrt((g.sortAnchor.x - remaining[i].sortAnchor.x) ** 2 + (g.sortAnchor.y - remaining[i].sortAnchor.y) ** 2);
+                    if (d < bestDist) { bestDist = d; bestIdx = i; }
+                }
+            }
+            if (bestDist > maxDist) break;
+            group.push(remaining.splice(bestIdx, 1)[0]);
         }
-
         groups.push(group);
     }
-
+    // Cleanup small tail groups
     if (groups.length > 1) {
-        const lastGroup = groups[groups.length - 1];
-        if (lastGroup.length < minGroupSize) {
-            const previousGroup = groups[groups.length - 2];
-
-            while (lastGroup.length < minGroupSize && previousGroup.length > minGroupSize) {
-                const moved = previousGroup.pop();
-                if (!moved) break;
-                lastGroup.unshift(moved);
-            }
-
-            if (lastGroup.length < minGroupSize) {
-                previousGroup.push(...lastGroup);
+        const last = groups[groups.length - 1];
+        if (last.length < min) {
+            const prev = groups[groups.length - 2];
+            if (prev.length + last.length <= max) {
+                prev.push(...last);
                 groups.pop();
+            } else {
+                while (last.length < min && prev.length > min) last.unshift(prev.pop()!);
+                if (last.length < min) { prev.push(...last); groups.pop(); }
             }
         }
     }
-
-    return groups.filter((group) => group.length >= minGroupSize);
+    return groups.filter(g => g.length >= min);
 }
 
-function selectionExists(snapshot: SupportState, selectedId: string): boolean {
-    if (snapshot.roots[selectedId]) return true;
-    if (snapshot.trunks[selectedId]) return true;
-    if (snapshot.branches[selectedId]) return true;
-    if (snapshot.leaves[selectedId]) return true;
-    if (snapshot.twigs[selectedId]) return true;
-    if (snapshot.sticks[selectedId]) return true;
-    if (snapshot.braces[selectedId]) return true;
-    if (snapshot.knots[selectedId]) return true;
-
-    if (selectedId.startsWith('braceSegment:')) {
-        const braceId = selectedId.slice('braceSegment:'.length);
-        return Boolean(snapshot.braces[braceId]);
-    }
-
-    return false;
-}
-
-function clearMissingSelection(snapshot: SupportState): SupportState {
-    if (!snapshot.selectedId) return snapshot;
-    if (selectionExists(snapshot, snapshot.selectedId)) return snapshot;
-
-    return {
-        ...snapshot,
-        selectedId: null,
-        selectedCategory: null,
-    };
-}
-
-function clearExistingBraceData(snapshot: SupportState): { snapshot: SupportState; removedBraceCount: number } {
-    const braceKnotIds = new Set<string>();
-    for (const brace of Object.values(snapshot.braces)) {
-        braceKnotIds.add(brace.startKnotId);
-        braceKnotIds.add(brace.endKnotId);
-    }
-
-    const preservedKnotIds = new Set<string>();
-    for (const branch of Object.values(snapshot.branches)) {
-        preservedKnotIds.add(branch.parentKnotId);
-    }
-    for (const leaf of Object.values(snapshot.leaves)) {
-        preservedKnotIds.add(leaf.parentKnotId);
-    }
-
-    const nextKnots: Record<string, Knot> = {};
-    for (const [knotId, knot] of Object.entries(snapshot.knots)) {
-        if (braceKnotIds.has(knotId) && !preservedKnotIds.has(knotId)) {
-            continue;
-        }
-        nextKnots[knotId] = knot;
-    }
-
-    return {
-        snapshot: {
-            ...snapshot,
-            braces: {},
-            knots: nextKnots,
-        },
-        removedBraceCount: Object.keys(snapshot.braces).length,
-    };
-}
-
-function normalizeAxisAngleRad(angleRad: number): number {
-    const pi = Math.PI;
-    let normalized = angleRad % pi;
-    if (normalized < 0) normalized += pi;
-    return normalized;
-}
-
-function axisSeparationDeg(aRad: number, bRad: number): number {
-    const diff = Math.abs(aRad - bRad);
-    const wrapped = Math.min(diff, Math.PI - diff);
-    return (wrapped * 180) / Math.PI;
-}
-
-function hasTwoDistinctAxes(angles: number[], minSeparationDeg: number): boolean {
-    if (angles.length < 2) return false;
-
-    for (let i = 0; i < angles.length; i += 1) {
-        for (let j = i + 1; j < angles.length; j += 1) {
-            if (axisSeparationDeg(angles[i], angles[j]) >= minSeparationDeg) {
-                return true;
-            }
-        }
-    }
-
-    return false;
-}
-
-function evaluateAnchorQualification(args: {
-    snapshot: SupportState;
-    supportSamples: SupportSample[];
-    anchorSpecBySupportId: Map<string, AnchorSpec>;
-}): { underQualifiedSupportCount: number } {
-    const { snapshot, supportSamples, anchorSpecBySupportId } = args;
-
-    const supportIdBySegmentId = new Map<string, string>();
-    for (const support of supportSamples) {
-        for (const segment of support.segments) {
-            supportIdBySegmentId.set(segment.segmentId, support.supportId);
-        }
-    }
-
-    const axisAnglesBySupportId = new Map<string, number[]>();
-    const axisMergeToleranceDeg = 2;
-
-    const addAxisAngle = (supportId: string, angleRad: number) => {
-        const normalized = normalizeAxisAngleRad(angleRad);
-        const list = axisAnglesBySupportId.get(supportId) ?? [];
-
-        const alreadyPresent = list.some((existing) => axisSeparationDeg(existing, normalized) <= axisMergeToleranceDeg);
-        if (!alreadyPresent) {
-            list.push(normalized);
-        }
-
-        axisAnglesBySupportId.set(supportId, list);
-    };
-
-    const registerAxisFromEndpoint = (endpointKnot: Knot, otherKnot: Knot, braceSection: SectionKey) => {
-        const supportId = supportIdBySegmentId.get(endpointKnot.parentShaftId);
-        if (!supportId) return;
-
-        const anchorSpec = anchorSpecBySupportId.get(supportId);
-        if (!anchorSpec) return;
-
-        // Only count braces from the anchor section for this support.
-        if (braceSection !== anchorSpec.section) return;
-
-        const dx = otherKnot.pos.x - endpointKnot.pos.x;
-        const dy = otherKnot.pos.y - endpointKnot.pos.y;
-        const lenSq = dx * dx + dy * dy;
-        if (lenSq <= 0.000001) return;
-
-        addAxisAngle(supportId, Math.atan2(dy, dx));
-    };
-
-    for (const brace of Object.values(snapshot.braces)) {
-        const startKnot = snapshot.knots[brace.startKnotId];
-        const endKnot = snapshot.knots[brace.endKnotId];
-        if (!startKnot || !endKnot) continue;
-
-        const braceSection = (brace.debugSection ?? 'top') as SectionKey;
-        registerAxisFromEndpoint(startKnot, endKnot, braceSection);
-        registerAxisFromEndpoint(endKnot, startKnot, braceSection);
-    }
-
-    let underQualifiedSupportCount = 0;
-    for (const support of supportSamples) {
-        if (!anchorSpecBySupportId.has(support.supportId)) continue;
-
-        const axisAngles = axisAnglesBySupportId.get(support.supportId) ?? [];
-        const qualified = hasTwoDistinctAxes(axisAngles, AUTO_BRACING_HARD_RULES.minAxisSeparationDeg);
-        if (!qualified) {
-            underQualifiedSupportCount += 1;
-        }
-    }
-
-    return { underQualifiedSupportCount };
-}
-
-export function buildAutoBracedSnapshot(
-    snapshot: SupportState,
-    inputSettings: AutoBracingSettings,
-): BuildSnapshotResult {
+export function buildAutoBracedSnapshot(snapshot: SupportState, inputSettings: AutoBracingSettings): BuildSnapshotResult {
     const settings = normalizeAutoBracingSettings(inputSettings);
-    const supportSamples = buildSupportSamples(snapshot);
-
+    const supportSamples = buildSupportSamples(snapshot).filter(s => s.supportKind === 'trunk');
     const byModel = new Map<string, SupportSample[]>();
-    for (const support of supportSamples) {
-        if (!byModel.has(support.modelId)) {
-            byModel.set(support.modelId, []);
-        }
-        byModel.get(support.modelId)!.push(support);
+    for (const s of supportSamples) {
+        if (!byModel.has(s.modelId)) byModel.set(s.modelId, []);
+        byModel.get(s.modelId)!.push(s);
     }
 
     const groupedSupports: SupportSample[][] = [];
-    for (const supportsForModel of byModel.values()) {
-        supportsForModel.sort(sortSupports);
-        const groups = partitionSupportsIntoGroups(
-            supportsForModel,
-            AUTO_BRACING_HARD_RULES.minGroupSize,
-            settings.maxGroupSize,
-        );
-        groupedSupports.push(...groups);
-    }
+    for (const list of byModel.values()) groupedSupports.push(...partitionSupportsIntoGroups(list, settings.maxGroupSize, settings.maxBraceLengthMm));
 
-    const groupedSupportIds = new Set<string>();
-    groupedSupports.forEach((group) => {
-        group.forEach((support) => groupedSupportIds.add(support.supportId));
-    });
+    const groupedIds = new Set<string>();
+    groupedSupports.forEach(g => g.forEach(s => groupedIds.add(s.supportId)));
 
-    const cleared = clearExistingBraceData(snapshot);
-    let nextSnapshot = cleared.snapshot;
+    const braceKnotIds = new Set<string>();
+    for (const b of Object.values(snapshot.braces)) { braceKnotIds.add(b.startKnotId); braceKnotIds.add(b.endKnotId); }
+    const preservedKnotIds = new Set<string>();
+    for (const b of Object.values(snapshot.branches)) preservedKnotIds.add(b.parentKnotId);
+    for (const l of Object.values(snapshot.leaves)) preservedKnotIds.add(l.parentKnotId);
 
-    const braceIdSet = new Set<string>(Object.keys(nextSnapshot.braces));
-    const knotIdSet = new Set<string>(Object.keys(nextSnapshot.knots));
-    const createBraceId = createUniqueIdFactory('auto-brace', braceIdSet);
-    const createKnotId = createUniqueIdFactory('auto-brace-knot', knotIdSet);
+    const nextKnots: Record<string, Knot> = {};
+    for (const [id, k] of Object.entries(snapshot.knots)) { if (!braceKnotIds.has(id) || preservedKnotIds.has(id)) nextKnots[id] = k; }
+
+    let nextSnapshot: SupportState = { ...snapshot, braces: {}, knots: nextKnots, selectedId: (snapshot.selectedId && snapshot.braces[snapshot.selectedId.replace('braceSegment:', '')]) ? null : snapshot.selectedId };
+
+    const braceIds = new Set<string>(Object.keys(nextSnapshot.braces));
+    const knotIds = new Set<string>(Object.keys(nextSnapshot.knots));
+    const createBraceId = createUniqueIdFactory('auto-brace', braceIds);
+    const createKnotId = createUniqueIdFactory('auto-brace-knot', knotIds);
 
     const generatedBraces: Record<string, Brace> = {};
     const generatedKnots: Record<string, Knot> = {};
-    const anchorSpecBySupportId = new Map<string, AnchorSpec>();
-
-    const sectionOrder: SectionKey[] = ['top', 'bottom', 'middle'];
-
-    // Track the highest placed knot Z per support per section for qualification anchor.
-    // Key: supportId, Value: { section, highestZ }
-    const placedAnchorZBySupportId = new Map<string, { section: SectionKey; highestZ: number }>();
-
-    const updatePlacedAnchor = (supportId: string, sectionKey: SectionKey, knotZ: number) => {
-        const existing = placedAnchorZBySupportId.get(supportId);
-        // Qualification anchor rule: top-most middle if present, else top.
-        // Middle always wins over top. Within same section, prefer highest Z.
-        if (!existing) {
-            placedAnchorZBySupportId.set(supportId, { section: sectionKey, highestZ: knotZ });
-            return;
-        }
-        const sectionPriority = (s: SectionKey) => s === 'middle' ? 2 : s === 'top' ? 1 : 0;
-        if (sectionPriority(sectionKey) > sectionPriority(existing.section)) {
-            placedAnchorZBySupportId.set(supportId, { section: sectionKey, highestZ: knotZ });
-        } else if (sectionKey === existing.section && knotZ > existing.highestZ) {
-            placedAnchorZBySupportId.set(supportId, { section: sectionKey, highestZ: knotZ });
-        }
-    };
-
-    const placeBrace = (anchorA: AnchorPoint, anchorB: AnchorPoint, sectionKey: SectionKey) => {
-        if (anchorA.modelId !== anchorB.modelId) return;
-        if (anchorA.segmentId === anchorB.segmentId && Math.abs(anchorA.t - anchorB.t) < 0.0001) return;
-        if (!bracePassesMeshClearance(anchorA.pos, anchorB.pos, anchorA.modelId, settings.braceDiameterMm)) return;
-
-        const startKnotId = createKnotId();
-        const endKnotId = createKnotId();
-        const braceId = createBraceId();
-
-        generatedKnots[startKnotId] = {
-            id: startKnotId,
-            parentShaftId: anchorA.segmentId,
-            t: anchorA.t,
-            pos: anchorA.pos,
-            diameter: Math.max(0.001, anchorA.hostDiameterMm) + JOINT_DIAMETER_OFFSET_MM,
-        };
-        generatedKnots[endKnotId] = {
-            id: endKnotId,
-            parentShaftId: anchorB.segmentId,
-            t: anchorB.t,
-            pos: anchorB.pos,
-            diameter: Math.max(0.001, anchorB.hostDiameterMm) + JOINT_DIAMETER_OFFSET_MM,
-        };
-        generatedBraces[braceId] = {
-            id: braceId,
-            modelId: anchorA.modelId,
-            startKnotId,
-            endKnotId,
-            profile: { diameter: settings.braceDiameterMm },
-            debugSection: sectionKey,
-        };
-
-        updatePlacedAnchor(anchorA.supportId, sectionKey, anchorA.pos.z);
-        updatePlacedAnchor(anchorB.supportId, sectionKey, anchorB.pos.z);
-    };
 
     for (const group of groupedSupports) {
+        const pairs = buildGroupPairs(group, settings.maxBraceLengthMm);
+        const maxZ = Math.max(...group.map(s => s.topReferenceZ));
 
-        for (const sectionKey of sectionOrder) {
-            const sectionPattern = sectionKey === 'top'
-                ? settings.topPattern
-                : sectionKey === 'bottom'
-                    ? settings.bottomPattern
-                    : settings.middlePattern;
+        const ladder: number[] = [settings.initialDistanceMm];
+        let curr = settings.initialDistanceMm + settings.patternIntervalMm;
+        while (curr <= maxZ) { ladder.push(curr); curr += settings.patternIntervalMm; }
 
-            const pairs = buildGroupPairs(group, sectionPattern);
+        ladder.forEach((anchorZ, tierIndex) => {
+            const isInitial = tierIndex === 0;
+            const pattern = isInitial ? settings.initialPattern : settings.repeatingPattern;
+            for (const edge of pairs) {
+                const dz = edge.hDist; // 45 degrees: dz = dx
 
-            const placePair = (supportA: SupportSample, supportB: SupportSample, sk: SectionKey) => {
-                const primary = resolvePairPlacement(supportA, supportB, sk, settings);
-                if (primary) placeBrace(primary.anchorA, primary.anchorB, sk);
+                // Termination: If the brace would end above or at the support tip, skip this tier for this pair.
+                if (anchorZ + dz >= edge.a.topReferenceZ - 0.1 || anchorZ + dz >= edge.b.topReferenceZ - 0.1) continue;
 
-                if (sectionPattern === 'crossDiagonal') {
-                    const mirror = resolveMirrorPlacement(supportA, supportB, sk, settings);
-                    if (mirror) placeBrace(mirror.anchorA, mirror.anchorB, sk);
-                }
-            };
+                const place = (lowS: SupportSample, highS: SupportSample, section: 'initial' | 'repeating') => {
+                    const lowAnchor = resolveAnchorAtZ(lowS, anchorZ);
+                    const highAnchor = resolveAnchorAtZ(highS, anchorZ + dz);
+                    if (!lowAnchor || !highAnchor) return;
 
-            if (sectionKey === 'middle') {
-                for (const [supportA, supportB] of pairs) {
-                    const middleStartsA = middleSectionSearchStarts(supportA, settings);
-                    const middleStartsB = middleSectionSearchStarts(supportB, settings);
-                    const tierCount = Math.max(middleStartsA.length, middleStartsB.length);
-                    for (let tierIndex = 0; tierIndex < tierCount; tierIndex += 1) {
-                        placePair(supportA, supportB, 'middle');
-                    }
-                }
-            } else {
-                for (const [supportA, supportB] of pairs) {
-                    placePair(supportA, supportB, sectionKey);
-                }
+                    if (!bracePassesMeshClearance(lowAnchor.pos, highAnchor.pos, lowAnchor.modelId, settings.braceDiameterMm)) return;
+
+                    const sId = createKnotId(), eId = createKnotId(), bId = createBraceId();
+                    generatedKnots[sId] = { id: sId, parentShaftId: lowAnchor.segmentId, t: lowAnchor.t, pos: lowAnchor.pos, diameter: lowAnchor.hostDiameterMm + JOINT_DIAMETER_OFFSET_MM };
+                    generatedKnots[eId] = { id: eId, parentShaftId: highAnchor.segmentId, t: highAnchor.t, pos: highAnchor.pos, diameter: highAnchor.hostDiameterMm + JOINT_DIAMETER_OFFSET_MM };
+                    generatedBraces[bId] = { id: bId, modelId: lowAnchor.modelId, startKnotId: sId, endKnotId: eId, profile: { diameter: settings.braceDiameterMm }, debugSection: section };
+                };
+
+                place(edge.a, edge.b, isInitial ? 'initial' : 'repeating');
+                if (pattern === 'crossDiagonal') place(edge.b, edge.a, isInitial ? 'initial' : 'repeating');
             }
-        }
+        });
     }
 
-    // Build anchorSpecBySupportId using sectionSearchStart as the anchor Z.
-    // We can't use placed.highestZ because the shared-ref approach intentionally
-    // places knots at the shorter support's Z, not each support's own section Z.
-    for (const [supportId, placed] of placedAnchorZBySupportId.entries()) {
-        const support = supportSamples.find((s) => s.supportId === supportId);
-        const qualSection: 'top' | 'middle' = placed.section === 'bottom' ? 'top' : placed.section;
-        const anchorZ = support
-            ? (sectionSearchStart(support, qualSection, settings) ?? placed.highestZ)
-            : placed.highestZ;
-        anchorSpecBySupportId.set(supportId, { section: qualSection, anchorZ });
-    }
-
-    nextSnapshot = clearMissingSelection({
-        ...nextSnapshot,
-        knots: {
-            ...nextSnapshot.knots,
-            ...generatedKnots,
-        },
-        braces: {
-            ...generatedBraces,
-        },
-    });
-
-    const qualification = evaluateAnchorQualification({
-        snapshot: nextSnapshot,
-        supportSamples,
-        anchorSpecBySupportId,
-    });
+    nextSnapshot.knots = { ...nextSnapshot.knots, ...generatedKnots };
+    nextSnapshot.braces = generatedBraces;
 
     const generatedBraceCount = Object.keys(generatedBraces).length;
-    const skippedSupportCount = supportSamples.length - groupedSupportIds.size;
-    const underQualifiedSupportCount = qualification.underQualifiedSupportCount;
-    const changed = cleared.removedBraceCount > 0 || generatedBraceCount > 0;
-
-    const message = !changed
-        ? 'No eligible supports were found for Auto Brace.'
-        : underQualifiedSupportCount > 0
-            ? `Auto Brace complete: generated ${generatedBraceCount} brace(s), removed ${cleared.removedBraceCount} previous brace(s), ${underQualifiedSupportCount} support(s) remain under-qualified at the anchor section.`
-            : `Auto Brace complete: generated ${generatedBraceCount} brace(s), removed ${cleared.removedBraceCount} previous brace(s).`;
+    const removedBraceCount = Object.keys(snapshot.braces).length;
+    const changed = generatedBraceCount > 0 || removedBraceCount > 0;
 
     return {
         snapshot: nextSnapshot,
         generatedBraceCount,
-        removedBraceCount: cleared.removedBraceCount,
-        skippedSupportCount,
-        underQualifiedSupportCount,
+        removedBraceCount,
+        skippedSupportCount: supportSamples.length - groupedIds.size,
         changed,
-        message,
+        message: changed
+            ? `Auto Brace complete: generated ${generatedBraceCount} brace(s), removed ${removedBraceCount} legacy brace(s).`
+            : "No eligible supports found for Auto Bracing.",
     };
 }
 
 export function runAutoBracing(): AutoBraceResult {
     const before = structuredClone(getSnapshot());
-    const activeSettings = normalizeAutoBracingSettings(getSettings().autoBracing);
-    const built = buildAutoBracedSnapshot(before, activeSettings);
+    const built = buildAutoBracedSnapshot(before, getSettings().autoBracing);
+    if (!built.changed) return built;
 
-    if (!built.changed) {
-        return {
-            generatedBraceCount: built.generatedBraceCount,
-            removedBraceCount: built.removedBraceCount,
-            skippedSupportCount: built.skippedSupportCount,
-            underQualifiedSupportCount: built.underQualifiedSupportCount,
-            changed: false,
-            message: built.message,
-        };
-    }
-
-    const after = structuredClone(built.snapshot);
-    setSnapshot(after);
-
-    const payload: SupportReplaceStatePayload = {
-        before,
-        after,
-    };
-
-    pushHistory({
-        type: SUPPORT_AUTO_BRACE_REPLACE,
-        payload,
-    });
-
-    return {
-        generatedBraceCount: built.generatedBraceCount,
-        removedBraceCount: built.removedBraceCount,
-        skippedSupportCount: built.skippedSupportCount,
-        underQualifiedSupportCount: built.underQualifiedSupportCount,
-        changed: true,
-        message: built.message,
-    };
+    setSnapshot(built.snapshot);
+    pushHistory({ type: SUPPORT_AUTO_BRACE_REPLACE, payload: { before, after: built.snapshot } });
+    return built;
 }
+
+type BuildSnapshotResult = AutoBraceResult & { snapshot: SupportState };

--- a/src/supports/autoBracing/generativeBracing.ts
+++ b/src/supports/autoBracing/generativeBracing.ts
@@ -1,0 +1,275 @@
+import * as THREE from 'three';
+import { getSettings, getGridSettings } from '../Settings/state';
+import { checkShaftCollision } from '../PlacementLogic/CollisionUtils';
+import { buildSupportBraceData } from '../SupportTypes/SupportBrace/supportBraceBuilder';
+import { snapToGridIndex } from '../PlacementLogic/Grid/gridMath';
+import type { SupportBraceBuildResult, SupportBraceHostTarget, SupportBraceState } from '../SupportTypes/SupportBrace/types';
+import type { SupportState, Trunk, Vec3, Segment, Roots } from '../types';
+import { AUTO_BRACING_HARD_RULES, type AutoBracingSettings } from './settings';
+import { getAllMeshEntriesForAutoBrace } from './meshGeometryStore';
+import { getTrunkSegmentEndpoints } from '../SupportPrimitives/Knot/knotUtils';
+
+const MIN_HEIGHT_FOR_MANDATORY_BRACING_MM = 25.0; // Reverted back to 25.0
+const DROP_COLLISION_SAMPLES = 20;
+
+function createVector3(v: Vec3) {
+    return new THREE.Vector3(v.x, v.y, v.z);
+}
+
+function normalizeAxisAngleRad(angleRad: number): number {
+    let n = angleRad % Math.PI;
+    if (n < 0) n += Math.PI;
+    return n;
+}
+
+function axisSeparationDeg(aRad: number, bRad: number): number {
+    const diff = Math.abs(aRad - bRad);
+    return (Math.min(diff, Math.PI - diff) * 180) / Math.PI;
+}
+
+/**
+ * Ensures that any trunk over 15mm tall has at least 2-axis bracing.
+ * If a trunk lacks bracing, this function calculates the placement for
+ * new Support Braces to satisfy the structural requirement.
+ */
+export function generateRequiredSupportBraces(
+    snapshot: SupportState,
+    supportBraceState: SupportBraceState,
+    settings: AutoBracingSettings,
+    existingBraceEdges: Array<{ a: string; b: string; angleRad: number }>
+): SupportBraceBuildResult[] {
+    const meshEntries = getAllMeshEntriesForAutoBrace();
+    const globalSettings = getSettings();
+    const gridSettings = getGridSettings();
+    const generatedSupportBraces: SupportBraceBuildResult[] = [];
+
+    // The maximum horizontal run a brace can physically reach based on the 3D max length setting
+    const maxHorizontalRun = settings.maxBraceLengthMm / Math.SQRT2;
+    // We want the new support brace to generate well within the max run so it definitely connects.
+    const GENERATION_DISTANCE_MM = Math.min(5.0, maxHorizontalRun * 0.8);
+
+    const segmentOwnerTrunkId = new Map<string, string>();
+    for (const trunk of Object.values(snapshot.trunks)) {
+        for (const seg of trunk.segments) {
+            segmentOwnerTrunkId.set(seg.id, trunk.id);
+        }
+    }
+
+    // Map existing brace axes to trunk IDs
+    const axesByTrunkId = new Map<string, number[]>();
+    for (const edge of existingBraceEdges) {
+        const aList = axesByTrunkId.get(edge.a) || [];
+        aList.push(edge.angleRad);
+        axesByTrunkId.set(edge.a, aList);
+        
+        const bList = axesByTrunkId.get(edge.b) || [];
+        bList.push(edge.angleRad);
+        axesByTrunkId.set(edge.b, bList);
+    }
+
+    // Mix in axes from existing Support Braces already hosted on this trunk
+    for (const sb of Object.values(supportBraceState.supportBraces)) {
+        const hostTrunkId = segmentOwnerTrunkId.get(sb.hostSegmentId);
+        if (!hostTrunkId) continue;
+        
+        const root = supportBraceState.roots[sb.rootId];
+        const hostKnot = supportBraceState.knots[sb.hostKnotId];
+        if (!root || !hostKnot) continue;
+
+        const angleRad = normalizeAxisAngleRad(Math.atan2(root.transform.pos.y - hostKnot.pos.y, root.transform.pos.x - hostKnot.pos.x));
+        
+        const list = axesByTrunkId.get(hostTrunkId) || [];
+        list.push(angleRad);
+        axesByTrunkId.set(hostTrunkId, list);
+    }
+
+    const checkSlantedCollision = (topPos: Vec3, bottomPos: Vec3, modelId: string, radius: number): boolean => {
+        const entry = meshEntries.get(modelId);
+        if (!entry) return false;
+
+        const bvh = (entry.geometry as any).boundsTree;
+        if (!bvh) return false;
+
+        const inverseMatrix = entry.transform.clone().invert();
+        const start = createVector3(topPos).applyMatrix4(inverseMatrix);
+        const end = createVector3(bottomPos).applyMatrix4(inverseMatrix);
+        
+        const resultTarget: { point?: THREE.Vector3; distance?: number } = {};
+
+        for (let i = 0; i <= DROP_COLLISION_SAMPLES; i++) {
+            const t = i / DROP_COLLISION_SAMPLES;
+            const p = new THREE.Vector3().lerpVectors(start, end, t);
+            const result = bvh.closestPointToPoint(p, resultTarget);
+            if (result && (result.distance as number) < radius) {
+                return true; // Collision detected
+            }
+        }
+        return false;
+    };
+
+    // 1. Find trunks > 15mm that lack 2-axis bracing
+    for (const trunk of Object.values(snapshot.trunks)) {
+        const root = snapshot.roots[trunk.rootId];
+        if (!root) continue;
+
+        let maxZ = root.transform.pos.z;
+        
+        interface CandidateAnchor {
+            segmentId: string;
+            t: number;
+            pos: Vec3;
+            diameterMm: number;
+        }
+        const candidateAnchors: CandidateAnchor[] = [];
+
+        trunk.segments.forEach((seg, idx) => {
+            const ep = getTrunkSegmentEndpoints(trunk, seg, idx, root);
+            if (ep) {
+                if (ep.end.z > maxZ) {
+                    maxZ = ep.end.z;
+                }
+                // Sample anchor points along the segment
+                for (let t = 0.9; t >= 0.1; t -= 0.2) {
+                    candidateAnchors.push({
+                        segmentId: seg.id,
+                        t,
+                        pos: {
+                            x: ep.start.x + (ep.end.x - ep.start.x) * t,
+                            y: ep.start.y + (ep.end.y - ep.start.y) * t,
+                            z: ep.start.z + (ep.end.z - ep.start.z) * t,
+                        },
+                        diameterMm: seg.diameter
+                    });
+                }
+            }
+        });
+
+        const trunkHeight = maxZ - root.transform.pos.z;
+        if (trunkHeight < MIN_HEIGHT_FOR_MANDATORY_BRACING_MM) continue;
+
+        const axes = axesByTrunkId.get(trunk.id) || [];
+        let hasTwoAxis = false;
+
+        for (let i = 0; i < axes.length; i++) {
+            for (let j = i + 1; j < axes.length; j++) {
+                if (axisSeparationDeg(axes[i], axes[j]) >= AUTO_BRACING_HARD_RULES.minAxisSeparationDeg) {
+                    hasTwoAxis = true;
+                    break;
+                }
+            }
+            if (hasTwoAxis) break;
+        }
+
+        if (hasTwoAxis) continue;
+
+        // Needs extra bracing!
+        const numBracesNeeded = axes.length === 0 ? 2 : 1;
+        
+        if (candidateAnchors.length === 0) continue;
+        
+        // Sort anchors highest to lowest so we attach as high as possible
+        candidateAnchors.sort((a, b) => b.pos.z - a.pos.z);
+
+        const rootPos = root.transform.pos;
+        let existingAxis = axes.length > 0 ? axes[0] : 0;
+        const braceRadius = settings.braceDiameterMm / 2;
+
+        const usedRootPositions: Vec3[] = [];
+
+        for (let i = 0; i < numBracesNeeded; i++) {
+            const angleOffset = numBracesNeeded === 2 ? (i === 0 ? 0 : existingAxis + Math.PI / 2) : (existingAxis + Math.PI / 2);
+            let dropDist = GENERATION_DISTANCE_MM;
+            let finalRootPos: Vec3 | null = null;
+            let chosenAnchor: CandidateAnchor | null = null;
+
+            // Iterate through possible anchor points (highest first)
+            for (const anchor of candidateAnchors) {
+                // Calculate the lateral drift of the trunk up to THIS anchor so we can mirror it
+                const trunkDx = anchor.pos.x - rootPos.x;
+                const trunkDy = anchor.pos.y - rootPos.y;
+
+                // Simple iterative solver to find a non-colliding drop from this anchor
+                for (let attempt = 0; attempt < 8; attempt++) { 
+                    const angle = angleOffset + (attempt % 2 === 0 ? 0 : Math.PI); // Try opposite side if first fails
+                    const currentDist = dropDist + Math.floor(attempt / 2) * 2; // Expand distance slowly
+
+                    if (currentDist > maxHorizontalRun) break; // Don't generate out of connection range
+
+                    // Calculate the top anchor point offset from the trunk
+                    const topAnchorX = anchor.pos.x + Math.cos(angle) * currentDist;
+                    const topAnchorY = anchor.pos.y + Math.sin(angle) * currentDist;
+
+                    // Drop parallel to the trunk: subtract the trunk's lateral drift from the top anchor
+                    let candidateRootX = topAnchorX - trunkDx;
+                    let candidateRootY = topAnchorY - trunkDy;
+
+                    if (gridSettings.enabled) {
+                        const gx = snapToGridIndex(candidateRootX, gridSettings.spacingMm);
+                        const gy = snapToGridIndex(candidateRootY, gridSettings.spacingMm);
+                        candidateRootX = gx * gridSettings.spacingMm;
+                        candidateRootY = gy * gridSettings.spacingMm;
+                    }
+
+                    const candidateRootPos = {
+                        x: candidateRootX,
+                        y: candidateRootY,
+                        z: 0 // Drop to build plate
+                    };
+
+                    // Prevent generating exactly on top of an already placed support brace root
+                    const isOverlapping = usedRootPositions.some(used => 
+                        Math.abs(used.x - candidateRootX) < 0.1 && Math.abs(used.y - candidateRootY) < 0.1
+                    );
+                    
+                    if (isOverlapping) {
+                        continue;
+                    }
+
+                    const topAnchorPos = { x: topAnchorX, y: topAnchorY, z: anchor.pos.z };
+
+                    if (!checkSlantedCollision(topAnchorPos, candidateRootPos, trunk.modelId, braceRadius + 1.0)) {
+                        finalRootPos = candidateRootPos;
+                        chosenAnchor = anchor;
+                        break;
+                    }
+                }
+
+                if (finalRootPos) break; // Found a valid drop path, stop walking down the trunk
+            }
+
+            if (finalRootPos && chosenAnchor) {
+                const hostTarget: SupportBraceHostTarget = {
+                    segmentId: chosenAnchor.segmentId,
+                    supportKind: 'trunk',
+                    t: chosenAnchor.t,
+                    pos: chosenAnchor.pos,
+                    diameterMm: chosenAnchor.diameterMm
+                };
+
+                const buildInput = {
+                    modelId: trunk.modelId,
+                    rootPos: finalRootPos,
+                    host: hostTarget
+                };
+                
+                try {
+                    const result = buildSupportBraceData(buildInput);
+                    generatedSupportBraces.push(result);
+                    
+                    const actualAngle = normalizeAxisAngleRad(Math.atan2(finalRootPos.y - rootPos.y, finalRootPos.x - rootPos.x));
+                    axes.push(actualAngle);
+                    
+                    if (i === 0) {
+                        existingAxis = actualAngle;
+                    }
+
+                    usedRootPositions.push(finalRootPos);
+                } catch (err) {
+                    console.warn("Failed to build generative Support Brace", err);
+                }
+            }
+        }
+    }
+
+    return generatedSupportBraces;
+}

--- a/src/supports/autoBracing/settings.ts
+++ b/src/supports/autoBracing/settings.ts
@@ -41,7 +41,7 @@ export const AUTO_BRACING_CONSTRAINTS = {
 
 export const DEBUG_SECTION_COLORS: Record<string, string> = {
     initial: '#00ff00', // Green
-    repeating: '#add8e6', // Light Blue
+    repeating: '#00e5ff', // Light Blue
 };
 
 export const AUTO_BRACING_HARD_RULES = {

--- a/src/supports/autoBracing/settings.ts
+++ b/src/supports/autoBracing/settings.ts
@@ -2,13 +2,12 @@ export type AutoBracingPattern = 'singleDiagonal' | 'crossDiagonal';
 
 export interface AutoBracingSettings {
     braceDiameterMm: number;
+    initialPattern: AutoBracingPattern;
+    initialDistanceMm: number;
+    repeatingPattern: AutoBracingPattern;
+    patternIntervalMm: number;
     maxGroupSize: number;
-    topPattern: AutoBracingPattern;
-    topOffsetFromTopMm: number;
-    middlePattern: AutoBracingPattern;
-    middleRepeatIntervalMm: number;
-    bottomPattern: AutoBracingPattern;
-    bottomOffsetFromBottomMm: number;
+    maxBraceLengthMm: number;
     debugSectionColorsEnabled: boolean;
 }
 
@@ -22,10 +21,10 @@ type NumericConstraint = {
 
 type NumericAutoBracingSettingKey =
     | 'braceDiameterMm'
+    | 'initialDistanceMm'
+    | 'patternIntervalMm'
     | 'maxGroupSize'
-    | 'topOffsetFromTopMm'
-    | 'middleRepeatIntervalMm'
-    | 'bottomOffsetFromBottomMm';
+    | 'maxBraceLengthMm';
 
 export const AUTO_BRACING_PATTERN_OPTIONS: readonly AutoBracingPattern[] = [
     'singleDiagonal',
@@ -34,24 +33,23 @@ export const AUTO_BRACING_PATTERN_OPTIONS: readonly AutoBracingPattern[] = [
 
 export const AUTO_BRACING_CONSTRAINTS = {
     braceDiameterMm: { min: 0.5, max: 2.0, step: 0.05, defaultValue: 0.7 },
-    maxGroupSize: { min: 3, max: 10, step: 1, defaultValue: 10, integer: true },
-    topOffsetFromTopMm: { min: 0.1, max: 25, step: 0.1, defaultValue: 2.0 },
-    middleRepeatIntervalMm: { min: 0.1, max: 25, step: 0.1, defaultValue: 3.0 },
-    bottomOffsetFromBottomMm: { min: 0.1, max: 25, step: 0.1, defaultValue: 2.0 },
+    initialDistanceMm: { min: 0.1, max: 25, step: 0.1, defaultValue: 2.0 },
+    patternIntervalMm: { min: 1.0, max: 50, step: 0.1, defaultValue: 10.0 },
+    maxGroupSize: { min: 3, max: 20, step: 1, defaultValue: 7, integer: true },
+    maxBraceLengthMm: { min: 1.0, max: 50, step: 0.1, defaultValue: 10.0 },
 } satisfies Record<NumericAutoBracingSettingKey, NumericConstraint>;
+
+export const DEBUG_SECTION_COLORS: Record<string, string> = {
+    initial: '#00ff00', // Green
+    repeating: '#add8e6', // Light Blue
+};
 
 export const AUTO_BRACING_HARD_RULES = {
     braceAngleDeg: 45,
-    maxBraceLengthMm: 10,
     minGroupSize: 3,
-    minAxisSeparationDeg: 20,
+    minAxisSeparationDeg: 50,
+    targetAxisSeparationDeg: 90,
     supportBraceMeshClearanceMm: 0.5,
-    minHeightForBottomSectionMm: 0,
-    minHeightForFirstMiddleTierMm: 0,
-    firstMiddleMinClearanceFromTopBottomMm: 0,
-    middleTierRepeatMinClearanceMm: 0,
-    sectionActivationOrder: ['top', 'bottom', 'middle'] as const,
-    qualificationAnchorSectionRule: 'top-most-middle-if-present-else-top' as const,
 };
 
 function precisionFromStep(step: number): number {
@@ -93,13 +91,12 @@ function normalizeBoolean(value: unknown, fallback: boolean): boolean {
 export function createDefaultAutoBracingSettings(): AutoBracingSettings {
     return {
         braceDiameterMm: AUTO_BRACING_CONSTRAINTS.braceDiameterMm.defaultValue,
+        initialPattern: 'singleDiagonal',
+        initialDistanceMm: AUTO_BRACING_CONSTRAINTS.initialDistanceMm.defaultValue,
+        repeatingPattern: 'singleDiagonal',
+        patternIntervalMm: AUTO_BRACING_CONSTRAINTS.patternIntervalMm.defaultValue,
         maxGroupSize: AUTO_BRACING_CONSTRAINTS.maxGroupSize.defaultValue,
-        topPattern: 'singleDiagonal',
-        topOffsetFromTopMm: AUTO_BRACING_CONSTRAINTS.topOffsetFromTopMm.defaultValue,
-        middlePattern: 'singleDiagonal',
-        middleRepeatIntervalMm: AUTO_BRACING_CONSTRAINTS.middleRepeatIntervalMm.defaultValue,
-        bottomPattern: 'singleDiagonal',
-        bottomOffsetFromBottomMm: AUTO_BRACING_CONSTRAINTS.bottomOffsetFromBottomMm.defaultValue,
+        maxBraceLengthMm: AUTO_BRACING_CONSTRAINTS.maxBraceLengthMm.defaultValue,
         debugSectionColorsEnabled: false,
     };
 }
@@ -110,13 +107,12 @@ export function normalizeAutoBracingSettings(input?: Partial<AutoBracingSettings
 
     return {
         braceDiameterMm: clampNumeric(source.braceDiameterMm, AUTO_BRACING_CONSTRAINTS.braceDiameterMm),
+        initialPattern: normalizePattern(source.initialPattern, defaults.initialPattern),
+        initialDistanceMm: clampNumeric(source.initialDistanceMm, AUTO_BRACING_CONSTRAINTS.initialDistanceMm),
+        repeatingPattern: normalizePattern(source.repeatingPattern, defaults.repeatingPattern),
+        patternIntervalMm: clampNumeric(source.patternIntervalMm, AUTO_BRACING_CONSTRAINTS.patternIntervalMm),
         maxGroupSize: clampNumeric(source.maxGroupSize, AUTO_BRACING_CONSTRAINTS.maxGroupSize),
-        topPattern: normalizePattern(source.topPattern, defaults.topPattern),
-        topOffsetFromTopMm: clampNumeric(source.topOffsetFromTopMm, AUTO_BRACING_CONSTRAINTS.topOffsetFromTopMm),
-        middlePattern: normalizePattern(source.middlePattern, defaults.middlePattern),
-        middleRepeatIntervalMm: clampNumeric(source.middleRepeatIntervalMm, AUTO_BRACING_CONSTRAINTS.middleRepeatIntervalMm),
-        bottomPattern: normalizePattern(source.bottomPattern, defaults.bottomPattern),
-        bottomOffsetFromBottomMm: clampNumeric(source.bottomOffsetFromBottomMm, AUTO_BRACING_CONSTRAINTS.bottomOffsetFromBottomMm),
+        maxBraceLengthMm: clampNumeric(source.maxBraceLengthMm, AUTO_BRACING_CONSTRAINTS.maxBraceLengthMm),
         debugSectionColorsEnabled: normalizeBoolean(source.debugSectionColorsEnabled, defaults.debugSectionColorsEnabled),
     };
 }

--- a/src/supports/types.ts
+++ b/src/supports/types.ts
@@ -179,7 +179,7 @@ export interface Brace extends SupportEntity {
     profile: {
         diameter: number;
     };
-    debugSection?: 'top' | 'bottom' | 'middle';
+    debugSection?: 'initial' | 'repeating';
 }
 
 // --- Collection State ---


### PR DESCRIPTION
## Description
- Added missing Support Brace root rendering to the main batched canvas (SupportRenderer) so they are visible when unselected.
- Implemented isolated generative bracing module (\generativeBracing.ts\) to enforce 2-axis stability on trunks > 25mm tall.
- Added parallel drop placement logic to spawn fallback Support Braces that perfectly mirror the host trunk's lean.
- Integrated grid-snapping into generative placement if global grid supports are enabled.
- Added BVH mesh collision sweeping to prevent spawned braces from clipping the model on drop.
- Fixed \partitionSupportsIntoGroups\ weight calculations so isolated trunks with generated Support Braces meet \minGroupSize\ rules and form cross-bracing ladders.
- Implemented state idempotency so repeated auto-brace executions detect existing 2-axis Support Braces and don't duplicate generation.
- Updated \Auto-Bracing (Ladder Model) - Rules.md\ to reflect new generative logic.