### PR TITLE
fix: Kickstand recursive deletion cascade

### DIFF
--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -2576,16 +2576,15 @@ export function SceneCanvas({
   React.useEffect(() => {
     if (mode !== 'support' || !isMarqueeSelecting) {
       window.dispatchEvent(new CustomEvent('support-marquee-hover', {
-        detail: { supportId: null, modelId: null },
+        detail: { supportId: null, supportIds: [], modelId: null },
       }));
       return;
     }
 
-    const firstSupportId = supportMarqueeCandidateIdSet.values().next().value ?? null;
-    const modelId = firstSupportId ? getModelIdForSupportEntityId(firstSupportId) : null;
-
+    const supportIds = Array.from(supportMarqueeCandidateIdSet);
+    const firstSupportId = supportIds[0] ?? null;
     window.dispatchEvent(new CustomEvent('support-marquee-hover', {
-      detail: { supportId: firstSupportId, modelId },
+      detail: { supportId: firstSupportId, supportIds, modelId: null },
     }));
   }, [isMarqueeSelecting, mode, supportMarqueeCandidateIdSet]);
 
@@ -3361,7 +3360,7 @@ export function SceneCanvas({
     if (e.button !== 0) return;
     if (!e.shiftKey) return;
     if (isGizmoDragging || isPostGizmoInteractionGuardActive) return;
-    if (hoveredModelId || supportStateForBounds.hoveredCategory !== 'none') return;
+    if (mode === 'prepare' && (hoveredModelId || supportStateForBounds.hoveredCategory !== 'none')) return;
 
     if (mode === 'prepare' && onActiveModelChange) {
       const hasSelection = !!activeModelId || !!selectedModelIds?.length;

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -248,6 +248,17 @@ export function StlMesh({
   const isGizmoHoverCategory = hit.category === 'gizmo';
   const isSupportLikeHoverCategory = hit.category === 'support' || hit.category === 'segment' || hit.category === 'joint' || hit.category === 'knot' || hit.category === 'raft';
   const shouldSuppressModelInteraction = !!suppressModelInteraction;
+  const isSupportShiftGesture = (
+    event: {
+      shiftKey?: boolean;
+      nativeEvent?: { shiftKey?: boolean } | null;
+      sourceEvent?: { shiftKey?: boolean } | null;
+    } | null | undefined,
+  ) => mode === 'support' && !!(
+    event?.shiftKey
+    || event?.nativeEvent?.shiftKey
+    || event?.sourceEvent?.shiftKey
+  );
   const hasExternalHoverSource = externalHoveredModelId !== undefined;
   const isExternallyHoveredModel = !shouldSuppressModelInteraction
     && !!externalHoveredModelId
@@ -405,6 +416,11 @@ export function StlMesh({
         position={meshLocalOffset}
         renderOrder={isSupportDimmed ? 2 : 0}
         onClick={(e) => {
+          if (isSupportShiftGesture(e)) {
+            e.stopPropagation();
+            return;
+          }
+
           if (shouldSuppressModelInteraction) {
             e.stopPropagation();
             return;
@@ -446,6 +462,19 @@ export function StlMesh({
           }
         }}
         onPointerMove={(e) => {
+          if (isSupportShiftGesture(e)) {
+            schedulePointerHover(false);
+            onModelHoverPointChange?.(null);
+            onModelHoverModelChange?.(null);
+            window.dispatchEvent(new CustomEvent('model-pointer-hover-immediate', {
+              detail: { modelId: null },
+            }));
+            if (mode === 'support' && onSupportHover) {
+              onSupportHover(null);
+            }
+            return;
+          }
+
           if (shouldSuppressModelInteraction || isGizmoHoverCategory) {
             schedulePointerHover(false);
             onModelHoverPointChange?.(null);
@@ -532,6 +561,10 @@ export function StlMesh({
           }
         }}
         onPointerDown={(e) => {
+          if (isSupportShiftGesture(e)) {
+            return;
+          }
+
           if (!shouldSuppressModelInteraction && mode === 'prepare' && e.button === 0) {
             // While transforming the selected model, don't consume pointer-down at
             // the model layer; this keeps gizmo handle clicks responsive.

--- a/src/features/supports/useSupportInteractionManager.ts
+++ b/src/features/supports/useSupportInteractionManager.ts
@@ -26,6 +26,7 @@ import {
   removeTwig,
   removeStick,
   removeTrunk,
+  removeKickstandCascade,
   removeJointById,
   updateKnot,
   updateTrunk,
@@ -38,7 +39,7 @@ import { registerDeleteHandler } from '@/features/delete/deleteRegistry';
 import { pushHistory } from '@/history/historyStore';
 import { SUPPORT_REMOVE_BRANCH, SUPPORT_REMOVE_BRACE, SUPPORT_REMOVE_LEAF, SUPPORT_REMOVE_TRUNK, SUPPORT_UPDATE_TRUNK, SUPPORT_UPDATE_BRANCH, SUPPORT_REMOVE_TWIG, SUPPORT_REMOVE_STICK, SUPPORT_AUTO_BRACE_REPLACE, SUPPORT_REMOVE_KICKSTAND } from '@/supports/history/actionTypes';
 import { clearSelection, getMultiSelectedSupportIds, selectAllSupports } from '@/supports/interaction/SupportSelection';
-import { getKickstandSnapshot, removeKickstand } from '@/supports/SupportTypes/Kickstand/kickstandStore';
+import { getKickstandSnapshot } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 
 interface SupportInteractionOptions {
   mode: SupportMode;
@@ -414,12 +415,12 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
         const kickstands = Object.values(getKickstandSnapshot().kickstands);
         const kickstand = kickstands.find((ks) => ks.hostKnotId === id);
         if (kickstand) {
-          const kickstandSnapshots = removeKickstand(kickstand.id);
+          const kickstandSnapshots = removeKickstandCascade(kickstand.id);
           if (!kickstandSnapshots) return false;
           if (recordHistory) {
             pushHistory({
               type: SUPPORT_REMOVE_KICKSTAND,
-              payload: { build: kickstandSnapshots },
+              payload: kickstandSnapshots,
             });
           }
           setSelectedId(null);
@@ -498,12 +499,12 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
       }
 
       if (category === 'brace') {
-        const kickstandSnapshots = removeKickstand(id);
+        const kickstandSnapshots = removeKickstandCascade(id);
         if (kickstandSnapshots) {
           if (recordHistory) {
             pushHistory({
               type: SUPPORT_REMOVE_KICKSTAND,
-              payload: { build: kickstandSnapshots },
+              payload: kickstandSnapshots,
             });
           }
           setSelectedId(null);

--- a/src/supports/SupportPrimitives/ContactCone/InstancedContactConeGroup.tsx
+++ b/src/supports/SupportPrimitives/ContactCone/InstancedContactConeGroup.tsx
@@ -184,6 +184,7 @@ function ConeBucketMesh({
                 <instancedMesh
                     ref={diskRef}
                     args={[undefined, undefined, bucket.cones.length]}
+                    frustumCulled={false}
                     {...sharedHandlers}
                 >
                     <cylinderGeometry args={[bucket.contactRadius, bucket.contactRadius, bucket.diskThickness + bucket.penetration, 10]} />
@@ -204,6 +205,7 @@ function ConeBucketMesh({
             <instancedMesh
                 ref={bodyRef}
                 args={[undefined, undefined, bucket.cones.length]}
+                frustumCulled={false}
                 {...sharedHandlers}
             >
                 <cylinderGeometry args={[bucket.contactRadius, bucket.bodyRadius, bucket.length, 10]} />
@@ -220,6 +222,7 @@ function ConeBucketMesh({
             <instancedMesh
                 ref={tipSphereRef}
                 args={[undefined, undefined, bucket.cones.length]}
+                frustumCulled={false}
                 {...sharedHandlers}
             >
                 <sphereGeometry args={[bucket.contactRadius, 10, 8]} />

--- a/src/supports/SupportPrimitives/Joint/InstancedJointGroup.tsx
+++ b/src/supports/SupportPrimitives/Joint/InstancedJointGroup.tsx
@@ -101,6 +101,7 @@ export function InstancedJointGroup({
         <instancedMesh
             ref={meshRef}
             args={[undefined, undefined, validJoints.length]}
+            frustumCulled={false}
             onClick={onJointClick ? handleClick : undefined}
             onPointerMove={onJointPointerMove ? handlePointerMove : undefined}
             onPointerOut={onJointPointerOut ? handlePointerOut : undefined}

--- a/src/supports/SupportPrimitives/Roots/InstancedRootsGroup.tsx
+++ b/src/supports/SupportPrimitives/Roots/InstancedRootsGroup.tsx
@@ -163,6 +163,7 @@ function RootBucketMesh({
             <instancedMesh
                 ref={diskRef}
                 args={[undefined, undefined, bucket.roots.length]}
+                frustumCulled={false}
                 onClick={onRootClick ? handleClick : undefined}
                 onPointerMove={onRootPointerMove ? handlePointerMove : undefined}
                 onPointerOut={onRootPointerOut ? handlePointerOut : undefined}
@@ -182,6 +183,7 @@ function RootBucketMesh({
                 <instancedMesh
                     ref={coneRef}
                     args={[undefined, undefined, bucket.roots.length]}
+                    frustumCulled={false}
                     onClick={onRootClick ? handleClick : undefined}
                     onPointerMove={onRootPointerMove ? handlePointerMove : undefined}
                     onPointerOut={onRootPointerOut ? handlePointerOut : undefined}
@@ -202,6 +204,7 @@ function RootBucketMesh({
                 <instancedMesh
                     ref={sphereRef}
                     args={[undefined, undefined, bucket.roots.length]}
+                    frustumCulled={false}
                     onClick={onRootClick ? handleClick : undefined}
                     onPointerMove={onRootPointerMove ? handlePointerMove : undefined}
                     onPointerOut={onRootPointerOut ? handlePointerOut : undefined}

--- a/src/supports/SupportPrimitives/Shaft/InstancedShaftGroup.tsx
+++ b/src/supports/SupportPrimitives/Shaft/InstancedShaftGroup.tsx
@@ -120,6 +120,7 @@ export function InstancedShaftGroup({
         <instancedMesh
             ref={meshRef}
             args={[undefined, undefined, validShafts.length]}
+            frustumCulled={false}
             onClick={onShaftClick ? handleClick : undefined}
             onPointerMove={onShaftPointerMove ? handlePointerMove : undefined}
             onPointerOut={onShaftPointerOut ? handlePointerOut : undefined}

--- a/src/supports/SupportRenderer.tsx
+++ b/src/supports/SupportRenderer.tsx
@@ -78,6 +78,27 @@ const BATCHED_JOINT_HEIGHT_SEGMENTS = 10;
 const MULTI_SELECTION_DETAIL_THRESHOLD = 24;
 const BULK_MULTI_SELECTED_COLOR = '#80fffd';
 const SCENE_JOINT_DIAMETER_BLEND_MM = JOINT_DIAMETER_OFFSET_MM * 0.75;
+const EMPTY_SUPPORT_ID_LIST: readonly string[] = Object.freeze([]);
+
+function normalizeSupportIdList(ids: readonly (string | null | undefined)[]) {
+    const normalized: string[] = [];
+    const seen = new Set<string>();
+    for (const id of ids) {
+        if (!id || seen.has(id)) continue;
+        seen.add(id);
+        normalized.push(id);
+    }
+    return normalized.length > 0 ? normalized : EMPTY_SUPPORT_ID_LIST;
+}
+
+function supportIdListsEqual(a: readonly string[], b: readonly string[]) {
+    if (a === b) return true;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+        if (a[i] !== b[i]) return false;
+    }
+    return true;
+}
 
 export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ mode, navigationLodActive = false, hidePlateContactPrimitives = false, clipLower, clipUpper, activeModelId = null, selectedModelIds = [], hoverModelId = null, modelDropOffsetsById, modelFilterId = null, excludeModelId = null, excludeModelIds = [], passive = false, disableSelectionAndHover = false, ghostOpacity = 1, ghostRenderOrder = 0 }, ref) => {
     const state = useSyncExternalStore(subscribe, getSnapshot);
@@ -98,7 +119,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
     const selectedId = selectionEnabled ? state.selectedId : null;
     const selectedCategory = selectionEnabled ? state.selectedCategory : null;
     const hasSupportMultiSelection = effectiveSelectedSupportIds.length > 0;
-    const useMultiSelectionDetail = hasSupportMultiSelection && selectedId !== null && selectedSupportIds.length <= MULTI_SELECTION_DETAIL_THRESHOLD;
+    const useMultiSelectionDetail = hasSupportMultiSelection && effectiveSelectedSupportIds.length <= MULTI_SELECTION_DETAIL_THRESHOLD;
     const dimNonSelected = selectedId !== null || hasSupportMultiSelection;
     const hideUnselectedKnots = selectedId !== null || hasSupportMultiSelection;
     const enableTwigSceneBatching = false;
@@ -126,8 +147,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
     const [immediatePrepareActiveModelId, setImmediatePrepareActiveModelId] = React.useState<string | null>(null);
     const [sceneHoveredSupportId, setSceneHoveredSupportId] = React.useState<string | null>(null);
     const [marqueeHoveredSupportId, setMarqueeHoveredSupportId] = React.useState<string | null>(null);
+    const [marqueeHoveredSupportIds, setMarqueeHoveredSupportIds] = React.useState<readonly string[]>(EMPTY_SUPPORT_ID_LIST);
     const pendingSceneHoverClearFrameRef = React.useRef<number | null>(null);
     const orbitInteractionActiveRef = React.useRef(false);
+    const marqueeHoveredSupportIdSet = useMemo(() => new Set(marqueeHoveredSupportIds), [marqueeHoveredSupportIds]);
     const entitySegmentModelIdById = useMemo(() => {
         const map = new Map<string, string | undefined>();
 
@@ -246,6 +269,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
             setSceneHoveredSupportId((prev) => (prev === null ? prev : null));
             setMarqueeHoveredSupportId((prev) => (prev === null ? prev : null));
+            setMarqueeHoveredSupportIds((prev) => (prev.length === 0 ? prev : EMPTY_SUPPORT_ID_LIST));
             emitSupportModelPointerHover(null);
         };
 
@@ -256,15 +280,22 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
         const handleSupportMarqueeHover = (event: Event) => {
             if (supportSelectionAndHoverSuppressed) {
                 setMarqueeHoveredSupportId((prev) => (prev === null ? prev : null));
+                setMarqueeHoveredSupportIds((prev) => (prev.length === 0 ? prev : EMPTY_SUPPORT_ID_LIST));
                 emitSupportModelPointerHover(null);
                 return;
             }
 
-            const customEvent = event as CustomEvent<{ supportId?: string | null; modelId?: string | null }>;
-            const supportId = customEvent.detail?.supportId ?? null;
+            const customEvent = event as CustomEvent<{ supportId?: string | null; supportIds?: string[]; modelId?: string | null }>;
+            const supportIds = normalizeSupportIdList(
+                Array.isArray(customEvent.detail?.supportIds) && customEvent.detail.supportIds.length > 0
+                    ? customEvent.detail.supportIds
+                    : [customEvent.detail?.supportId ?? null],
+            );
+            const supportId = supportIds[0] ?? null;
             const modelId = customEvent.detail?.modelId ?? null;
 
-            setMarqueeHoveredSupportId(supportId);
+            setMarqueeHoveredSupportIds((prev) => (supportIdListsEqual(prev, supportIds) ? prev : supportIds));
+            setMarqueeHoveredSupportId((prev) => (prev === supportId ? prev : supportId));
             emitSupportModelPointerHover(modelId);
         };
 
@@ -393,6 +424,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
         setSceneHoveredSupportId((prev) => (prev === null ? prev : null));
         setMarqueeHoveredSupportId((prev) => (prev === null ? prev : null));
+        setMarqueeHoveredSupportIds((prev) => (prev.length === 0 ? prev : EMPTY_SUPPORT_ID_LIST));
         setImmediateModelHoverId((prev) => (prev === null ? prev : null));
         emitSupportModelPointerHover(null);
     }, [supportSelectionAndHoverSuppressed]);
@@ -1570,10 +1602,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
     const sceneBatchedTwigShaftGroups = useMemo(() => {
         if (!enableTwigSceneBatching) {
-            return [] as Array<{ modelId?: string; shafts: InstancedShaft[] }>;
+            return [] as Array<{ modelId?: string; color: string; shafts: InstancedShaft[] }>;
         }
 
-        const grouped = new Map<string, { modelId?: string; shafts: InstancedShaft[] }>();
+        const grouped = new Map<string, { modelId?: string; color: string; shafts: InstancedShaft[] }>();
 
         for (const twig of Object.values(state.twigs)) {
             if (!isModelVisible(twig.modelId, twig.id)) continue;
@@ -1581,21 +1613,23 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             if (!shaftSet) continue;
             if (selectedTwigIds.has(twig.id)) continue;
 
+            const color = resolveSceneSupportColor(shaftSet.modelId, twig.id);
             const modelKey = shaftSet.modelId ?? '__unassigned__';
-            const existing = grouped.get(modelKey) ?? { modelId: shaftSet.modelId, shafts: [] };
+            const groupKey = `${modelKey}:${color}`;
+            const existing = grouped.get(groupKey) ?? { modelId: shaftSet.modelId, color, shafts: [] };
             existing.shafts.push(...shaftSet.shafts.map((shaft) => ({
                 ...shaft,
                 start: applyDropToVec3Like(shaft.start, shaft.modelId),
                 end: applyDropToVec3Like(shaft.end, shaft.modelId),
             })));
-            if (existing.shafts.length > 0) grouped.set(modelKey, existing);
+            if (existing.shafts.length > 0) grouped.set(groupKey, existing);
         }
 
         return Array.from(grouped.values());
-    }, [state.twigs, twigShaftsBySupport, selectedTwigIds, isModelVisible, applyDropToVec3Like, enableTwigSceneBatching]);
+    }, [state.twigs, twigShaftsBySupport, selectedTwigIds, isModelVisible, applyDropToVec3Like, enableTwigSceneBatching, resolveSceneSupportColor]);
 
     const sceneBatchedStickShaftGroups = useMemo(() => {
-        const grouped = new Map<string, { modelId?: string; shafts: InstancedShaft[] }>();
+        const grouped = new Map<string, { modelId?: string; color: string; shafts: InstancedShaft[] }>();
 
         for (const stick of Object.values(state.sticks)) {
             if (!isModelVisible(stick.modelId, stick.id)) continue;
@@ -1603,21 +1637,23 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             if (!shaftSet) continue;
             if (selectedStickIds.has(stick.id)) continue;
 
+            const color = resolveSceneSupportColor(shaftSet.modelId, stick.id);
             const modelKey = shaftSet.modelId ?? '__unassigned__';
-            const existing = grouped.get(modelKey) ?? { modelId: shaftSet.modelId, shafts: [] };
+            const groupKey = `${modelKey}:${color}`;
+            const existing = grouped.get(groupKey) ?? { modelId: shaftSet.modelId, color, shafts: [] };
             existing.shafts.push(...shaftSet.shafts.map((shaft) => ({
                 ...shaft,
                 start: applyDropToVec3Like(shaft.start, shaft.modelId),
                 end: applyDropToVec3Like(shaft.end, shaft.modelId),
             })));
-            if (existing.shafts.length > 0) grouped.set(modelKey, existing);
+            if (existing.shafts.length > 0) grouped.set(groupKey, existing);
         }
 
         return Array.from(grouped.values());
-    }, [state.sticks, stickShaftsBySupport, selectedStickIds, isModelVisible, applyDropToVec3Like]);
+    }, [state.sticks, stickShaftsBySupport, selectedStickIds, isModelVisible, applyDropToVec3Like, resolveSceneSupportColor]);
 
     const sceneBatchedKickstandShaftGroups = useMemo(() => {
-        const grouped = new Map<string, { modelId?: string; shafts: InstancedShaft[] }>();
+        const grouped = new Map<string, { modelId?: string; color: string; shafts: InstancedShaft[] }>();
 
         for (const kickstand of Object.values(kickstandState.kickstands)) {
             if (!isModelVisible(kickstand.modelId, kickstand.id)) continue;
@@ -1625,21 +1661,23 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             if (!shaftSet) continue;
             if (selectedKickstandIds.has(kickstand.id)) continue;
 
+            const color = resolveSceneSupportColor(shaftSet.modelId, kickstand.id);
             const modelKey = shaftSet.modelId ?? '__unassigned__';
-            const existing = grouped.get(modelKey) ?? { modelId: shaftSet.modelId, shafts: [] };
+            const groupKey = `${modelKey}:${color}`;
+            const existing = grouped.get(groupKey) ?? { modelId: shaftSet.modelId, color, shafts: [] };
             existing.shafts.push(...shaftSet.shafts.map((shaft) => ({
                 ...shaft,
                 start: applyDropToVec3Like(shaft.start, shaft.modelId),
                 end: applyDropToVec3Like(shaft.end, shaft.modelId),
             })));
-            if (existing.shafts.length > 0) grouped.set(modelKey, existing);
+            if (existing.shafts.length > 0) grouped.set(groupKey, existing);
         }
 
         return Array.from(grouped.values());
-    }, [kickstandState.kickstands, kickstandShaftsBySupport, selectedKickstandIds, isModelVisible, applyDropToVec3Like]);
+    }, [kickstandState.kickstands, kickstandShaftsBySupport, selectedKickstandIds, isModelVisible, applyDropToVec3Like, resolveSceneSupportColor]);
 
     const sceneBatchedBraceShaftGroups = useMemo(() => {
-        const grouped = new Map<string, { modelId?: string; debugSection?: 'initial' | 'repeating' | null; shafts: InstancedShaft[] }>();
+        const grouped = new Map<string, { modelId?: string; color: string; shafts: InstancedShaft[] }>();
 
         const sectionColorsEnabled = !!settings.autoBracing.debugSectionColorsEnabled;
         const splitByDebugSection = sectionColorsEnabled && !dimNonSelected;
@@ -1655,7 +1693,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             const debugSection = splitByDebugSection
                 ? (brace.debugSection ?? null)
                 : null;
-            const groupKey = debugSection ? `${modelKey}:${debugSection}` : modelKey;
+            const color = debugSection
+                ? AUTO_BRACING_DEBUG_SECTION_COLORS[debugSection]
+                : resolveSceneSupportColor(shaftSet.modelId, brace.id);
+            const groupKey = `${modelKey}:${color}`;
 
             const existing = grouped.get(groupKey);
             if (existing) {
@@ -1667,7 +1708,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             } else {
                 grouped.set(groupKey, {
                     modelId: shaftSet.modelId,
-                    debugSection,
+                    color,
                     shafts: shaftSet.shafts.map((shaft) => ({
                         ...shaft,
                         start: applyDropToVec3Like(shaft.start, shaft.modelId),
@@ -1678,10 +1719,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
         }
 
         return Array.from(grouped.values());
-    }, [state.braces, braceShaftsBySupport, selectedBraceIds, isModelVisible, applyDropToVec3Like, settings.autoBracing.debugSectionColorsEnabled, dimNonSelected]);
+    }, [state.braces, braceShaftsBySupport, selectedBraceIds, isModelVisible, applyDropToVec3Like, settings.autoBracing.debugSectionColorsEnabled, dimNonSelected, resolveSceneSupportColor]);
 
     const sceneBatchedTrunkShaftGroups = useMemo(() => {
-        const grouped = new Map<string, { modelId?: string; shafts: InstancedShaft[] }>();
+        const grouped = new Map<string, { modelId?: string; color: string; shafts: InstancedShaft[] }>();
 
         for (const trunk of Object.values(state.trunks)) {
             if (!isModelVisible(trunk.modelId, trunk.id)) continue;
@@ -1690,22 +1731,24 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
             if (selectedTrunkIds.has(trunk.id)) continue;
 
+            const color = resolveSceneSupportColor(shaftSet.modelId, trunk.id);
             const modelKey = shaftSet.modelId ?? '__unassigned__';
-            const existing = grouped.get(modelKey) ?? { modelId: shaftSet.modelId, shafts: [] };
+            const groupKey = `${modelKey}:${color}`;
+            const existing = grouped.get(groupKey) ?? { modelId: shaftSet.modelId, color, shafts: [] };
             existing.shafts.push(...shaftSet.shafts.map((shaft) => ({
                 ...shaft,
                 start: applyDropToVec3Like(shaft.start, shaft.modelId),
                 end: applyDropToVec3Like(shaft.end, shaft.modelId),
             })));
 
-            if (existing.shafts.length > 0) grouped.set(modelKey, existing);
+            if (existing.shafts.length > 0) grouped.set(groupKey, existing);
         }
 
         return Array.from(grouped.values());
-    }, [state.trunks, trunkShaftsBySupport, selectedTrunkIds, isModelVisible, applyDropToVec3Like]);
+    }, [state.trunks, trunkShaftsBySupport, selectedTrunkIds, isModelVisible, applyDropToVec3Like, resolveSceneSupportColor]);
 
     const sceneBatchedBranchShaftGroups = useMemo(() => {
-        const grouped = new Map<string, { modelId?: string; shafts: InstancedShaft[] }>();
+        const grouped = new Map<string, { modelId?: string; color: string; shafts: InstancedShaft[] }>();
 
         for (const branch of Object.values(state.branches)) {
             if (!isModelVisible(branch.modelId)) continue;
@@ -1714,8 +1757,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
             if (selectedBranchIds.has(branch.id)) continue;
 
+            const color = resolveSceneSupportColor(shaftSet.modelId, branch.id);
             const modelKey = shaftSet.modelId ?? '__unassigned__';
-            const existing = grouped.get(modelKey) ?? { modelId: shaftSet.modelId, shafts: [] };
+            const groupKey = `${modelKey}:${color}`;
+            const existing = grouped.get(groupKey) ?? { modelId: shaftSet.modelId, color, shafts: [] };
             existing.shafts.push(...shaftSet.shafts.map((shaft) => ({
                 ...shaft,
                 start: applyDropToVec3Like(shaft.start, shaft.modelId),
@@ -1723,12 +1768,12 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             })));
 
             if (existing.shafts.length > 0) {
-                grouped.set(modelKey, existing);
+                grouped.set(groupKey, existing);
             }
         }
 
         return Array.from(grouped.values());
-    }, [state.branches, branchShaftsBySupport, selectedBranchIds, isModelVisible, applyDropToVec3Like]);
+    }, [state.branches, branchShaftsBySupport, selectedBranchIds, isModelVisible, applyDropToVec3Like, resolveSceneSupportColor]);
 
     const sceneBatchedTrunkRootGroups = useMemo(() => {
         if (hidePlateContactPrimitivesEffective) return [] as Array<{ color: string; roots: InstancedRoot[] }>;
@@ -2054,6 +2099,179 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
         }));
     }, [hoveredSupportJointSet, applyDropToVec3Like]);
 
+    const buildHighlightedRootOverlay = React.useCallback((supportId: string): InstancedRoot | null => {
+        const hasSolidBottom = raftSettings.bottomMode === 'solid';
+        const raftThickness = raftSettings.thickness ?? 0;
+
+        const trunk = state.trunks[supportId];
+        if (trunk) {
+            const root = state.roots[trunk.rootId];
+            if (!root) return null;
+
+            const shaftDiameter = Math.max(0.001, trunk.segments[0]?.diameter ?? 1.5);
+            const topRadius = shaftDiameter / 2;
+            const bottomRadius = Math.max(0.001, root.diameter / 2);
+            const effectiveDiskHeight = hasSolidBottom ? 0.05 : Math.max(0.001, root.diskHeight);
+            const verticalOffset = hasSolidBottom ? Math.max(raftThickness - effectiveDiskHeight, 0) : 0;
+
+            return {
+                id: root.id,
+                supportId: trunk.id,
+                modelId: trunk.modelId,
+                basePos: applyDropToVec3Like({
+                    x: root.transform.pos.x,
+                    y: root.transform.pos.y,
+                    z: root.transform.pos.z + verticalOffset,
+                }, trunk.modelId),
+                bottomRadius,
+                topRadius,
+                effectiveDiskHeight,
+                coneHeight: Math.max(0, root.coneHeight),
+            };
+        }
+
+        const kickstand = kickstandState.kickstands[supportId];
+        if (kickstand) {
+            const root = kickstandState.roots[kickstand.rootId];
+            if (!root) return null;
+
+            const shaftDiameter = Math.max(
+                0.001,
+                kickstand.segments[0]?.diameter ?? kickstand.profile.bodyDiameterMm,
+            );
+            const topRadius = shaftDiameter / 2;
+            const bottomRadius = Math.max(0.001, root.diameter / 2);
+            const effectiveDiskHeight = hasSolidBottom ? 0.05 : Math.max(0.001, root.diskHeight);
+            const verticalOffset = hasSolidBottom ? Math.max(raftThickness - effectiveDiskHeight, 0) : 0;
+
+            return {
+                id: root.id,
+                supportId: kickstand.id,
+                modelId: kickstand.modelId,
+                basePos: applyDropToVec3Like({
+                    x: root.transform.pos.x,
+                    y: root.transform.pos.y,
+                    z: root.transform.pos.z + verticalOffset,
+                }, kickstand.modelId),
+                bottomRadius,
+                topRadius,
+                effectiveDiskHeight,
+                coneHeight: Math.max(0, root.coneHeight),
+            };
+        }
+
+        return null;
+    }, [
+        raftSettings.bottomMode,
+        raftSettings.thickness,
+        state.trunks,
+        state.roots,
+        kickstandState.kickstands,
+        kickstandState.roots,
+        applyDropToVec3Like,
+    ]);
+
+    const hoveredSupportOverlayRoots = useMemo(() => {
+        if (hidePlateContactPrimitivesEffective) return [] as InstancedRoot[];
+        if (!isInteractable) return [] as InstancedRoot[];
+
+        const hoveredSupportId = marqueeHoveredSupportId ?? sceneHoveredSupportId ?? (hoveredCategoryForVisual === 'support' ? hoveredIdForVisual : null);
+        if (!hoveredSupportId) return [] as InstancedRoot[];
+
+        const overlay = buildHighlightedRootOverlay(hoveredSupportId);
+        return overlay ? [overlay] : [];
+    }, [
+        hidePlateContactPrimitivesEffective,
+        isInteractable,
+        marqueeHoveredSupportId,
+        sceneHoveredSupportId,
+        hoveredCategoryForVisual,
+        hoveredIdForVisual,
+        buildHighlightedRootOverlay,
+    ]);
+
+    const additionalMarqueeHoveredSupportIds = useMemo(() => {
+        if (!isInteractable || marqueeHoveredSupportIds.length <= 1) return EMPTY_SUPPORT_ID_LIST;
+        return marqueeHoveredSupportIds.slice(1);
+    }, [isInteractable, marqueeHoveredSupportIds]);
+
+    const marqueeHoveredOverlayShafts = useMemo(() => {
+        if (additionalMarqueeHoveredSupportIds.length === 0) return [] as InstancedShaft[];
+
+        const overlays: InstancedShaft[] = [];
+        for (const supportId of additionalMarqueeHoveredSupportIds) {
+            const shaftSet = trunkShaftsBySupport.get(supportId)
+                ?? branchShaftsBySupport.get(supportId)
+                ?? braceShaftsBySupport.get(supportId)
+                ?? twigShaftsBySupport.get(supportId)
+                ?? stickShaftsBySupport.get(supportId)
+                ?? kickstandShaftsBySupport.get(supportId)
+                ?? null;
+            if (!shaftSet) continue;
+            overlays.push(...shaftSet.shafts.map((shaft) => ({
+                ...shaft,
+                start: applyDropToVec3Like(shaft.start, shaft.modelId),
+                end: applyDropToVec3Like(shaft.end, shaft.modelId),
+                diameter: shaft.diameter * 1.02,
+            })));
+        }
+        return overlays;
+    }, [additionalMarqueeHoveredSupportIds, trunkShaftsBySupport, branchShaftsBySupport, braceShaftsBySupport, twigShaftsBySupport, stickShaftsBySupport, kickstandShaftsBySupport, applyDropToVec3Like]);
+
+    const marqueeHoveredOverlayCones = useMemo(() => {
+        if (additionalMarqueeHoveredSupportIds.length === 0) return [] as InstancedContactCone[];
+
+        const overlays: InstancedContactCone[] = [];
+        for (const supportId of additionalMarqueeHoveredSupportIds) {
+            const coneSet = contactConesBySupport.get(supportId);
+            if (!coneSet) continue;
+            overlays.push(...coneSet.cones.map((cone) => ({
+                ...cone,
+                pos: applyDropToVec3Like(cone.pos, cone.modelId),
+            })));
+        }
+        return overlays;
+    }, [additionalMarqueeHoveredSupportIds, contactConesBySupport, applyDropToVec3Like]);
+
+    const marqueeHoveredOverlayJoints = useMemo(() => {
+        if (additionalMarqueeHoveredSupportIds.length === 0) return [] as InstancedJoint[];
+
+        const overlays: InstancedJoint[] = [];
+        for (const supportId of additionalMarqueeHoveredSupportIds) {
+            const jointSet = trunkJointsBySupport.get(supportId)
+                ?? branchJointsBySupport.get(supportId)
+                ?? twigJointsBySupport.get(supportId)
+                ?? stickJointsBySupport.get(supportId)
+                ?? kickstandJointsBySupport.get(supportId)
+                ?? null;
+            if (!jointSet) continue;
+            overlays.push(...jointSet.joints.map((joint) => ({
+                ...joint,
+                pos: applyDropToVec3Like(joint.pos, joint.modelId),
+                diameter: joint.diameter * 1.06,
+            })));
+        }
+        return overlays;
+    }, [additionalMarqueeHoveredSupportIds, trunkJointsBySupport, branchJointsBySupport, twigJointsBySupport, stickJointsBySupport, kickstandJointsBySupport, applyDropToVec3Like]);
+
+    const marqueeHoveredOverlayRoots = useMemo(() => {
+        if (hidePlateContactPrimitivesEffective) return [] as InstancedRoot[];
+        if (additionalMarqueeHoveredSupportIds.length === 0) return [] as InstancedRoot[];
+
+        const overlays: InstancedRoot[] = [];
+
+        for (const supportId of additionalMarqueeHoveredSupportIds) {
+            const overlay = buildHighlightedRootOverlay(supportId);
+            if (overlay) overlays.push(overlay);
+        }
+
+        return overlays;
+    }, [
+        hidePlateContactPrimitivesEffective,
+        additionalMarqueeHoveredSupportIds,
+        buildHighlightedRootOverlay,
+    ]);
+
     const handleSceneBatchedShaftClick = React.useCallback((shaft: InstancedShaft, event: { nativeEvent?: Event }) => {
         if (!isPointerInteractable) return;
         if (isPreparePointerInteractable) {
@@ -2319,10 +2537,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
             {/* Render Trunks */}
             {sceneBatchedTrunkShaftGroups.map((group) => (
-                <group key={`scene-trunk-batch:${group.modelId ?? 'none'}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
+                <group key={`scene-trunk-batch:${group.modelId ?? 'none'}:${group.color}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
                     <InstancedShaftGroup
                         shafts={group.shafts}
-                        color={dimNonSelected ? '#666666' : resolveBaseColor(group.modelId)}
+                        color={group.color}
                         transparent={ghostTransparent}
                         opacity={ghostOpacityClamped}
                         radialSegments={sceneBatchedShaftRadialSegments}
@@ -2435,6 +2653,84 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 />
             )}
 
+            {hoveredSupportOverlayRoots.length > 0 && (
+                <InstancedRootsGroup
+                    key={`scene-root-hover-overlay:${hoveredSupportOverlayRoots.map((root) => root.supportId ?? root.id).join(':')}:${hoveredSupportOverlayRoots.length}`}
+                    roots={hoveredSupportOverlayRoots}
+                    color={dimNonSelected ? '#666666' : resolveBaseColor(hoveredSupportOverlayRoots[0]?.modelId)}
+                    emissive="#ffffff"
+                    emissiveIntensity={0.3}
+                    transparent={ghostTransparent}
+                    opacity={ghostOpacityClamped}
+                    onRootClick={isPointerInteractable ? handleSceneBatchedRootClick : undefined}
+                    onRootPointerMove={isPointerInteractable ? handleSceneBatchedRootPointerMove : undefined}
+                    onRootPointerOut={isPointerInteractable ? handleSceneBatchedShaftPointerOut : undefined}
+                />
+            )}
+
+            {marqueeHoveredOverlayShafts.length > 0 && (
+                <InstancedShaftGroup
+                    key={`scene-marquee-overlay-shafts:${marqueeHoveredSupportIds.join(':')}:${marqueeHoveredOverlayShafts.length}`}
+                    shafts={marqueeHoveredOverlayShafts}
+                    color={BULK_MULTI_SELECTED_COLOR}
+                    emissive="#ffffff"
+                    emissiveIntensity={0.3}
+                    transparent={ghostTransparent}
+                    opacity={ghostOpacityClamped}
+                    radialSegments={BATCHED_SHAFT_RADIAL_SEGMENTS}
+                    onShaftClick={isPointerInteractable ? handleSceneBatchedShaftClick : undefined}
+                    onShaftPointerMove={isPointerInteractable ? handleSceneBatchedShaftPointerMove : undefined}
+                    onShaftPointerOut={isPointerInteractable ? handleSceneBatchedShaftPointerOut : undefined}
+                />
+            )}
+
+            {marqueeHoveredOverlayCones.length > 0 && (
+                <InstancedContactConeGroup
+                    key={`scene-marquee-overlay-cones:${marqueeHoveredSupportIds.join(':')}:${marqueeHoveredOverlayCones.length}`}
+                    cones={marqueeHoveredOverlayCones}
+                    color={BULK_MULTI_SELECTED_COLOR}
+                    emissive="#ffffff"
+                    emissiveIntensity={0.3}
+                    transparent={ghostTransparent}
+                    opacity={ghostOpacityClamped}
+                    onConeClick={isPointerInteractable ? handleSceneBatchedConeClick : undefined}
+                    onConePointerMove={isPointerInteractable ? handleSceneBatchedConePointerMove : undefined}
+                    onConePointerOut={isPointerInteractable ? handleSceneBatchedShaftPointerOut : undefined}
+                />
+            )}
+
+            {marqueeHoveredOverlayJoints.length > 0 && (
+                <InstancedJointGroup
+                    key={`scene-marquee-overlay-joints:${marqueeHoveredSupportIds.join(':')}:${marqueeHoveredOverlayJoints.length}`}
+                    joints={marqueeHoveredOverlayJoints}
+                    color={BULK_MULTI_SELECTED_COLOR}
+                    emissive="#ffffff"
+                    emissiveIntensity={0.3}
+                    transparent={ghostTransparent}
+                    opacity={ghostOpacityClamped}
+                    widthSegments={BATCHED_JOINT_WIDTH_SEGMENTS}
+                    heightSegments={BATCHED_JOINT_HEIGHT_SEGMENTS}
+                    onJointClick={isPointerInteractable ? handleSceneBatchedJointClick : undefined}
+                    onJointPointerMove={isPointerInteractable ? handleSceneBatchedJointPointerMove : undefined}
+                    onJointPointerOut={isPointerInteractable ? handleSceneBatchedShaftPointerOut : undefined}
+                />
+            )}
+
+            {marqueeHoveredOverlayRoots.length > 0 && (
+                <InstancedRootsGroup
+                    key={`scene-marquee-overlay-roots:${marqueeHoveredSupportIds.join(':')}:${marqueeHoveredOverlayRoots.length}`}
+                    roots={marqueeHoveredOverlayRoots}
+                    color={BULK_MULTI_SELECTED_COLOR}
+                    emissive="#ffffff"
+                    emissiveIntensity={0.3}
+                    transparent={ghostTransparent}
+                    opacity={ghostOpacityClamped}
+                    onRootClick={isPointerInteractable ? handleSceneBatchedRootClick : undefined}
+                    onRootPointerMove={isPointerInteractable ? handleSceneBatchedRootPointerMove : undefined}
+                    onRootPointerOut={isPointerInteractable ? handleSceneBatchedShaftPointerOut : undefined}
+                />
+            )}
+
             {Object.values(state.trunks).map(trunk => {
                 if (!isModelVisible(trunk.modelId, trunk.id)) return null;
                 const root = state.roots[trunk.rootId];
@@ -2447,7 +2743,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
                 const isTrunkHovered = (hoveredCategoryForVisual === 'support' && hoveredIdForVisual === trunk.id)
                     || sceneHoveredSupportId === trunk.id
-                    || marqueeHoveredSupportId === trunk.id;
+                    || marqueeHoveredSupportIdSet.has(trunk.id);
                 const deferTrunkInteractionToSceneBatch = !effectiveSelected && !hasBezierSegment;
 
                 return (
@@ -2475,10 +2771,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
             {/* Render Branches */}
             {sceneBatchedBranchShaftGroups.map((group) => (
-                <group key={`scene-branch-batch:${group.modelId ?? 'none'}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
+                <group key={`scene-branch-batch:${group.modelId ?? 'none'}:${group.color}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
                     <InstancedShaftGroup
                         shafts={group.shafts}
-                        color={dimNonSelected ? '#666666' : resolveBaseColor(group.modelId)}
+                        color={group.color}
                         transparent={ghostTransparent}
                         opacity={ghostOpacityClamped}
                         radialSegments={sceneBatchedShaftRadialSegments}
@@ -2501,7 +2797,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
                 const isBranchHovered = (hoveredCategoryForVisual === 'support' && hoveredIdForVisual === branch.id)
                     || sceneHoveredSupportId === branch.id
-                    || marqueeHoveredSupportId === branch.id;
+                    || marqueeHoveredSupportIdSet.has(branch.id);
                 const deferBranchInteractionToSceneBatch = !effectiveSelected && !hasBezierSegment;
                 const showKnots = !hideUnselectedKnots || effectiveSelected;
 
@@ -2565,7 +2861,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
                 const isTwigHovered = (hoveredCategoryForVisual === 'support' && hoveredIdForVisual === twig.id)
                     || sceneHoveredSupportId === twig.id
-                    || marqueeHoveredSupportId === twig.id;
+                    || marqueeHoveredSupportIdSet.has(twig.id);
                 const deferTwigInteractionToSceneBatch = !effectiveSelected && isTwigBatchable;
 
                 return (
@@ -2588,10 +2884,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             })}
 
             {sceneBatchedTwigShaftGroups.map((group) => (
-                <group key={`scene-twig-batch:${group.modelId ?? 'none'}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
+                <group key={`scene-twig-batch:${group.modelId ?? 'none'}:${group.color}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
                     <InstancedShaftGroup
                         shafts={group.shafts}
-                        color={dimNonSelected ? '#666666' : resolveBaseColor(group.modelId)}
+                        color={group.color}
                         transparent={ghostTransparent}
                         opacity={ghostOpacityClamped}
                         radialSegments={sceneBatchedShaftRadialSegments}
@@ -2612,7 +2908,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
                 const isStickHovered = (hoveredCategoryForVisual === 'support' && hoveredIdForVisual === stick.id)
                     || sceneHoveredSupportId === stick.id
-                    || marqueeHoveredSupportId === stick.id;
+                    || marqueeHoveredSupportIdSet.has(stick.id);
                 const deferStickInteractionToSceneBatch = !effectiveSelected && isStickBatchable;
 
                 return (
@@ -2636,10 +2932,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             })}
 
             {sceneBatchedStickShaftGroups.map((group) => (
-                <group key={`scene-stick-batch:${group.modelId ?? 'none'}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
+                <group key={`scene-stick-batch:${group.modelId ?? 'none'}:${group.color}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
                     <InstancedShaftGroup
                         shafts={group.shafts}
-                        color={dimNonSelected ? '#666666' : resolveBaseColor(group.modelId)}
+                        color={group.color}
                         transparent={ghostTransparent}
                         opacity={ghostOpacityClamped}
                         radialSegments={sceneBatchedShaftRadialSegments}
@@ -2652,16 +2948,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
             {/* Render Braces */}
             {sceneBatchedBraceShaftGroups.map((group) => (
-                <group key={`scene-brace-batch:${group.modelId ?? 'none'}:${group.debugSection ?? 'none'}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
+                <group key={`scene-brace-batch:${group.modelId ?? 'none'}:${group.color}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
                     <InstancedShaftGroup
                         shafts={group.shafts}
-                        color={
-                            dimNonSelected
-                                ? '#666666'
-                                : (settings.autoBracing.debugSectionColorsEnabled && group.debugSection
-                                    ? AUTO_BRACING_DEBUG_SECTION_COLORS[group.debugSection]
-                                    : resolveBaseColor(group.modelId))
-                        }
+                        color={group.color}
                         transparent={ghostTransparent}
                         opacity={ghostOpacityClamped}
                         radialSegments={sceneBatchedShaftRadialSegments}
@@ -2685,7 +2975,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
                 const isBraceHovered = (hoveredCategoryForVisual === 'support' && hoveredIdForVisual === brace.id)
                     || sceneHoveredSupportId === brace.id
-                    || marqueeHoveredSupportId === brace.id;
+                    || marqueeHoveredSupportIdSet.has(brace.id);
                 const deferBraceInteractionToSceneBatch = !effectiveSelected && isBraceBatchable;
                 const showKnots = !hideUnselectedKnots || effectiveSelected;
 
@@ -2725,7 +3015,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
                 const isKickstandHovered = (hoveredCategoryForVisual === 'support' && hoveredIdForVisual === kickstand.id)
                     || sceneHoveredSupportId === kickstand.id
-                    || marqueeHoveredSupportId === kickstand.id;
+                    || marqueeHoveredSupportIdSet.has(kickstand.id);
                 const deferKickstandInteractionToSceneBatch = !effectiveSelected && isKickstandBatchable;
                 const showKnot = !hideUnselectedKnots || effectiveSelected;
 
@@ -2753,10 +3043,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             })}
 
             {sceneBatchedKickstandShaftGroups.map((group) => (
-                <group key={`scene-kickstand-batch:${group.modelId ?? 'none'}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
+                <group key={`scene-kickstand-batch:${group.modelId ?? 'none'}:${group.color}:${group.shafts.length}`} userData={{ modelId: group.modelId ?? null }}>
                     <InstancedShaftGroup
                         shafts={group.shafts}
-                        color={dimNonSelected ? '#666666' : resolveBaseColor(group.modelId)}
+                        color={group.color}
                         transparent={ghostTransparent}
                         opacity={ghostOpacityClamped}
                         radialSegments={sceneBatchedShaftRadialSegments}

--- a/src/supports/SupportTypes/Kickstand/types.ts
+++ b/src/supports/SupportTypes/Kickstand/types.ts
@@ -1,4 +1,4 @@
-import type { Knot, Roots, Segment, SupportEntity, Vec3 } from '../../types';
+import type { Branch, Brace, Knot, Leaf, Roots, Segment, SupportEntity, Vec3 } from '../../types';
 
 export type KickstandHostKind = 'trunk' | 'branch';
 
@@ -43,6 +43,15 @@ export interface KickstandBuildResult {
     root: Roots;
     hostKnot: Knot;
     kickstand: Kickstand;
+}
+
+export interface KickstandRemoveResult {
+    build: KickstandBuildResult;
+    branches: Branch[];
+    braces: Brace[];
+    kickstands: KickstandBuildResult[];
+    leaves: Leaf[];
+    knots: Knot[];
 }
 
 export interface KickstandState {

--- a/src/supports/__tests__/kickstandDeletionCascade.test.ts
+++ b/src/supports/__tests__/kickstandDeletionCascade.test.ts
@@ -1,0 +1,305 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getSnapshot, removeKickstandCascade, resetStore, setSnapshot } from '../state';
+import { getKickstandSnapshot, setKickstandSnapshot } from '../SupportTypes/Kickstand/kickstandStore';
+import type { KickstandState } from '../SupportTypes/Kickstand/types';
+import type { SupportState } from '../types';
+
+function makeState(): SupportState {
+  return {
+    roots: {
+      'root-1': {
+        id: 'root-1',
+        modelId: 'model-1',
+        transform: {
+          pos: { x: 0, y: 0, z: 0 },
+          rot: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        diameter: 4,
+        diskHeight: 0.5,
+        coneHeight: 1,
+      },
+      'kickstand-root': {
+        id: 'kickstand-root',
+        modelId: 'model-1',
+        transform: {
+          pos: { x: 6, y: 0, z: 0 },
+          rot: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        diameter: 2,
+        diskHeight: 0.4,
+        coneHeight: 0.7,
+      },
+    },
+    trunks: {
+      'trunk-1': {
+        id: 'trunk-1',
+        modelId: 'model-1',
+        rootId: 'root-1',
+        segments: [
+          {
+            id: 'trunk-seg-1',
+            diameter: 1.2,
+            bottomJoint: {
+              id: 'trunk-j0',
+              pos: { x: 0, y: 0, z: 1.5 },
+              diameter: 1.3,
+            },
+            topJoint: {
+              id: 'trunk-j1',
+              pos: { x: 0, y: 0, z: 12 },
+              diameter: 1.3,
+            },
+          },
+        ],
+      },
+    },
+    branches: {
+      'branch-1': {
+        id: 'branch-1',
+        modelId: 'model-1',
+        parentKnotId: 'kickstand-branch-knot',
+        segments: [
+          {
+            id: 'branch-seg-1',
+            diameter: 0.8,
+            bottomJoint: {
+              id: 'branch-j0',
+              pos: { x: 6.2, y: 0, z: 4.5 },
+              diameter: 0.9,
+            },
+            topJoint: {
+              id: 'branch-j1',
+              pos: { x: 7.2, y: 0, z: 8.5 },
+              diameter: 0.9,
+            },
+          },
+        ],
+      },
+    },
+    leaves: {
+      'leaf-direct': {
+        id: 'leaf-direct',
+        modelId: 'model-1',
+        parentKnotId: 'kickstand-leaf-knot',
+        contactCone: {
+          id: 'leaf-direct-cone',
+          pos: { x: 7, y: 1, z: 7 },
+          normal: { x: 0, y: 0, z: 1 },
+          profile: {
+            contactDiameterMm: 0.4,
+            bodyDiameterMm: 1,
+            lengthMm: 2,
+            penetrationMm: 0.1,
+          },
+        },
+      },
+      'leaf-nested': {
+        id: 'leaf-nested',
+        modelId: 'model-1',
+        parentKnotId: 'branch-leaf-knot',
+        contactCone: {
+          id: 'leaf-nested-cone',
+          pos: { x: 8, y: 0, z: 9 },
+          normal: { x: 0, y: 0, z: 1 },
+          profile: {
+            contactDiameterMm: 0.4,
+            bodyDiameterMm: 1,
+            lengthMm: 2,
+            penetrationMm: 0.1,
+          },
+        },
+      },
+    },
+    twigs: {},
+    sticks: {},
+    braces: {
+      'brace-1': {
+        id: 'brace-1',
+        modelId: 'model-1',
+        startKnotId: 'trunk-brace-knot',
+        endKnotId: 'kickstand-brace-knot',
+        profile: {
+          diameter: 0.7,
+        },
+      },
+    },
+    knots: {
+      'kickstand-host-knot': {
+        id: 'kickstand-host-knot',
+        parentShaftId: 'trunk-seg-1',
+        t: 0.75,
+        pos: { x: 0, y: 0, z: 9 },
+        diameter: 1.3,
+      },
+      'kickstand-branch-knot': {
+        id: 'kickstand-branch-knot',
+        parentShaftId: 'kickstand-seg-1',
+        t: 0.4,
+        pos: { x: 6, y: 0, z: 4 },
+        diameter: 0.9,
+      },
+      'kickstand-leaf-knot': {
+        id: 'kickstand-leaf-knot',
+        parentShaftId: 'kickstand-seg-2',
+        t: 0.55,
+        pos: { x: 6.8, y: 0.5, z: 6.5 },
+        diameter: 0.9,
+      },
+      'kickstand-brace-knot': {
+        id: 'kickstand-brace-knot',
+        parentShaftId: 'kickstand-seg-3',
+        t: 0.65,
+        pos: { x: 7.4, y: 0, z: 8.2 },
+        diameter: 0.9,
+      },
+      'trunk-brace-knot': {
+        id: 'trunk-brace-knot',
+        parentShaftId: 'trunk-seg-1',
+        t: 0.5,
+        pos: { x: 0, y: 0, z: 6 },
+        diameter: 1.3,
+      },
+      'branch-leaf-knot': {
+        id: 'branch-leaf-knot',
+        parentShaftId: 'branch-seg-1',
+        t: 0.7,
+        pos: { x: 7.8, y: 0, z: 8.8 },
+        diameter: 0.9,
+      },
+    },
+    selectedId: null,
+    selectedCategory: null,
+    hoveredId: null,
+    hoveredCategory: 'none',
+    interactionWarning: null,
+  };
+}
+
+function makeKickstandState(): KickstandState {
+  return {
+    kickstands: {
+      'kickstand-1': {
+        id: 'kickstand-1',
+        modelId: 'model-1',
+        rootId: 'kickstand-root',
+        hostKnotId: 'kickstand-host-knot',
+        hostSegmentId: 'trunk-seg-1',
+        hostMinT: 0,
+        segments: [
+          {
+            id: 'kickstand-seg-1',
+            diameter: 0.8,
+            bottomJoint: {
+              id: 'kickstand-j0',
+              pos: { x: 6, y: 0, z: 1.2 },
+              diameter: 0.9,
+            },
+            topJoint: {
+              id: 'kickstand-j1',
+              pos: { x: 6, y: 0, z: 4.8 },
+              diameter: 0.9,
+            },
+          },
+          {
+            id: 'kickstand-seg-2',
+            diameter: 0.8,
+            bottomJoint: {
+              id: 'kickstand-j1',
+              pos: { x: 6, y: 0, z: 4.8 },
+              diameter: 0.9,
+            },
+            topJoint: {
+              id: 'kickstand-j2',
+              pos: { x: 6.7, y: 0.4, z: 7 },
+              diameter: 0.9,
+            },
+          },
+          {
+            id: 'kickstand-seg-3',
+            diameter: 0.8,
+            bottomJoint: {
+              id: 'kickstand-j2',
+              pos: { x: 6.7, y: 0.4, z: 7 },
+              diameter: 0.9,
+            },
+            topJoint: {
+              id: 'kickstand-j3',
+              pos: { x: 7.5, y: 0, z: 8.8 },
+              diameter: 0.9,
+            },
+          },
+        ],
+        profile: {
+          bodyDiameterMm: 0.8,
+          terminalStartDiameterMm: 0.8,
+          terminalEndDiameterMm: 1.2,
+        },
+      },
+    },
+    roots: {
+      'kickstand-root': {
+        id: 'kickstand-root',
+        modelId: 'model-1',
+        transform: {
+          pos: { x: 6, y: 0, z: 0 },
+          rot: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        diameter: 2,
+        diskHeight: 0.4,
+        coneHeight: 0.7,
+      },
+    },
+    knots: {
+      'kickstand-host-knot': {
+        id: 'kickstand-host-knot',
+        parentShaftId: 'trunk-seg-1',
+        t: 0.75,
+        pos: { x: 0, y: 0, z: 9 },
+        diameter: 1.3,
+      },
+    },
+    selectedId: null,
+  };
+}
+
+test('removeKickstandCascade removes kickstand descendants and mirrored state', () => {
+  resetStore();
+  setSnapshot(makeState());
+  setKickstandSnapshot(makeKickstandState());
+
+  const removed = removeKickstandCascade('kickstand-1');
+
+  assert.ok(removed, 'Expected kickstand removal snapshots');
+  assert.equal(removed?.build.kickstand.id, 'kickstand-1');
+  assert.deepEqual(new Set(removed?.branches.map((branch) => branch.id)), new Set(['branch-1']));
+  assert.deepEqual(new Set(removed?.braces.map((brace) => brace.id)), new Set(['brace-1']));
+  assert.deepEqual(new Set(removed?.leaves.map((leaf) => leaf.id)), new Set(['leaf-direct', 'leaf-nested']));
+  assert.deepEqual(
+    new Set(removed?.knots.map((knot) => knot.id)),
+    new Set(['kickstand-branch-knot', 'kickstand-leaf-knot', 'kickstand-brace-knot', 'trunk-brace-knot', 'branch-leaf-knot']),
+  );
+
+  const snapshot = getSnapshot();
+  const kickstandSnapshot = getKickstandSnapshot();
+
+  assert.ok(snapshot.trunks['trunk-1'], 'Expected trunk to remain');
+  assert.equal(snapshot.branches['branch-1'], undefined);
+  assert.equal(snapshot.leaves['leaf-direct'], undefined);
+  assert.equal(snapshot.leaves['leaf-nested'], undefined);
+  assert.equal(snapshot.braces['brace-1'], undefined);
+  assert.equal(snapshot.knots['kickstand-host-knot'], undefined);
+  assert.equal(snapshot.knots['kickstand-branch-knot'], undefined);
+  assert.equal(snapshot.knots['kickstand-leaf-knot'], undefined);
+  assert.equal(snapshot.knots['kickstand-brace-knot'], undefined);
+  assert.equal(snapshot.knots['trunk-brace-knot'], undefined);
+  assert.equal(snapshot.knots['branch-leaf-knot'], undefined);
+  assert.equal(snapshot.roots['kickstand-root'], undefined);
+
+  assert.deepEqual(kickstandSnapshot.kickstands, {});
+  assert.deepEqual(kickstandSnapshot.roots, {});
+  assert.deepEqual(kickstandSnapshot.knots, {});
+
+  resetStore();
+});

--- a/src/supports/history/actionTypes.ts
+++ b/src/supports/history/actionTypes.ts
@@ -1,6 +1,5 @@
 import type { Roots, Trunk, Leaf, Knot, Branch, Brace, Twig, Stick, SupportState } from '../types';
-import type { KickstandBuildResult } from '../SupportTypes/Kickstand/types';
-import type { KickstandState } from '../SupportTypes/Kickstand/types';
+import type { KickstandBuildResult, KickstandRemoveResult, KickstandState } from '../SupportTypes/Kickstand/types';
 
 export const SUPPORT_ADD_TRUNK = 'support:add-trunk' as const;
 export const SUPPORT_REMOVE_TRUNK = 'support:remove-trunk' as const;
@@ -119,6 +118,8 @@ export interface BraceLinkPayload {
 export interface SupportKickstandPayload {
   build: KickstandBuildResult;
 }
+
+export type SupportKickstandRemovePayload = KickstandRemoveResult;
 
 export interface SupportReplaceTrunkPayload {
   before: SupportState;

--- a/src/supports/history/useSupportHistoryHandlers.ts
+++ b/src/supports/history/useSupportHistoryHandlers.ts
@@ -31,9 +31,10 @@ import {
   SupportReplaceTrunkPayload,
   SupportReplaceStatePayload,
   SupportKickstandPayload,
+  SupportKickstandRemovePayload,
 } from './actionTypes';
-import { addKnot, addLeaf, addRoot, addTrunk, addBranch, addTwig, addStick, addBrace, removeLeaf, removeTrunk, removeBranch, removeTwig, removeStick, removeBrace, removeKnotById, removeRootById, updateTrunk, updateBranch, updateKnot, setSnapshot } from '../state';
-import { addKickstand, removeKickstand, setKickstandSnapshot } from '../SupportTypes/Kickstand/kickstandStore';
+import { addKnot, addLeaf, addRoot, addTrunk, addBranch, addTwig, addStick, addBrace, removeLeaf, removeTrunk, removeBranch, removeTwig, removeStick, removeBrace, removeKickstandCascade, updateTrunk, updateBranch, updateKnot, setSnapshot } from '../state';
+import { addKickstand, setKickstandSnapshot } from '../SupportTypes/Kickstand/kickstandStore';
 
 export function useSupportHistoryHandlers(enabled = true) {
   useEffect(() => {
@@ -215,9 +216,7 @@ export function useSupportHistoryHandlers(enabled = true) {
         const payload = action.payload as SupportKickstandPayload | undefined;
         if (!payload?.build) return false;
         if (direction === 'undo') {
-          removeKickstand(payload.build.kickstand.id);
-          removeRootById(payload.build.root.id);
-          removeKnotById(payload.build.hostKnot.id);
+          removeKickstandCascade(payload.build.kickstand.id);
         } else {
           addKickstand(payload.build);
           addRoot(payload.build.root);
@@ -226,16 +225,23 @@ export function useSupportHistoryHandlers(enabled = true) {
         return true;
       }),
       registerHistoryHandler(SUPPORT_REMOVE_KICKSTAND, (action, direction) => {
-        const payload = action.payload as SupportKickstandPayload | undefined;
+        const payload = action.payload as SupportKickstandRemovePayload | undefined;
         if (!payload?.build) return false;
         if (direction === 'undo') {
-          addKickstand(payload.build);
           addRoot(payload.build.root);
+          addKickstand(payload.build);
           addKnot(payload.build.hostKnot);
+          for (const knot of payload.knots ?? []) addKnot(knot);
+          for (const leaf of payload.leaves ?? []) addLeaf(leaf);
+          for (const brace of payload.braces ?? []) addBrace(brace);
+          for (const kickstand of payload.kickstands ?? []) {
+            addKickstand(kickstand);
+            addRoot(kickstand.root);
+            addKnot(kickstand.hostKnot);
+          }
+          for (const branch of payload.branches ?? []) addBranch(branch);
         } else {
-          removeKickstand(payload.build.kickstand.id);
-          removeRootById(payload.build.root.id);
-          removeKnotById(payload.build.hostKnot.id);
+          removeKickstandCascade(payload.build.kickstand.id);
         }
         return true;
       }),

--- a/src/supports/state.ts
+++ b/src/supports/state.ts
@@ -6,7 +6,7 @@ import { getFinalSocketPosition } from './SupportPrimitives/ContactCone/contactC
 import { calculateDiskThickness } from './SupportPrimitives/ContactDisk/contactDiskUtils';
 import { JOINT_DIAMETER_OFFSET_MM } from './constants';
 import { addKickstand, getKickstandSnapshot, reassignAllKickstandModelIds, removeKickstand, resetKickstandStore, transformAllKickstands, transformKickstandsForModel, updateKickstand } from './SupportTypes/Kickstand/kickstandStore';
-import type { Kickstand, KickstandBuildResult } from './SupportTypes/Kickstand/types';
+import type { Kickstand, KickstandBuildResult, KickstandRemoveResult } from './SupportTypes/Kickstand/types';
 import * as THREE from 'three';
 import { quaternionFromGlobalEuler } from '@/utils/rotation';
 
@@ -2241,6 +2241,146 @@ export function removeBrace(braceId: string): { brace: Brace; startKnot: Knot | 
     return snapshots;
 }
 
+export function removeKickstandCascade(kickstandId: string): KickstandRemoveResult | null {
+    const kickstandState = getKickstandSnapshot();
+    const kickstand = kickstandState.kickstands[kickstandId];
+    if (!kickstand) return null;
+
+    const kickstandSegmentIds = new Set(kickstand.segments.map((segment) => segment.id));
+    const directKnotIds = new Set<string>();
+    for (const knot of Object.values(state.knots)) {
+        if (kickstandSegmentIds.has(knot.parentShaftId)) {
+            directKnotIds.add(knot.id);
+        }
+    }
+
+    const branchIdsToRemove: string[] = [];
+    for (const branch of Object.values(state.branches)) {
+        if (branch.parentKnotId && directKnotIds.has(branch.parentKnotId)) {
+            branchIdsToRemove.push(branch.id);
+        }
+    }
+
+    const leafIdsToRemove: string[] = [];
+    for (const leaf of Object.values(state.leaves)) {
+        if (leaf.parentKnotId && directKnotIds.has(leaf.parentKnotId)) {
+            leafIdsToRemove.push(leaf.id);
+        }
+    }
+
+    const braceIdsToRemove: string[] = [];
+    for (const brace of Object.values(state.braces)) {
+        if ((brace.startKnotId && directKnotIds.has(brace.startKnotId)) || (brace.endKnotId && directKnotIds.has(brace.endKnotId))) {
+            braceIdsToRemove.push(brace.id);
+        }
+    }
+
+    const build = removeKickstand(kickstandId);
+    if (!build) return null;
+
+    const snapshots: KickstandRemoveResult = {
+        build,
+        branches: [],
+        braces: [],
+        kickstands: [],
+        leaves: [],
+        knots: [],
+    };
+
+    const seenBranchIds = new Set<string>();
+    const seenBraceIds = new Set<string>();
+    const seenKickstandIds = new Set<string>();
+    const seenLeafIds = new Set<string>();
+    const seenKnotIds = new Set<string>();
+
+    for (const branchId of branchIdsToRemove) {
+        const removed = removeBranch(branchId);
+        if (!removed) continue;
+
+        for (const branch of removed.branches ?? []) {
+            if (!branch || seenBranchIds.has(branch.id)) continue;
+            seenBranchIds.add(branch.id);
+            snapshots.branches.push(branch);
+        }
+
+        for (const brace of removed.braces ?? []) {
+            if (!brace || seenBraceIds.has(brace.id)) continue;
+            seenBraceIds.add(brace.id);
+            snapshots.braces.push(brace);
+        }
+
+        for (const nestedKickstand of removed.kickstands ?? []) {
+            if (!nestedKickstand || seenKickstandIds.has(nestedKickstand.kickstand.id)) continue;
+            seenKickstandIds.add(nestedKickstand.kickstand.id);
+            snapshots.kickstands.push(nestedKickstand);
+        }
+
+        for (const leaf of removed.leaves ?? []) {
+            if (!leaf || seenLeafIds.has(leaf.id)) continue;
+            seenLeafIds.add(leaf.id);
+            snapshots.leaves.push(leaf);
+        }
+
+        for (const knot of removed.knots ?? []) {
+            if (!knot || seenKnotIds.has(knot.id)) continue;
+            seenKnotIds.add(knot.id);
+            snapshots.knots.push(knot);
+        }
+    }
+
+    for (const leafId of leafIdsToRemove) {
+        const removed = removeLeaf(leafId);
+        if (!removed) continue;
+
+        if (removed.leaf && !seenLeafIds.has(removed.leaf.id)) {
+            seenLeafIds.add(removed.leaf.id);
+            snapshots.leaves.push(removed.leaf);
+        }
+
+        if (removed.knot && !seenKnotIds.has(removed.knot.id)) {
+            seenKnotIds.add(removed.knot.id);
+            snapshots.knots.push(removed.knot);
+        }
+    }
+
+    for (const braceId of braceIdsToRemove) {
+        const removed = removeBrace(braceId);
+        if (!removed) continue;
+
+        if (removed.brace && !seenBraceIds.has(removed.brace.id)) {
+            seenBraceIds.add(removed.brace.id);
+            snapshots.braces.push(removed.brace);
+        }
+
+        if (removed.startKnot && !seenKnotIds.has(removed.startKnot.id)) {
+            seenKnotIds.add(removed.startKnot.id);
+            snapshots.knots.push(removed.startKnot);
+        }
+
+        if (removed.endKnot && !seenKnotIds.has(removed.endKnot.id)) {
+            seenKnotIds.add(removed.endKnot.id);
+            snapshots.knots.push(removed.endKnot);
+        }
+    }
+
+    for (const knotId of directKnotIds) {
+        const removedKnot = removeKnotById(knotId);
+        if (!removedKnot || seenKnotIds.has(removedKnot.id)) continue;
+        seenKnotIds.add(removedKnot.id);
+        snapshots.knots.push(removedKnot);
+    }
+
+    if (state.knots[build.hostKnot.id]) {
+        removeKnotById(build.hostKnot.id);
+    }
+
+    if (state.roots[build.root.id]) {
+        removeRootById(build.root.id);
+    }
+
+    return snapshots;
+}
+
 export function removeBranch(branchId: string): { branches: Branch[]; braces: Brace[]; kickstands: KickstandBuildResult[]; leaves: Leaf[]; knots: Knot[] } | null {
     const rootBranch = state.branches[branchId];
     if (!rootBranch) return null;
@@ -2324,27 +2464,21 @@ export function removeBranch(branchId: string): { branches: Branch[]; braces: Br
 
     const kickstandRootIdsToRemove = new Set<string>();
     for (const kickstandId of kickstandIdsToRemove) {
-        const currentKickstandState = getKickstandSnapshot();
-        const kickstand = currentKickstandState.kickstands[kickstandId];
-        if (!kickstand) continue;
+        const removed = removeKickstandCascade(kickstandId);
+        if (!removed) continue;
 
-        kickstandRootIdsToRemove.add(kickstand.rootId);
-        knotIdsToRemove.add(kickstand.hostKnotId);
+        snapshots.kickstands.push(removed.build);
+        kickstandRootIdsToRemove.add(removed.build.root.id);
 
-        const root = currentKickstandState.roots[kickstand.rootId];
-        const hostKnot = currentKickstandState.knots[kickstand.hostKnotId] ?? state.knots[kickstand.hostKnotId];
-
-        if (root && hostKnot) {
-            snapshots.kickstands.push({
-                kickstand: deepClone(kickstand),
-                root: deepClone(root),
-                hostKnot: deepClone(hostKnot),
-            });
-            kickstandRootIdsToRemove.add(root.id);
-            knotIdsToRemove.add(hostKnot.id);
+        for (const nestedKickstand of removed.kickstands ?? []) {
+            snapshots.kickstands.push(nestedKickstand);
+            kickstandRootIdsToRemove.add(nestedKickstand.root.id);
         }
 
-        removeKickstand(kickstandId);
+        snapshots.branches.push(...removed.branches);
+        snapshots.braces.push(...removed.braces);
+        snapshots.leaves.push(...removed.leaves);
+        snapshots.knots.push(...removed.knots);
     }
 
     const nextBranches = { ...state.branches };
@@ -2667,34 +2801,45 @@ export function removeTrunk(
     }
 
     for (const kickstandId of kickstandIdsToRemove) {
-        const currentKickstandState = getKickstandSnapshot();
-        const kickstand = currentKickstandState.kickstands[kickstandId];
-        if (!kickstand) continue;
+        const removed = removeKickstandCascade(kickstandId);
+        if (!removed) continue;
 
-        kickstandRootIdsToRemove.add(kickstand.rootId);
-        if (!seenKnotIds.has(kickstand.hostKnotId) && state.knots[kickstand.hostKnotId]) {
-            seenKnotIds.add(kickstand.hostKnotId);
-            snapshots.knots.push(deepClone(state.knots[kickstand.hostKnotId]));
+        if (!seenKickstandIds.has(removed.build.kickstand.id)) {
+            seenKickstandIds.add(removed.build.kickstand.id);
+            snapshots.kickstands.push(removed.build);
+            kickstandRootIdsToRemove.add(removed.build.root.id);
         }
 
-        const root = currentKickstandState.roots[kickstand.rootId];
-        const hostKnot = currentKickstandState.knots[kickstand.hostKnotId] ?? state.knots[kickstand.hostKnotId];
-
-        if (root && hostKnot && !seenKickstandIds.has(kickstand.id)) {
-            seenKickstandIds.add(kickstand.id);
-            snapshots.kickstands.push({
-                kickstand: deepClone(kickstand),
-                root: deepClone(root),
-                hostKnot: deepClone(hostKnot),
-            });
-            kickstandRootIdsToRemove.add(root.id);
-            if (!seenKnotIds.has(hostKnot.id)) {
-                seenKnotIds.add(hostKnot.id);
-                snapshots.knots.push(deepClone(hostKnot));
-            }
+        for (const nestedKickstand of removed.kickstands ?? []) {
+            if (!nestedKickstand || seenKickstandIds.has(nestedKickstand.kickstand.id)) continue;
+            seenKickstandIds.add(nestedKickstand.kickstand.id);
+            snapshots.kickstands.push(nestedKickstand);
+            kickstandRootIdsToRemove.add(nestedKickstand.root.id);
         }
 
-        removeKickstand(kickstandId);
+        for (const branch of removed.branches ?? []) {
+            if (!branch || seenBranchIds.has(branch.id)) continue;
+            seenBranchIds.add(branch.id);
+            snapshots.branches.push(branch);
+        }
+
+        for (const brace of removed.braces ?? []) {
+            if (!brace || seenBraceIds.has(brace.id)) continue;
+            seenBraceIds.add(brace.id);
+            snapshots.braces.push(brace);
+        }
+
+        for (const leaf of removed.leaves ?? []) {
+            if (!leaf || seenLeafIds.has(leaf.id)) continue;
+            seenLeafIds.add(leaf.id);
+            snapshots.leaves.push(leaf);
+        }
+
+        for (const knot of removed.knots ?? []) {
+            if (!knot || seenKnotIds.has(knot.id)) continue;
+            seenKnotIds.add(knot.id);
+            snapshots.knots.push(knot);
+        }
     }
 
     const remainingKnotsToRemove: string[] = [];


### PR DESCRIPTION
## What changed
- added recursive kickstand deletion for attached branches, leaves, and braces
- updated the delete/history flow to preserve undo and redo behavior for the full removal cascade
- added focused regression coverage for kickstand delete cascade behavior

## Why
- deleting a kickstand should also remove support elements that depend on it
- this prevents orphaned connected support pieces from being left behind

## How to test
- create a kickstand with connected branches, leaves, or braces
- delete the kickstand
- confirm all dependent connected support pieces are removed
- run: node --import tsx --test src/supports/__tests__/kickstandDeletionCascade.test.ts

## Known risks
- support deletion touches shared supports state and history wiring, so the main risk area is undo/redo behavior around nested support graphs