### PR TITLE
fix: Support occlusion placement and x-ray plate ordering

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9607,7 +9607,7 @@ export default function Home() {
             leafPlacementPreview={supports.leafPlacement.previewData}
             bracePlacementPreview={supports.bracePreview}
             kickstandPlacementPreview={supports.kickstandPreview}
-            blockSupportPlacement={supports.isPlacementDisabled}
+            blockSupportPlacement={supports.isPlacementHardDisabled}
             isBranchPlacementActive={supports.branchPlacement.isActive}
             isLeafPlacementActive={supports.leafPlacement.isActive}
             isBracePlacementActive={supports.bracePlacement.isActive}

--- a/src/components/picking/PickingRenderer.tsx
+++ b/src/components/picking/PickingRenderer.tsx
@@ -30,6 +30,10 @@ interface PickingRendererProps {
   mouseNDC: React.MutableRefObject<{ x: number; y: number } | null>;
 }
 
+function shouldExcludeFromPickClone(object: THREE.Object3D): boolean {
+  return object.userData?.excludeFromPickingClone === true;
+}
+
 /**
  * PickingRenderer - Handles the offscreen render pass for GPU picking.
  * 
@@ -125,7 +129,7 @@ export function PickingRenderer({
         depthTest: !noDepthTest,
         depthWrite: !noDepthTest,
         transparent: false,
-        side: THREE.DoubleSide, // Render both sides for reliable picking
+        side: THREE.FrontSide,
       });
       materialCacheRef.current.set(cacheKey, material);
     }
@@ -143,6 +147,10 @@ export function PickingRenderer({
     const pickObject = sourceObject.clone(true);
     pickObject.traverse((child) => {
       child.matrixAutoUpdate = false;
+      if (shouldExcludeFromPickClone(child)) {
+        child.visible = false;
+        return;
+      }
       if (child instanceof THREE.Mesh) {
         child.material = pickMaterial;
       }
@@ -160,7 +168,7 @@ export function PickingRenderer({
 
       const { source, pick } = next;
 
-      pick.visible = source.visible;
+      pick.visible = source.visible && !shouldExcludeFromPickClone(source);
       pick.matrixAutoUpdate = false;
       pick.matrix.copy(source.matrix);
       pick.matrixWorld.copy(source.matrixWorld);

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -434,7 +434,7 @@ export function StlMesh({
         userData={{ modelId }}
         geometry={geometry}
         position={meshLocalOffset}
-        renderOrder={isSupportDimmed ? 2 : 0}
+        renderOrder={baseShaderType === 'xray' || isSupportDimmed ? 2 : 0}
         onClick={(e) => {
           if (isSupportShiftGesture(e)) {
             e.stopPropagation();
@@ -508,6 +508,8 @@ export function StlMesh({
             return;
           }
 
+          e.stopPropagation();
+
           schedulePointerHover(true);
           onModelHoverPointChange?.(e.point.clone());
           onModelHoverModelChange?.(modelId);
@@ -549,7 +551,7 @@ export function StlMesh({
             }
 
             // Mute hover if hovering a gizmo OR support (using GPU picking for accuracy)
-            if (isGizmoHoverCategory || isSupportLikeHoverCategory) {
+            if (isGizmoHoverCategory) {
               onSupportHover(null);
               return;
             }

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -201,6 +201,26 @@ export function StlMesh({
   const internalMeshRef = React.useRef<THREE.Mesh>(null);
   const groupRef = React.useRef<THREE.Group | null>(null);
 
+  const { register, unregister } = usePicking();
+  const pickIdRef = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    if (!internalMeshRef.current) return;
+    
+    pickIdRef.current = register({
+      category: 'model',
+      objectId: modelId,
+      object: internalMeshRef.current,
+    });
+
+    return () => {
+      if (pickIdRef.current !== null) {
+        unregister(pickIdRef.current);
+        pickIdRef.current = null;
+      }
+    };
+  }, [modelId, register, unregister]);
+
   const defaultPosition = React.useMemo(() => new THREE.Vector3(0, 0, 0), []);
   const defaultQuaternion = React.useMemo(() => new THREE.Quaternion(), []);
   const defaultScale = React.useMemo(() => new THREE.Vector3(1, 1, 1), []);

--- a/src/features/supports/useSupportInteractionManager.ts
+++ b/src/features/supports/useSupportInteractionManager.ts
@@ -161,7 +161,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
   const jointCreationState = useJointCreationState();
 
   // Centralized interaction status
-  const { isPlacementDisabled } = useInteractionStatus();
+  const { isPlacementDisabled, isPlacementHardDisabled } = useInteractionStatus();
 
   // Joint selection state for gizmo transformation
   const globalSelectedId = useSyncExternalStore(subscribe, getSelectedId, getSelectedId);
@@ -171,7 +171,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
 
   // Handler for MODEL hover (used for trunk placement preview, or branch tip preview)
   const onModelHover = useCallback((hit: THREE.Intersection | null) => {
-    if (isPlacementDisabled) {
+    if (isPlacementHardDisabled) {
       trunkPlacementV2.onSupportHover(null);
       branchPlacement.onModelHover(null);
       leafPlacement.onModelHover(null);
@@ -211,7 +211,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
       // Normal trunk placement preview
       trunkPlacementV2.onSupportHover(hit);
     }
-  }, [isPlacementDisabled, trunkPlacementV2, branchPlacement, leafPlacement, bracePlacement.isActive, kickstandPlacement.isActive, jointCreationState.isActive]);
+  }, [isPlacementHardDisabled, trunkPlacementV2, branchPlacement, leafPlacement, bracePlacement.isActive, kickstandPlacement.isActive, jointCreationState.isActive]);
 
   // Handler for MODEL click (trunk placement, or branch tip placement)
   const onModelClick = useCallback((hit: THREE.Intersection) => {
@@ -680,6 +680,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
     kickstandPlacement,
     jointCreationState,
     isPlacementDisabled,
+    isPlacementHardDisabled,
     globalSelectedId,
     globalSelectedCategory,
     selectedJointId,

--- a/src/supports/Renderers/BezierRenderer.tsx
+++ b/src/supports/Renderers/BezierRenderer.tsx
@@ -1,9 +1,11 @@
-import React, { useMemo, useRef, useEffect } from 'react';
+import React, { useMemo, useRef, useEffect, useState } from 'react';
 import * as THREE from 'three';
 import { Vec3 } from '../types';
 import { toVector3 } from '../Curves/BezierUtils';
 import { usePicking } from '@/components/picking';
 import { useBracePlacementState } from '../SupportTypes/Brace/bracePlacementState';
+import { useImmediateModelHoverId } from '../interaction/useInteractionStatus';
+import { emitImmediateModelHover, getFrontBlockingModelId } from '../interaction/pointerOcclusion';
 
 interface BezierRendererProps {
     id: string;
@@ -71,6 +73,8 @@ export function BezierRenderer({
     const pickRadius = Math.max(Math.max(visualStartRadius, visualEndRadius) * PICK_RADIUS_MULTIPLIER, MIN_PICK_RADIUS_MM);
     const { altActive: braceAltActive } = useBracePlacementState();
     const enableSegmentInteraction = (isParentSelected || braceAltActive) === true;
+    const immediateModelHoverId = useImmediateModelHoverId();
+    const [frontBlockingModelId, setFrontBlockingModelId] = useState<string | null>(null);
 
     const geometry = useMemo(() => {
         const tubularSegments = Math.max(2, resolution);
@@ -163,10 +167,30 @@ export function BezierRenderer({
     }, [register, unregister, id, enableSegmentInteraction]);
 
     // Determine Hover State
-    const isPickingHovered = enableSegmentInteraction && hit.category === 'segment' && hit.objectId === id;
+    const isTopPickedSegment = enableSegmentInteraction
+        && immediateModelHoverId === null
+        && frontBlockingModelId === null
+        && hit.category === 'segment'
+        && hit.objectId === id;
+    const isPickingHovered = isTopPickedSegment;
     const isHovered = isPickingHovered && !isSelected && isParentSelected && !braceAltActive;
 
     const handleClick = (e: any) => {
+        const frontModelId = getFrontBlockingModelId(e, groupRef.current);
+        if (frontModelId) {
+            setFrontBlockingModelId((prev) => (prev === frontModelId ? prev : frontModelId));
+            emitImmediateModelHover(frontModelId);
+            window.dispatchEvent(new CustomEvent('shaft-leave', {
+                detail: { segmentId: id }
+            }));
+            return;
+        }
+
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
+
         const altDown = !!(e?.nativeEvent?.altKey || e?.altKey);
         const ctrlDown = !!(e?.nativeEvent?.ctrlKey || e?.ctrlKey);
 
@@ -179,6 +203,8 @@ export function BezierRenderer({
                 e.nativeEvent.stopImmediatePropagation();
             }
         }
+
+        if ((altDown || ctrlDown || isParentSelected) && !isTopPickedSegment) return;
 
         if (altDown || ctrlDown || isParentSelected) {
             window.dispatchEvent(new CustomEvent('shaft-click', {
@@ -222,7 +248,26 @@ export function BezierRenderer({
     };
 
     const handlePointerMove = (e: any) => {
-        if (!enableSegmentInteraction) return;
+        const frontModelId = getFrontBlockingModelId(e, groupRef.current);
+        if (frontModelId) {
+            setFrontBlockingModelId((prev) => (prev === frontModelId ? prev : frontModelId));
+            emitImmediateModelHover(frontModelId);
+            window.dispatchEvent(new CustomEvent('shaft-leave', {
+                detail: { segmentId: id }
+            }));
+            return;
+        }
+
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
+
+        const isTopPickedSegmentNow = enableSegmentInteraction
+            && immediateModelHoverId === null
+            && hit.category === 'segment'
+            && hit.objectId === id;
+        if (!isTopPickedSegmentNow) return;
 
         window.dispatchEvent(new CustomEvent('shaft-hover', {
             detail: {
@@ -234,7 +279,12 @@ export function BezierRenderer({
     };
 
     const handlePointerOut = () => {
-        if (!enableSegmentInteraction) return;
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
+
+        if (!enableSegmentInteraction || !isTopPickedSegment) return;
 
         window.dispatchEvent(new CustomEvent('shaft-leave', {
             detail: { segmentId: id }
@@ -250,6 +300,7 @@ export function BezierRenderer({
             {pickGeometry && (
                 <mesh
                     raycast={raycast}
+                    userData={{ excludeFromPickingClone: true }}
                     onClick={handleClick}
                     onPointerMove={enableSegmentInteraction ? handlePointerMove : undefined}
                     onPointerOut={enableSegmentInteraction ? handlePointerOut : undefined}

--- a/src/supports/SupportPrimitives/Joint/JointRenderer.tsx
+++ b/src/supports/SupportPrimitives/Joint/JointRenderer.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useRef, useSyncExternalStore } from 'react';
+import React, { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import * as THREE from 'three';
 import { Joint } from '../../types';
 import { usePicking } from '@/components/picking';
 import { JOINT_DIAMETER_OFFSET_MM } from '../../constants';
 import { subscribe, getSnapshot, setSelectedId } from '../../state';
 import { handleJointClick } from '../../interaction/clickHandlers';
+import { useImmediateModelHoverId } from '../../interaction/useInteractionStatus';
+import { emitImmediateModelHover, getFrontBlockingModelId } from '../../interaction/pointerOcclusion';
 
 interface JointRendererProps {
     joint: Joint;
@@ -43,6 +45,8 @@ export function JointRenderer({
     const displayDiameter = isParentSelected ? resolvedDiameter : blendedDiameter;
     const radius = displayDiameter / 2;
     const groupRef = useRef<THREE.Group>(null);
+    const immediateModelHoverId = useImmediateModelHoverId();
+    const [frontBlockingModelId, setFrontBlockingModelId] = useState<string | null>(null);
 
     // State Subscription
     const state = useSyncExternalStore(subscribe, getSnapshot);
@@ -80,7 +84,12 @@ export function JointRenderer({
 
     // Determine Hover State
     // Only show hover if parent is selected (editable mode) AND joint is not already selected
-    const isHovered = (hit.category === 'joint' && hit.objectId === joint.id) && !isSelected && isParentSelected;
+    const isTopPickedJoint = immediateModelHoverId === null
+        && frontBlockingModelId === null
+        && hit.category === 'joint'
+        && hit.objectId === joint.id
+        && isParentSelected;
+    const isHovered = isTopPickedJoint && !isSelected;
     
     // Visual State
     // If hovered, glow white. If selected, be blue. Else default/prop color.
@@ -89,6 +98,19 @@ export function JointRenderer({
     const displayEmissiveIntensity = isHovered ? 0.5 : propEmissiveIntensity;
 
     const handleClick = (e: any) => {
+        const frontModelId = getFrontBlockingModelId(e, groupRef.current);
+        if (frontModelId) {
+            setFrontBlockingModelId((prev) => (prev === frontModelId ? prev : frontModelId));
+            emitImmediateModelHover(frontModelId);
+            return;
+        }
+
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
+
+        if (!isTopPickedJoint) return;
         handleJointClick(e, joint.id, !!isInteractable, isParentSelected, isSelected, (id) => {
             if (onSelect) onSelect(id);
             if (onClick) onClick(e);
@@ -97,9 +119,21 @@ export function JointRenderer({
     
     // Handle pointer down for direct dragging (left-click only)
     const handlePointerDown = (e: any) => {
+        const frontModelId = getFrontBlockingModelId(e, groupRef.current);
+        if (frontModelId) {
+            setFrontBlockingModelId((prev) => (prev === frontModelId ? prev : frontModelId));
+            emitImmediateModelHover(frontModelId);
+            return;
+        }
+
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
+
         // Only allow left-click (button 0) for dragging
         if (e.button !== 0) return;
-        if (!isParentSelected || !isInteractable) return;
+        if (!isParentSelected || !isInteractable || !isTopPickedJoint) return;
         
         e.stopPropagation();
         
@@ -129,7 +163,25 @@ export function JointRenderer({
         }
     }, [isHovered, isInteractable]);
     
+    const handlePointerMove = (e: any) => {
+        const frontModelId = getFrontBlockingModelId(e, groupRef.current);
+        if (frontModelId) {
+            setFrontBlockingModelId((prev) => (prev === frontModelId ? prev : frontModelId));
+            emitImmediateModelHover(frontModelId);
+            return;
+        }
+
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
+    };
+
     const handlePointerLeave = () => {
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
         document.body.style.cursor = '';
     };
     
@@ -142,10 +194,11 @@ export function JointRenderer({
             position={[joint.pos.x, joint.pos.y, joint.pos.z]}
             onClick={handleClick}
             onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
             onPointerLeave={handlePointerLeave}
         >
             {/* Hitbox Mesh - Only expanded when parent is selected */}
-            <mesh raycast={raycast}>
+            <mesh raycast={raycast} userData={{ excludeFromPickingClone: true }}>
                 <sphereGeometry args={[hitboxRadius, 16, 12]} />
                 <meshBasicMaterial transparent opacity={0} depthWrite={false} />
             </mesh>

--- a/src/supports/SupportPrimitives/Knot/KnotRenderer.tsx
+++ b/src/supports/SupportPrimitives/Knot/KnotRenderer.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useRef, useSyncExternalStore } from 'react';
+import React, { useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import * as THREE from 'three';
 import { Knot } from '../../types';
 import { usePicking } from '@/components/picking';
 import { JOINT_DIAMETER_OFFSET_MM } from '../../constants';
 import { getSnapshot, subscribe } from '../../state';
 import { handleKnotClick } from '../../interaction/clickHandlers';
+import { useImmediateModelHoverId } from '../../interaction/useInteractionStatus';
+import { emitImmediateModelHover, getFrontBlockingModelId } from '../../interaction/pointerOcclusion';
 
 interface KnotRendererProps {
     knot: Knot;
@@ -42,6 +44,8 @@ export function KnotRenderer({
     const displayDiameter = isParentSelected ? resolvedDiameter : blendedDiameter;
     const radius = displayDiameter / 2;
     const groupRef = useRef<THREE.Group>(null);
+    const immediateModelHoverId = useImmediateModelHoverId();
+    const [frontBlockingModelId, setFrontBlockingModelId] = useState<string | null>(null);
 
     const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
     const isSelected = state.selectedId === knot.id;
@@ -75,8 +79,12 @@ export function KnotRenderer({
         };
     }, [register, unregister, knot.id, enablePicking, isParentSelected]);
 
-    const isHovered =
-        hit.category === 'knot' && hit.objectId === knot.id && !isSelected && isParentSelected;
+    const isTopPickedKnot = immediateModelHoverId === null
+        && frontBlockingModelId === null
+        && hit.category === 'knot'
+        && hit.objectId === knot.id
+        && isParentSelected;
+    const isHovered = isTopPickedKnot && !isSelected;
 
     const displayColor = isSelected ? '#1a75ff' : (isParentSelected ? '#00ff00' : propColor);
     const displayEmissive = isHovered ? '#ffffff' : propEmissive;
@@ -86,6 +94,19 @@ export function KnotRenderer({
     const { onDragStart, onDragEnd } = usePicking();
 
     const handleClick = (e: any) => {
+        const frontModelId = getFrontBlockingModelId(e, groupRef.current);
+        if (frontModelId) {
+            setFrontBlockingModelId((prev) => (prev === frontModelId ? prev : frontModelId));
+            emitImmediateModelHover(frontModelId);
+            return;
+        }
+
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
+
+        if (!isTopPickedKnot) return;
         handleKnotClick(e, knot.id, !!isInteractable, isParentSelected, isSelected, (id) => {
             if (onSelect) onSelect(id);
             if (onClick) onClick(e);
@@ -94,9 +115,21 @@ export function KnotRenderer({
 
     // Handle pointer down for direct dragging (left-click only)
     const handlePointerDown = (e: any) => {
+        const frontModelId = getFrontBlockingModelId(e, groupRef.current);
+        if (frontModelId) {
+            setFrontBlockingModelId((prev) => (prev === frontModelId ? prev : frontModelId));
+            emitImmediateModelHover(frontModelId);
+            return;
+        }
+
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
+
         // Only allow left-click (button 0) for dragging
         if (e.button !== 0) return;
-        if (!isParentSelected || !isInteractable) return;
+        if (!isParentSelected || !isInteractable || !isTopPickedKnot) return;
 
         e.stopPropagation();
 
@@ -121,7 +154,25 @@ export function KnotRenderer({
         }
     }, [isHovered, isInteractable]);
 
+    const handlePointerMove = (e: any) => {
+        const frontModelId = getFrontBlockingModelId(e, groupRef.current);
+        if (frontModelId) {
+            setFrontBlockingModelId((prev) => (prev === frontModelId ? prev : frontModelId));
+            emitImmediateModelHover(frontModelId);
+            return;
+        }
+
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
+    };
+
     const handlePointerLeave = () => {
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
         document.body.style.cursor = '';
     };
 
@@ -133,9 +184,10 @@ export function KnotRenderer({
             position={[knot.pos.x, knot.pos.y, knot.pos.z]}
             onClick={handleClick}
             onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
             onPointerLeave={handlePointerLeave}
         >
-            <mesh raycast={raycast}>
+            <mesh raycast={raycast} userData={{ excludeFromPickingClone: true }}>
                 <sphereGeometry args={[hitboxRadius, 8, 8]} />
                 <meshBasicMaterial transparent opacity={0} depthWrite={false} />
             </mesh>

--- a/src/supports/SupportPrimitives/Shaft/ShaftRenderer.tsx
+++ b/src/supports/SupportPrimitives/Shaft/ShaftRenderer.tsx
@@ -1,8 +1,10 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import * as THREE from 'three';
 import { Vec3 } from '../../types';
 import { usePicking } from '@/components/picking';
 import { useBracePlacementState } from '../../SupportTypes/Brace/bracePlacementState';
+import { useImmediateModelHoverId } from '../../interaction/useInteractionStatus';
+import { emitImmediateModelHover, getFrontBlockingModelId } from '../../interaction/pointerOcclusion';
 
 interface ShaftRendererProps {
     id: string;
@@ -59,6 +61,8 @@ export function ShaftRenderer({
 
     const { altActive: braceAltActive } = useBracePlacementState();
     const enableSegmentInteraction = (isParentSelected || braceAltActive) === true;
+    const immediateModelHoverId = useImmediateModelHoverId();
+    const [frontBlockingModelId, setFrontBlockingModelId] = useState<string | null>(null);
     
     // GPU Picking Setup
     const pickIdRef = useRef<number | null>(null);
@@ -93,7 +97,12 @@ export function ShaftRenderer({
     }, [register, unregister, id, enablePicking, enableSegmentInteraction]);
 
     // Determine Hover State
-    const isPickingHovered = enableSegmentInteraction && hit.category === 'segment' && hit.objectId === id;
+    const isTopPickedSegment = enableSegmentInteraction
+        && immediateModelHoverId === null
+        && frontBlockingModelId === null
+        && hit.category === 'segment'
+        && hit.objectId === id;
+    const isPickingHovered = isTopPickedSegment;
     const isHovered = isPickingHovered && !isSelected && isParentSelected && !braceAltActive;
 
     // Vector math
@@ -110,6 +119,21 @@ export function ShaftRenderer({
     const quaternion = new THREE.Quaternion().setFromUnitVectors(up, direction);
     
     const handleClick = (e: any) => {
+        const frontModelId = getFrontBlockingModelId(e, groupRef.current);
+        if (frontModelId) {
+            setFrontBlockingModelId((prev) => (prev === frontModelId ? prev : frontModelId));
+            emitImmediateModelHover(frontModelId);
+            window.dispatchEvent(new CustomEvent('shaft-leave', {
+                detail: { segmentId: id }
+            }));
+            return;
+        }
+
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
+
         const altDown = !!(e?.nativeEvent?.altKey || e?.altKey);
         const ctrlDown = !!(e?.nativeEvent?.ctrlKey || e?.ctrlKey);
 
@@ -123,7 +147,7 @@ export function ShaftRenderer({
             }
         }
 
-        if (altDown || ctrlDown || isParentSelected) {
+        if ((altDown || ctrlDown || isParentSelected) && isTopPickedSegment) {
             // Emit global event for branch placement and editable-segment clicks only.
             window.dispatchEvent(new CustomEvent('shaft-click', {
                 detail: {
@@ -159,7 +183,26 @@ export function ShaftRenderer({
     
     // Handle pointer move for branch placement preview
     const handlePointerMove = (e: any) => {
-        if (!enableSegmentInteraction) return;
+        const frontModelId = getFrontBlockingModelId(e, groupRef.current);
+        if (frontModelId) {
+            setFrontBlockingModelId((prev) => (prev === frontModelId ? prev : frontModelId));
+            emitImmediateModelHover(frontModelId);
+            window.dispatchEvent(new CustomEvent('shaft-leave', {
+                detail: { segmentId: id }
+            }));
+            return;
+        }
+
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
+
+        const isTopPickedSegmentNow = enableSegmentInteraction
+            && immediateModelHoverId === null
+            && hit.category === 'segment'
+            && hit.objectId === id;
+        if (!isTopPickedSegmentNow) return;
 
         // Emit global event for branch placement preview
         window.dispatchEvent(new CustomEvent('shaft-hover', {
@@ -177,7 +220,12 @@ export function ShaftRenderer({
 
     // Handle pointer leaving shaft - clear branch preview
     const handlePointerOut = () => {
-        if (!enableSegmentInteraction) return;
+        if (frontBlockingModelId !== null) {
+            setFrontBlockingModelId(null);
+            emitImmediateModelHover(null);
+        }
+
+        if (!enableSegmentInteraction || !isTopPickedSegment) return;
 
         window.dispatchEvent(new CustomEvent('shaft-leave', {
             detail: { segmentId: id }
@@ -195,7 +243,7 @@ export function ShaftRenderer({
             onPointerOut={enableSegmentInteraction ? handlePointerOut : undefined}
         >
             {enableSegmentInteraction && (
-                <mesh raycast={raycast}>
+                <mesh raycast={raycast} userData={{ excludeFromPickingClone: true }}>
                     <cylinderGeometry args={[pickRadiusEnd, pickRadiusStart, 1, Math.max(8, radialSegments)]} />
                     <meshBasicMaterial transparent opacity={0} depthWrite={false} />
                 </mesh>

--- a/src/supports/SupportRenderer.tsx
+++ b/src/supports/SupportRenderer.tsx
@@ -128,6 +128,11 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
     const [gizmoInteractionLockActive, setGizmoInteractionLockActive] = React.useState(false);
     const knotGizmoInteractionLockTimeoutRef = React.useRef<number | null>(null);
     const rawHoveredCategory = state.hoveredCategory as string | null | undefined;
+    const rawSupportLikeHover = rawHoveredCategory === 'support'
+        || rawHoveredCategory === 'segment'
+        || rawHoveredCategory === 'joint'
+        || rawHoveredCategory === 'knot'
+        || rawHoveredCategory === 'raft';
     const jointCategoryHoverSuppressed = rawHoveredCategory === 'joint' || rawHoveredCategory === 'join';
     const supportInteractionSuppressed = mode === 'support' && (disableSelectionAndHover || gizmoInteractionLockActive);
     const supportSelectionAndHoverSuppressed = supportInteractionSuppressed || (mode === 'support' && jointCategoryHoverSuppressed);
@@ -439,11 +444,117 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
     }, []);
 
     const effectiveHoverModelId = supportSelectionAndHoverSuppressed ? null : (immediateModelHoverId ?? hoverModelId);
+    const suppressSupportLikeVisualHoverFromModel = !supportSelectionAndHoverSuppressed
+        && rawSupportLikeHover
+        && immediateModelHoverId !== null;
     const effectiveVisualActiveModelId = mode === 'prepare'
         ? (immediatePrepareActiveModelId ?? activeModelId)
         : activeModelId;
-    const hoveredCategoryForVisual = supportSelectionAndHoverSuppressed ? 'none' : state.hoveredCategory;
-    const hoveredIdForVisual = supportSelectionAndHoverSuppressed ? null : state.hoveredId;
+    const hoveredCategoryForVisual = supportSelectionAndHoverSuppressed || suppressSupportLikeVisualHoverFromModel ? 'none' : state.hoveredCategory;
+    const hoveredIdForVisual = supportSelectionAndHoverSuppressed || suppressSupportLikeVisualHoverFromModel ? null : state.hoveredId;
+    const supportIdBySegmentId = useMemo(() => {
+        const map = new Map<string, string>();
+
+        for (const trunk of Object.values(state.trunks)) {
+            for (const segment of trunk.segments) map.set(segment.id, trunk.id);
+        }
+
+        for (const branch of Object.values(state.branches)) {
+            for (const segment of branch.segments) map.set(segment.id, branch.id);
+        }
+
+        for (const twig of Object.values(state.twigs)) {
+            for (const segment of twig.segments) map.set(segment.id, twig.id);
+        }
+
+        for (const stick of Object.values(state.sticks)) {
+            for (const segment of stick.segments) map.set(segment.id, stick.id);
+        }
+
+        for (const brace of Object.values(state.braces)) {
+            map.set(`braceSegment:${brace.id}`, brace.id);
+        }
+
+        for (const kickstand of Object.values(kickstandState.kickstands)) {
+            for (const segment of kickstand.segments) map.set(segment.id, kickstand.id);
+        }
+
+        return map;
+    }, [state.trunks, state.branches, state.twigs, state.sticks, state.braces, kickstandState.kickstands]);
+
+    const supportIdByJointId = useMemo(() => {
+        const map = new Map<string, string>();
+
+        for (const trunk of Object.values(state.trunks)) {
+            for (const segment of trunk.segments) {
+                if (segment.topJoint?.id) map.set(segment.topJoint.id, trunk.id);
+            }
+        }
+
+        for (const branch of Object.values(state.branches)) {
+            for (const segment of branch.segments) {
+                if (segment.topJoint?.id) map.set(segment.topJoint.id, branch.id);
+            }
+        }
+
+        for (const twig of Object.values(state.twigs)) {
+            for (const segment of twig.segments) {
+                if (segment.bottomJoint?.id) map.set(segment.bottomJoint.id, twig.id);
+                if (segment.topJoint?.id) map.set(segment.topJoint.id, twig.id);
+            }
+        }
+
+        for (const stick of Object.values(state.sticks)) {
+            for (const segment of stick.segments) {
+                if (segment.bottomJoint?.id) map.set(segment.bottomJoint.id, stick.id);
+                if (segment.topJoint?.id) map.set(segment.topJoint.id, stick.id);
+            }
+        }
+
+        for (const kickstand of Object.values(kickstandState.kickstands)) {
+            for (const segment of kickstand.segments) {
+                if (segment.topJoint?.id) map.set(segment.topJoint.id, kickstand.id);
+            }
+        }
+
+        return map;
+    }, [state.trunks, state.branches, state.twigs, state.sticks, kickstandState.kickstands]);
+
+    const supportIdByKnotId = useMemo(() => {
+        const map = new Map<string, string>();
+
+        for (const branch of Object.values(state.branches)) {
+            map.set(branch.parentKnotId, branch.id);
+        }
+
+        for (const leaf of Object.values(state.leaves)) {
+            map.set(leaf.parentKnotId, leaf.id);
+        }
+
+        for (const brace of Object.values(state.braces)) {
+            map.set(brace.startKnotId, brace.id);
+            map.set(brace.endKnotId, brace.id);
+        }
+
+        for (const kickstand of Object.values(kickstandState.kickstands)) {
+            map.set(kickstand.hostKnotId, kickstand.id);
+        }
+
+        return map;
+    }, [state.branches, state.leaves, state.braces, kickstandState.kickstands]);
+
+    const hoveredSupportIdFromPicking = useMemo(() => {
+        if (!hoveredIdForVisual) return null;
+        if (hoveredCategoryForVisual === 'support') return hoveredIdForVisual;
+        if (hoveredCategoryForVisual === 'segment') return supportIdBySegmentId.get(hoveredIdForVisual) ?? null;
+        if (hoveredCategoryForVisual === 'joint') return supportIdByJointId.get(hoveredIdForVisual) ?? null;
+        if (hoveredCategoryForVisual === 'knot') return supportIdByKnotId.get(hoveredIdForVisual) ?? null;
+        return null;
+    }, [hoveredCategoryForVisual, hoveredIdForVisual, supportIdBySegmentId, supportIdByJointId, supportIdByKnotId]);
+
+    const hoveredSupportIdForVisual = suppressSupportLikeVisualHoverFromModel
+        ? null
+        : (marqueeHoveredSupportId ?? hoveredSupportIdFromPicking ?? sceneHoveredSupportId);
 
     useEffect(() => {
         if (mode !== 'prepare') {
@@ -2002,7 +2113,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
     const hoveredSupportShaftSet = useMemo(() => {
         if (!isInteractable) return null;
 
-        const hoveredSupportId = marqueeHoveredSupportId ?? sceneHoveredSupportId ?? (hoveredCategoryForVisual === 'support' ? hoveredIdForVisual : null);
+        const hoveredSupportId = hoveredSupportIdForVisual;
         if (!hoveredSupportId) return null;
 
         const trunkSet = trunkShaftsBySupport.get(hoveredSupportId);
@@ -2024,7 +2135,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
         if (kickstandSet) return kickstandSet;
 
         return null;
-    }, [isInteractable, marqueeHoveredSupportId, sceneHoveredSupportId, hoveredCategoryForVisual, hoveredIdForVisual, trunkShaftsBySupport, branchShaftsBySupport, braceShaftsBySupport, twigShaftsBySupport, stickShaftsBySupport, kickstandShaftsBySupport]);
+    }, [isInteractable, hoveredSupportIdForVisual, trunkShaftsBySupport, branchShaftsBySupport, braceShaftsBySupport, twigShaftsBySupport, stickShaftsBySupport, kickstandShaftsBySupport]);
 
     const hoveredSupportOverlayShafts = useMemo(() => {
         if (!hoveredSupportShaftSet) return [] as InstancedShaft[];
@@ -2040,11 +2151,11 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
     const hoveredSupportConeSet = useMemo(() => {
         if (!isInteractable) return null;
 
-        const hoveredSupportId = marqueeHoveredSupportId ?? sceneHoveredSupportId ?? (hoveredCategoryForVisual === 'support' ? hoveredIdForVisual : null);
+        const hoveredSupportId = hoveredSupportIdForVisual;
         if (!hoveredSupportId) return null;
 
         return contactConesBySupport.get(hoveredSupportId) ?? null;
-    }, [isInteractable, marqueeHoveredSupportId, sceneHoveredSupportId, hoveredCategoryForVisual, hoveredIdForVisual, contactConesBySupport]);
+    }, [isInteractable, hoveredSupportIdForVisual, contactConesBySupport]);
 
     const hoveredSupportOverlayCones = useMemo(() => {
         if (!hoveredSupportConeSet) return [] as InstancedContactCone[];
@@ -2057,7 +2168,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
     const hoveredSupportJointSet = useMemo(() => {
         if (!isInteractable) return null;
 
-        const hoveredSupportId = marqueeHoveredSupportId ?? sceneHoveredSupportId ?? (hoveredCategoryForVisual === 'support' ? hoveredIdForVisual : null);
+        const hoveredSupportId = hoveredSupportIdForVisual;
         if (!hoveredSupportId) return null;
 
         const trunkSet = trunkJointsBySupport.get(hoveredSupportId);
@@ -2078,10 +2189,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
         return null;
     }, [
         isInteractable,
-        marqueeHoveredSupportId,
-        sceneHoveredSupportId,
-        hoveredCategoryForVisual,
-        hoveredIdForVisual,
+        hoveredSupportIdForVisual,
         trunkJointsBySupport,
         branchJointsBySupport,
         twigJointsBySupport,
@@ -2175,7 +2283,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
         if (hidePlateContactPrimitivesEffective) return [] as InstancedRoot[];
         if (!isInteractable) return [] as InstancedRoot[];
 
-        const hoveredSupportId = marqueeHoveredSupportId ?? sceneHoveredSupportId ?? (hoveredCategoryForVisual === 'support' ? hoveredIdForVisual : null);
+        const hoveredSupportId = hoveredSupportIdForVisual;
         if (!hoveredSupportId) return [] as InstancedRoot[];
 
         const overlay = buildHighlightedRootOverlay(hoveredSupportId);
@@ -2183,10 +2291,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
     }, [
         hidePlateContactPrimitivesEffective,
         isInteractable,
-        marqueeHoveredSupportId,
-        sceneHoveredSupportId,
-        hoveredCategoryForVisual,
-        hoveredIdForVisual,
+        hoveredSupportIdForVisual,
         buildHighlightedRootOverlay,
     ]);
 
@@ -2741,8 +2846,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 const renderDetailedTrunk = effectiveSelected || hasBezierSegment;
                 if (!renderDetailedTrunk) return null;
 
-                const isTrunkHovered = (hoveredCategoryForVisual === 'support' && hoveredIdForVisual === trunk.id)
-                    || sceneHoveredSupportId === trunk.id
+                const isTrunkHovered = hoveredSupportIdForVisual === trunk.id
                     || marqueeHoveredSupportIdSet.has(trunk.id);
                 const deferTrunkInteractionToSceneBatch = !effectiveSelected && !hasBezierSegment;
 
@@ -2795,8 +2899,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 const renderDetailedBranch = effectiveSelected || hasBezierSegment;
                 if (!renderDetailedBranch) return null;
 
-                const isBranchHovered = (hoveredCategoryForVisual === 'support' && hoveredIdForVisual === branch.id)
-                    || sceneHoveredSupportId === branch.id
+                const isBranchHovered = hoveredSupportIdForVisual === branch.id
                     || marqueeHoveredSupportIdSet.has(branch.id);
                 const deferBranchInteractionToSceneBatch = !effectiveSelected && !hasBezierSegment;
                 const showKnots = !hideUnselectedKnots || effectiveSelected;
@@ -2859,8 +2962,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 const renderDetailedTwig = effectiveSelected || !isTwigBatchable;
                 if (!renderDetailedTwig) return null;
 
-                const isTwigHovered = (hoveredCategoryForVisual === 'support' && hoveredIdForVisual === twig.id)
-                    || sceneHoveredSupportId === twig.id
+                const isTwigHovered = hoveredSupportIdForVisual === twig.id
                     || marqueeHoveredSupportIdSet.has(twig.id);
                 const deferTwigInteractionToSceneBatch = !effectiveSelected && isTwigBatchable;
 
@@ -2906,8 +3008,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 const renderDetailedStick = effectiveSelected || !isStickBatchable;
                 if (!renderDetailedStick) return null;
 
-                const isStickHovered = (hoveredCategoryForVisual === 'support' && hoveredIdForVisual === stick.id)
-                    || sceneHoveredSupportId === stick.id
+                const isStickHovered = hoveredSupportIdForVisual === stick.id
                     || marqueeHoveredSupportIdSet.has(stick.id);
                 const deferStickInteractionToSceneBatch = !effectiveSelected && isStickBatchable;
 
@@ -2973,8 +3074,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 const renderDetailedBrace = effectiveSelected || !isBraceBatchable;
                 if (!renderDetailedBrace) return null;
 
-                const isBraceHovered = (hoveredCategoryForVisual === 'support' && hoveredIdForVisual === brace.id)
-                    || sceneHoveredSupportId === brace.id
+                const isBraceHovered = hoveredSupportIdForVisual === brace.id
                     || marqueeHoveredSupportIdSet.has(brace.id);
                 const deferBraceInteractionToSceneBatch = !effectiveSelected && isBraceBatchable;
                 const showKnots = !hideUnselectedKnots || effectiveSelected;
@@ -3013,8 +3113,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 const renderDetailedKickstand = effectiveSelected || !isKickstandBatchable;
                 if (!renderDetailedKickstand) return null;
 
-                const isKickstandHovered = (hoveredCategoryForVisual === 'support' && hoveredIdForVisual === kickstand.id)
-                    || sceneHoveredSupportId === kickstand.id
+                const isKickstandHovered = hoveredSupportIdForVisual === kickstand.id
                     || marqueeHoveredSupportIdSet.has(kickstand.id);
                 const deferKickstandInteractionToSceneBatch = !effectiveSelected && isKickstandBatchable;
                 const showKnot = !hideUnselectedKnots || effectiveSelected;

--- a/src/supports/SupportTypes/Brace/BracePlacementController.tsx
+++ b/src/supports/SupportTypes/Brace/BracePlacementController.tsx
@@ -17,6 +17,7 @@ import { useKickstandStoreState } from '../Kickstand/kickstandStore';
 import { bracePlacementStore, useBracePlacementState } from './bracePlacementState';
 import { branchPlacementStore } from '../Branch/branchPlacementState';
 import { generateUuid } from '@/utils/uuid';
+import { clearSelection } from '../../interaction/SupportSelection';
 
 interface ShaftHoverDetail {
     segmentId?: string | null;
@@ -951,6 +952,7 @@ export function BracePlacementController() {
 
                 bracePlacementStore.finalize();
                 bracePlacementStore.reset();
+                clearSelection();
                 return;
             }
 
@@ -1018,6 +1020,7 @@ export function BracePlacementController() {
 
             bracePlacementStore.finalize();
             bracePlacementStore.reset();
+            clearSelection();
         };
 
         window.addEventListener('shaft-click', handleShaftClick as any, true);

--- a/src/supports/SupportTypes/Brace/BraceRenderer.tsx
+++ b/src/supports/SupportTypes/Brace/BraceRenderer.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import * as THREE from 'three';
 import type { Brace, Knot } from '../../types';
 import { useHighlight } from '../../interaction/useHighlight';
-import { handleSupportClick, emitSupportModelPointerHover } from '../../interaction/clickHandlers';
+import { handleSupportClick } from '../../interaction/clickHandlers';
 import { KnotRenderer } from '../../SupportPrimitives/Knot/KnotRenderer';
 import { ShaftRenderer } from '../../SupportPrimitives/Shaft/ShaftRenderer';
 import { InstancedShaftGroup, type InstancedShaft } from '../../SupportPrimitives/Shaft/InstancedShaftGroup';
@@ -58,7 +58,7 @@ export const BraceRenderer = React.memo(function BraceRenderer({
     const { pickRef, visuals } = useHighlight({
         id: brace.id,
         category: 'support',
-        enabled: !!isInteractable && !suppressHover && !deferInteractionToSceneBatch,
+        enabled: !!isInteractable && !suppressHover && !deferInteractionToSceneBatch && !isSelected,
         isSelected,
         suppressHover,
         externalHover: propHovered,
@@ -120,14 +120,6 @@ export const BraceRenderer = React.memo(function BraceRenderer({
         handleSupportClick(e, brace.id, !!isInteractable);
     };
 
-    const handlePointerMove = React.useCallback(() => {
-        emitSupportModelPointerHover(brace.modelId ?? null);
-    }, [brace.modelId]);
-
-    const handlePointerOut = React.useCallback(() => {
-        emitSupportModelPointerHover(null);
-    }, []);
-
     const straight = useMemo(() => {
         const dir = endVec.clone().sub(startVec);
         const len = dir.length();
@@ -139,8 +131,6 @@ export const BraceRenderer = React.memo(function BraceRenderer({
     return (
         <group
             onClick={handleClick}
-            onPointerMove={deferInteractionToSceneBatch ? undefined : handlePointerMove}
-            onPointerOut={deferInteractionToSceneBatch ? undefined : handlePointerOut}
         >
             <group ref={pickRef as any}>
                 <group>

--- a/src/supports/SupportTypes/Branch/BranchPlacementController.tsx
+++ b/src/supports/SupportTypes/Branch/BranchPlacementController.tsx
@@ -33,14 +33,17 @@ import { buildStick } from '../Stick/stickBuilder';
 import type { SupportData } from '../../rendering/SupportBuilder';
 import { generateUuid } from '@/utils/uuid';
 import { clearSelection } from '../../interaction/SupportSelection';
+import { useImmediateModelHoverId } from '../../interaction/useInteractionStatus';
 
 export function BranchPlacementController() {
     const { isActive, altActive, stage, tipPosition, tipNormal, modelId } = useBranchPlacementState();
     const supportState = useSyncExternalStore(subscribe, getSnapshot);
-    const isHoveringSupportTarget = supportState.hoveredCategory === 'support'
+    const immediateModelHoverId = useImmediateModelHoverId();
+    const rawHoveringSupportTarget = supportState.hoveredCategory === 'support'
         || supportState.hoveredCategory === 'segment'
         || supportState.hoveredCategory === 'joint'
         || supportState.hoveredCategory === 'knot';
+    const isHoveringSupportTarget = rawHoveringSupportTarget && immediateModelHoverId === null;
 
     const meshHoverRef = useRef<{ pos: Vec3; normal: Vec3; modelId: string } | null>(null);
     const meshKindRef = useRef<'twig' | 'stick' | null>(null);

--- a/src/supports/SupportTypes/Branch/BranchPlacementController.tsx
+++ b/src/supports/SupportTypes/Branch/BranchPlacementController.tsx
@@ -32,6 +32,7 @@ import { buildTwig } from '../Twig/twigBuilder';
 import { buildStick } from '../Stick/stickBuilder';
 import type { SupportData } from '../../rendering/SupportBuilder';
 import { generateUuid } from '@/utils/uuid';
+import { clearSelection } from '../../interaction/SupportSelection';
 
 export function BranchPlacementController() {
     const { isActive, altActive, stage, tipPosition, tipNormal, modelId } = useBranchPlacementState();
@@ -505,6 +506,7 @@ export function BranchPlacementController() {
                 meshHoverRef.current = null;
                 meshKindRef.current = null;
                 resetSnapping();
+                clearSelection();
                 return;
             }
 
@@ -548,6 +550,7 @@ export function BranchPlacementController() {
             // This prevents useFrame from re-setting preview before React re-renders
             branchPlacementStore.finalize();
             branchPlacementStore.reset();
+            clearSelection();
         };
 
         window.addEventListener('click', handleClick, true);

--- a/src/supports/SupportTypes/Branch/BranchRenderer.tsx
+++ b/src/supports/SupportTypes/Branch/BranchRenderer.tsx
@@ -6,7 +6,7 @@ import { ShaftRenderer } from '../../SupportPrimitives/Shaft/ShaftRenderer';
 import { InstancedShaftGroup, type InstancedShaft } from '../../SupportPrimitives/Shaft/InstancedShaftGroup';
 import { BezierRenderer } from '../../Renderers/BezierRenderer';
 import { ContactConeRenderer, getFinalSocketPosition } from '../../SupportPrimitives/ContactCone';
-import { handleSupportClick, emitSupportModelPointerHover } from '../../interaction/clickHandlers';
+import { handleSupportClick } from '../../interaction/clickHandlers';
 import { useHighlight } from '../../interaction/useHighlight';
 import { KnotRenderer } from '../../SupportPrimitives/Knot/KnotRenderer';
 import { setSelectedId } from '../../state';
@@ -51,10 +51,10 @@ export const BranchRenderer = React.memo(function BranchRenderer({
   const useLowDetailPrimitives = !isSelected && !propHovered;
 
   // Use universal highlight hook (matches TrunkRenderer pattern)
-  const { pickRef, visuals } = useHighlight({
+  const { pickRef, visuals, isPickingHovered } = useHighlight({
     id: branch.id,
     category: 'support',
-    enabled: !!isInteractable && !suppressHover && !deferInteractionToSceneBatch,
+    enabled: !!isInteractable && !suppressHover && !deferInteractionToSceneBatch && !isSelected,
     isSelected,
     suppressHover,
     externalHover: propHovered,
@@ -65,16 +65,9 @@ export const BranchRenderer = React.memo(function BranchRenderer({
 
   // Handle Click
   const handleClick = (e: any) => {
+    if (!isPickingHovered) return;
     handleSupportClick(e, branch.id, !!isInteractable);
   };
-
-  const handlePointerMove = React.useCallback(() => {
-    emitSupportModelPointerHover(branch.modelId ?? null);
-  }, [branch.modelId]);
-
-  const handlePointerOut = React.useCallback(() => {
-    emitSupportModelPointerHover(null);
-  }, []);
 
   // Start point is the Knot position
   const startPos = parentKnot.pos 
@@ -203,8 +196,6 @@ export const BranchRenderer = React.memo(function BranchRenderer({
   return (
     <group
       onClick={handleClick}
-      onPointerMove={deferInteractionToSceneBatch ? undefined : handlePointerMove}
-      onPointerOut={deferInteractionToSceneBatch ? undefined : handlePointerOut}
     >
       {/* Branch Picking Group - Contains Shafts, Cone */}
       <group ref={pickRef as any}>

--- a/src/supports/SupportTypes/Branch/useBranchPlacement.ts
+++ b/src/supports/SupportTypes/Branch/useBranchPlacement.ts
@@ -22,7 +22,7 @@ export function useBranchPlacement() {
     const binding = getHotkey('SUPPORTS', 'BRANCH_PLACEMENT');
     const BRANCH_KEY = binding.key;
 
-    const { isPlacementDisabled } = useInteractionStatus();
+    const { isPlacementHardDisabled } = useInteractionStatus();
     const state = useBranchPlacementState();
 
     // Track branch placement hotkey globally
@@ -101,7 +101,7 @@ export function useBranchPlacement() {
 
     // Click on model to set tip
     const onModelClick = useCallback((hit: THREE.Intersection | null) => {
-        if (isPlacementDisabled || !hit) return;
+        if (isPlacementHardDisabled || !hit) return;
 
         const nativeEvent = (hit as any)?.nativeEvent;
         const altDown = !!(nativeEvent?.altKey ?? (hit as any)?.altKey);
@@ -123,7 +123,7 @@ export function useBranchPlacement() {
         branchPlacementStore.setTip(pos, normal, modelId);
 
         console.log('[BranchPlacement] Tip set at', pos, 'awaiting base click on support');
-    }, [isPlacementDisabled]);
+    }, [isPlacementHardDisabled]);
 
     // These are no-ops - snapping is handled by BranchPlacementController
     const onSupportHover = useCallback((hit: THREE.Intersection | null) => { }, []);
@@ -131,10 +131,10 @@ export function useBranchPlacement() {
 
     // Clear if placement disabled and idle
     useEffect(() => {
-        if (isPlacementDisabled && state.stage === 'idle') {
+        if (isPlacementHardDisabled && state.stage === 'idle') {
             branchPlacementStore.reset();
         }
-    }, [isPlacementDisabled, state.stage]);
+    }, [isPlacementHardDisabled, state.stage]);
 
     return {
         altActive: state.altActive,

--- a/src/supports/SupportTypes/Kickstand/KickstandPlacementController.tsx
+++ b/src/supports/SupportTypes/Kickstand/KickstandPlacementController.tsx
@@ -17,6 +17,7 @@ import { getKickstandPlacementOffsetMm } from './kickstandSettings';
 import { kickstandPlacementStore, useKickstandPlacementState, type KickstandPlacementTarget } from './kickstandPlacementState';
 import type { KickstandHostKind } from './types';
 import type { Vec3 } from '../../types';
+import { clearSelection } from '../../interaction/SupportSelection';
 
 type DesiredBand = 'left' | 'right' | 'front';
 
@@ -641,21 +642,25 @@ export function KickstandPlacementController() {
             addKickstand(build);
             addRoot(build.root);
             addKnot(build.hostKnot);
+
             pushHistory({
                 type: SUPPORT_ADD_KICKSTAND,
                 payload: { build },
             });
-            setSelectedId(build.kickstand.id);
+
+            clearSelection();
             kickstandPlacementStore.clearPreview();
             desiredBandRef.current = 'front';
             lastPreviewSegmentIdRef.current = null;
+            resetSnapping();
         };
 
         window.addEventListener('shaft-click', handleShaftClick);
+
         return () => {
             window.removeEventListener('shaft-click', handleShaftClick);
         };
-    }, [buildPlacementFromSnap, camera, camera.position, pointer, raycaster, targetMetaById]);
+    }, [buildPlacementFromSnap, hotkeyActive, resetSnapping, camera, pointer, raycaster, targetMetaById]);
 
     return null;
 }

--- a/src/supports/SupportTypes/Kickstand/KickstandRenderer.tsx
+++ b/src/supports/SupportTypes/Kickstand/KickstandRenderer.tsx
@@ -4,7 +4,7 @@ import type { ThreeEvent } from '@react-three/fiber';
 import type { Knot, Roots } from '../../types';
 import { setSelectedId } from '../../state';
 import { useHighlight } from '../../interaction/useHighlight';
-import { handleSupportClick, emitSupportModelPointerHover } from '../../interaction/clickHandlers';
+import { handleSupportClick } from '../../interaction/clickHandlers';
 import { JointRenderer } from '../../SupportPrimitives/Joint/JointRenderer';
 import { KnotRenderer } from '../../SupportPrimitives/Knot/KnotRenderer';
 import { RootsRenderer } from '../../SupportPrimitives/Roots/RootsRenderer';
@@ -57,7 +57,7 @@ export const KickstandRenderer = React.memo(function KickstandRenderer({
     const { pickRef, visuals } = useHighlight({
         id: kickstand.id,
         category: 'support',
-        enabled: !!isInteractable && !suppressHover && !deferInteractionToSceneBatch,
+        enabled: !!isInteractable && !suppressHover && !deferInteractionToSceneBatch && !isSelected,
         isSelected,
         suppressHover,
         externalHover: propHovered,
@@ -69,14 +69,6 @@ export const KickstandRenderer = React.memo(function KickstandRenderer({
     const handleClick = (e: ThreeEvent<MouseEvent>) => {
         handleSupportClick(e, kickstand.id, !!isInteractable);
     };
-
-    const handlePointerMove = React.useCallback(() => {
-        emitSupportModelPointerHover(kickstand.modelId ?? null);
-    }, [kickstand.modelId]);
-
-    const handlePointerOut = React.useCallback(() => {
-        emitSupportModelPointerHover(null);
-    }, []);
 
     const basePos = new THREE.Vector3(root.transform.pos.x, root.transform.pos.y, root.transform.pos.z);
     const startZ = root.diskHeight + root.coneHeight;
@@ -179,8 +171,6 @@ export const KickstandRenderer = React.memo(function KickstandRenderer({
     return (
         <group
             onClick={handleClick}
-            onPointerMove={deferInteractionToSceneBatch ? undefined : handlePointerMove}
-            onPointerOut={deferInteractionToSceneBatch ? undefined : handlePointerOut}
         >
             {!hidePlateContactPrimitives && (
                 <RootsRenderer

--- a/src/supports/SupportTypes/Leaf/LeafPlacementController.tsx
+++ b/src/supports/SupportTypes/Leaf/LeafPlacementController.tsx
@@ -14,6 +14,7 @@ import type { SupportData } from '../../rendering/SupportBuilder';
 import { SUPPORT_ADD_LEAF } from '../../history/actionTypes';
 import { JOINT_DIAMETER_OFFSET_MM } from '../../constants';
 import { generateUuid } from '@/utils/uuid';
+import { clearSelection } from '../../interaction/SupportSelection';
 
 export function LeafPlacementController() {
     const { isActive, stage, tipPosition, surfaceNormal, modelId } = useLeafPlacementState();
@@ -377,6 +378,7 @@ export function LeafPlacementController() {
 
             leafPlacementStore.finalize();
             leafPlacementStore.reset();
+            clearSelection();
 
             e.stopPropagation();
             e.preventDefault();

--- a/src/supports/SupportTypes/Leaf/LeafRenderer.tsx
+++ b/src/supports/SupportTypes/Leaf/LeafRenderer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Leaf, Knot } from '../../types';
 import { ContactConeRenderer } from '../../SupportPrimitives/ContactCone';
-import { handleSupportClick, emitSupportModelPointerHover } from '../../interaction/clickHandlers';
+import { handleSupportClick } from '../../interaction/clickHandlers';
 import { useHighlight } from '../../interaction/useHighlight';
 import { KnotRenderer } from '../../SupportPrimitives/Knot/KnotRenderer';
 
@@ -41,7 +41,7 @@ export const LeafRenderer = React.memo(function LeafRenderer({
     const { pickRef, visuals } = useHighlight({
         id: leaf.id,
         category: 'support',
-        enabled: !!isInteractable && !suppressHover,
+        enabled: !!isInteractable && !suppressHover && !isSelected,
         isSelected,
         suppressHover,
         externalHover: propHovered,
@@ -71,16 +71,8 @@ export const LeafRenderer = React.memo(function LeafRenderer({
         handleSupportClick(e, leaf.id, !!isInteractable);
     };
 
-    const handlePointerMove = React.useCallback(() => {
-        emitSupportModelPointerHover(leaf.modelId ?? null);
-    }, [leaf.modelId]);
-
-    const handlePointerOut = React.useCallback(() => {
-        emitSupportModelPointerHover(null);
-    }, []);
-
     return (
-        <group onClick={handleClick} onPointerMove={handlePointerMove} onPointerOut={handlePointerOut}>
+        <group onClick={handleClick}>
             <group ref={pickRef as any}>
                 {leaf.contactCone && !deferContactConesToSceneBatch && (
                     <ContactConeRenderer

--- a/src/supports/SupportTypes/Stick/StickRenderer.tsx
+++ b/src/supports/SupportTypes/Stick/StickRenderer.tsx
@@ -6,7 +6,7 @@ import { ShaftRenderer } from '../../SupportPrimitives/Shaft/ShaftRenderer';
 import { InstancedShaftGroup, type InstancedShaft } from '../../SupportPrimitives/Shaft/InstancedShaftGroup';
 import { BezierRenderer } from '../../Renderers/BezierRenderer';
 import { ContactConeRenderer, getFinalSocketPosition } from '../../SupportPrimitives/ContactCone';
-import { handleSupportClick, emitSupportModelPointerHover } from '../../interaction/clickHandlers';
+import { handleSupportClick } from '../../interaction/clickHandlers';
 import { useHighlight } from '../../interaction/useHighlight';
 import { setSelectedId } from '../../state';
 
@@ -48,7 +48,7 @@ export const StickRenderer = React.memo(function StickRenderer({
   const { pickRef, visuals } = useHighlight({
     id: stick.id,
     category: 'support',
-    enabled: !!isInteractable && !suppressHover && !deferInteractionToSceneBatch,
+    enabled: !!isInteractable && !suppressHover && !deferInteractionToSceneBatch && !isSelected,
     isSelected,
     suppressHover,
     externalHover: propHovered,
@@ -60,14 +60,6 @@ export const StickRenderer = React.memo(function StickRenderer({
   const handleClick = (e: any) => {
     handleSupportClick(e, stick.id, !!isInteractable);
   };
-
-  const handlePointerMove = React.useCallback(() => {
-    emitSupportModelPointerHover(stick.modelId ?? null);
-  }, [stick.modelId]);
-
-  const handlePointerOut = React.useCallback(() => {
-    emitSupportModelPointerHover(null);
-  }, []);
 
   const shafts: React.ReactNode[] = [];
   const batchedStraightShafts: InstancedShaft[] = [];
@@ -193,8 +185,6 @@ export const StickRenderer = React.memo(function StickRenderer({
   return (
     <group
       onClick={handleClick}
-      onPointerMove={deferInteractionToSceneBatch ? undefined : handlePointerMove}
-      onPointerOut={deferInteractionToSceneBatch ? undefined : handlePointerOut}
     >
       <group ref={pickRef as any}>
         <InstancedShaftGroup

--- a/src/supports/SupportTypes/Trunk/TrunkRenderer.tsx
+++ b/src/supports/SupportTypes/Trunk/TrunkRenderer.tsx
@@ -9,7 +9,7 @@ import { BezierRenderer } from '../../Renderers/BezierRenderer';
 import { validateBezierConstraints } from '../../Curves/BezierUtils';
 import { RootsRenderer } from '../../SupportPrimitives/Roots/RootsRenderer';
 import { ContactConeRenderer, getFinalSocketPosition } from '../../SupportPrimitives/ContactCone';
-import { handleSupportClick, emitSupportModelPointerHover } from '../../interaction/clickHandlers';
+import { handleSupportClick } from '../../interaction/clickHandlers';
 import { useHighlight } from '../../interaction/useHighlight';
 import { setSelectedId } from '../../state';
 import { subscribeToSettings, getSettingsSnapshot } from '../../Settings';
@@ -39,10 +39,10 @@ export const TrunkRenderer = React.memo(function TrunkRenderer({ trunk, root, is
     const useLowDetailPrimitives = !isSelected && !propHovered;
 
     // Use universal highlight hook
-    const { pickRef, visuals } = useHighlight({
+    const { pickRef, visuals, isPickingHovered } = useHighlight({
         id: trunk.id,
         category: 'support',
-        enabled: !!isInteractable && !suppressHover && !deferInteractionToSceneBatch,
+        enabled: !!isInteractable && !suppressHover && !deferInteractionToSceneBatch && !isSelected,
         isSelected,
         suppressHover,
         externalHover: propHovered,
@@ -59,16 +59,9 @@ export const TrunkRenderer = React.memo(function TrunkRenderer({ trunk, root, is
 
     // Handle Click
     const handleClick = (e: any) => {
+        if (!isPickingHovered) return;
         handleSupportClick(e, trunk.id, !!isInteractable);
     };
-
-    const handlePointerMove = React.useCallback(() => {
-        emitSupportModelPointerHover(trunk.modelId ?? null);
-    }, [trunk.modelId]);
-
-    const handlePointerOut = React.useCallback(() => {
-        emitSupportModelPointerHover(null);
-    }, []);
 
     // --- Roots parameters for segment start calculation ---
     const basePos = new THREE.Vector3(root.transform.pos.x, root.transform.pos.y, root.transform.pos.z);
@@ -223,8 +216,6 @@ export const TrunkRenderer = React.memo(function TrunkRenderer({ trunk, root, is
     return (
         <group
             onClick={handleClick}
-            onPointerMove={deferInteractionToSceneBatch ? undefined : handlePointerMove}
-            onPointerOut={deferInteractionToSceneBatch ? undefined : handlePointerOut}
         >
             {/* Trunk Picking Group - Contains Roots, Shafts, Cones */}
             <group ref={pickRef as any}>

--- a/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
+++ b/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
@@ -11,6 +11,7 @@ import type { LimitationCode, WarningCode } from '../../types';
 import { calculateSmoothedNormal } from '../../PlacementLogic/PlacementUtils';
 import { getSettings } from '../../Settings';
 import { decideGridPlacement } from '../../PlacementLogic/Grid';
+import { clearSelection } from '../../interaction/SupportSelection';
 
 export function useTrunkPlacementV2() {
     const HOVER_MIN_INTERVAL_MS = 9;
@@ -242,6 +243,7 @@ export function useTrunkPlacementV2() {
                     knotUpdates: trunkUpdate?.knotUpdates ?? undefined,
                 },
             });
+            clearSelection();
             return;
         }
 
@@ -275,6 +277,8 @@ export function useTrunkPlacementV2() {
             const ok = applyTrunkReplacement(planWithBuild, before);
             if (!ok) {
                 setSnapshot(before);
+            } else {
+                clearSelection();
             }
 
             return;
@@ -298,6 +302,7 @@ export function useTrunkPlacementV2() {
             },
         });
         
+        clearSelection();
         console.log('[V2] Added trunk:', trunkBuild.trunk.id, 'to model:', modelId);
     }, [isPlacementDisabled]);
 

--- a/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
+++ b/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
@@ -21,7 +21,7 @@ export function useTrunkPlacementV2() {
     const [previewData, setPreviewData] = useState<SupportData | null>(null);
     const [previewError, setPreviewError] = useState<LimitationCode | null>(null);
     const [previewWarning, setPreviewWarning] = useState<WarningCode | null>(null);
-    const { isPlacementDisabled } = useInteractionStatus();
+    const { isPlacementHardDisabled } = useInteractionStatus();
     const hoverFrameRef = useRef<number | null>(null);
     const latestHoverRef = useRef<THREE.Intersection | null>(null);
     const normalMatrixRef = useRef(new THREE.Matrix3());
@@ -43,10 +43,10 @@ export function useTrunkPlacementV2() {
 
     // Auto-clear preview when placement is disabled (e.g. hovering another object)
     useEffect(() => {
-        if (isPlacementDisabled) {
+        if (isPlacementHardDisabled) {
             clearPreview();
         }
-    }, [clearPreview, isPlacementDisabled]);
+    }, [clearPreview, isPlacementHardDisabled]);
 
     useEffect(() => {
         return () => {
@@ -58,7 +58,7 @@ export function useTrunkPlacementV2() {
     }, []);
 
     const processSupportHover = useCallback((hit: THREE.Intersection | null) => {
-        if (isPlacementDisabled) {
+        if (isPlacementHardDisabled) {
             clearPreview();
             lastProcessedHoverRef.current = null;
             return;
@@ -175,7 +175,7 @@ export function useTrunkPlacementV2() {
                     : null
         );
         setPreviewWarning((prev) => (prev === null ? prev : null));
-    }, [HOVER_MIN_INTERVAL_MS, HOVER_NORMAL_DOT_MIN, HOVER_POS_EPSILON_MM, clearPreview, isPlacementDisabled]);
+    }, [HOVER_MIN_INTERVAL_MS, HOVER_NORMAL_DOT_MIN, HOVER_POS_EPSILON_MM, clearPreview, isPlacementHardDisabled]);
 
     const onSupportHover = useCallback((hit: THREE.Intersection | null) => {
         latestHoverRef.current = hit;
@@ -189,7 +189,7 @@ export function useTrunkPlacementV2() {
     }, [processSupportHover]);
 
     const onSupportClick = useCallback((hit: THREE.Intersection) => {
-        if (isPlacementDisabled || !hit) return;
+        if (isPlacementHardDisabled || !hit) return;
 
         // Re-calculate smoothed normal for click
         const tipNormal = calculateSmoothedNormal(hit);
@@ -304,7 +304,7 @@ export function useTrunkPlacementV2() {
         
         clearSelection();
         console.log('[V2] Added trunk:', trunkBuild.trunk.id, 'to model:', modelId);
-    }, [isPlacementDisabled]);
+    }, [isPlacementHardDisabled]);
 
     return {
         onSupportHover,

--- a/src/supports/SupportTypes/Twig/TwigRenderer.tsx
+++ b/src/supports/SupportTypes/Twig/TwigRenderer.tsx
@@ -7,7 +7,7 @@ import { InstancedShaftGroup, type InstancedShaft } from '../../SupportPrimitive
 import { BezierRenderer } from '../../Renderers/BezierRenderer';
 import { ContactDiskRenderer } from '../../SupportPrimitives/ContactDisk/ContactDiskRenderer';
 import { calculateDiskThickness } from '../../SupportPrimitives/ContactDisk/contactDiskUtils';
-import { handleSupportClick, emitSupportModelPointerHover } from '../../interaction/clickHandlers';
+import { handleSupportClick } from '../../interaction/clickHandlers';
 import { useHighlight } from '../../interaction/useHighlight';
 import { setSelectedId } from '../../state';
 
@@ -44,10 +44,10 @@ export const TwigRenderer = React.memo(function TwigRenderer({
   const lowDetailPrimitiveSegments = 8;
   const useLowDetailPrimitives = !isSelected && !propHovered;
 
-  const { pickRef, visuals } = useHighlight({
+  const { pickRef, visuals, isPickingHovered } = useHighlight({
     id: twig.id,
     category: 'support',
-    enabled: !!isInteractable && !suppressHover && !deferInteractionToSceneBatch,
+    enabled: !!isInteractable && !suppressHover && !deferInteractionToSceneBatch && !isSelected,
     isSelected,
     suppressHover,
     externalHover: propHovered,
@@ -57,16 +57,9 @@ export const TwigRenderer = React.memo(function TwigRenderer({
   });
 
   const handleClick = (e: unknown) => {
+    if (!isPickingHovered) return;
     handleSupportClick(e, twig.id, !!isInteractable);
   };
-
-  const handlePointerMove = React.useCallback(() => {
-    emitSupportModelPointerHover(twig.modelId ?? null);
-  }, [twig.modelId]);
-
-  const handlePointerOut = React.useCallback(() => {
-    emitSupportModelPointerHover(null);
-  }, []);
 
   const shafts: React.ReactNode[] = [];
   const batchedStraightShafts: InstancedShaft[] = [];
@@ -199,8 +192,6 @@ export const TwigRenderer = React.memo(function TwigRenderer({
   return (
     <group
       onClick={handleClick}
-      onPointerMove={deferInteractionToSceneBatch ? undefined : handlePointerMove}
-      onPointerOut={deferInteractionToSceneBatch ? undefined : handlePointerOut}
     >
       <group ref={pickRef as React.Ref<THREE.Group>}>
         <InstancedShaftGroup

--- a/src/supports/interaction/SupportSelection.ts
+++ b/src/supports/interaction/SupportSelection.ts
@@ -78,6 +78,9 @@ export function selectJoint(id: string) {
 export function clearSelection() {
     clearSelectedSupportIds();
     setSelectedId(null);
+    if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('support-selection-cleared'));
+    }
 }
 
 /**

--- a/src/supports/interaction/pointerOcclusion.ts
+++ b/src/supports/interaction/pointerOcclusion.ts
@@ -1,0 +1,46 @@
+import * as THREE from 'three';
+
+type PointerIntersectionLike = {
+    object?: THREE.Object3D | null;
+};
+
+type PointerEventLike = {
+    intersections?: PointerIntersectionLike[] | null;
+};
+
+function isWithinTargetSubtree(object: THREE.Object3D | null | undefined, targetRoot: THREE.Object3D | null | undefined): boolean {
+    let current = object ?? null;
+    while (current) {
+        if (current === targetRoot) return true;
+        current = current.parent;
+    }
+    return false;
+}
+
+export function getFrontBlockingModelId(event: PointerEventLike | null | undefined, targetRoot: THREE.Object3D | null | undefined): string | null {
+    if (!targetRoot) return null;
+
+    const intersections = Array.isArray(event?.intersections) ? event.intersections : [];
+    for (const entry of intersections) {
+        const object = entry?.object ?? null;
+        if (!object) continue;
+        if (isWithinTargetSubtree(object, targetRoot)) return null;
+
+        const modelId = object.userData?.modelId;
+        if (typeof modelId === 'string' && modelId.length > 0) return modelId;
+    }
+
+    return null;
+}
+
+export function hasFrontBlockingModel(event: PointerEventLike | null | undefined, targetRoot: THREE.Object3D | null | undefined): boolean {
+    return getFrontBlockingModelId(event, targetRoot) !== null;
+}
+
+export function emitImmediateModelHover(modelId: string | null) {
+    if (typeof window === 'undefined') return;
+
+    window.dispatchEvent(new CustomEvent('model-pointer-hover-immediate', {
+        detail: { modelId }
+    }));
+}

--- a/src/supports/interaction/useHighlight.ts
+++ b/src/supports/interaction/useHighlight.ts
@@ -47,6 +47,7 @@ export function useHighlight({
 
     return {
         pickRef,
+        isPickingHovered,
         isHighlighted,
         visuals: {
             color,

--- a/src/supports/interaction/useInteractionStatus.ts
+++ b/src/supports/interaction/useInteractionStatus.ts
@@ -1,5 +1,59 @@
 import { useSyncExternalStore } from 'react';
-import { subscribe, getSelectedCategory, getHoveredId, getHoveredCategory } from '../state';
+import { subscribe, getSelectedCategory, getHoveredCategory } from '../state';
+
+const immediateModelHoverListeners = new Set<() => void>();
+let immediateModelHoverId: string | null = null;
+let immediateModelHoverStoreInitialized = false;
+
+function notifyImmediateModelHoverListeners() {
+    immediateModelHoverListeners.forEach((listener) => listener());
+}
+
+function setImmediateModelHoverId(nextModelId: string | null) {
+    if (immediateModelHoverId === nextModelId) return;
+    immediateModelHoverId = nextModelId;
+    notifyImmediateModelHoverListeners();
+}
+
+function initializeImmediateModelHoverStore() {
+    if (immediateModelHoverStoreInitialized || typeof window === 'undefined') return;
+    immediateModelHoverStoreInitialized = true;
+
+    const handleModelHover = (event: Event) => {
+        const customEvent = event as CustomEvent<{ modelId?: string | null }>;
+        setImmediateModelHoverId(customEvent.detail?.modelId ?? null);
+    };
+
+    const clearModelHover = () => {
+        setImmediateModelHoverId(null);
+    };
+
+    window.addEventListener('model-pointer-hover-immediate', handleModelHover as EventListener);
+    window.addEventListener('sat-hover-model-changed', handleModelHover as EventListener);
+    window.addEventListener('blur', clearModelHover);
+    document.addEventListener('visibilitychange', clearModelHover);
+}
+
+function subscribeImmediateModelHover(listener: () => void) {
+    initializeImmediateModelHoverStore();
+    immediateModelHoverListeners.add(listener);
+    return () => {
+        immediateModelHoverListeners.delete(listener);
+    };
+}
+
+function getImmediateModelHoverId() {
+    initializeImmediateModelHoverStore();
+    return immediateModelHoverId;
+}
+
+export function useImmediateModelHoverId() {
+    return useSyncExternalStore(
+        subscribeImmediateModelHover,
+        getImmediateModelHoverId,
+        () => null
+    );
+}
 
 /**
  * Hook to determine the global interaction status.
@@ -17,17 +71,28 @@ export function useInteractionStatus() {
         getHoveredCategory,
         () => 'none' // Server snapshot
     );
+
+    const rawHoveredModelId = useImmediateModelHoverId();
     
     // If a Joint is selected, the Gizmo is active -> Disable placement
     const isGizmoActive = selectedCategory === 'joint';
 
-    // If hovering over any interactive element (support, joint, raft, gizmo), disable placement.
-    // 'model' and 'none' are safe for placement.
-    const isHoveringElement = hoveredCategory !== 'none' && hoveredCategory !== 'model';
+    const isSupportLikeHover =
+        hoveredCategory === 'support'
+        || hoveredCategory === 'segment'
+        || hoveredCategory === 'joint'
+        || hoveredCategory === 'knot'
+        || hoveredCategory === 'raft';
+
+    const allowPlacementFromModelHoverOverride = isSupportLikeHover && rawHoveredModelId !== null;
+    const isHoveringElement = hoveredCategory !== 'none'
+        && hoveredCategory !== 'model'
+        && !allowPlacementFromModelHoverOverride;
     
     return {
         isGizmoActive,
         isHoveringElement,
-        isPlacementDisabled: isGizmoActive || isHoveringElement
+        isPlacementDisabled: isGizmoActive || isHoveringElement,
+        isPlacementHardDisabled: isGizmoActive
     };
 }


### PR DESCRIPTION
## What changed
- fixed selected support hover/placement behavior so occluded support pieces behind a model no longer block support placement preview
- unified the placement-blocking logic around authoritative front-most model hover so hidden support hover does not suppress preview or placement
- added a small xray render-order fix so the xray model does not incorrectly slip behind the build plate at low camera angles

## Why
- selected support child pieces could still act hovered through the model mesh and suppress placement preview even when they were fully occluded
- xray rendering could sort behind the build plate at shallow view angles despite being visually in front

## How to test
- select a support behind a model and hover where the support is occluded by the mesh
- confirm no hidden support hover appears and support placement preview remains visible
- confirm placement still works on the visible model surface in that case
- switch to xray and rotate the camera low near the build plate
- confirm the xray model stays visually in front of the build plate when it should

## Known risks
- the placement fix touches shared hover and placement gating used by support tools, so exposed front-most support interactions should be sanity-checked
- the xray fix adjusts render ordering for xray meshes, so other transparent overlay combinations should be spot-checked