### PR TITLE
feat(cli): full pipeline CLI — Rust slicer + TS scene/support tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ yarn-error.log*
 next-env.d.ts
 
 # local/project-specific
+/fixtures/
+/spec/
 /supports_legacy
 conversion/
 Scratch/

--- a/rust/dragonfruit-cli/Cargo.lock
+++ b/rust/dragonfruit-cli/Cargo.lock
@@ -291,13 +291,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dragonfruit-cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "dragonfruit-islands",
+ "dragonfruit-slicer-v3",
+ "proptest",
+ "serde",
+ "serde_json",
+ "zip",
+]
+
+[[package]]
 name = "dragonfruit-islands"
 version = "0.1.0"
 dependencies = [
  "clap",
  "dragonfruit-slicer-v3",
  "indexmap",
- "proptest",
  "rayon",
  "serde",
  "serde_json",

--- a/rust/dragonfruit-cli/Cargo.toml
+++ b/rust/dragonfruit-cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "dragonfruit-cli"
+version = "0.1.0"
+edition = "2021"
+default-run = "dragonfruit-cli"
+
+[[bin]]
+name = "dragonfruit-cli"
+path = "src/main.rs"
+
+[lib]
+name = "dragonfruit_cli"
+path = "src/lib.rs"
+
+[dependencies]
+dragonfruit-slicer-v3 = { path = "../dragonfruit-slicer-v3" }
+dragonfruit-islands = { path = "../dragonfruit-islands" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+clap = { version = "4", features = ["derive"] }
+zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
+
+[dev-dependencies]
+proptest = "1.9.0"

--- a/rust/dragonfruit-cli/docs/CLI.md
+++ b/rust/dragonfruit-cli/docs/CLI.md
@@ -1,0 +1,477 @@
+# DragonFruit CLI Reference
+
+Two CLI tools expose the full DragonFruit pipeline for headless / LLM-agent use.
+Every command produces JSON output (`--json`) and reports timing metrics.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  dragonfruit-cli (Rust)                                     │
+│  Wraps existing Rust backend — same code as Tauri IPC       │
+│                                                             │
+│  mesh ──── read-stl, info, export-stl                       │
+│  island ── rasterize, scan, track, analyze, full, bench     │
+│  slice ─── run, preview-layer, info                         │
+│  print ─── save, read-bytes, read-layer, cleanup            │
+│  info                                                       │
+└─────────────────────────────────────────────────────────────┘
+        ▲ positions.bin / .nanodlp
+        │
+┌─────────────────────────────────────────────────────────────┐
+│  dragonfruit-ts-cli (TypeScript / tsx)                       │
+│  Wraps existing TS modules — same code as GUI               │
+│                                                             │
+│  scene ─── create, add-model, remove-model, list-models,    │
+│            transform-model, duplicate, arrange, slice, load  │
+│  support ─ add-trunk, add-branch, add-leaf, add-brace,      │
+│            add-knot, remove, list                            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Shared file formats** — both CLIs and the GUI operate on the same data:
+- `.voxl` — scene + support state (VOXL V1 JSON, optional zlib compression)
+- `positions.bin` — flat `f32` triangle vertices `[x,y,z,...]`
+- `.nanodlp` — sliced layer archive (ZIP of PNGs)
+
+---
+
+## Rust CLI — `dragonfruit-cli`
+
+Binary: `rust/dragonfruit-slicer-v3/target/release/dragonfruit-cli`
+
+Build: `cargo build --release` (from `rust/dragonfruit-slicer-v3/`)
+
+Every command prints `[command] Xms` timing to stderr.
+
+### `mesh` — Mesh I/O
+
+| Command | Description | Wraps |
+|---------|-------------|-------|
+| `mesh read-stl <input.stl> -o <dir>` | Parse binary STL → `positions.bin` + `mesh-info.json` | `cli::load_binary_stl` |
+| `mesh info <dir-or-stl> [--json]` | Print triangles, bbox, volume | `geometry::parse_triangles` + `cli::compute_bbox` |
+| `mesh export-stl -i <dir> -o <out.stl>` | Write `positions.bin` back to binary STL | `cli::read_positions_bin` |
+
+**Example:**
+```bash
+dragonfruit-cli mesh read-stl model.stl -o /tmp/mesh
+# read-stl: 957808 triangles, bbox (-23.77,-11.94,0.00)-(23.77,11.94,67.21)
+#   [mesh read-stl] 165.7ms
+
+dragonfruit-cli mesh info /tmp/mesh --json
+# { "triangles": 957808, "volume_mm3": 6838.85, ... }
+#   [mesh info] 100.5ms
+```
+
+### `island` — Island Detection Pipeline
+
+| Command | Description | Wraps |
+|---------|-------------|-------|
+| `island rasterize -i <dir> -o <dir>` | Triangles → per-layer RLE masks | `islands::rasterize::rasterize_for_island_scan` |
+| `island scan -i <dir> -o <dir>` | Support subtraction + CCL | `islands::scan::scan_layer` |
+| `island track -i <dir> -o <dir>` | Cross-layer island tracking | `islands::tracker::IslandTracker` |
+| `island analyze -i <dir> -o <dir>` | Volume calculation + filtering | Island volume aggregation |
+| `island full <input.stl> -o <dir> [--json]` | All stages in one pass | Full pipeline |
+| `island bench <input.stl> [--iterations N] [--json]` | Timing breakdown | Benchmarking harness |
+
+**Key flags** (apply to `full`, `bench`, and individual stages):
+- `--px-mm 0.1` — raster pixel size
+- `--layer-height 0.05` — slice step (mm)
+- `--buffer 0.6` — support buffer (mm)
+- `--connectivity 4` — CCL connectivity (4 or 8)
+- `--overlap 4` — island tracking overlap threshold (px)
+- `--min-area 0.0` — filter islands below this area (mm²)
+- `--params-json <file>` — load params from JSON (CLI flags override)
+
+**Example:**
+```bash
+dragonfruit-cli island full model.stl -o /tmp/islands --json
+# { "triangles": 957808, "islands_total": 42, "islands_filtered": 15,
+#   "raster_ms": 890, "scan_ms": 450, "total_ms": 1340, ... }
+#   [island full] 1892.3ms
+```
+
+### `slice` — Slicing Pipeline
+
+| Command | Description | Wraps |
+|---------|-------------|-------|
+| `slice run <input> -o <out.nanodlp> [--json]` | Full slice → archive | `engine::slice_with_progress_v3_to_path` |
+| `slice preview-layer <archive> --layer N -o <out.png>` | Extract layer PNG | Same as Tauri `read_print_layer_png` |
+| `slice info` | List formats + defaults | `encoders::registry::supported_output_formats` |
+
+**Input:** STL file or `positions.bin` (from `mesh read-stl` or `scene slice` merge).
+
+**Key flags for `slice run`:**
+- `--layer-height 0.05` — layer step (mm)
+- `--build-width-mm 218.0` — build plate width
+- `--build-depth-mm 122.0` — build plate depth
+- `--source-width-px 11400` — raster resolution X
+- `--source-height-px 6400` — raster resolution Y
+- `--png-compression balanced` — fastest / balanced / smallest / optimal
+- `--anti-aliasing Off` — Off / 2x / 4x / 8x
+- `--mirror-x`, `--mirror-y` — mirror axes
+- `--metadata-json '{}'` — opaque metadata passthrough
+
+**Example:**
+```bash
+dragonfruit-cli slice run model.stl -o /tmp/out.nanodlp --json
+# { "layers": 1345, "total_s": 39.7, "layers_per_second": 33.9,
+#   "perf": { "index_build_ns": 43894216, "render_wall_ns": 39055515810, ... } }
+#   [slice run] 39751.5ms
+
+dragonfruit-cli slice preview-layer /tmp/out.nanodlp --layer 500 -o /tmp/layer500.png
+#   [slice preview-layer] 24.4ms
+```
+
+### `print` — Print File Operations
+
+| Command | Description | Wraps |
+|---------|-------------|-------|
+| `print save <input> -o <output>` | Copy archive to destination | Tauri `save_print_file_from_path` |
+| `print read-bytes <input> -o <output>` | Raw binary read | Tauri `read_print_file_bytes` |
+| `print read-layer <archive> --layer N -o <out.png>` | Extract layer PNG | Tauri `read_print_layer_png` |
+| `print cleanup [--path P] [--all] [--max-age-seconds N]` | Clean temp files | Tauri `delete_print_temp_file` / `cleanup_*` |
+
+**Safety:** `print cleanup --path` refuses to delete non-DragonFruit temp artifacts (same guard as Tauri `is_dragonfruit_temp_artifact`).
+
+### `info`
+
+```bash
+dragonfruit-cli info
+# { "name": "dragonfruit-cli", "supported_formats": [".nanodlp"],
+#   "commands": ["mesh","island","slice","print","info"], ... }
+```
+
+---
+
+## TypeScript CLI — `dragonfruit-ts-cli`
+
+Run: `npx tsx scripts/dragonfruit-ts-cli.ts <command> <subcommand> [args]`
+
+Operates on `.voxl` files — the same scene format the GUI saves/loads.
+Every command injects `_perf: { command, elapsed_ms }` into JSON output
+and prints `[command] Xms` to stderr.
+
+### `scene` — Scene Management
+
+| Command | Description | Wraps |
+|---------|-------------|-------|
+| `scene create --o <scene.voxl>` | Create empty scene | `voxl/codec::buildVoxlDocumentV1` |
+| `scene add-model <voxl> --mesh <stl> [--name N] [--position x,y,z]` | Add model | VOXL model entry |
+| `scene remove-model <voxl> --id <id>` | Remove model (cascades supports) | VOXL mutation |
+| `scene list-models <voxl> [--json]` | List models with transforms | VOXL read |
+| `scene transform-model <voxl> --id <id> [--position x,y,z] [--rotate x,y,z] [--scale x,y,z]` | Set transform | VOXL mutation |
+| `scene duplicate <voxl> --id <id> [--count N] [--offset x,y,z]` | Duplicate model | VOXL mutation |
+| `scene arrange <voxl> --mesh-dir <dir> [--spacing 2] [--build-width-mm 218] [--build-depth-mm 122] [--anchor center]` | Auto-arrange on plate | `highPrecisionArrange` (SAT nesting) |
+| `scene slice <voxl> --o <out.nanodlp> --mesh-dir <dir> [--layer-height 0.05] [--build-width-mm 218]` | Merge + slice via Rust | Loads STLs → applies transforms → `dragonfruit-cli slice run` |
+| `scene load <voxl> [--json]` | Dump full scene | `voxl/codec::parseVoxlDocument` |
+
+**Arrange wraps the same algorithm as the GUI** (`src/features/scene/arrange/highPrecisionArrange.ts`):
+- 2.5D SAT nesting with convex hull footprints
+- Multi-order constructive search with fit-rate rescue
+- Post-pack compaction + anchor alignment
+
+**Anchor modes:** `center`, `front_left`, `front_right`, `back_left`, `back_right`
+
+### `support` — Support Management
+
+| Command | Description |
+|---------|-------------|
+| `support add-trunk <voxl> --model-id <id> --position x,y,z [--diameter 2.0]` | Add trunk + root |
+| `support add-branch <voxl> --model-id <id> --parent-knot-id <id> [--diameter 1.0]` | Add branch |
+| `support add-leaf <voxl> --model-id <id> --parent-knot-id <id> --contact x,y,z [--normal x,y,z]` | Add leaf contact |
+| `support add-brace <voxl> --model-id <id> --start-knot <id> --end-knot <id> [--diameter 0.5]` | Add brace |
+| `support add-knot <voxl> --parent-shaft-id <id> --position x,y,z [--t 0.5]` | Add knot on shaft |
+| `support remove <voxl> --id <id>` | Remove element (cascading) |
+| `support list <voxl> [--json]` | List all supports |
+
+**Support types match the GUI's `DragonfruitImportFormat`** (`src/supports/types.ts`):
+- Roots, Trunks, Branches, Leaves, Braces, Knots, Kickstands
+- Removing a root cascades to its trunk → knots → branches/braces
+
+---
+
+## End-to-End Pipeline Example
+
+```bash
+# 1. Create scene
+npx tsx scripts/dragonfruit-ts-cli.ts scene create --o scene.voxl
+
+# 2. Add model
+npx tsx scripts/dragonfruit-ts-cli.ts scene add-model scene.voxl \
+  --mesh model.stl --name "Part"
+
+# 3. Duplicate
+MODEL_ID=$(npx tsx scripts/dragonfruit-ts-cli.ts scene list-models scene.voxl --json \
+  | jq -r '.models[0].id')
+npx tsx scripts/dragonfruit-ts-cli.ts scene duplicate scene.voxl \
+  --id "$MODEL_ID" --count 2 --offset 0,0,0
+
+# 4. Arrange (SAT nesting — same algo as GUI)
+npx tsx scripts/dragonfruit-ts-cli.ts scene arrange scene.voxl \
+  --mesh-dir . --spacing 5 --build-width-mm 218 --build-depth-mm 122
+
+# 5. Slice (TS merges scene → Rust slices)
+npx tsx scripts/dragonfruit-ts-cli.ts scene slice scene.voxl \
+  --o sliced.nanodlp --mesh-dir . --json
+
+# 6. Extract layer preview
+dragonfruit-cli slice preview-layer sliced.nanodlp --layer 500 -o preview.png
+
+# 7. Island scan (independent of scene — operates on STL directly)
+dragonfruit-cli island full model.stl -o /tmp/islands --json
+
+# 8. Save to final print file
+dragonfruit-cli print save sliced.nanodlp -o final.nanodlp
+```
+
+### Pipeline Timing (957K triangle model × 3 copies, 218×122mm plate)
+
+| Step | Command | Time |
+|------|---------|------|
+| Create scene | `scene create` | 5ms |
+| Add model | `scene add-model` | 5ms |
+| Duplicate ×2 | `scene duplicate` | 6ms |
+| Arrange (SAT) | `scene arrange` | 505ms |
+| Slice (merge + Rust engine) | `scene slice` | 45,141ms |
+| &nbsp;&nbsp;└ Rust slice engine | `slice run` | 43,631ms |
+| &nbsp;&nbsp;&nbsp;&nbsp;└ index build | | 99ms |
+| &nbsp;&nbsp;&nbsp;&nbsp;└ render (wall) | | 42,696ms |
+| &nbsp;&nbsp;&nbsp;&nbsp;└ archive encode | | 451ms |
+| Extract layer | `slice preview-layer` | 24ms |
+
+---
+
+## Performance Metrics
+
+### Rust CLI
+
+Every command prints `[command] Xms` to stderr.
+
+`slice run --json` includes detailed engine perf:
+```json
+{
+  "total_s": 43.35,
+  "layers_per_second": 31.0,
+  "perf": {
+    "total_ns": 43352094093,
+    "index_build_ns": 99444275,
+    "render_wall_ns": 42696194233,
+    "render_ns": 160167975799,
+    "png_encode_ns": 509564718513,
+    "archive_encode_ns": 450898940
+  }
+}
+```
+
+`island full --json` includes rasterize/scan breakdown:
+```json
+{
+  "raster_ms": 890.0,
+  "scan_ms": 450.0,
+  "total_ms": 1340.0
+}
+```
+
+`island bench --json` reports best-of-N with throughput:
+```json
+{
+  "best_ms": { "read_stl": 42, "rasterize": 890, "scan": 300, "track": 120, "analyze": 1, "total": 1353 },
+  "throughput": { "layers_per_sec": 994, "mpx_per_sec": 12.5 }
+}
+```
+
+### TypeScript CLI
+
+Every command injects `_perf` into JSON output:
+```json
+{
+  "arranged": [...],
+  "_perf": {
+    "command": "scene arrange",
+    "elapsed_ms": 504.95
+  }
+}
+```
+
+Non-JSON mode prints `[command] Xms` to stderr.
+
+---
+
+## Backend Coverage
+
+| Tauri IPC Command | CLI Equivalent |
+|---|---|
+| `slice_solid_native` | `slice run` (to stdout via `--json`) |
+| `slice_solid_native_to_temp_path` | `slice run -o <path>` |
+| `stage_mesh_binary` | implicit (CLI reads STL/positions.bin directly) |
+| `cancel_slicing` | N/A (CLI runs to completion) |
+| `run_island_scan_native` | `island full` |
+| `save_print_file` / `save_print_file_from_path` | `print save` |
+| `write_bytes_to_path` | `print save` |
+| `read_print_file_bytes` | `print read-bytes` |
+| `read_print_layer_png` | `print read-layer` / `slice preview-layer` |
+| `delete_print_temp_file` | `print cleanup --path` |
+| `cleanup_stale_print_temp_files` | `print cleanup --max-age-seconds` |
+| `cleanup_all_print_temp_files` | `print cleanup --all` |
+| `pick_open_files` / `pick_save_path` | N/A (CLI uses paths directly) |
+| `focus_main_window_command` | N/A (no GUI) |
+| Scene state (React) | `scene *` (via VOXL files) |
+| Support state (`supports/state.ts`) | `support *` (via VOXL files) |
+| Arrange (`highPrecisionArrange.ts`) | `scene arrange` (same algorithm) |
+| `plugin_network_request` | Not covered (plugin dispatch) |
+
+---
+
+## Full Coverage Audit
+
+Comprehensive audit of every data-producing operation across Rust, Tauri IPC, and TypeScript.
+
+### Tauri IPC Commands (19 total)
+
+| # | Command | Status | CLI Equivalent | Notes |
+|---|---------|--------|----------------|-------|
+| 1 | `slice_solid_native` | COVERED | `slice run --json` | Returns archive bytes |
+| 2 | `stage_mesh_binary` | IMPLICIT | CLI reads files directly | Binary IPC staging |
+| 3 | `slice_solid_native_to_temp_path` | COVERED | `slice run -o <path>` | Two-phase slice |
+| 4 | `cancel_slicing` | N/A | — | CLI runs to completion |
+| 5 | `run_island_scan_native` | COVERED | `island full` | Full pipeline |
+| 6 | `save_print_file` | COVERED | `print save` | CLI uses path, no dialog |
+| 7 | `save_print_file_from_path` | COVERED | `print save` | Direct path copy |
+| 8 | `pick_save_path` | N/A | — | GUI dialog only |
+| 9 | `write_bytes_to_path` | COVERED | `print save` | Byte write |
+| 10 | `pick_open_files` | N/A | — | GUI dialog only |
+| 11 | `get_launch_scene_files` | N/A | — | App launch only |
+| 12 | `notify_launch_scene_handoff` | N/A | — | App launch only |
+| 13 | `focus_main_window_command` | N/A | — | GUI window only |
+| 14 | `read_print_file_bytes` | COVERED | `print read-bytes` | Raw file read |
+| 15 | `read_print_layer_png` | COVERED | `print read-layer` | ZIP layer extract |
+| 16 | `delete_print_temp_file` | COVERED | `print cleanup --path` | Safe delete |
+| 17 | `cleanup_stale_print_temp_files` | COVERED | `print cleanup --max-age-seconds` | Age sweep |
+| 18 | `cleanup_all_print_temp_files` | COVERED | `print cleanup --all` | Full sweep |
+| 19 | `plugin_network_request` | GAP | — | Plugin HTTP dispatch |
+
+**Summary:** 12/19 covered, 5 N/A (GUI-only), 1 implicit, 1 gap (plugin dispatch).
+
+### Rust Public API (dragonfruit-slicer-v3)
+
+| Module | Public Functions | Used in CLI | Not in CLI |
+|--------|-----------------|-------------|------------|
+| `engine` | `slice_with_progress_v3`, `slice_with_progress_v3_to_path`, `slice_and_rasterize_v3`, `dispatch_encode_by_format`, `dispatch_encode_by_format_to_path` | `slice_with_progress_v3_to_path` | `slice_and_rasterize_v3` (internal), `dispatch_encode_*` (internal) |
+| `cli` | `load_binary_stl`, `write_positions_bin`, `read_positions_bin`, `compute_bbox`, `write_json`, `read_json`, `write_rle_mask_json`, `read_rle_mask_json`, `write_rle_labels_json`, `read_rle_labels_json`, `ensure_dir` | All 11 | — |
+| `geometry` | `parse_triangles` | Yes | — |
+| `islands::rasterize` | `rasterize_for_island_scan` | Yes | — |
+| `islands::scan` | `scan_layer` | Yes | — |
+| `islands::tracker` | `IslandTracker::new`, `process_layer`, `get_islands`, `finalize_islands` | All 4 | — |
+| `islands::rle` | `rle_encode`, `rle_decode`, `rle_encode_labels`, `rle_decode_labels`, `rle_intersect_dilated`, `rle_subtract`, `rle_label_components` | `rle_label_components` (via scan) | 6 individual ops |
+| `islands::pipeline` | `run_island_scan` | Yes (island full) | — |
+| `encoders::registry` | `find_encoder`, `supported_output_formats` | Both | — |
+| `raster` | `rasterize_layer`, `rasterize_layer_with_stats` | Via pipeline | Not direct |
+| `pipeline` | `render_layers_bounded` | Via engine | Not direct |
+| `encode` | `encode_grayscale_png` | Via pipeline | Not direct |
+| `index` | `build_layer_index` | Via engine | Not direct |
+| `benchmark` | `run_benchmark_v3` | **GAP** | Synthetic benchmark |
+| `metrics` | `SlicingPerfV3::total_s`, `layers_per_second` | Yes | — |
+
+**Gaps:**
+- `benchmark::run_benchmark_v3` — synthetic slicer benchmark, useful for CI/perf monitoring
+- Individual `rle_*` operations — useful for debugging island pipeline stages
+
+### TypeScript Support State (`supports/state.ts` — 60+ exports)
+
+| Operation Type | Total | CLI Covered | Could Cover | Cannot Cover |
+|----------------|-------|-------------|-------------|--------------|
+| **Add** (addRoot, addTrunk, addBranch, addLeaf, addBrace, addTwig, addStick, addKnot) | 8 | 5 (trunk+root, branch, leaf, brace, knot) | 3 (twig, stick, root standalone) | 0 |
+| **Update** (updateTrunk, updateBranch, updateLeaf, updateBrace, updateTwig, updateStick, updateKnot) | 7 | 0 | 7 (pure state) | 0 |
+| **Remove** (removeTrunk, removeBranch, removeLeaf, removeBrace, removeTwig, removeStick, removeKnotById, removeRootById, removeJoint, removeBranchJoint, removeJointById, removeKickstandCascade) | 12 | 1 (generic remove) | 11 (pure state) | 0 |
+| **Transform** (transformSupportsForModel, transformAllSupportsForSingleModel) | 2 | 0 | 0 | 2 (THREE.js matrix) |
+| **Toggle** (toggleSegmentCurve) | 1 | 0 | 1 (pure logic) | 0 |
+| **State** (setSnapshot, resetStore, loadFromLychee, mergeFromLychee) | 4 | 1 (load via VOXL) | 3 | 0 |
+| **Selection** (setSelectedId, setHoveredId, setHoveredCategory, setInteractionWarning) | 4 | 0 | 0 | 4 (UI state) |
+| **Read** (getSnapshot, getRoots, getTrunks, getBranches, etc.) | 20+ | All (via JSON) | — | — |
+
+**Summary:** 38 mutating operations. 5 covered, 25 extractable, 6 GUI-only, 2 THREE.js-only.
+
+### TypeScript Scene Operations (`useSceneCollectionManager.ts`)
+
+| Operation | CLI Coverage | Notes |
+|-----------|-------------|-------|
+| Add model | COVERED | `scene add-model` |
+| Remove model | COVERED | `scene remove-model` |
+| Duplicate model | COVERED | `scene duplicate` |
+| Transform model | COVERED | `scene transform-model` |
+| Arrange models | COVERED | `scene arrange` (same SAT algo) |
+| Load from VOXL | COVERED | `scene load` |
+| Save to VOXL | COVERED | `scene create` / all mutations auto-save |
+| Load from LYS | GAP | LYS → VOXL conversion |
+| Export to STL | GAP | Requires THREE.js STLExporter |
+| Export to 3MF | GAP | Requires THREE.js + XML builder |
+| Group models | GAP | Pure logic, not wired |
+| Ungroup models | GAP | Pure logic, not wired |
+| Center XY | GAP | Pure arithmetic on transform |
+| Place on platform | GAP | Requires geometry bbox |
+| Auto-lift Z | GAP | Requires geometry bbox |
+
+### TypeScript Kickstand State (`kickstandStore.ts`)
+
+| Operation | CLI Coverage | Extractable |
+|-----------|-------------|-------------|
+| `addKickstand` | GAP | Yes (pure logic) |
+| `updateKickstand` | GAP | Yes (pure logic) |
+| `removeKickstand` | GAP | Yes (pure logic) |
+| `reassignAllKickstandModelIds` | GAP | Yes (pure logic) |
+| `transformKickstandsForModel` | N/A | No (THREE.js matrix) |
+| `transformAllKickstands` | N/A | No (THREE.js matrix) |
+
+### TypeScript Export Operations
+
+| Operation | CLI Coverage | Extractable |
+|-----------|-------------|-------------|
+| VOXL export | COVERED | Yes (codec.ts) |
+| STL export | GAP | No (THREE.js STLExporter) |
+| 3MF export | GAP | No (THREE.js + XML) |
+| Raster layer ZIP | GAP | No (THREE.js geometry) |
+| Slice export orchestration | COVERED | Via `scene slice` → Rust slicer |
+
+---
+
+## Coverage Summary
+
+### By Category
+
+| Category | Total Ops | Covered | Gaps (Extractable) | N/A (GUI-only) |
+|----------|-----------|---------|--------------------|-----------------|
+| Tauri IPC | 19 | 12 | 1 (plugin dispatch) | 6 |
+| Rust public API | 35 | 28 | 2 (benchmark, RLE ops) | 5 (internal) |
+| TS support state | 38 | 5 | 25 | 8 |
+| TS scene ops | 15 | 7 | 5 | 3 |
+| TS kickstand | 6 | 0 | 4 | 2 |
+| TS export | 5 | 2 | 0 | 3 |
+| **Total** | **118** | **54 (46%)** | **37 (31%)** | **27 (23%)** |
+
+### Gaps Worth Closing
+
+**High value (enables new LLM agent workflows):**
+
+1. **`support update-*`** — update existing trunks/branches/leaves/braces (7 operations, pure state)
+2. **`support add-twig`** / **`support add-stick`** — twig and stick support types (2 operations)
+3. **`scene group`** / **`scene ungroup`** — model grouping (2 operations, pure logic)
+4. **`scene center-xy`** — center model on plate (1 operation, arithmetic on transform)
+5. **`scene import-lys`** — LYS → VOXL conversion (1 operation, pure logic)
+6. **`benchmark run`** — Rust synthetic benchmark (1 operation, `benchmark::run_benchmark_v3`)
+
+**Lower priority (niche use cases):**
+
+7. **`island rle-*`** — expose individual RLE operations for debugging
+8. **`plugin network-request`** — dispatch plugin HTTP from CLI
+9. **`support add-kickstand`** — kickstand placement (pure logic portion)
+
+### Not Extractable (GUI-only, by design)
+
+These operations require THREE.js geometry in memory and cannot run headlessly:
+
+- `transformSupportsForModel` / `transformAllSupportsForSingleModel` — 3D matrix transforms on support geometry
+- STL/3MF export — THREE.js `STLExporter` / `ThreeMFExporter`
+- Raster layer ZIP — JavaScript rasterization with THREE.js geometry
+- Auto-lift / place-on-platform — requires geometry bounding box computation
+- File dialogs — `pick_open_files`, `pick_save_path`

--- a/rust/dragonfruit-cli/docs/CLI_E2E_PIPELINE.md
+++ b/rust/dragonfruit-cli/docs/CLI_E2E_PIPELINE.md
@@ -1,0 +1,282 @@
+# End-to-End CLI Pipeline Report
+
+Full pipeline demonstration using both CLI tools on `lilith-lilith-part1.stl` (957K triangles, 67mm tall).
+
+## Pipeline Flow
+
+```
+TS CLI: scene create → add-model → rotate 15° → place-on-platform
+     → duplicate ×2 → arrange (SAT nesting)
+                                    │
+Rust CLI: island full ─────────────┤  (detect unsupported regions)
+                                    │
+TS CLI: add supports (2 trunks, knots, branch, leaf, brace, twig)
+     → update trunk diameter → group models
+     → scene slice ────────────────┤
+                                    │
+Rust CLI: slice run ───────────────┘  (1311 layers, 59 layers/s)
+     → preview-layer (300, 800)
+     → export-stl → export-3mf
+     → print save
+```
+
+## Step 1: Create scene
+
+```bash
+npx tsx scripts/dragonfruit-ts-cli.ts scene create --o /tmp/pipeline/scene.voxl
+```
+```
+scene create: /tmp/pipeline/scene.voxl
+  [scene create] 4.34ms
+```
+
+## Step 2: Add model
+
+```bash
+npx tsx scripts/dragonfruit-ts-cli.ts scene add-model /tmp/pipeline/scene.voxl \
+  --mesh ~/Downloads/lilith-lilith-part1.stl --name "Lilith"
+```
+```
+add-model: 'Lilith' id=d0e4e837-b21a-4585-8953-ef7eac1928fe
+  [scene add-model] 6.64ms
+```
+
+## Step 3: Rotate 15° around X axis + place on platform
+
+```bash
+# Rotate (0.2618 rad = 15°)
+npx tsx scripts/dragonfruit-ts-cli.ts scene transform-model /tmp/pipeline/scene.voxl \
+  --id $MID --rotate 0.2618,0,0
+
+# Auto-place on platform (adjusts Z so model sits on build plate)
+npx tsx scripts/dragonfruit-ts-cli.ts scene place-on-platform /tmp/pipeline/scene.voxl \
+  --id $MID --mesh-dir ~/Downloads
+```
+```
+transform-model: d0e4e837...
+  [scene transform-model] 5.22ms
+place-on-platform: d0e4e837... z=0.00 -> 0.00 (mesh minZ=0.00)
+  [scene place-on-platform] 167.35ms
+```
+
+## Step 4: Duplicate + auto-arrange
+
+```bash
+npx tsx scripts/dragonfruit-ts-cli.ts scene duplicate /tmp/pipeline/scene.voxl \
+  --id $MID --count 2 --offset 0,0,0
+
+npx tsx scripts/dragonfruit-ts-cli.ts scene arrange /tmp/pipeline/scene.voxl \
+  --mesh-dir ~/Downloads --spacing 5 --build-width-mm 218 --build-depth-mm 122
+```
+```
+duplicate: d0e4e837... x2 -> 9ca6ffd5..., a2ab8be8...
+  [scene duplicate] 5.48ms
+arrange: 3 models on 218x122mm plate (anchor=center, spacing=5mm)
+  Lilith: (-52.5, 0.7)
+  Lilith (1): (0.0, 0.7)
+  Lilith (2): (52.5, 0.7)
+  [scene arrange] 635.05ms
+```
+
+## Step 5: Island detection (Rust)
+
+```bash
+dragonfruit-cli island full ~/Downloads/lilith-lilith-part1.stl \
+  -o /tmp/pipeline/islands --px-mm 0.1 --layer-height 0.05 --min-area 1.0 --json
+```
+```
+642 total, 30 significant (>1mm²)
+raster=1678ms scan=2679ms
+
+Top 5 islands:
+  id= 55 L483-549  area=4105.0mm²  centroid=(256,129,503)
+  id= 18 L283-487  area=2747.4mm²  centroid=(254,116,314)
+  id= 61 L543-715  area=2459.8mm²  centroid=(259,130,559)
+  id=130 L916-989  area=1695.2mm²  centroid=(281,122,949)
+  id= 60 L536-801  area= 892.0mm²  centroid=(278,110,721)
+```
+
+## Step 6: Add supports at island locations (TS)
+
+```bash
+# Trunk 1 near island 55
+TID1=$(npx tsx scripts/dragonfruit-ts-cli.ts support add-trunk /tmp/pipeline/scene.voxl \
+  --model-id $MID --position 5,3,0 --diameter 2.0 --json | jq -r '.trunk_id')
+
+KID1=$(npx tsx scripts/dragonfruit-ts-cli.ts support add-knot /tmp/pipeline/scene.voxl \
+  --parent-shaft-id $TID1 --position 5,3,25 --t 0.5 --json | jq -r '.knot_id')
+
+# Trunk 2 near island 18
+TID2=$(npx tsx scripts/dragonfruit-ts-cli.ts support add-trunk /tmp/pipeline/scene.voxl \
+  --model-id $MID --position -5,-2,0 --diameter 2.0 --json | jq -r '.trunk_id')
+
+KID2=$(npx tsx scripts/dragonfruit-ts-cli.ts support add-knot /tmp/pipeline/scene.voxl \
+  --parent-shaft-id $TID2 --position -5,-2,20 --t 0.4 --json | jq -r '.knot_id')
+
+# Branch + leaf on trunk 1
+npx tsx scripts/dragonfruit-ts-cli.ts support add-branch /tmp/pipeline/scene.voxl \
+  --model-id $MID --parent-knot-id $KID1 --diameter 1.0
+
+npx tsx scripts/dragonfruit-ts-cli.ts support add-leaf /tmp/pipeline/scene.voxl \
+  --model-id $MID --parent-knot-id $KID1 --contact 8,5,40 --tip-diameter 0.3
+
+# Brace between trunks
+npx tsx scripts/dragonfruit-ts-cli.ts support add-brace /tmp/pipeline/scene.voxl \
+  --model-id $MID --start-knot $KID1 --end-knot $KID2 --diameter 0.5
+
+# Twig (model-to-model contact)
+npx tsx scripts/dragonfruit-ts-cli.ts support add-twig /tmp/pipeline/scene.voxl \
+  --model-id $MID --contact-a 10,0,15 --contact-b 10,0,35
+```
+
+## Step 7: Update support
+
+```bash
+npx tsx scripts/dragonfruit-ts-cli.ts support update /tmp/pipeline/scene.voxl \
+  --id $TID1 --diameter 3.0
+```
+```
+update: 4662f42b...
+  [support update] 7.38ms
+```
+
+## Step 8: Group models
+
+```bash
+npx tsx scripts/dragonfruit-ts-cli.ts scene group /tmp/pipeline/scene.voxl \
+  --ids $MID,$MID2 --name "Print Batch"
+```
+```
+group: a2a7951e... 'Print Batch' with 2 models
+  [scene group] 8.03ms
+```
+
+## Step 9: Scene summary
+
+```bash
+npx tsx scripts/dragonfruit-ts-cli.ts scene list-models /tmp/pipeline/scene.voxl
+npx tsx scripts/dragonfruit-ts-cli.ts support list /tmp/pipeline/scene.voxl
+npx tsx scripts/dragonfruit-ts-cli.ts scene list-groups /tmp/pipeline/scene.voxl
+```
+```
+3 models:
+  d0e4e837... 'Lilith'     pos=(-52.5,0.7,0.0)
+  9ca6ffd5... 'Lilith (1)' pos=(0.0,0.7,0.0)
+  a2ab8be8... 'Lilith (2)' pos=(52.5,0.7,0.0)
+
+9 support elements:
+  2 roots, 2 trunks, 1 branches
+  1 leaves, 1 braces, 2 knots
+
+1 groups:
+  a2a7951e... 'Print Batch' [d0e4e837..., 9ca6ffd5...]
+```
+
+## Step 10: Slice scene (TS merges + Rust slices)
+
+```bash
+npx tsx scripts/dragonfruit-ts-cli.ts scene slice /tmp/pipeline/scene.voxl \
+  --o /tmp/pipeline/print.nanodlp --mesh-dir ~/Downloads \
+  --build-width-mm 218 --build-depth-mm 122
+```
+```
+scene slice: 3 visible models
+  loading Lilith: lilith-lilith-part1.stl
+    transform: pos=(-52.5,0.7,0.0) rot=(0.262,0.000,0.000) scale=(1,1,1)
+  loading Lilith (1): lilith-lilith-part1.stl
+    transform: pos=(0.0,0.7,0.0) rot=(0.262,0.000,0.000) scale=(1,1,1)
+  loading Lilith (2): lilith-lilith-part1.stl
+    transform: pos=(52.5,0.7,0.0) rot=(0.262,0.000,0.000) scale=(1,1,1)
+  merged: 2873424 triangles
+
+Slice result:
+  layers: 1311
+  total_s: 22.06
+  layers_per_second: 59.4
+  resolution: 11400x6400 px
+  [scene slice] 23398ms
+```
+
+## Step 11: Extract layer previews (Rust)
+
+```bash
+dragonfruit-cli slice preview-layer /tmp/pipeline/print.nanodlp --layer 300 -o layer300.png
+dragonfruit-cli slice preview-layer /tmp/pipeline/print.nanodlp --layer 800 -o layer800.png
+```
+```
+extract: layer 300 (87454 bytes)   [slice preview-layer] 24.3ms
+extract: layer 800 (70944 bytes)   [slice preview-layer] 24.8ms
+```
+
+Layer 300: three 15°-rotated busts, full torso cross-sections.
+Layer 800: near the tips of the tilted models, tiny cross-sections.
+
+## Step 12: Export merged scene (TS + Rust)
+
+```bash
+# TS merges scene → Rust writes STL
+npx tsx scripts/dragonfruit-ts-cli.ts scene export-stl /tmp/pipeline/scene.voxl \
+  --o /tmp/pipeline/merged.stl --mesh-dir ~/Downloads
+
+# Rust reads STL → writes 3MF
+dragonfruit-cli mesh read-stl /tmp/pipeline/merged.stl -o /tmp/pipeline/mesh
+dragonfruit-cli mesh export-3mf -i /tmp/pipeline/mesh -o /tmp/pipeline/merged.3mf
+```
+```
+export-stl: 2873424 triangles   [scene export-stl] 1240.9ms
+mesh info: 2873424 tris, vol=20517mm³
+export-3mf: 2873424 triangles   [mesh export-3mf] 11666.7ms
+```
+
+## Step 13: Save final print file (Rust)
+
+```bash
+dragonfruit-cli print save /tmp/pipeline/print.nanodlp -o /tmp/pipeline/final.nanodlp
+```
+```
+print save: print.nanodlp -> final.nanodlp   [print save] 0.3ms
+```
+
+## Output Artifacts
+
+| File | Size | Description |
+|------|------|-------------|
+| `scene.voxl` | 2.2K | Scene state (models + supports + groups) |
+| `print.nanodlp` | 98M | Sliced layer archive (1311 layers) |
+| `final.nanodlp` | 98M | Final print file |
+| `merged.stl` | 137M | Merged scene as binary STL |
+| `merged.3mf` | 49M | Merged scene as 3MF |
+| `layer300.png` | 85K | Layer 300 cross-section preview |
+| `layer800.png` | 69K | Layer 800 cross-section preview |
+| `islands/` | dir | Island scan results (642 islands) |
+
+## Timing Summary
+
+| Step | Tool | Command | Time |
+|------|------|---------|------|
+| Create scene | TS | `scene create` | 4ms |
+| Add model | TS | `scene add-model` | 7ms |
+| Rotate 15° | TS | `scene transform-model` | 5ms |
+| Place on platform | TS | `scene place-on-platform` | 167ms |
+| Duplicate ×2 | TS | `scene duplicate` | 5ms |
+| Arrange (SAT) | TS | `scene arrange` | 635ms |
+| Island scan | Rust | `island full` | 4,357ms |
+| Add 9 supports | TS | `support add-*` ×7 | ~50ms |
+| Update support | TS | `support update` | 7ms |
+| Group models | TS | `scene group` | 8ms |
+| Slice (merge+engine) | TS→Rust | `scene slice` | 23,398ms |
+| Layer preview ×2 | Rust | `slice preview-layer` | 49ms |
+| Export STL | TS→Rust | `scene export-stl` | 1,241ms |
+| Export 3MF | Rust | `mesh export-3mf` | 11,667ms |
+| Print save | Rust | `print save` | 0.3ms |
+| **Total** | | | **~42s** |
+
+## Interoperability
+
+| Direction | Mechanism |
+|-----------|-----------|
+| TS → TS | `.voxl` file (VOXL V1 JSON, zlib compressed) |
+| TS → Rust | `positions.bin` (flat f32 triangles) via temp file |
+| Rust → TS | JSON stdout (`--json` flag) |
+| Rust → Rust | `positions.bin` / `.nanodlp` archive / `.stl` / `.3mf` |
+| GUI ↔ CLI | `.voxl` files (same format the GUI saves/loads) |

--- a/rust/dragonfruit-cli/docs/CLI_GAPS_PLAN.md
+++ b/rust/dragonfruit-cli/docs/CLI_GAPS_PLAN.md
@@ -1,0 +1,390 @@
+# CLI Gaps Implementation Plan
+
+Moldable Development → TDD → DDD approach.
+**Rule: NO new logic. Only wrappers to existing functions.**
+
+## Triage
+
+37 gaps identified. THREE.js runs in Node.js (proven by `scene arrange`).
+Split into 4 work streams by where the existing code lives.
+
+---
+
+## Stream 1: Rust CLI — STL/3MF Export + Benchmark
+
+### 1A. Move STL Export to Library (refactor, not new code)
+
+**Observe:** `cmd_mesh_export_stl` in `dragonfruit_cli.rs:381-439` has the STL writer inline.
+Same binary STL format as `cli::load_binary_stl` reads.
+
+**Model:** Move to `cli.rs` as `pub fn write_binary_stl(path, positions) -> Result<()>`.
+Value Object: `BBox` (already exists). No new types needed.
+
+**Test (write first):**
+```rust
+// cli.rs tests
+#[test]
+fn stl_write_roundtrip() {
+    let positions = vec![0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    let dir = temp_dir();
+    write_binary_stl(&dir.join("rt.stl"), &positions).unwrap();
+    let back = load_binary_stl(&dir.join("rt.stl")).unwrap();
+    assert_eq!(positions.len(), back.len());
+    for (a, b) in positions.iter().zip(back.iter()) {
+        assert!((a - b).abs() < 1e-6);
+    }
+}
+
+proptest! {
+    #[test]
+    fn stl_roundtrip_prop(positions in proptest::collection::vec(-100.0f32..100.0, 0..90)
+        .prop_map(|mut v| { v.truncate(v.len() / 9 * 9); v }))
+    {
+        if positions.is_empty() { return Ok(()); }
+        let dir = temp_dir();
+        write_binary_stl(&dir.join("prop.stl"), &positions).unwrap();
+        let back = load_binary_stl(&dir.join("prop.stl")).unwrap();
+        prop_assert_eq!(positions.len(), back.len());
+        for (a, b) in positions.iter().zip(back.iter()) {
+            prop_assert!((a - b).abs() < 1e-5);
+        }
+    }
+}
+```
+
+**Implement:** Extract the body of `cmd_mesh_export_stl` into `cli::write_binary_stl`. CLI calls the new function.
+
+**Expose:** Already exposed as `mesh export-stl`. No CLI change needed.
+
+### 1B. 3MF Export (New Rust encoder — smallest viable)
+
+**Observe:** No 3MF code exists anywhere in Rust. The GUI imports 3MF via TypeScript
+(`loadMeshGeometry` in `useSceneCollectionManager.ts`), but no Rust writer.
+
+3MF is a ZIP containing XML + binary mesh data. Minimal spec:
+- `[Content_Types].xml`
+- `_rels/.rels`
+- `3D/3dmodel.model` (XML with `<mesh>` → `<vertices>` + `<triangles>`)
+
+**Model:** Domain Service `write_3mf(positions: &[f32], path: &Path) -> Result<()>`.
+No new types — reuses existing `Vec<f32>` positions format.
+
+**Test (write first):**
+```rust
+#[test]
+fn write_3mf_produces_valid_zip() {
+    let positions = vec![0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    let dir = temp_dir();
+    write_3mf(&positions, &dir.join("test.3mf")).unwrap();
+    // Verify it's a valid ZIP with expected entries
+    let file = std::fs::File::open(&dir.join("test.3mf")).unwrap();
+    let mut zip = zip::ZipArchive::new(file).unwrap();
+    assert!(zip.by_name("[Content_Types].xml").is_ok());
+    assert!(zip.by_name("3D/3dmodel.model").is_ok());
+}
+
+#[test]
+fn write_3mf_contains_correct_vertex_count() {
+    let positions = vec![0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+                         0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+    let dir = temp_dir();
+    write_3mf(&positions, &dir.join("test2.3mf")).unwrap();
+    let file = std::fs::File::open(&dir.join("test2.3mf")).unwrap();
+    let mut zip = zip::ZipArchive::new(file).unwrap();
+    let mut model = String::new();
+    zip.by_name("3D/3dmodel.model").unwrap().read_to_string(&mut model).unwrap();
+    // 6 vertices (2 triangles × 3 verts), 2 triangles
+    assert!(model.contains("<vertex x="));
+    assert!(model.contains("<triangle v1="));
+}
+```
+
+**Implement:** `cli::write_3mf` using the existing `zip` crate (already a dependency).
+
+**Expose:** Add `mesh export-3mf -i <dir> -o <out.3mf>` CLI command.
+
+### 1C. Benchmark CLI Command
+
+**Observe:** `benchmark::run_benchmark_v3(cfg)` exists in `benchmark.rs:118`.
+Takes `BenchmarkConfigV3`, returns `BenchmarkResultV3`.
+
+**Test:** Not needed for wrapper — the benchmark module has its own tests.
+
+**Implement:** Add `benchmark` subcommand to CLI that constructs `BenchmarkConfigV3`
+from flags and calls `run_benchmark_v3`.
+
+**Expose:**
+```
+dragonfruit-cli benchmark [--cube-count N] [--width-px W] [--height-px H] [--layers L] [--json]
+```
+
+---
+
+## Stream 2: TS CLI — Support Mutations (wrap state.ts directly)
+
+THREE.js works in Node.js. Import `supports/state.ts` functions directly.
+
+### 2A. Support Updates
+
+**Observe:** `state.ts` exports `updateTrunk(trunk)`, `updateBranch(branch)`, etc.
+These mutate the in-memory state singleton. For CLI, we need to:
+1. Load VOXL → hydrate state via `loadFromLychee`
+2. Call the update function
+3. Export state → save back to VOXL
+
+**Model:** The CLI operates at VOXL file level. We need a bridge pattern:
+```
+load VOXL → loadFromLychee(supports) → mutation → getSnapshot() → save VOXL
+```
+
+But `loadFromLychee` does geometry normalization with THREE.js. For pure data updates
+(changing a trunk's diameter, a knot's position), we can operate directly on the
+`DragonfruitImportFormat` JSON inside the VOXL — no state.ts needed.
+
+**Decision:** For simple field updates (diameter, position, etc.), operate on VOXL JSON
+directly. Same as current `add-*` commands. No state.ts import needed.
+
+**Test (in pipeline — run CLI and verify JSON output):**
+```bash
+# Add trunk, then update its diameter
+npx tsx scripts/dragonfruit-ts-cli.ts support add-trunk scene.voxl --model-id m1 --position 5,0,0 --diameter 2 --json
+npx tsx scripts/dragonfruit-ts-cli.ts support update scene.voxl --id <trunk-id> --diameter 3.5 --json
+npx tsx scripts/dragonfruit-ts-cli.ts support list scene.voxl --json | jq '.supports.trunks[0].segments[0].diameter'
+# should be 3.5
+```
+
+**Implement:** Add `support update` command that finds element by ID across all
+collections (roots, trunks, branches, leaves, braces, knots) and patches fields.
+
+**Expose:**
+```
+support update <voxl> --id <id> [--diameter N] [--position x,y,z] [--tip-diameter N] [--json]
+```
+
+### 2B. Cascading Removes (already partially done)
+
+**Observe:** Current `support remove` does cascading for roots → trunks → knots → branches.
+But it doesn't cascade trunk removal to knots → branches → leaves → braces (the full cascade
+in `state.ts::removeTrunk`).
+
+**Test:**
+```bash
+# Add trunk + knot + branch + leaf, then remove trunk — all should cascade
+npx tsx scripts/dragonfruit-ts-cli.ts support add-trunk scene.voxl ...
+npx tsx scripts/dragonfruit-ts-cli.ts support add-knot scene.voxl ...
+npx tsx scripts/dragonfruit-ts-cli.ts support add-branch scene.voxl ...
+npx tsx scripts/dragonfruit-ts-cli.ts support add-leaf scene.voxl ...
+npx tsx scripts/dragonfruit-ts-cli.ts support remove scene.voxl --id <trunk-id>
+npx tsx scripts/dragonfruit-ts-cli.ts support list scene.voxl --json
+# all 0
+```
+
+**Implement:** Fix cascade in existing `supportRemove` to handle trunk removal properly
+(currently misses leaves attached to knots that are attached to branches).
+
+### 2C. Kickstand Operations
+
+**Observe:** `kickstandStore.ts` exports `addKickstand(build: KickstandBuildResult)`,
+`removeKickstand(id)`, `updateKickstand(build)`. These are **pure data operations** — no THREE.js.
+
+The `KickstandBuildResult` type has: `{ root, hostKnot, kickstand }`.
+Kickstands are stored in `DragonfruitImportFormat.kickstands[]`.
+
+**Test:**
+```bash
+npx tsx scripts/dragonfruit-ts-cli.ts support add-kickstand scene.voxl \
+  --model-id m1 --base 5,5 --contact 10,10,20 --diameter 1.5 --json
+npx tsx scripts/dragonfruit-ts-cli.ts support list scene.voxl --json | jq '.kickstands'
+```
+
+**Implement:** Add `support add-kickstand` command. Construct `KickstandBuildResult`-shaped
+JSON and append to `doc.supports.kickstands[]`.
+
+**Expose:**
+```
+support add-kickstand <voxl> --model-id <id> --base x,y --contact x,y,z [--diameter 1.5] [--json]
+support remove-kickstand <voxl> --id <id> [--json]
+```
+
+### 2D. Toggle Segment Curve
+
+**Observe:** `state.ts::toggleSegmentCurve(segmentId)` converts straight ↔ bezier.
+Uses `calculateBezierControlPoints` (THREE.js).
+
+For CLI: operate on VOXL JSON directly. A straight segment has no `type` or `type: 'straight'`.
+A bezier segment has `type: 'bezier'` + control points. Toggle = change the type field.
+
+For straight→bezier: need control points. Can't compute without THREE.js geometry context.
+For bezier→straight: just remove the bezier fields.
+
+**Decision:** Support `bezier-to-straight` only in CLI (removes curve data).
+`straight-to-bezier` requires geometry context → GUI only.
+
+**Expose:**
+```
+support straighten-segment <voxl> --id <segment-id> [--json]
+```
+
+---
+
+## Stream 3: TS CLI — Scene Operations (wrap VOXL directly)
+
+### 3A. Group / Ungroup
+
+**Observe:** `useSceneCollectionManager.ts:1879` has `groupModels(modelIds, groupName)`.
+It sets `groupId` and `groupName` on each model's `LoadedModel` record. Pure state.
+
+In VOXL: models don't have an explicit group field in the spec. But the CLI can use
+the `extensions` field on `VoxlDocumentV1` to store groups, or add groupId to model entries.
+
+**Decision:** Since VOXL `VoxlModelEntry` doesn't have `groupId`, store groups in
+`doc.extensions.groups` as `{ id, name, modelIds }[]`. The GUI doesn't read this
+(it manages groups in React state), but it's preserved in the file for CLI round-trips.
+
+**Test:**
+```bash
+npx tsx scripts/dragonfruit-ts-cli.ts scene group scene.voxl --ids id1,id2 --name "Assembly" --json
+npx tsx scripts/dragonfruit-ts-cli.ts scene list-groups scene.voxl --json
+npx tsx scripts/dragonfruit-ts-cli.ts scene ungroup scene.voxl --group-id g1 --json
+```
+
+**Expose:**
+```
+scene group <voxl> --ids <id1,id2,...> [--name "Group"] [--json]
+scene ungroup <voxl> --group-id <id> [--json]
+scene list-groups <voxl> [--json]
+```
+
+### 3B. Center XY
+
+**Observe:** `useModelTransform.ts:82` — `centerXY` sets position X=0, Y=0, preserves Z.
+
+For CLI: set `model.transform.position.x = 0`, `model.transform.position.y = 0`.
+
+**Test:**
+```bash
+npx tsx scripts/dragonfruit-ts-cli.ts scene transform-model scene.voxl --id m1 --position 50,30,10
+npx tsx scripts/dragonfruit-ts-cli.ts scene center-xy scene.voxl --id m1 --json
+# position should be (0, 0, 10)
+```
+
+**Expose:**
+```
+scene center-xy <voxl> --id <model-id> [--json]
+```
+
+### 3C. LYS Import
+
+**Observe:** `useLysImport.ts` handles `.lys` file parsing. It's a Lychee slicer format
+with embedded mesh data + support state. The import pipeline:
+1. Parse LYS JSON
+2. Extract mesh geometry
+3. Build `DragonfruitImportFormat` for supports
+4. Load into scene
+
+The LYS parser is in TypeScript and uses THREE.js for geometry construction.
+For CLI: parse LYS → extract to VOXL (same interchange format).
+
+**Decision:** Import `useLysImport` logic. THREE.js works in Node.
+
+**Test:**
+```bash
+npx tsx scripts/dragonfruit-ts-cli.ts scene import-lys input.lys --o scene.voxl --json
+npx tsx scripts/dragonfruit-ts-cli.ts scene list-models scene.voxl --json
+```
+
+**Expose:**
+```
+scene import-lys <input.lys> --o <output.voxl> [--json]
+```
+
+---
+
+## Stream 4: Rust — 3MF Writer
+
+### 4A. Minimal 3MF Writer
+
+**Observe:** No existing code. Must implement from scratch.
+3MF Core Spec: ZIP with XML model file. Minimal structure:
+
+```
+[Content_Types].xml
+_rels/.rels
+3D/3dmodel.model   ← XML with <mesh><vertices/><triangles/></mesh>
+```
+
+**Model:** Domain Service in `cli.rs`:
+```rust
+pub fn write_3mf(positions: &[f32], path: &Path) -> Result<(), String>
+```
+
+**Test (write first):**
+```rust
+#[test]
+fn write_3mf_roundtrip_structure() { ... }
+
+#[test]
+fn write_3mf_rejects_non_multiple_of_9() {
+    let result = write_3mf(&[1.0, 2.0], &PathBuf::from("/tmp/bad.3mf"));
+    assert!(result.is_err());
+}
+
+proptest! {
+    #[test]
+    fn write_3mf_vertex_count_matches(positions in proptest::collection::vec(-100.0f32..100.0, 0..90)
+        .prop_map(|mut v| { v.truncate(v.len() / 9 * 9); v }))
+    {
+        if positions.is_empty() { return Ok(()); }
+        let dir = temp_dir();
+        write_3mf(&positions, &dir.join("prop.3mf")).unwrap();
+        // Verify ZIP is valid and triangle count matches
+        let file = std::fs::File::open(&dir.join("prop.3mf")).unwrap();
+        let zip = zip::ZipArchive::new(file).unwrap();
+        prop_assert!(zip.len() >= 3); // Content_Types, rels, model
+    }
+}
+```
+
+**Implement:** Write XML using string formatting (no XML crate needed for this minimal output).
+Uses existing `zip` crate dependency.
+
+**Expose:**
+```
+dragonfruit-cli mesh export-3mf -i <dir> -o <output.3mf>
+```
+
+---
+
+## Implementation Order
+
+| Phase | Stream | Task | Effort | Tests |
+|-------|--------|------|--------|-------|
+| 1 | 1A | Extract `write_binary_stl` to `cli.rs` | S | 2 (unit + prop) |
+| 2 | 1C | Add `benchmark` CLI command | S | 0 (existing) |
+| 3 | 2A | Add `support update` command | S | Pipeline test |
+| 4 | 2B | Fix cascading removes | S | Pipeline test |
+| 5 | 2C | Add kickstand commands | S | Pipeline test |
+| 6 | 3A | Add group/ungroup commands | S | Pipeline test |
+| 7 | 3B | Add `scene center-xy` | XS | Pipeline test |
+| 8 | 2D | Add `support straighten-segment` | S | Pipeline test |
+| 9 | 4A | Write minimal 3MF writer | M | 3 (unit + prop + structure) |
+| 10 | 1A | Add `mesh export-3mf` CLI command | S | Pipeline test |
+| 11 | 3C | Add `scene import-lys` | M | Pipeline test |
+
+**Total: 11 tasks, ~37 gaps closed.**
+
+## Verification
+
+After each phase, run:
+```bash
+cargo nextest run                                    # Rust tests
+npx tsx scripts/dragonfruit-ts-cli.ts --help          # TS CLI still works
+# Pipeline smoke test:
+npx tsx scripts/dragonfruit-ts-cli.ts scene create --o /tmp/test.voxl
+npx tsx scripts/dragonfruit-ts-cli.ts scene add-model /tmp/test.voxl --mesh model.stl --name Test
+npx tsx scripts/dragonfruit-ts-cli.ts scene arrange /tmp/test.voxl --mesh-dir .
+npx tsx scripts/dragonfruit-ts-cli.ts scene slice /tmp/test.voxl --o /tmp/test.nanodlp --mesh-dir .
+```
+
+After all phases, update `docs/CLI.md` coverage table — target: **91/118 (77%)** covered
+(up from 54/118 = 46%).

--- a/rust/dragonfruit-cli/docs/CLI_NEW_FORMAT_PLAN.md
+++ b/rust/dragonfruit-cli/docs/CLI_NEW_FORMAT_PLAN.md
@@ -1,0 +1,124 @@
+# CLI New Format Support Plan
+
+4 features to implement, wrapping existing code only.
+
+## Available Formats (after #88 CTB merge)
+
+| Extension | Encoder | Versions | Notes |
+|-----------|---------|----------|-------|
+| `.nanodlp` | Athena | — | ZIP of PNGs + metadata |
+| `.ctb` | CTB plugin | v4 (default), v5, v5enc (encrypted) | Binary format with RLE-compressed layers |
+
+Format version is controlled by `SliceJobV3.format_version: Option<String>`.
+CTB accepts: `None` (v4 default), `"v5"`, `"v5enc"`.
+
+## Feature 1: `slice formats` — list formats with details
+
+**Wraps:** `encoders::registry::supported_output_formats()` + encoder trait methods.
+
+**Output:**
+```json
+{
+  "formats": [
+    {
+      "extension": ".nanodlp",
+      "requires_area_stats": false,
+      "requires_png_layers": true,
+      "requires_raw_mask_layers": false
+    },
+    {
+      "extension": ".ctb",
+      "versions": ["v4", "v5", "v5enc"],
+      "requires_area_stats": true,
+      "requires_png_layers": false,
+      "requires_raw_mask_layers": true
+    }
+  ]
+}
+```
+
+**Problem:** The `FormatEncoder` trait doesn't expose version info or metadata schema.
+We can hardcode known format metadata for now, or add a `format_info()` method to the trait.
+
+**Decision:** Hardcode — the encoder plugins are compiled-in and change rarely.
+Query `requires_area_stats`, `requires_png_layers`, `requires_raw_mask_layers` from the trait.
+Add version/metadata info as static JSON per known format.
+
+**Implementation:**
+- Add `SliceCommands::Formats` variant (no args, always JSON)
+- In `cmd_slice_formats()`: call `find_encoder` for each format, query capabilities
+- Merge with static metadata for version info
+
+## Feature 2: `slice run --format-version` flag
+
+**Wraps:** `SliceJobV3.format_version` field (already exists, just not exposed in CLI).
+
+**Current CLI `slice run` code:**
+```rust
+let job = SliceJobV3 {
+    // ...
+    format_version: None,          // ← always None
+    minimum_aa_alpha_percent: 0.0, // ← always 0
+};
+```
+
+**Implementation:**
+- Add `--format-version <VERSION>` optional flag to `SliceCommands::Run`
+- Add `--min-aa-alpha <PERCENT>` optional flag
+- Pass through to `SliceJobV3`
+
+**Example:**
+```bash
+dragonfruit-cli slice run model.stl -o out.ctb --format-version v5enc --json
+```
+
+## Feature 3: `island batch` — process multiple STLs
+
+**Wraps:** Existing `island full` logic, run in a loop with aggregated JSON output.
+
+**Implementation:**
+- Add `IslandCommands::Batch` variant with `inputs: Vec<PathBuf>` (glob-expanded)
+- For each input: run same logic as `cmd_island_full`
+- Aggregate results into a single JSON array
+- Report per-file timing
+
+**Example:**
+```bash
+dragonfruit-cli island batch models/*.stl -o /tmp/results --json
+# Output: [{ "stl": "model1.stl", "islands_filtered": 15, ... }, ...]
+```
+
+**Note:** Each STL is independent — could parallelize with rayon `par_iter` over files.
+
+## Feature 4: `print inspect` — read metadata from archives
+
+**Wraps:** `zip::ZipArchive` to list contents + read metadata entries.
+
+CTB files aren't ZIP — they're a custom binary format. So this is primarily for
+nanodlp/ZIP-based archives. For CTB inspection, we'd need to parse the binary header.
+
+**Decision:** Start with ZIP-based archives (list entries, read manifest).
+CTB binary inspection can be added later if needed.
+
+**Implementation:**
+- Add `PrintCommands::Inspect` variant
+- Open as ZIP, list entries with sizes
+- If `manifest.json` or `metadata.json` exists, parse and include in output
+- Report layer count, total size, compression ratio
+
+**Example:**
+```bash
+dragonfruit-cli print inspect out.nanodlp --json
+# Output: { "format": "zip", "entries": 1345, "layers": 1344, "total_bytes": 98000000, ... }
+```
+
+## Implementation Order
+
+| # | Feature | Effort | Files |
+|---|---------|--------|-------|
+| 1 | `--format-version` flag | XS | `main.rs` only (2 lines) |
+| 2 | `slice formats` | S | `main.rs` (new command + handler) |
+| 3 | `print inspect` | S | `main.rs` (new command + handler) |
+| 4 | `island batch` | M | `main.rs` (new command + loop logic) |
+
+Total: ~100 lines of new code, all wrapping existing functions.

--- a/rust/dragonfruit-cli/docs/CLI_WONT_DO.md
+++ b/rust/dragonfruit-cli/docs/CLI_WONT_DO.md
@@ -1,0 +1,50 @@
+# CLI — Won't Do (Review Later)
+
+Operations that cannot be exposed via CLI without significant new code or
+fundamental architecture changes. Revisit when requirements change.
+
+## GUI-Only by Design
+
+| Operation | Reason |
+|-----------|--------|
+| `cancel_slicing` | CLI runs to completion — no interactive cancellation |
+| `pick_open_files` / `pick_save_path` | OS file dialogs — CLI uses paths directly |
+| `focus_main_window_command` | Tauri window management |
+| `get_launch_scene_files` / `notify_launch_scene_handoff` | App launch handoff |
+| `setSelectedId` / `setHoveredId` / `setHoveredCategory` / `setInteractionWarning` | UI interaction state |
+
+## THREE.js Geometry-Dependent (no headless path)
+
+| Operation | Reason |
+|-----------|--------|
+| `transformSupportsForModel` | Requires delta Matrix4 from model transform change — the matrix is computed from the difference between before/after THREE.js Euler/Scale/Position, not available from file state alone |
+| `transformAllSupportsForSingleModel` | Same — needs live delta matrix |
+| `transformKickstandsForModel` / `transformAllKickstands` | Same — needs Matrix4 |
+| Raster layer ZIP export (`rasterLayerZipExport.ts`) | Requires THREE.js BufferGeometry for scanline rasterization — the Rust slicer does this natively via `slice run` |
+| Auto-lift Z / snap-to-platform with geometry | `useTransformManager.ts::getLowestWorldZForTransform` needs THREE.js geometry bounds computation. **Workaround:** `scene place-on-platform` loads STL and computes bbox directly |
+| `toggleSegmentCurve` straight→bezier | Needs `calculateBezierControlPoints` which requires THREE.js Vector3 math for control point placement. **Workaround:** `support straighten-segment` handles bezier→straight direction |
+
+## Plugin System
+
+| Operation | Reason |
+|-----------|--------|
+| `plugin_network_request` | Requires plugin registry initialization (`plugin_registry::initialize_plugins`) which loads compiled-in plugin modules. Could be exposed but the plugin registry is tightly coupled to the Tauri build — would need refactoring to work standalone |
+
+## Import Formats
+
+| Operation | Reason |
+|-----------|--------|
+| `scene import-lys` | LYS import (`useLysImport.ts`, `LysParser.ts`, `LysConverter.ts`) is ~1000 lines with THREE.js geometry construction for mesh loading. Could work in Node.js with THREE but needs significant wiring. Lower priority since VOXL is the primary interchange format |
+| 3MF import (read) | No existing Rust or TS reader that produces `positions.bin`. The GUI uses `loadMeshGeometry` which delegates to THREE.js loaders. Would need a Rust 3MF parser crate or porting the XML parsing |
+
+## Unused Internal APIs
+
+| Operation | Reason |
+|-----------|--------|
+| `rle_encode` / `rle_decode` | Encoding from dense grids — useful only if CLI produces raw raster data, which it doesn't (island pipeline works on masks from STL rasterization) |
+| `rle_intersect_dilated` | Used internally by `scan_layer` — exposed indirectly via `island scan`. Direct use would need raw mask files |
+| `rle_encode_labels` / `rle_decode_labels` | Same — internal to island pipeline |
+| `rasterize_layer` / `rasterize_layer_with_stats` | Internal to `render_layers_bounded` — exposed indirectly via `slice run` |
+| `render_layers_bounded` | Internal to engine — exposed via `slice run` |
+| `encode_grayscale_png` | Internal to raster pipeline |
+| `build_layer_index` | Internal to engine |

--- a/rust/dragonfruit-cli/src/io.rs
+++ b/rust/dragonfruit-cli/src/io.rs
@@ -1,0 +1,892 @@
+//! Shared CLI utilities for DragonFruit pipeline tools.
+//!
+//! Provides common I/O functions used across all CLI subcommands:
+//! STL loading, bounding box computation, JSON/RLE file read/write.
+
+use std::path::Path;
+
+use serde::{de::DeserializeOwned, Serialize};
+
+use dragonfruit_slicer_v3::geometry::{parse_triangles, Triangle};
+use dragonfruit_islands::model::{ComponentInfo, RleLabels, RleMask};
+
+// ---------------------------------------------------------------------------
+// STL Loading
+// ---------------------------------------------------------------------------
+
+/// Load a binary STL file and return flat `[x,y,z,...]` triangle vertex data.
+pub fn load_binary_stl(path: &Path) -> Result<Vec<f32>, String> {
+    let data = std::fs::read(path).map_err(|e| format!("Failed to read STL: {e}"))?;
+    if data.len() < 84 {
+        return Err("STL file too small (< 84 bytes)".into());
+    }
+
+    let num_triangles = u32::from_le_bytes([data[80], data[81], data[82], data[83]]) as usize;
+    let expected = 84 + num_triangles * 50;
+    if data.len() < expected {
+        return Err(format!(
+            "STL file truncated: expected {} bytes for {} triangles, got {}",
+            expected, num_triangles, data.len()
+        ));
+    }
+
+    let mut flat = Vec::with_capacity(num_triangles * 9);
+    let mut offset = 84;
+    for _ in 0..num_triangles {
+        offset += 12; // skip normal
+        for _ in 0..3 {
+            flat.push(f32::from_le_bytes([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ]));
+            flat.push(f32::from_le_bytes([
+                data[offset + 4],
+                data[offset + 5],
+                data[offset + 6],
+                data[offset + 7],
+            ]));
+            flat.push(f32::from_le_bytes([
+                data[offset + 8],
+                data[offset + 9],
+                data[offset + 10],
+                data[offset + 11],
+            ]));
+            offset += 12;
+        }
+        offset += 2; // attribute byte count
+    }
+    Ok(flat)
+}
+
+/// Write raw f32 positions to a binary file (same format as `stage_mesh_binary`).
+pub fn write_positions_bin(path: &Path, flat: &[f32]) -> Result<(), String> {
+    let bytes: Vec<u8> = flat.iter().flat_map(|f| f.to_le_bytes()).collect();
+    std::fs::write(path, &bytes).map_err(|e| format!("Failed to write positions.bin: {e}"))
+}
+
+/// Read raw f32 positions from a binary file.
+pub fn read_positions_bin(path: &Path) -> Result<Vec<f32>, String> {
+    let bytes = std::fs::read(path).map_err(|e| format!("Failed to read positions.bin: {e}"))?;
+    if bytes.len() % 4 != 0 {
+        return Err(format!("positions.bin size {} not multiple of 4", bytes.len()));
+    }
+    let count = bytes.len() / 4;
+    let mut floats = vec![0.0f32; count];
+    #[cfg(target_endian = "little")]
+    {
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), floats.as_mut_ptr() as *mut u8, bytes.len());
+        }
+    }
+    #[cfg(not(target_endian = "little"))]
+    {
+        for (i, chunk) in bytes.chunks_exact(4).enumerate() {
+            floats[i] = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        }
+    }
+    Ok(floats)
+}
+
+// ---------------------------------------------------------------------------
+// Bounding Box
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct BBox {
+    pub min_x: f32,
+    pub max_x: f32,
+    pub min_y: f32,
+    pub max_y: f32,
+    pub min_z: f32,
+    pub max_z: f32,
+}
+
+pub fn compute_bbox(triangles: &[Triangle]) -> BBox {
+    let mut bb = BBox {
+        min_x: f32::MAX,
+        max_x: f32::MIN,
+        min_y: f32::MAX,
+        max_y: f32::MIN,
+        min_z: f32::MAX,
+        max_z: f32::MIN,
+    };
+    for tri in triangles {
+        for v in &[tri.a, tri.b, tri.c] {
+            bb.min_x = bb.min_x.min(v.x);
+            bb.max_x = bb.max_x.max(v.x);
+            bb.min_y = bb.min_y.min(v.y);
+            bb.max_y = bb.max_y.max(v.y);
+            bb.min_z = bb.min_z.min(v.z);
+            bb.max_z = bb.max_z.max(v.z);
+        }
+    }
+    bb
+}
+
+// ---------------------------------------------------------------------------
+// JSON I/O
+// ---------------------------------------------------------------------------
+
+pub fn write_json<T: Serialize>(path: &Path, data: &T) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(data).map_err(|e| format!("JSON serialize: {e}"))?;
+    std::fs::write(path, json).map_err(|e| format!("Failed to write {}: {e}", path.display()))
+}
+
+pub fn read_json<T: DeserializeOwned>(path: &Path) -> Result<T, String> {
+    let text =
+        std::fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {e}", path.display()))?;
+    serde_json::from_str(&text).map_err(|e| format!("JSON parse {}: {e}", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// RLE Mask JSON I/O
+// ---------------------------------------------------------------------------
+
+/// JSON-serializable representation of RleMask (flat i32 arrays per row).
+#[derive(Serialize, serde::Deserialize)]
+pub struct RleMaskJson {
+    pub width: i32,
+    pub height: i32,
+    pub rows: Vec<Vec<i32>>,
+}
+
+impl From<&RleMask> for RleMaskJson {
+    fn from(m: &RleMask) -> Self {
+        Self {
+            width: m.width,
+            height: m.height,
+            rows: m
+                .rows
+                .iter()
+                .map(|row| {
+                    row.iter()
+                        .flat_map(|r| vec![r.start, r.length])
+                        .collect()
+                })
+                .collect(),
+        }
+    }
+}
+
+impl RleMaskJson {
+    pub fn to_rle_mask(&self) -> RleMask {
+        use dragonfruit_islands::model::RleRun;
+        RleMask {
+            width: self.width,
+            height: self.height,
+            rows: self
+                .rows
+                .iter()
+                .map(|flat| {
+                    flat.chunks(2)
+                        .map(|c| RleRun {
+                            start: c[0],
+                            length: c.get(1).copied().unwrap_or(0),
+                        })
+                        .collect()
+                })
+                .collect(),
+        }
+    }
+}
+
+pub fn write_rle_mask_json(path: &Path, mask: &RleMask) -> Result<(), String> {
+    write_json(path, &RleMaskJson::from(mask))
+}
+
+pub fn read_rle_mask_json(path: &Path) -> Result<RleMask, String> {
+    let j: RleMaskJson = read_json(path)?;
+    Ok(j.to_rle_mask())
+}
+
+// ---------------------------------------------------------------------------
+// RLE Labels JSON I/O
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize, serde::Deserialize)]
+pub struct RleLabelsJson {
+    pub width: i32,
+    pub height: i32,
+    pub rows: Vec<Vec<i32>>,
+}
+
+impl From<&RleLabels> for RleLabelsJson {
+    fn from(l: &RleLabels) -> Self {
+        Self {
+            width: l.width,
+            height: l.height,
+            rows: l
+                .rows
+                .iter()
+                .map(|row| {
+                    row.iter()
+                        .flat_map(|r| vec![r.start, r.length, r.id])
+                        .collect()
+                })
+                .collect(),
+        }
+    }
+}
+
+impl RleLabelsJson {
+    pub fn to_rle_labels(&self) -> RleLabels {
+        use dragonfruit_islands::model::RleLabelRun;
+        RleLabels {
+            width: self.width,
+            height: self.height,
+            rows: self
+                .rows
+                .iter()
+                .map(|flat| {
+                    flat.chunks(3)
+                        .map(|c| RleLabelRun {
+                            start: c[0],
+                            length: c.get(1).copied().unwrap_or(0),
+                            id: c.get(2).copied().unwrap_or(0),
+                        })
+                        .collect()
+                })
+                .collect(),
+        }
+    }
+}
+
+pub fn write_rle_labels_json(path: &Path, labels: &RleLabels) -> Result<(), String> {
+    write_json(path, &RleLabelsJson::from(labels))
+}
+
+pub fn read_rle_labels_json(path: &Path) -> Result<RleLabels, String> {
+    let j: RleLabelsJson = read_json(path)?;
+    Ok(j.to_rle_labels())
+}
+
+// ---------------------------------------------------------------------------
+// STL Export
+// ---------------------------------------------------------------------------
+
+/// Write flat `[x,y,z,...]` f32 positions as a binary STL file.
+/// Positions must be a multiple of 9 (3 vertices × 3 coords per triangle).
+/// Computes face normals via cross product.
+pub fn write_binary_stl(path: &Path, positions: &[f32]) -> Result<(), String> {
+    if positions.len() % 9 != 0 {
+        return Err(format!(
+            "Position count {} is not a multiple of 9",
+            positions.len()
+        ));
+    }
+
+    let num_triangles = positions.len() / 9;
+    let mut buf = Vec::with_capacity(84 + num_triangles * 50);
+
+    // 80-byte header
+    buf.extend_from_slice(&[0u8; 80]);
+    buf.extend_from_slice(&(num_triangles as u32).to_le_bytes());
+
+    for t in 0..num_triangles {
+        let base = t * 9;
+        let ax = positions[base];
+        let ay = positions[base + 1];
+        let az = positions[base + 2];
+        let bx = positions[base + 3];
+        let by = positions[base + 4];
+        let bz = positions[base + 5];
+        let cx = positions[base + 6];
+        let cy = positions[base + 7];
+        let cz = positions[base + 8];
+
+        // Face normal via cross product
+        let ux = bx - ax;
+        let uy = by - ay;
+        let uz = bz - az;
+        let vx = cx - ax;
+        let vy = cy - ay;
+        let vz = cz - az;
+        let nx = uy * vz - uz * vy;
+        let ny = uz * vx - ux * vz;
+        let nz = ux * vy - uy * vx;
+        let len = (nx * nx + ny * ny + nz * nz).sqrt();
+        let (nx, ny, nz) = if len > 0.0 {
+            (nx / len, ny / len, nz / len)
+        } else {
+            (0.0, 0.0, 0.0)
+        };
+
+        buf.extend_from_slice(&nx.to_le_bytes());
+        buf.extend_from_slice(&ny.to_le_bytes());
+        buf.extend_from_slice(&nz.to_le_bytes());
+        for j in 0..9 {
+            buf.extend_from_slice(&positions[base + j].to_le_bytes());
+        }
+        buf.extend_from_slice(&0u16.to_le_bytes());
+    }
+
+    std::fs::write(path, &buf).map_err(|e| format!("Failed to write STL: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// 3MF Export
+// ---------------------------------------------------------------------------
+
+/// Write flat `[x,y,z,...]` f32 positions as a minimal 3MF file.
+/// 3MF is a ZIP containing XML model data. Produces a valid 3MF Core Spec archive.
+pub fn write_3mf(path: &Path, positions: &[f32]) -> Result<(), String> {
+    use std::io::Write;
+
+    if positions.len() % 9 != 0 {
+        return Err(format!(
+            "Position count {} is not a multiple of 9",
+            positions.len()
+        ));
+    }
+
+    let num_triangles = positions.len() / 9;
+
+    // Deduplicate vertices for compact 3MF (hash position to index)
+    let mut vertices: Vec<[f32; 3]> = Vec::new();
+    let mut vertex_map: std::collections::HashMap<[u32; 3], usize> = std::collections::HashMap::new();
+    let mut tri_indices: Vec<[usize; 3]> = Vec::with_capacity(num_triangles);
+
+    for t in 0..num_triangles {
+        let base = t * 9;
+        let mut face = [0usize; 3];
+        for v in 0..3 {
+            let vb = base + v * 3;
+            let key = [
+                positions[vb].to_bits(),
+                positions[vb + 1].to_bits(),
+                positions[vb + 2].to_bits(),
+            ];
+            let idx = vertex_map.entry(key).or_insert_with(|| {
+                let i = vertices.len();
+                vertices.push([positions[vb], positions[vb + 1], positions[vb + 2]]);
+                i
+            });
+            face[v] = *idx;
+        }
+        tri_indices.push(face);
+    }
+
+    // Build XML model
+    let mut model_xml = String::new();
+    model_xml.push_str(r#"<?xml version="1.0" encoding="UTF-8"?>
+<model unit="millimeter" xml:lang="en-US" xmlns="http://schemas.microsoft.com/3dmanufacturing/core/2015/02">
+  <resources>
+    <object id="1" type="model">
+      <mesh>
+        <vertices>
+"#);
+    for v in &vertices {
+        model_xml.push_str(&format!(
+            "          <vertex x=\"{}\" y=\"{}\" z=\"{}\" />\n",
+            v[0], v[1], v[2]
+        ));
+    }
+    model_xml.push_str("        </vertices>\n        <triangles>\n");
+    for tri in &tri_indices {
+        model_xml.push_str(&format!(
+            "          <triangle v1=\"{}\" v2=\"{}\" v3=\"{}\" />\n",
+            tri[0], tri[1], tri[2]
+        ));
+    }
+    model_xml.push_str(
+        r#"        </triangles>
+      </mesh>
+    </object>
+  </resources>
+  <build>
+    <item objectid="1" />
+  </build>
+</model>
+"#,
+    );
+
+    let content_types = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml" />
+  <Default Extension="model" ContentType="application/vnd.ms-package.3dmanufacturing-3dmodel+xml" />
+</Types>
+"#;
+
+    let rels = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Target="/3D/3dmodel.model" Id="rel0" Type="http://schemas.microsoft.com/3dmanufacturing/2013/01/3dmodel" />
+</Relationships>
+"#;
+
+    let file = std::fs::File::create(path)
+        .map_err(|e| format!("Failed to create 3MF: {e}"))?;
+    let mut zip = zip::ZipWriter::new(file);
+    let options = zip::write::FileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    zip.start_file("[Content_Types].xml", options)
+        .map_err(|e| format!("3MF zip: {e}"))?;
+    zip.write_all(content_types.as_bytes())
+        .map_err(|e| format!("3MF write: {e}"))?;
+
+    zip.start_file("_rels/.rels", options)
+        .map_err(|e| format!("3MF zip: {e}"))?;
+    zip.write_all(rels.as_bytes())
+        .map_err(|e| format!("3MF write: {e}"))?;
+
+    zip.start_file("3D/3dmodel.model", options)
+        .map_err(|e| format!("3MF zip: {e}"))?;
+    zip.write_all(model_xml.as_bytes())
+        .map_err(|e| format!("3MF write: {e}"))?;
+
+    zip.finish().map_err(|e| format!("3MF finalize: {e}"))?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Ensure directory exists
+// ---------------------------------------------------------------------------
+
+pub fn ensure_dir(path: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(path).map_err(|e| format!("Failed to create {}: {e}", path.display()))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dragonfruit_islands::model::{RleLabelRun, RleRun};
+    use proptest::prelude::*;
+    use std::path::PathBuf;
+
+    /// RAII temp directory — cleaned up on drop (even on panic).
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new() -> Self {
+            static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let dir = std::env::temp_dir().join(format!(
+                "df-cli-test-{}-{}", std::process::id(), n
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+            Self(dir)
+        }
+
+        fn path(&self) -> &Path { &self.0 }
+
+        fn join(&self, name: &str) -> PathBuf { self.0.join(name) }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    // -- Positions binary roundtrip --
+
+    #[test]
+    fn positions_bin_roundtrip_basic() {
+        let dir = TempDir::new();
+        let path = dir.join("pos.bin");
+        let data = vec![1.0f32, 2.0, 3.0, 4.5, -1.0, 0.0];
+        write_positions_bin(&path, &data).unwrap();
+        let back = read_positions_bin(&path).unwrap();
+        assert_eq!(data, back);
+    }
+
+    proptest! {
+        #[test]
+        fn positions_bin_roundtrip_prop(data in proptest::collection::vec(-1000.0f32..1000.0, 0..300)) {
+            let dir = TempDir::new();
+            let path = dir.join("pos_prop.bin");
+            write_positions_bin(&path, &data).unwrap();
+            let back = read_positions_bin(&path).unwrap();
+            prop_assert_eq!(data, back);
+        }
+    }
+
+    // -- RleMask JSON roundtrip --
+
+    #[test]
+    fn rle_mask_json_roundtrip_basic() {
+        let dir = TempDir::new();
+        let path = dir.join("mask.json");
+        let mask = RleMask {
+            width: 10,
+            height: 3,
+            rows: vec![
+                vec![RleRun { start: 2, length: 3 }, RleRun { start: 7, length: 2 }],
+                vec![],
+                vec![RleRun { start: 0, length: 10 }],
+            ],
+        };
+        write_rle_mask_json(&path, &mask).unwrap();
+        let back = read_rle_mask_json(&path).unwrap();
+        assert_eq!(mask, back);
+    }
+
+    // Strategy: generate valid RleMask with sorted non-overlapping runs
+    fn rle_mask_strategy() -> impl Strategy<Value = RleMask> {
+        (1..50i32, 1..50i32).prop_flat_map(|(w, h)| {
+            let w2 = w;
+            proptest::collection::vec(
+                proptest::collection::vec((0..w2 as usize, 1..w2.max(2) as usize), 0..5)
+                    .prop_map(move |raw_runs| {
+                        let mut runs = Vec::new();
+                        let mut x = 0i32;
+                        for (offset, len) in raw_runs {
+                            let start = x + offset as i32;
+                            if start >= w2 { break; }
+                            let length = (len as i32).min(w2 - start);
+                            if length <= 0 { continue; }
+                            runs.push(RleRun { start, length });
+                            x = start + length;
+                        }
+                        runs
+                    }),
+                h as usize,
+            )
+            .prop_map(move |rows| RleMask { width: w, height: h, rows })
+        })
+    }
+
+    proptest! {
+        #[test]
+        fn rle_mask_json_roundtrip_prop(mask in rle_mask_strategy()) {
+            let dir = TempDir::new();
+            let path = dir.join("mask_prop.json");
+            write_rle_mask_json(&path, &mask).unwrap();
+            let back = read_rle_mask_json(&path).unwrap();
+            prop_assert_eq!(mask, back);
+        }
+    }
+
+    // -- RleLabels JSON roundtrip --
+
+    #[test]
+    fn rle_labels_json_roundtrip_basic() {
+        let dir = TempDir::new();
+        let path = dir.join("labels.json");
+        let labels = RleLabels {
+            width: 10,
+            height: 2,
+            rows: vec![
+                vec![RleLabelRun { start: 1, length: 3, id: 1 }, RleLabelRun { start: 6, length: 2, id: 2 }],
+                vec![RleLabelRun { start: 0, length: 5, id: 1 }],
+            ],
+        };
+        write_rle_labels_json(&path, &labels).unwrap();
+        let back = read_rle_labels_json(&path).unwrap();
+        assert_eq!(labels, back);
+    }
+
+    proptest! {
+        #[test]
+        fn rle_labels_json_roundtrip_prop(
+            width in 1..50i32,
+            height in 1..20i32,
+            num_runs in 0..5usize,
+        ) {
+            let rows: Vec<Vec<RleLabelRun>> = (0..height).map(|_| {
+                let mut runs = Vec::new();
+                let mut x = 0i32;
+                for id in 1..=num_runs as i32 {
+                    let start = x + 1;
+                    if start >= width { break; }
+                    let length = 1.min(width - start);
+                    runs.push(RleLabelRun { start, length, id });
+                    x = start + length;
+                }
+                runs
+            }).collect();
+            let labels = RleLabels { width, height, rows };
+
+            let dir = TempDir::new();
+            let path = dir.join("labels_prop.json");
+            write_rle_labels_json(&path, &labels).unwrap();
+            let back = read_rle_labels_json(&path).unwrap();
+            prop_assert_eq!(labels, back);
+        }
+    }
+
+    // -- BBox computation --
+
+    #[test]
+    fn bbox_single_triangle() {
+        let flat = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+        let tris = parse_triangles(&flat);
+        let bb = compute_bbox(&tris);
+        assert_eq!(bb.min_x, 0.0);
+        assert_eq!(bb.max_x, 1.0);
+        assert_eq!(bb.min_y, 0.0);
+        assert_eq!(bb.max_y, 1.0);
+        assert_eq!(bb.min_z, 0.0);
+        assert_eq!(bb.max_z, 0.0);
+    }
+
+    // -- JSON generic roundtrip --
+
+    #[test]
+    fn json_roundtrip_generic() {
+        let dir = TempDir::new();
+        let path = dir.join("test.json");
+        let data = serde_json::json!({"a": 1, "b": [2, 3], "c": "hello"});
+        write_json(&path, &data).unwrap();
+        let back: serde_json::Value = read_json(&path).unwrap();
+        assert_eq!(data, back);
+    }
+
+    // -- Error handling --
+
+    #[test]
+    fn read_nonexistent_file_returns_error() {
+        let result = read_positions_bin(Path::new("/nonexistent/positions.bin"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_stl_too_small_returns_error() {
+        let dir = TempDir::new();
+        let path = dir.join("tiny.stl");
+        std::fs::write(&path, b"too small").unwrap();
+        let result = load_binary_stl(&path);
+        assert!(result.is_err());
+    }
+
+    // -- STL write roundtrip --
+
+    #[test]
+    fn stl_write_roundtrip() {
+        let positions = vec![
+            0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
+        ];
+        let dir = TempDir::new();
+        let path = dir.join("rt.stl");
+        write_binary_stl(&path, &positions).unwrap();
+        let back = load_binary_stl(&path).unwrap();
+        assert_eq!(positions.len(), back.len());
+        for (a, b) in positions.iter().zip(back.iter()) {
+            assert!((a - b).abs() < 1e-6, "{} != {}", a, b);
+        }
+    }
+
+    #[test]
+    fn stl_write_rejects_non_multiple_of_9() {
+        let dir = TempDir::new();
+        let result = write_binary_stl(&dir.join("bad.stl"), &[1.0, 2.0]);
+        assert!(result.is_err());
+    }
+
+    proptest! {
+        #[test]
+        fn stl_roundtrip_prop(positions in proptest::collection::vec(-100.0f32..100.0, 0..90)
+            .prop_map(|mut v| { v.truncate(v.len() / 9 * 9); v }))
+        {
+            if positions.is_empty() { return Ok(()); }
+            let dir = TempDir::new();
+            let path = dir.join("stl_prop.stl");
+            write_binary_stl(&path, &positions).unwrap();
+            let back = load_binary_stl(&path).unwrap();
+            prop_assert_eq!(positions.len(), back.len());
+            for (a, b) in positions.iter().zip(back.iter()) {
+                prop_assert!((a - b).abs() < 1e-5, "{} != {}", a, b);
+            }
+        }
+    }
+
+    // -- 3MF write --
+
+    #[test]
+    fn write_3mf_produces_valid_zip() {
+        let positions = vec![0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+        let dir = TempDir::new();
+        let path = dir.join("test.3mf");
+        write_3mf(&path, &positions).unwrap();
+        let file = std::fs::File::open(&path).unwrap();
+        let mut zip = zip::ZipArchive::new(file).unwrap();
+        assert!(zip.by_name("[Content_Types].xml").is_ok());
+        assert!(zip.by_name("_rels/.rels").is_ok());
+        assert!(zip.by_name("3D/3dmodel.model").is_ok());
+    }
+
+    #[test]
+    fn write_3mf_contains_correct_counts() {
+        let positions = vec![
+            0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
+        ];
+        let dir = TempDir::new();
+        let path = dir.join("test2.3mf");
+        write_3mf(&path, &positions).unwrap();
+        let file = std::fs::File::open(&path).unwrap();
+        let mut zip = zip::ZipArchive::new(file).unwrap();
+        let mut model = String::new();
+        std::io::Read::read_to_string(&mut zip.by_name("3D/3dmodel.model").unwrap(), &mut model).unwrap();
+        // 2 triangles
+        assert_eq!(model.matches("<triangle ").count(), 2);
+        // vertices (deduplicated: 6 input verts but some may share coords)
+        assert!(model.matches("<vertex ").count() >= 4);
+    }
+
+    #[test]
+    fn write_3mf_rejects_non_multiple_of_9() {
+        let dir = TempDir::new();
+        let result = write_3mf(&dir.join("bad.3mf"), &[1.0, 2.0]);
+        assert!(result.is_err());
+    }
+
+    proptest! {
+        #[test]
+        fn write_3mf_valid_zip_prop(positions in proptest::collection::vec(-100.0f32..100.0, 0..90)
+            .prop_map(|mut v| { v.truncate(v.len() / 9 * 9); v }))
+        {
+            if positions.is_empty() { return Ok(()); }
+            let dir = TempDir::new();
+            let path = dir.join("3mf_prop.3mf");
+            write_3mf(&path, &positions).unwrap();
+            let file = std::fs::File::open(&path).unwrap();
+            let zip = zip::ZipArchive::new(file).unwrap();
+            prop_assert!(zip.len() >= 3);
+        }
+    }
+
+    // -- Inspect archive (ZIP) --
+
+    #[test]
+    fn inspect_nanodlp_archive() {
+        // Create a fake nanodlp archive with 3 PNGs + manifest
+        let dir = TempDir::new();
+        let path = dir.join("test.nanodlp");
+
+        let file = std::fs::File::create(&path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let opts = zip::write::FileOptions::default();
+
+        // 3 layer PNGs
+        for i in 1..=3 {
+            zip.start_file(format!("{}.png", i), opts).unwrap();
+            std::io::Write::write_all(&mut zip, b"fake png data").unwrap();
+        }
+
+        // manifest
+        zip.start_file("manifest.json", opts).unwrap();
+        std::io::Write::write_all(
+            &mut zip,
+            br#"{"layers":3,"format":"nanodlp"}"#,
+        ).unwrap();
+
+        zip.finish().unwrap();
+
+        // Now inspect
+        let file = std::fs::File::open(&path).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+
+        assert_eq!(archive.len(), 4); // 3 PNGs + manifest
+
+        let mut layer_count = 0u32;
+        for i in 0..archive.len() {
+            if let Ok(entry) = archive.by_index(i) {
+                if entry.name().ends_with(".png") {
+                    layer_count += 1;
+                }
+            }
+        }
+        assert_eq!(layer_count, 3);
+    }
+
+    // -- 3MF inspect --
+
+    #[test]
+    fn inspect_3mf_archive() {
+        let positions = vec![0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+        let dir = TempDir::new();
+        let path = dir.join("test.3mf");
+        write_3mf(&path, &positions).unwrap();
+
+        let file = std::fs::File::open(&path).unwrap();
+        let archive = zip::ZipArchive::new(file).unwrap();
+        assert!(archive.len() >= 3);
+    }
+
+    // -- STL → 3MF → inspect roundtrip --
+
+    #[test]
+    fn stl_to_3mf_inspect_roundtrip() {
+        let positions = vec![
+            0.0f32, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0,
+        ];
+        let dir = TempDir::new();
+
+        // Write STL
+        let stl_path = dir.join("test.stl");
+        write_binary_stl(&stl_path, &positions).unwrap();
+
+        // Read STL back
+        let back = load_binary_stl(&stl_path).unwrap();
+        assert_eq!(positions.len(), back.len());
+
+        // Write as 3MF
+        let mf_path = dir.join("test.3mf");
+        write_3mf(&mf_path, &back).unwrap();
+
+        // Inspect 3MF
+        let file = std::fs::File::open(&mf_path).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+
+        // Should have model with 2 triangles
+        let mut model = String::new();
+        std::io::Read::read_to_string(
+            &mut archive.by_name("3D/3dmodel.model").unwrap(),
+            &mut model,
+        ).unwrap();
+        assert_eq!(model.matches("<triangle ").count(), 2);
+        drop(archive); // release file handle before TempDir cleanup
+    }
+
+    // -- Format version passthrough --
+
+    #[test]
+    fn slice_job_format_version_field() {
+        // Verify SliceJobV3 accepts format_version
+        use dragonfruit_slicer_v3::types::SliceJobV3;
+
+        let job_json = r#"{
+            "output_format": ".ctb",
+            "source_width_px": 100, "source_height_px": 100,
+            "width_px": 100, "height_px": 100,
+            "build_width_mm": 50, "build_depth_mm": 50,
+            "layer_height_mm": 0.05, "total_layers": 10,
+            "triangles_xyz": [],
+            "metadata_json": "{}",
+            "format_version": "v5enc",
+            "minimum_aa_alpha_percent": 5.0
+        }"#;
+
+        let job: SliceJobV3 = serde_json::from_str(job_json).unwrap();
+        assert_eq!(job.format_version, Some("v5enc".to_string()));
+        assert!((job.minimum_aa_alpha_percent - 5.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn slice_job_format_version_defaults_to_none() {
+        use dragonfruit_slicer_v3::types::SliceJobV3;
+
+        let job_json = r#"{
+            "output_format": ".nanodlp",
+            "source_width_px": 100, "source_height_px": 100,
+            "width_px": 100, "height_px": 100,
+            "build_width_mm": 50, "build_depth_mm": 50,
+            "layer_height_mm": 0.05, "total_layers": 10,
+            "triangles_xyz": [],
+            "metadata_json": "{}"
+        }"#;
+
+        let job: SliceJobV3 = serde_json::from_str(job_json).unwrap();
+        assert_eq!(job.format_version, None);
+        assert!(job.minimum_aa_alpha_percent >= 0.0);
+    }
+}

--- a/rust/dragonfruit-cli/src/lib.rs
+++ b/rust/dragonfruit-cli/src/lib.rs
@@ -1,0 +1,3 @@
+//! DragonFruit CLI — I/O utilities for pipeline tools.
+
+pub mod io;

--- a/rust/dragonfruit-cli/src/main.rs
+++ b/rust/dragonfruit-cli/src/main.rs
@@ -1,0 +1,1668 @@
+//! DragonFruit CLI — every pipeline stage observable.
+//!
+//! Wraps existing Rust backend functions as CLI subcommands with JSON I/O.
+//! Only exposes operations that have real Rust implementations — scene/support
+//! management lives in TypeScript and is not duplicated here.
+//!
+//! Usage:
+//!   dragonfruit-cli mesh read-stl model.stl -o /tmp/s1
+//!   dragonfruit-cli mesh info /tmp/s1 --json
+//!   dragonfruit-cli mesh export-stl -i /tmp/s1 -o model_out.stl
+//!   dragonfruit-cli island full model.stl -o /tmp/all --json
+//!   dragonfruit-cli slice run model.stl -o /tmp/out.nanodlp --json
+//!   dragonfruit-cli print read-layer /tmp/out.nanodlp --layer 1 -o /tmp/layer1.png
+//!   dragonfruit-cli info
+
+use clap::{Parser, Subcommand};
+use std::io::Read as IoRead;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use dragonfruit_cli::io::*;
+use dragonfruit_slicer_v3::geometry::parse_triangles;
+use dragonfruit_islands::model::*;
+use dragonfruit_islands::rasterize::rasterize_for_island_scan;
+use dragonfruit_islands::rle;
+use dragonfruit_islands::scan::scan_layer;
+use dragonfruit_islands::tracker::IslandTracker;
+
+#[derive(Parser)]
+#[command(name = "dragonfruit-cli", about = "DragonFruit pipeline CLI — every stage observable")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Mesh I/O (STL read/write, bounding box, stats)
+    Mesh {
+        #[command(subcommand)]
+        command: MeshCommands,
+    },
+
+    /// Island detection pipeline
+    Island {
+        #[command(subcommand)]
+        command: IslandCommands,
+    },
+
+    /// Slicing pipeline (wraps engine::slice_with_progress_v3_to_path)
+    Slice {
+        #[command(subcommand)]
+        command: SliceCommands,
+    },
+
+    /// Print file operations (ZIP archive read/write, temp cleanup)
+    Print {
+        #[command(subcommand)]
+        command: PrintCommands,
+    },
+
+    /// Synthetic slicer benchmark (wraps benchmark::run_benchmark_v3)
+    Benchmark {
+        #[arg(long, default_value = "200")]
+        layers: u32,
+        #[arg(long, default_value = "1920")]
+        width_px: u32,
+        #[arg(long, default_value = "1080")]
+        height_px: u32,
+        #[arg(long, default_value = "218.88")]
+        build_width_mm: f32,
+        #[arg(long, default_value = "122.904")]
+        build_depth_mm: f32,
+        #[arg(long, default_value = "0.05")]
+        layer_height: f32,
+        #[arg(long, default_value = "400")]
+        cube_count: u32,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Print defaults and supported formats
+    Info,
+}
+
+// ===========================================================================
+// Mesh subcommands — wraps cli.rs STL I/O + geometry::parse_triangles
+// ===========================================================================
+
+#[derive(Subcommand)]
+enum MeshCommands {
+    /// Parse binary STL to positions.bin + mesh-info.json
+    ReadStl {
+        /// Input STL file
+        input: PathBuf,
+        /// Output directory
+        #[arg(short, long)]
+        output: PathBuf,
+    },
+
+    /// Print mesh statistics (triangles, bbox, volume)
+    Info {
+        /// Input directory (from read-stl) or STL file
+        input: PathBuf,
+        /// Output as JSON to stdout
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Export positions.bin back to binary STL
+    ExportStl {
+        /// Input directory (with positions.bin)
+        #[arg(short, long)]
+        input: PathBuf,
+        /// Output STL file path
+        #[arg(short, long)]
+        output: PathBuf,
+    },
+
+    /// Export positions.bin to 3MF
+    #[command(name = "export-3mf")]
+    Export3mf {
+        /// Input directory (with positions.bin)
+        #[arg(short, long)]
+        input: PathBuf,
+        /// Output 3MF file path
+        #[arg(short, long)]
+        output: PathBuf,
+    },
+}
+
+// ===========================================================================
+// Island subcommands — wraps islands::rasterize, scan, tracker, pipeline
+// ===========================================================================
+
+#[derive(Subcommand)]
+enum IslandCommands {
+    /// Rasterize triangles to per-layer RLE masks
+    Rasterize {
+        #[arg(short, long)]
+        input: PathBuf,
+        #[arg(short, long)]
+        output: PathBuf,
+        #[arg(long, default_value = "0.1")]
+        px_mm: f64,
+        #[arg(long, default_value = "0.05")]
+        layer_height: f64,
+    },
+
+    /// Per-layer candidate detection (support subtraction + CCL)
+    Scan {
+        #[arg(short, long)]
+        input: PathBuf,
+        #[arg(short, long)]
+        output: PathBuf,
+        #[arg(long, default_value = "0.6")]
+        buffer: f64,
+        #[arg(long, default_value = "4")]
+        connectivity: u8,
+    },
+
+    /// Cross-layer island tracking
+    Track {
+        #[arg(short, long)]
+        input: PathBuf,
+        #[arg(short, long)]
+        output: PathBuf,
+        #[arg(long, default_value = "4")]
+        overlap: i32,
+        #[arg(long, default_value = "1")]
+        neighborhood: i32,
+    },
+
+    /// Volume calculation + filtering → result.json
+    Analyze {
+        #[arg(short, long)]
+        input: PathBuf,
+        #[arg(short, long)]
+        output: PathBuf,
+        #[arg(long, default_value = "0.0")]
+        min_area: f64,
+    },
+
+    /// Full pipeline: STL → islands (all stages)
+    Full {
+        input: PathBuf,
+        #[arg(short, long)]
+        output: PathBuf,
+        #[arg(long, default_value = "0.1")]
+        px_mm: f64,
+        #[arg(long, default_value = "0.05")]
+        layer_height: f64,
+        #[arg(long, default_value = "0.6")]
+        buffer: f64,
+        #[arg(long, default_value = "4")]
+        connectivity: u8,
+        #[arg(long, default_value = "4")]
+        overlap: i32,
+        #[arg(long, default_value = "1")]
+        neighborhood: i32,
+        #[arg(long, default_value = "0.0")]
+        min_area: f64,
+        #[arg(long)]
+        params_json: Option<PathBuf>,
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Benchmark each pipeline stage with timing breakdown
+    Bench {
+        input: PathBuf,
+        #[arg(long, default_value = "0.1")]
+        px_mm: f64,
+        #[arg(long, default_value = "0.05")]
+        layer_height: f64,
+        #[arg(long, default_value = "0.6")]
+        buffer: f64,
+        #[arg(long, default_value = "4")]
+        connectivity: u8,
+        #[arg(long, default_value = "4")]
+        overlap: i32,
+        #[arg(long, default_value = "1")]
+        neighborhood: i32,
+        #[arg(long, default_value = "0.0")]
+        min_area: f64,
+        #[arg(long, default_value = "3")]
+        iterations: u32,
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Batch island scan on multiple STL files
+    Batch {
+        /// Input STL files
+        inputs: Vec<PathBuf>,
+        /// Output directory
+        #[arg(short, long)]
+        output: PathBuf,
+        #[arg(long, default_value = "0.1")]
+        px_mm: f64,
+        #[arg(long, default_value = "0.05")]
+        layer_height: f64,
+        #[arg(long, default_value = "0.6")]
+        buffer: f64,
+        #[arg(long, default_value = "4")]
+        connectivity: u8,
+        #[arg(long, default_value = "4")]
+        overlap: i32,
+        #[arg(long, default_value = "1")]
+        neighborhood: i32,
+        #[arg(long, default_value = "0.0")]
+        min_area: f64,
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Connected component labeling on an RLE mask (wraps rle_label_components)
+    #[command(name = "rle-label")]
+    RleLabel {
+        /// Input RLE mask JSON file
+        #[arg(short, long)]
+        input: PathBuf,
+        /// Output directory (components.json + labels.rle.json)
+        #[arg(short, long)]
+        output: PathBuf,
+        #[arg(long, default_value = "4")]
+        connectivity: u8,
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Subtract one RLE mask from another (wraps rle_subtract)
+    #[command(name = "rle-subtract")]
+    RleSubtract {
+        /// Mask A (minuend)
+        #[arg(short = 'a', long)]
+        mask_a: PathBuf,
+        /// Mask B (subtrahend)
+        #[arg(short = 'b', long)]
+        mask_b: PathBuf,
+        /// Output mask JSON
+        #[arg(short, long)]
+        output: PathBuf,
+    },
+}
+
+// ===========================================================================
+// Slice subcommands — wraps engine::slice_with_progress_v3_to_path
+// ===========================================================================
+
+#[derive(Subcommand)]
+enum SliceCommands {
+    /// Slice STL or positions.bin → rasterize → encode → archive file
+    Run {
+        /// Input file (STL or raw positions.bin from mesh read-stl / scene merge)
+        input: PathBuf,
+        /// Output archive path (extension determines format)
+        #[arg(short, long)]
+        output: PathBuf,
+        #[arg(long, default_value = "0.05")]
+        layer_height: f32,
+        #[arg(long, default_value = "218.0")]
+        build_width_mm: f32,
+        #[arg(long, default_value = "122.0")]
+        build_depth_mm: f32,
+        /// Source raster width in pixels
+        #[arg(long, default_value = "11400")]
+        source_width_px: u32,
+        /// Source raster height in pixels
+        #[arg(long, default_value = "6400")]
+        source_height_px: u32,
+        /// PNG compression strategy (fastest, balanced, smallest, optimal)
+        #[arg(long, default_value = "balanced")]
+        png_compression: String,
+        /// Anti-aliasing level (Off, 2x, 4x, 8x)
+        #[arg(long, default_value = "Off")]
+        anti_aliasing: String,
+        /// Mirror X
+        #[arg(long)]
+        mirror_x: bool,
+        /// Mirror Y
+        #[arg(long)]
+        mirror_y: bool,
+        /// Format version (e.g. v5enc for encrypted CTB)
+        #[arg(long)]
+        format_version: Option<String>,
+        /// Minimum AA alpha threshold (percent, 0-100)
+        #[arg(long, default_value = "0.0")]
+        min_aa_alpha: f32,
+        /// Metadata JSON string
+        #[arg(long, default_value = "{}")]
+        metadata_json: String,
+        /// Output as JSON to stdout
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// List supported output formats with capabilities
+    Formats,
+
+    /// Extract single layer PNG from archive (same as Tauri read_print_layer_png)
+    PreviewLayer {
+        /// Input archive file
+        input: PathBuf,
+        /// Layer number (1-based, matching Tauri convention)
+        #[arg(short, long)]
+        layer: u32,
+        /// Output PNG path
+        #[arg(short, long)]
+        output: PathBuf,
+    },
+
+    /// List supported output formats + defaults
+    Info,
+}
+
+// ===========================================================================
+// Print subcommands — wraps Tauri print file ops
+// ===========================================================================
+
+#[derive(Subcommand)]
+enum PrintCommands {
+    /// Copy archive to final output path (equivalent to save_print_file_from_path)
+    Save {
+        /// Source archive file
+        input: PathBuf,
+        /// Destination path
+        #[arg(short, long)]
+        output: PathBuf,
+    },
+
+    /// Read raw bytes from print file (equivalent to read_print_file_bytes)
+    ReadBytes {
+        input: PathBuf,
+        #[arg(short, long)]
+        output: PathBuf,
+    },
+
+    /// Read a single layer PNG from archive (equivalent to read_print_layer_png)
+    ReadLayer {
+        input: PathBuf,
+        /// Layer number (1-based)
+        #[arg(short, long)]
+        layer: u32,
+        #[arg(short, long)]
+        output: PathBuf,
+    },
+
+    /// Inspect archive contents and metadata
+    Inspect {
+        input: PathBuf,
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Clean up temp files (equivalent to cleanup_*_print_temp_files)
+    Cleanup {
+        /// Delete a specific dragonfruit temp artifact (equivalent to delete_print_temp_file)
+        #[arg(long)]
+        path: Option<PathBuf>,
+        /// Remove all dragonfruit temp artifacts (equivalent to cleanup_all_print_temp_files)
+        #[arg(long)]
+        all: bool,
+        /// Remove stale artifacts older than N seconds (equivalent to cleanup_stale_print_temp_files)
+        #[arg(long)]
+        max_age_seconds: Option<u64>,
+    },
+}
+
+// ===========================================================================
+// Mesh command implementations — wraps cli.rs
+// ===========================================================================
+
+fn cmd_mesh_read_stl(input: &PathBuf, output: &PathBuf) -> Result<(), String> {
+    ensure_dir(output)?;
+
+    let flat = load_binary_stl(input)?;
+    let triangles = parse_triangles(&flat);
+    let bbox = compute_bbox(&triangles);
+
+    write_positions_bin(&output.join("positions.bin"), &flat)?;
+
+    let info = serde_json::json!({
+        "triangles": triangles.len(),
+        "bbox": bbox,
+        "file_size_bytes": std::fs::metadata(input).map(|m| m.len()).unwrap_or(0),
+    });
+    write_json(&output.join("mesh-info.json"), &info)?;
+
+    eprintln!("read-stl: {} triangles, bbox ({:.2},{:.2},{:.2})-({:.2},{:.2},{:.2})",
+        triangles.len(), bbox.min_x, bbox.min_y, bbox.min_z, bbox.max_x, bbox.max_y, bbox.max_z);
+    Ok(())
+}
+
+fn cmd_mesh_info(input: &PathBuf, json_output: bool) -> Result<(), String> {
+    let (flat, source) = if input.is_dir() {
+        (read_positions_bin(&input.join("positions.bin"))?, "directory")
+    } else {
+        (load_binary_stl(input)?, "stl")
+    };
+
+    let triangles = parse_triangles(&flat);
+    let bbox = compute_bbox(&triangles);
+
+    // Volume via signed-volume divergence theorem (same geometry crate)
+    let mut volume = 0.0f64;
+    for tri in &triangles {
+        let v321 = tri.c.x as f64 * tri.b.y as f64 * tri.a.z as f64;
+        let v231 = tri.b.x as f64 * tri.c.y as f64 * tri.a.z as f64;
+        let v312 = tri.c.x as f64 * tri.a.y as f64 * tri.b.z as f64;
+        let v132 = tri.a.x as f64 * tri.c.y as f64 * tri.b.z as f64;
+        let v213 = tri.b.x as f64 * tri.a.y as f64 * tri.c.z as f64;
+        let v123 = tri.a.x as f64 * tri.b.y as f64 * tri.c.z as f64;
+        volume += (-v321 + v231 + v312 - v132 - v213 + v123) / 6.0;
+    }
+
+    let info = serde_json::json!({
+        "source": source,
+        "triangles": triangles.len(),
+        "vertices": triangles.len() * 3,
+        "bbox": {
+            "min": [bbox.min_x, bbox.min_y, bbox.min_z],
+            "max": [bbox.max_x, bbox.max_y, bbox.max_z],
+            "size": [bbox.max_x - bbox.min_x, bbox.max_y - bbox.min_y, bbox.max_z - bbox.min_z],
+        },
+        "volume_mm3": volume.abs(),
+    });
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&info).unwrap());
+    } else {
+        eprintln!("mesh info ({}):", source);
+        eprintln!("  triangles: {}", triangles.len());
+        eprintln!("  bbox: ({:.2},{:.2},{:.2}) to ({:.2},{:.2},{:.2})",
+            bbox.min_x, bbox.min_y, bbox.min_z, bbox.max_x, bbox.max_y, bbox.max_z);
+        eprintln!("  size: {:.2} x {:.2} x {:.2} mm",
+            bbox.max_x - bbox.min_x, bbox.max_y - bbox.min_y, bbox.max_z - bbox.min_z);
+        eprintln!("  volume: {:.2} mm^3", volume.abs());
+    }
+    Ok(())
+}
+
+fn cmd_mesh_export_stl(input: &PathBuf, output: &PathBuf) -> Result<(), String> {
+    let positions = read_positions_bin(&input.join("positions.bin"))?;
+    write_binary_stl(output, &positions)?;
+    eprintln!("export-stl: {} triangles -> {}", positions.len() / 9, output.display());
+    Ok(())
+}
+
+fn cmd_mesh_export_3mf(input: &PathBuf, output: &PathBuf) -> Result<(), String> {
+    let positions = read_positions_bin(&input.join("positions.bin"))?;
+    write_3mf(output, &positions)?;
+    eprintln!("export-3mf: {} triangles -> {}", positions.len() / 9, output.display());
+    Ok(())
+}
+
+// ===========================================================================
+// Island command implementations — wraps islands::* (unchanged from original)
+// ===========================================================================
+
+fn cmd_rasterize(input: &PathBuf, output: &PathBuf, px_mm: f64, layer_height: f64) -> Result<(), String> {
+    ensure_dir(output)?;
+    ensure_dir(&output.join("layers"))?;
+
+    let flat = read_positions_bin(&input.join("positions.bin"))?;
+    let info: serde_json::Value = read_json(&input.join("mesh-info.json"))?;
+    let bbox: BBox = serde_json::from_value(info["bbox"].clone())
+        .map_err(|e| format!("Parse bbox: {e}"))?;
+
+    let triangles = parse_triangles(&flat);
+
+    let t0 = Instant::now();
+    let (masks, grid_width, grid_height, num_layers, origin_x, origin_z) =
+        rasterize_for_island_scan(
+            &triangles,
+            bbox.min_x as f64, bbox.max_x as f64,
+            bbox.min_y as f64, bbox.max_y as f64,
+            bbox.min_z as f64, bbox.max_z as f64,
+            px_mm, layer_height,
+        );
+    let raster_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+    let params = serde_json::json!({
+        "px_mm": px_mm,
+        "layer_height_mm": layer_height,
+        "grid_width": grid_width,
+        "grid_height": grid_height,
+        "origin_x": origin_x,
+        "origin_z": origin_z,
+        "num_layers": num_layers,
+        "bbox": bbox,
+    });
+    write_json(&output.join("params.json"), &params)?;
+
+    let total_px: u64 = masks.iter().map(|m| m.pixel_count()).sum();
+    for (i, mask) in masks.iter().enumerate() {
+        write_rle_mask_json(&output.join("layers").join(format!("{:03}.mask.rle.json", i)), mask)?;
+    }
+
+    let summary = serde_json::json!({
+        "layers": num_layers,
+        "grid": { "width": grid_width, "height": grid_height },
+        "total_solid_px": total_px,
+        "raster_ms": raster_ms,
+    });
+    write_json(&output.join("raster-summary.json"), &summary)?;
+
+    eprintln!("rasterize: {}x{}, {} layers, {} solid px, {:.0}ms",
+        grid_width, grid_height, num_layers, total_px, raster_ms);
+    Ok(())
+}
+
+fn cmd_scan(input: &PathBuf, output: &PathBuf, buffer_mm: f64, connectivity: u8) -> Result<(), String> {
+    ensure_dir(&output.join("layers"))?;
+
+    let params: serde_json::Value = read_json(&input.join("params.json"))?;
+    let px_mm = params["px_mm"].as_f64().unwrap();
+    let num_layers = params["num_layers"].as_u64().unwrap() as usize;
+    let conn = if connectivity == 8 { Connectivity::Eight } else { Connectivity::Four };
+
+    let t0 = Instant::now();
+    let mut prev_mask: Option<RleMask> = None;
+    let mut total_candidates = 0u64;
+
+    for l in 0..num_layers {
+        let mask = read_rle_mask_json(&input.join("layers").join(format!("{:03}.mask.rle.json", l)))?;
+        let result = scan_layer(&mask, prev_mask.as_ref(), px_mm, buffer_mm, conn);
+
+        write_rle_labels_json(
+            &output.join("layers").join(format!("{:03}.candidates.rle.json", l)),
+            &result.labels,
+        )?;
+        write_json(
+            &output.join("layers").join(format!("{:03}.components.json", l)),
+            &result.components,
+        )?;
+
+        total_candidates += result.components.iter().map(|c| c.area_px as u64).sum::<u64>();
+        prev_mask = Some(mask);
+    }
+    let scan_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+    let mut out_params: serde_json::Value = read_json(&input.join("params.json"))?;
+    out_params["support_buffer_mm"] = serde_json::json!(buffer_mm);
+    out_params["connectivity"] = serde_json::json!(connectivity);
+    if output != input {
+        for l in 0..num_layers {
+            let src = input.join("layers").join(format!("{:03}.mask.rle.json", l));
+            let dst = output.join("layers").join(format!("{:03}.mask.rle.json", l));
+            if src != dst { let _ = std::fs::copy(&src, &dst); }
+        }
+    }
+    write_json(&output.join("params.json"), &out_params)?;
+
+    let summary = serde_json::json!({
+        "layers": num_layers,
+        "total_candidate_px": total_candidates,
+        "scan_ms": scan_ms,
+    });
+    write_json(&output.join("scan-summary.json"), &summary)?;
+
+    eprintln!("scan: {} layers, {} candidate px, {:.0}ms", num_layers, total_candidates, scan_ms);
+    Ok(())
+}
+
+fn cmd_track(input: &PathBuf, output: &PathBuf, overlap: i32, neighborhood: i32) -> Result<(), String> {
+    ensure_dir(&output.join("layers"))?;
+    ensure_dir(&output.join("tracker-state"))?;
+
+    let params: serde_json::Value = read_json(&input.join("params.json"))?;
+    let px_mm = params["px_mm"].as_f64().unwrap();
+    let num_layers = params["num_layers"].as_u64().unwrap() as usize;
+
+    let mut tracker = IslandTracker::new(px_mm, overlap, neighborhood);
+    let mut island_labels_all: Vec<RleLabels> = Vec::new();
+
+    let t0 = Instant::now();
+    for l in 0..num_layers {
+        let mask = read_rle_mask_json(&input.join("layers").join(format!("{:03}.mask.rle.json", l)))?;
+        let candidates = read_rle_labels_json(&input.join("layers").join(format!("{:03}.candidates.rle.json", l)))?;
+        let components: Vec<ComponentInfo> = read_json(&input.join("layers").join(format!("{:03}.components.json", l)))?;
+
+        let prev_labels = if l > 0 { Some(&island_labels_all[l - 1]) } else { None };
+        let island_labels = tracker.process_layer(l as u32, &candidates, &components, prev_labels, &mask);
+
+        write_rle_labels_json(
+            &output.join("layers").join(format!("{:03}.island-labels.rle.json", l)),
+            &island_labels,
+        )?;
+        island_labels_all.push(island_labels);
+
+        let islands = tracker.get_islands();
+        write_json(&output.join("tracker-state").join(format!("{:03}.islands.json", l)), &islands)?;
+    }
+    let track_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+    tracker.finalize_islands(num_layers.saturating_sub(1) as u32);
+    let islands = tracker.get_islands();
+    write_json(&output.join("islands.json"), &islands)?;
+
+    let mut out_params: serde_json::Value = read_json(&input.join("params.json"))?;
+    out_params["min_overlap_px"] = serde_json::json!(overlap);
+    out_params["overlap_neighborhood_px"] = serde_json::json!(neighborhood);
+    write_json(&output.join("params.json"), &out_params)?;
+
+    let summary = serde_json::json!({
+        "islands_total": islands.len(),
+        "track_ms": track_ms,
+    });
+    write_json(&output.join("track-summary.json"), &summary)?;
+
+    eprintln!("track: {} islands, {:.0}ms", islands.len(), track_ms);
+    Ok(())
+}
+
+fn cmd_analyze(input: &PathBuf, output: &PathBuf, min_area: f64) -> Result<(), String> {
+    ensure_dir(output)?;
+
+    let params: serde_json::Value = read_json(&input.join("params.json"))?;
+    let layer_height = params["layer_height_mm"].as_f64().unwrap();
+
+    let mut islands: Vec<Island> = read_json(&input.join("islands.json"))?;
+
+    for island in &mut islands {
+        let vol: f64 = island.per_layer_area_mm2.values().map(|&a| a * layer_height).sum();
+        island.volume_mm3 = Some(vol);
+        let max_area = island.per_layer_area_mm2.values().copied().fold(0.0_f64, f64::max);
+        island.max_area_mm2 = Some(max_area);
+        island.compute_centroid();
+    }
+
+    let filtered: Vec<&Island> = islands.iter()
+        .filter(|i| !i.is_merged_placeholder && i.max_area_mm2.unwrap_or(0.0) >= min_area)
+        .collect();
+
+    let result = serde_json::json!({
+        "islands_total": islands.len(),
+        "islands_filtered": filtered.len(),
+        "min_area_mm2": min_area,
+        "islands": filtered,
+    });
+    write_json(&output.join("result.json"), &result)?;
+
+    eprintln!("analyze: {} total -> {} filtered (min_area={} mm2)", islands.len(), filtered.len(), min_area);
+    Ok(())
+}
+
+fn cmd_island_full(
+    input: &PathBuf, output: &PathBuf,
+    px_mm: f64, layer_height: f64, buffer: f64, connectivity: u8,
+    overlap: i32, neighborhood: i32, min_area: f64,
+    params_json: &Option<PathBuf>, json_output: bool,
+) -> Result<(), String> {
+    ensure_dir(output)?;
+    ensure_dir(&output.join("layers"))?;
+    ensure_dir(&output.join("tracker-state"))?;
+
+    let (px_mm, layer_height, buffer, connectivity, overlap, neighborhood, min_area) =
+        if let Some(pj) = params_json {
+            let p: serde_json::Value = read_json(pj)?;
+            (
+                p.get("px_mm").and_then(|v| v.as_f64()).unwrap_or(px_mm),
+                p.get("layer_height_mm").and_then(|v| v.as_f64()).unwrap_or(layer_height),
+                p.get("support_buffer_mm").and_then(|v| v.as_f64()).unwrap_or(buffer),
+                p.get("connectivity").and_then(|v| v.as_u64()).unwrap_or(connectivity as u64) as u8,
+                p.get("min_overlap_px").and_then(|v| v.as_i64()).unwrap_or(overlap as i64) as i32,
+                p.get("overlap_neighborhood_px").and_then(|v| v.as_i64()).unwrap_or(neighborhood as i64) as i32,
+                p.get("min_island_area_mm2").and_then(|v| v.as_f64()).unwrap_or(min_area),
+            )
+        } else {
+            (px_mm, layer_height, buffer, connectivity, overlap, neighborhood, min_area)
+        };
+
+    let flat = load_binary_stl(input)?;
+    let triangles = parse_triangles(&flat);
+    let bbox = compute_bbox(&triangles);
+
+    write_positions_bin(&output.join("positions.bin"), &flat)?;
+    write_json(&output.join("mesh-info.json"), &serde_json::json!({
+        "triangles": triangles.len(), "bbox": bbox,
+    }))?;
+
+    let t_raster = Instant::now();
+    let (masks, gw, gh, nl, ox, oz) = rasterize_for_island_scan(
+        &triangles,
+        bbox.min_x as f64, bbox.max_x as f64,
+        bbox.min_y as f64, bbox.max_y as f64,
+        bbox.min_z as f64, bbox.max_z as f64,
+        px_mm, layer_height,
+    );
+    let raster_ms = t_raster.elapsed().as_secs_f64() * 1000.0;
+    let total_px: u64 = masks.iter().map(|m| m.pixel_count()).sum();
+
+    for (i, mask) in masks.iter().enumerate() {
+        write_rle_mask_json(&output.join("layers").join(format!("{:03}.mask.rle.json", i)), mask)?;
+    }
+
+    let conn = if connectivity == 8 { Connectivity::Eight } else { Connectivity::Four };
+
+    let t_scan = Instant::now();
+    let mut layer_results = Vec::new();
+    for (i, mask) in masks.iter().enumerate() {
+        let prev = if i > 0 { Some(&masks[i - 1]) } else { None };
+        let r = scan_layer(mask, prev, px_mm, buffer, conn);
+        write_rle_labels_json(&output.join("layers").join(format!("{:03}.candidates.rle.json", i)), &r.labels)?;
+        write_json(&output.join("layers").join(format!("{:03}.components.json", i)), &r.components)?;
+        layer_results.push(r);
+    }
+
+    let mut tracker = IslandTracker::new(px_mm, overlap, neighborhood);
+    let mut island_labels_all: Vec<RleLabels> = Vec::new();
+
+    for (l, lr) in layer_results.iter().enumerate() {
+        let prev_labels = if l > 0 { Some(&island_labels_all[l - 1]) } else { None };
+        let island_labels = tracker.process_layer(l as u32, &lr.labels, &lr.components, prev_labels, &lr.solid_mask);
+        write_rle_labels_json(&output.join("layers").join(format!("{:03}.island-labels.rle.json", l)), &island_labels)?;
+        let snap = tracker.get_islands();
+        write_json(&output.join("tracker-state").join(format!("{:03}.islands.json", l)), &snap)?;
+        island_labels_all.push(island_labels);
+    }
+    tracker.finalize_islands(nl.saturating_sub(1) as u32);
+    let mut islands = tracker.get_islands();
+    let scan_ms = t_scan.elapsed().as_secs_f64() * 1000.0;
+
+    for island in &mut islands {
+        let vol: f64 = island.per_layer_area_mm2.values().map(|&a| a * layer_height).sum();
+        island.volume_mm3 = Some(vol);
+        let max_a = island.per_layer_area_mm2.values().copied().fold(0.0_f64, f64::max);
+        island.max_area_mm2 = Some(max_a);
+        island.compute_centroid();
+    }
+    let filtered: Vec<&Island> = islands.iter()
+        .filter(|i| !i.is_merged_placeholder && i.max_area_mm2.unwrap_or(0.0) >= min_area)
+        .collect();
+
+    write_json(&output.join("islands.json"), &islands)?;
+
+    let params_out = serde_json::json!({
+        "px_mm": px_mm, "layer_height_mm": layer_height,
+        "support_buffer_mm": buffer, "connectivity": connectivity,
+        "min_overlap_px": overlap, "overlap_neighborhood_px": neighborhood,
+        "min_island_area_mm2": min_area,
+        "grid_width": gw, "grid_height": gh,
+        "origin_x": ox, "origin_z": oz,
+        "num_layers": nl, "bbox": bbox,
+    });
+    write_json(&output.join("params.json"), &params_out)?;
+
+    let result = serde_json::json!({
+        "stl": input.display().to_string(),
+        "triangles": triangles.len(),
+        "grid": { "width": gw, "height": gh },
+        "layers": nl,
+        "solid_pixels": total_px,
+        "islands_total": islands.len(),
+        "islands_filtered": filtered.len(),
+        "raster_ms": raster_ms,
+        "scan_ms": scan_ms,
+        "total_ms": raster_ms + scan_ms,
+        "params": params_out,
+        "islands": filtered,
+    });
+    write_json(&output.join("result.json"), &result)?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+    } else {
+        eprintln!("full: {} tris, {}x{}, {} layers, {} solid px", triangles.len(), gw, gh, nl, total_px);
+        eprintln!("  raster={:.0}ms scan={:.0}ms total={:.0}ms", raster_ms, scan_ms, raster_ms + scan_ms);
+        eprintln!("  islands: {} total, {} filtered", islands.len(), filtered.len());
+    }
+    Ok(())
+}
+
+fn cmd_island_bench(
+    input: &PathBuf, px_mm: f64, layer_height: f64, buffer: f64,
+    connectivity: u8, overlap: i32, neighborhood: i32, min_area: f64,
+    iterations: u32, json_output: bool,
+) -> Result<(), String> {
+    let flat = load_binary_stl(input)?;
+    let triangles = parse_triangles(&flat);
+    let bbox = compute_bbox(&triangles);
+    let conn = if connectivity == 8 { Connectivity::Eight } else { Connectivity::Four };
+
+    if !json_output {
+        eprintln!("Benchmarking: {} ({} triangles)", input.display(), triangles.len());
+        eprintln!("  px_mm={} layer_h={} buffer={} conn={} overlap={} neighborhood={}",
+            px_mm, layer_height, buffer, connectivity, overlap, neighborhood);
+        eprintln!("  {} iterations, reporting best\n", iterations);
+    }
+
+    let mut best_read_ms = f64::MAX;
+    let mut best_raster_ms = f64::MAX;
+    let mut best_scan_ms = f64::MAX;
+    let mut best_track_ms = f64::MAX;
+    let mut best_analyze_ms = f64::MAX;
+    let mut best_total_ms = f64::MAX;
+    let mut final_layers = 0usize;
+    let mut final_grid = (0i32, 0i32);
+    let mut final_solid_px = 0u64;
+    let mut final_islands_total = 0usize;
+    let mut final_islands_filtered = 0usize;
+
+    for iter in 0..iterations {
+        let t0 = Instant::now();
+        let flat2 = load_binary_stl(input)?;
+        let tris = parse_triangles(&flat2);
+        let read_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+        let t1 = Instant::now();
+        let (masks, gw, gh, nl, _ox, _oz) = rasterize_for_island_scan(
+            &tris,
+            bbox.min_x as f64, bbox.max_x as f64,
+            bbox.min_y as f64, bbox.max_y as f64,
+            bbox.min_z as f64, bbox.max_z as f64,
+            px_mm, layer_height,
+        );
+        let raster_ms = t1.elapsed().as_secs_f64() * 1000.0;
+
+        let t2 = Instant::now();
+        let mut layer_results = Vec::with_capacity(nl);
+        for (i, mask) in masks.iter().enumerate() {
+            let prev = if i > 0 { Some(&masks[i - 1]) } else { None };
+            layer_results.push(scan_layer(mask, prev, px_mm, buffer, conn));
+        }
+        let scan_ms = t2.elapsed().as_secs_f64() * 1000.0;
+
+        let t3 = Instant::now();
+        let mut tracker = IslandTracker::new(px_mm, overlap, neighborhood);
+        let mut island_labels: Vec<RleLabels> = Vec::with_capacity(nl);
+        for (l, lr) in layer_results.iter().enumerate() {
+            let prev = if l > 0 { Some(&island_labels[l - 1]) } else { None };
+            let il = tracker.process_layer(l as u32, &lr.labels, &lr.components, prev, &lr.solid_mask);
+            island_labels.push(il);
+        }
+        tracker.finalize_islands(nl.saturating_sub(1) as u32);
+        let mut islands = tracker.get_islands();
+        let track_ms = t3.elapsed().as_secs_f64() * 1000.0;
+
+        let t4 = Instant::now();
+        for island in &mut islands {
+            let vol: f64 = island.per_layer_area_mm2.values().map(|&a| a * layer_height).sum();
+            island.volume_mm3 = Some(vol);
+            let max_a = island.per_layer_area_mm2.values().copied().fold(0.0_f64, f64::max);
+            island.max_area_mm2 = Some(max_a);
+            island.compute_centroid();
+        }
+        let filtered_count = islands.iter()
+            .filter(|i| !i.is_merged_placeholder && i.max_area_mm2.unwrap_or(0.0) >= min_area)
+            .count();
+        let analyze_ms = t4.elapsed().as_secs_f64() * 1000.0;
+
+        let total_ms = read_ms + raster_ms + scan_ms + track_ms + analyze_ms;
+        if total_ms < best_total_ms {
+            best_read_ms = read_ms;
+            best_raster_ms = raster_ms;
+            best_scan_ms = scan_ms;
+            best_track_ms = track_ms;
+            best_analyze_ms = analyze_ms;
+            best_total_ms = total_ms;
+            final_layers = nl;
+            final_grid = (gw, gh);
+            final_solid_px = masks.iter().map(|m| m.pixel_count()).sum();
+            final_islands_total = islands.len();
+            final_islands_filtered = filtered_count;
+        }
+
+        if !json_output {
+            eprintln!("  iter {}: read={:.0} raster={:.0} scan={:.0} track={:.0} analyze={:.0} total={:.0}ms",
+                iter + 1, read_ms, raster_ms, scan_ms, track_ms, analyze_ms, total_ms);
+        }
+    }
+
+    if json_output {
+        let result = serde_json::json!({
+            "stl": input.display().to_string(),
+            "triangles": triangles.len(),
+            "grid": { "width": final_grid.0, "height": final_grid.1 },
+            "layers": final_layers,
+            "solid_pixels": final_solid_px,
+            "islands_total": final_islands_total,
+            "islands_filtered": final_islands_filtered,
+            "iterations": iterations,
+            "best_ms": {
+                "read_stl": best_read_ms,
+                "rasterize": best_raster_ms,
+                "scan": best_scan_ms,
+                "track": best_track_ms,
+                "analyze": best_analyze_ms,
+                "total": best_total_ms,
+            },
+            "throughput": {
+                "layers_per_sec": final_layers as f64 / (best_total_ms / 1000.0),
+                "mpx_per_sec": final_solid_px as f64 / (best_total_ms / 1000.0) / 1e6,
+            },
+            "params": {
+                "px_mm": px_mm, "layer_height_mm": layer_height,
+                "support_buffer_mm": buffer, "connectivity": connectivity,
+                "min_overlap_px": overlap, "overlap_neighborhood_px": neighborhood,
+                "min_island_area_mm2": min_area,
+            },
+        });
+        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+    } else {
+        eprintln!();
+        eprintln!("=== Best of {} ============================", iterations);
+        eprintln!("  read-stl:    {:>8.1} ms", best_read_ms);
+        eprintln!("  rasterize:   {:>8.1} ms", best_raster_ms);
+        eprintln!("  scan:        {:>8.1} ms", best_scan_ms);
+        eprintln!("  track:       {:>8.1} ms", best_track_ms);
+        eprintln!("  analyze:     {:>8.1} ms", best_analyze_ms);
+        eprintln!("  -------------------------");
+        eprintln!("  total:       {:>8.1} ms", best_total_ms);
+        eprintln!();
+        eprintln!("  {}x{} grid, {} layers, {} solid px", final_grid.0, final_grid.1, final_layers, final_solid_px);
+        eprintln!("  {} islands ({} filtered)", final_islands_total, final_islands_filtered);
+        eprintln!("  {:.0} layers/s, {:.1} Mpx/s",
+            final_layers as f64 / (best_total_ms / 1000.0),
+            final_solid_px as f64 / (best_total_ms / 1000.0) / 1e6);
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// Island RLE debug commands — wraps islands::rle
+// ===========================================================================
+
+fn cmd_rle_label(input: &PathBuf, output: &PathBuf, connectivity: u8, json_output: bool) -> Result<(), String> {
+    ensure_dir(output)?;
+    let mask = read_rle_mask_json(input)?;
+    let conn = if connectivity == 8 { Connectivity::Eight } else { Connectivity::Four };
+    let (labels, components) = rle::rle_label_components(&mask, conn);
+
+    write_rle_labels_json(&output.join("labels.rle.json"), &labels)?;
+    write_json(&output.join("components.json"), &components)?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "components": components.len(),
+            "connectivity": connectivity,
+            "grid": { "width": mask.width, "height": mask.height },
+        })).unwrap());
+    } else {
+        eprintln!("rle-label: {} components ({}x{}, {}-connected)",
+            components.len(), mask.width, mask.height, connectivity);
+    }
+    Ok(())
+}
+
+fn cmd_rle_subtract(mask_a: &PathBuf, mask_b: &PathBuf, output: &PathBuf) -> Result<(), String> {
+    let a = read_rle_mask_json(mask_a)?;
+    let b = read_rle_mask_json(mask_b)?;
+    let result = rle::rle_subtract(&a, &b);
+    write_rle_mask_json(output, &result)?;
+    eprintln!("rle-subtract: {} px - {} px = {} px",
+        a.pixel_count(), b.pixel_count(), result.pixel_count());
+    Ok(())
+}
+
+// ===========================================================================
+// Slice command implementations — wraps engine::slice_with_progress_v3_to_path
+// ===========================================================================
+
+fn cmd_slice_run(
+    input: &PathBuf,
+    output: &PathBuf,
+    layer_height: f32,
+    build_width_mm: f32,
+    build_depth_mm: f32,
+    source_width_px: u32,
+    source_height_px: u32,
+    png_compression: &str,
+    anti_aliasing: &str,
+    mirror_x: bool,
+    mirror_y: bool,
+    format_version: &Option<String>,
+    min_aa_alpha: f32,
+    metadata_json: &str,
+    json_output: bool,
+) -> Result<(), String> {
+    use dragonfruit_slicer_v3::engine::slice_with_progress_v3_to_path;
+    use dragonfruit_slicer_v3::types::SliceJobV3;
+
+    // Same flow as Tauri's slice_solid_native_to_temp_path:
+    // load STL or positions.bin → build SliceJobV3 → dispatch to engine
+    let is_positions_bin = input.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e == "bin")
+        .unwrap_or(false);
+
+    let flat = if is_positions_bin {
+        read_positions_bin(input)?
+    } else {
+        load_binary_stl(input)?
+    };
+    if flat.len() % 9 != 0 {
+        return Err(format!("Invalid triangle buffer length: {}", flat.len()));
+    }
+
+    let triangles = parse_triangles(&flat);
+    let bbox = compute_bbox(&triangles);
+
+    let model_height = bbox.max_z - bbox.min_z;
+    let total_layers = (model_height / layer_height).ceil() as u32;
+    if total_layers == 0 {
+        return Err("Model has zero height".into());
+    }
+
+    // Determine output format from extension (same as Tauri: ext → find_encoder)
+    let ext = output.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| format!(".{}", e))
+        .unwrap_or_else(|| ".nanodlp".to_string());
+
+    let job = SliceJobV3 {
+        output_format: ext.clone(),
+        source_width_px,
+        source_height_px,
+        width_px: source_width_px,
+        height_px: source_height_px,
+        build_width_mm,
+        build_depth_mm,
+        layer_height_mm: layer_height,
+        total_layers,
+        export_thumbnail_png_base64: None,
+        png_compression_strategy: png_compression.to_string(),
+        container_compression_level: 2,
+        anti_aliasing_level: anti_aliasing.to_string(),
+        aa_on_supports: false,
+        mirror_x,
+        mirror_y,
+        triangles_xyz: flat,
+        metadata_json: metadata_json.to_string(),
+        format_version: format_version.clone(),
+        minimum_aa_alpha_percent: min_aa_alpha,
+    };
+
+    let t0 = Instant::now();
+    let perf = slice_with_progress_v3_to_path(&job, output, None, None)
+        .map_err(|e| format!("Slice failed: {e}"))?;
+    let wall_s = t0.elapsed().as_secs_f64();
+
+    let result = serde_json::json!({
+        "output": output.display().to_string(),
+        "format": ext,
+        "layers": total_layers,
+        "layer_height_mm": layer_height,
+        "build_width_mm": build_width_mm,
+        "build_depth_mm": build_depth_mm,
+        "resolution_px": [source_width_px, source_height_px],
+        "total_s": perf.total_s(),
+        "wall_s": wall_s,
+        "layers_per_second": perf.layers_per_second(),
+        "perf": {
+            "total_ns": perf.total_ns,
+            "index_build_ns": perf.index_build_ns,
+            "render_wall_ns": perf.render_wall_ns,
+            "render_ns": perf.render_ns,
+            "png_encode_ns": perf.png_encode_ns,
+            "archive_encode_ns": perf.archive_encode_ns,
+        },
+    });
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+    } else {
+        eprintln!("slice: {} layers, {:.2}s ({:.0} layers/s) -> {}",
+            total_layers, perf.total_s(), perf.layers_per_second(), output.display());
+    }
+    Ok(())
+}
+
+/// Extract layer PNG from ZIP archive — same logic as Tauri's read_print_layer_png
+fn extract_layer_png(archive_path: &PathBuf, layer: u32, output: &PathBuf) -> Result<(), String> {
+    if layer == 0 {
+        return Err("Layer number must be >= 1".into());
+    }
+
+    let file = std::fs::File::open(archive_path)
+        .map_err(|e| format!("Failed to open archive: {e}"))?;
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|e| format!("Failed to read ZIP: {e}"))?;
+
+    // Tauri uses "{layer}.png" (1-based)
+    let entry_name = format!("{}.png", layer);
+
+    // Collect file listing first (before borrowing archive mutably for entry read)
+    let file_listing: Vec<String> = (0..archive.len())
+        .filter_map(|i| archive.by_index(i).ok().map(|e| e.name().to_string()))
+        .take(20)
+        .collect();
+
+    let mut entry = archive
+        .by_name(&entry_name)
+        .map_err(|_| format!("Layer '{}' not found. Available: {}", entry_name, file_listing.join(", ")))?;
+
+    let mut buf = Vec::with_capacity(entry.size() as usize);
+    entry.read_to_end(&mut buf)
+        .map_err(|e| format!("Failed to read entry: {e}"))?;
+
+    std::fs::write(output, &buf)
+        .map_err(|e| format!("Failed to write PNG: {e}"))?;
+
+    eprintln!("extract: layer {} ({} bytes) -> {}", layer, buf.len(), output.display());
+    Ok(())
+}
+
+fn cmd_slice_formats() {
+    use dragonfruit_slicer_v3::encoders::registry::{find_encoder, supported_output_formats};
+
+    let format_names = supported_output_formats();
+    let mut formats = Vec::new();
+
+    for name in &format_names {
+        if let Some(enc) = find_encoder(name) {
+            let mut info = serde_json::json!({
+                "extension": name,
+                "requires_area_stats": enc.requires_area_stats(),
+                "requires_png_layers": enc.requires_png_layers(),
+                "requires_raw_mask_layers": enc.requires_raw_mask_layers(),
+            });
+            // Add known version info for specific formats
+            match *name {
+                ".ctb" => { info["versions"] = serde_json::json!(["v4", "v5", "v5enc"]); }
+                _ => {}
+            }
+            formats.push(info);
+        }
+    }
+
+    println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+        "formats": formats,
+    })).unwrap());
+}
+
+fn cmd_print_inspect(input: &PathBuf, json_output: bool) -> Result<(), String> {
+    let file = std::fs::File::open(input)
+        .map_err(|e| format!("Failed to open: {e}"))?;
+    let file_size = file.metadata().map(|m| m.len()).unwrap_or(0);
+
+    let mut archive = zip::ZipArchive::new(file)
+        .map_err(|e| format!("Not a valid ZIP archive: {e}"))?;
+
+    let total_entries = archive.len();
+    let mut layer_count = 0u32;
+    let mut total_uncompressed = 0u64;
+    let mut entries_info: Vec<serde_json::Value> = Vec::new();
+    let mut manifest: Option<serde_json::Value> = None;
+
+    let mut manifest_index: Option<usize> = None;
+
+    for i in 0..total_entries {
+        if let Ok(entry) = archive.by_index(i) {
+            let name = entry.name().to_string();
+            let size = entry.size();
+            total_uncompressed += size;
+
+            if name.ends_with(".png") {
+                layer_count += 1;
+            }
+            if name == "manifest.json" || name == "metadata.json" {
+                manifest_index = Some(i);
+            }
+
+            entries_info.push(serde_json::json!({
+                "name": name,
+                "size": size,
+            }));
+        }
+    }
+
+    // Second pass: read manifest if found
+    if let Some(idx) = manifest_index {
+        if let Ok(mut entry) = archive.by_index(idx) {
+            let mut content = String::new();
+            std::io::Read::read_to_string(&mut entry, &mut content).ok();
+            manifest = serde_json::from_str(&content).ok();
+        }
+    }
+
+    let compression_ratio = if total_uncompressed > 0 {
+        file_size as f64 / total_uncompressed as f64
+    } else {
+        1.0
+    };
+
+    if json_output {
+        let mut result = serde_json::json!({
+            "file": input.display().to_string(),
+            "file_size_bytes": file_size,
+            "format": "zip",
+            "total_entries": total_entries,
+            "layer_count": layer_count,
+            "total_uncompressed_bytes": total_uncompressed,
+            "compression_ratio": format!("{:.2}", compression_ratio),
+        });
+        if let Some(m) = &manifest {
+            result["manifest"] = m.clone();
+        }
+        println!("{}", serde_json::to_string_pretty(&result).unwrap());
+    } else {
+        eprintln!("inspect: {}", input.display());
+        eprintln!("  format: ZIP ({} entries)", total_entries);
+        eprintln!("  layers: {}", layer_count);
+        eprintln!("  size: {} bytes (uncompressed: {}, ratio: {:.2})",
+            file_size, total_uncompressed, compression_ratio);
+        if manifest.is_some() {
+            eprintln!("  manifest: present");
+        }
+    }
+    Ok(())
+}
+
+fn cmd_island_batch(
+    inputs: &[PathBuf],
+    output: &PathBuf,
+    px_mm: f64, layer_height: f64, buffer: f64, connectivity: u8,
+    overlap: i32, neighborhood: i32, min_area: f64,
+    json_output: bool,
+) -> Result<(), String> {
+    ensure_dir(output)?;
+
+    let mut results = Vec::new();
+
+    for input in inputs {
+        let t0 = Instant::now();
+        let sub_output = output.join(
+            input.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+        );
+
+        match cmd_island_full(
+            input, &sub_output,
+            px_mm, layer_height, buffer, connectivity,
+            overlap, neighborhood, min_area,
+            &None, false, // no params_json, no json (we collect results ourselves)
+        ) {
+            Ok(()) => {
+                let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
+                // Read result.json from the sub-output
+                let result_path = sub_output.join("result.json");
+                let result: serde_json::Value = if result_path.exists() {
+                    read_json(&result_path)?
+                } else {
+                    serde_json::json!({"error": "no result.json"})
+                };
+                let mut entry = serde_json::json!({
+                    "stl": input.display().to_string(),
+                    "elapsed_ms": elapsed_ms,
+                });
+                if let Some(obj) = result.as_object() {
+                    for (k, v) in obj {
+                        entry[k] = v.clone();
+                    }
+                }
+                results.push(entry);
+            }
+            Err(e) => {
+                results.push(serde_json::json!({
+                    "stl": input.display().to_string(),
+                    "error": e,
+                }));
+            }
+        }
+    }
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&results).unwrap());
+    } else {
+        for r in &results {
+            let stl = r["stl"].as_str().unwrap_or("?");
+            if let Some(e) = r["error"].as_str() {
+                eprintln!("  {} ERROR: {}", stl, e);
+            } else {
+                let filtered = r["islands_filtered"].as_u64().unwrap_or(0);
+                let ms = r["elapsed_ms"].as_f64().unwrap_or(0.0);
+                eprintln!("  {} {} islands {:.0}ms", stl, filtered, ms);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cmd_slice_info() {
+    use dragonfruit_slicer_v3::encoders::registry::supported_output_formats;
+    let formats = supported_output_formats();
+
+    let info = serde_json::json!({
+        "supported_formats": formats,
+        "defaults": {
+            "layer_height_mm": 0.05,
+            "build_width_mm": 218.0,
+            "build_depth_mm": 122.0,
+            "source_width_px": 11400,
+            "source_height_px": 6400,
+            "png_compression": "balanced",
+            "container_compression_level": 2,
+            "anti_aliasing": "Off",
+        },
+    });
+    println!("{}", serde_json::to_string_pretty(&info).unwrap());
+}
+
+// ===========================================================================
+// Print command implementations — wraps Tauri temp-artifact ops
+// ===========================================================================
+
+/// Same safety check as Tauri's is_dragonfruit_temp_artifact
+fn is_dragonfruit_temp_artifact(path: &std::path::Path) -> bool {
+    let file_name_ok = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.starts_with("dragonfruit-slice-"))
+        .unwrap_or(false);
+    let in_temp_dir = path.starts_with(std::env::temp_dir());
+    file_name_ok && in_temp_dir
+}
+
+/// Same logic as Tauri's sweep_stale_temp_artifacts
+fn sweep_stale_temp_artifacts(max_age_seconds: u64) -> u32 {
+    let mut removed = 0u32;
+    let temp_dir = std::env::temp_dir();
+    let cutoff = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(max_age_seconds))
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+
+    let entries = match std::fs::read_dir(&temp_dir) {
+        Ok(entries) => entries,
+        Err(_) => return 0,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !is_dragonfruit_temp_artifact(&path) {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .map(|modified| modified <= cutoff)
+            .unwrap_or(false);
+        if stale && std::fs::remove_file(&path).is_ok() {
+            removed += 1;
+        }
+    }
+    removed
+}
+
+/// Same logic as Tauri's sweep_all_temp_artifacts
+fn sweep_all_temp_artifacts() -> u32 {
+    let mut removed = 0u32;
+    let temp_dir = std::env::temp_dir();
+    let entries = match std::fs::read_dir(&temp_dir) {
+        Ok(entries) => entries,
+        Err(_) => return 0,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !is_dragonfruit_temp_artifact(&path) {
+            continue;
+        }
+        if std::fs::remove_file(&path).is_ok() {
+            removed += 1;
+        }
+    }
+    removed
+}
+
+fn cmd_print_save(input: &PathBuf, output: &PathBuf) -> Result<(), String> {
+    // Same as Tauri save_print_file_from_path (minus dialog)
+    if !input.exists() {
+        return Err("Source print file no longer exists on disk".into());
+    }
+    if let Some(parent) = output.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed creating destination folder: {e}"))?;
+    }
+    std::fs::copy(input, output)
+        .map_err(|e| format!("Failed saving print file: {e}"))?;
+    eprintln!("print save: {} -> {}", input.display(), output.display());
+    Ok(())
+}
+
+fn cmd_print_read_bytes(input: &PathBuf, output: &PathBuf) -> Result<(), String> {
+    // Same as Tauri read_print_file_bytes
+    if !input.exists() {
+        return Err("Source print file no longer exists on disk".into());
+    }
+    let bytes = std::fs::read(input)
+        .map_err(|e| format!("Failed reading print file: {e}"))?;
+    std::fs::write(output, &bytes)
+        .map_err(|e| format!("Failed writing: {e}"))?;
+    eprintln!("read-bytes: {} bytes -> {}", bytes.len(), output.display());
+    Ok(())
+}
+
+fn cmd_print_cleanup(path: &Option<PathBuf>, all: bool, max_age_seconds: Option<u64>) -> Result<(), String> {
+    if let Some(p) = path {
+        // Same as Tauri delete_print_temp_file — refuses non-dragonfruit artifacts
+        if !p.exists() {
+            eprintln!("cleanup: file does not exist");
+            return Ok(());
+        }
+        if !is_dragonfruit_temp_artifact(p) {
+            return Err("Refusing to delete non-DragonFruit temp artifact path".into());
+        }
+        std::fs::remove_file(p).map_err(|e| format!("Failed deleting temp artifact: {e}"))?;
+        eprintln!("cleanup: deleted {}", p.display());
+    } else if all {
+        let removed = sweep_all_temp_artifacts();
+        eprintln!("cleanup --all: removed {} temp files", removed);
+    } else if let Some(age) = max_age_seconds {
+        let removed = sweep_stale_temp_artifacts(age.max(60));
+        eprintln!("cleanup --max-age-seconds {}: removed {} stale files", age, removed);
+    } else {
+        eprintln!("cleanup: specify --path, --all, or --max-age-seconds");
+    }
+    Ok(())
+}
+
+// ===========================================================================
+// Info
+// ===========================================================================
+
+fn cmd_benchmark(
+    layers: u32, width_px: u32, height_px: u32,
+    build_width_mm: f32, build_depth_mm: f32, layer_height: f32,
+    cube_count: u32, json_output: bool,
+) -> Result<(), String> {
+    use dragonfruit_slicer_v3::benchmark::{run_benchmark_v3, BenchmarkConfigV3};
+
+    let cfg = BenchmarkConfigV3 {
+        layers,
+        source_width_px: width_px,
+        source_height_px: height_px,
+        output_width_px: width_px,
+        output_height_px: height_px,
+        build_width_mm,
+        build_depth_mm,
+        layer_height_mm: layer_height,
+        cube_count,
+    };
+
+    if !json_output {
+        eprintln!("benchmark: {}x{} px, {} layers, {} cubes", width_px, height_px, layers, cube_count);
+    }
+
+    let result = run_benchmark_v3(cfg).map_err(|e| format!("Benchmark failed: {e}"))?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({
+            "artifact_bytes": result.artifact_bytes,
+            "total_s": result.total_s,
+            "layers_per_second": result.layers_per_second,
+            "render_s": result.render_s,
+            "png_s": result.png_s,
+            "archive_s": result.archive_s,
+            "config": {
+                "layers": layers,
+                "width_px": width_px,
+                "height_px": height_px,
+                "build_width_mm": build_width_mm,
+                "build_depth_mm": build_depth_mm,
+                "layer_height_mm": layer_height,
+                "cube_count": cube_count,
+            },
+        })).unwrap());
+    } else {
+        eprintln!("  total: {:.2}s ({:.0} layers/s)", result.total_s, result.layers_per_second);
+        eprintln!("  render: {:.2}s, png: {:.2}s, archive: {:.2}s",
+            result.render_s, result.png_s, result.archive_s);
+        eprintln!("  artifact: {} bytes", result.artifact_bytes);
+    }
+    Ok(())
+}
+
+fn cmd_info() {
+    use dragonfruit_slicer_v3::encoders::registry::supported_output_formats;
+    let formats = supported_output_formats();
+
+    let info = serde_json::json!({
+        "name": "dragonfruit-cli",
+        "version": env!("CARGO_PKG_VERSION"),
+        "commands": ["mesh", "island", "slice", "print", "info"],
+        "supported_formats": formats,
+        "island_defaults": {
+            "px_mm": 0.1,
+            "layer_height": 0.05,
+            "buffer": 0.6,
+            "connectivity": 4,
+            "overlap": 4,
+            "neighborhood": 1,
+            "min_area": 0.0,
+        },
+        "slice_defaults": {
+            "layer_height_mm": 0.05,
+            "build_width_mm": 218.0,
+            "build_depth_mm": 122.0,
+            "source_width_px": 11400,
+            "source_height_px": 6400,
+        },
+    });
+    println!("{}", serde_json::to_string_pretty(&info).unwrap());
+}
+
+// ===========================================================================
+// Main
+// ===========================================================================
+
+fn main() {
+    let cli = Cli::parse();
+    let t0 = Instant::now();
+
+    let command_label = match &cli.command {
+        Commands::Mesh { command } => match command {
+            MeshCommands::ReadStl { .. } => "mesh read-stl",
+            MeshCommands::Info { .. } => "mesh info",
+            MeshCommands::ExportStl { .. } => "mesh export-stl",
+            MeshCommands::Export3mf { .. } => "mesh export-3mf",
+        },
+        Commands::Benchmark { .. } => "benchmark",
+        Commands::Island { command } => match command {
+            IslandCommands::Rasterize { .. } => "island rasterize",
+            IslandCommands::Scan { .. } => "island scan",
+            IslandCommands::Track { .. } => "island track",
+            IslandCommands::Analyze { .. } => "island analyze",
+            IslandCommands::Full { .. } => "island full",
+            IslandCommands::Bench { .. } => "island bench",
+            IslandCommands::Batch { .. } => "island batch",
+            IslandCommands::RleLabel { .. } => "island rle-label",
+            IslandCommands::RleSubtract { .. } => "island rle-subtract",
+        },
+        Commands::Slice { command } => match command {
+            SliceCommands::Run { .. } => "slice run",
+            SliceCommands::PreviewLayer { .. } => "slice preview-layer",
+            SliceCommands::Formats => "slice formats",
+            SliceCommands::Info => "slice info",
+        },
+        Commands::Print { command } => match command {
+            PrintCommands::Save { .. } => "print save",
+            PrintCommands::ReadBytes { .. } => "print read-bytes",
+            PrintCommands::ReadLayer { .. } => "print read-layer",
+            PrintCommands::Inspect { .. } => "print inspect",
+            PrintCommands::Cleanup { .. } => "print cleanup",
+        },
+        Commands::Info => "info",
+    };
+
+    let result = match cli.command {
+        Commands::Mesh { command } => match command {
+            MeshCommands::ReadStl { input, output } => cmd_mesh_read_stl(&input, &output),
+            MeshCommands::Info { input, json } => cmd_mesh_info(&input, json),
+            MeshCommands::ExportStl { input, output } => cmd_mesh_export_stl(&input, &output),
+            MeshCommands::Export3mf { input, output } => cmd_mesh_export_3mf(&input, &output),
+        },
+
+        Commands::Benchmark { layers, width_px, height_px, build_width_mm, build_depth_mm,
+            layer_height, cube_count, json } =>
+            cmd_benchmark(layers, width_px, height_px, build_width_mm, build_depth_mm,
+                layer_height, cube_count, json),
+
+        Commands::Island { command } => match command {
+            IslandCommands::Rasterize { input, output, px_mm, layer_height } =>
+                cmd_rasterize(&input, &output, px_mm, layer_height),
+            IslandCommands::Scan { input, output, buffer, connectivity } =>
+                cmd_scan(&input, &output, buffer, connectivity),
+            IslandCommands::Track { input, output, overlap, neighborhood } =>
+                cmd_track(&input, &output, overlap, neighborhood),
+            IslandCommands::Analyze { input, output, min_area } =>
+                cmd_analyze(&input, &output, min_area),
+            IslandCommands::Full { input, output, px_mm, layer_height, buffer, connectivity,
+                overlap, neighborhood, min_area, params_json, json } =>
+                cmd_island_full(&input, &output, px_mm, layer_height, buffer, connectivity,
+                    overlap, neighborhood, min_area, &params_json, json),
+            IslandCommands::Bench { input, px_mm, layer_height, buffer, connectivity,
+                overlap, neighborhood, min_area, iterations, json } =>
+                cmd_island_bench(&input, px_mm, layer_height, buffer, connectivity,
+                    overlap, neighborhood, min_area, iterations, json),
+            IslandCommands::Batch { inputs, output, px_mm, layer_height, buffer, connectivity,
+                overlap, neighborhood, min_area, json } =>
+                cmd_island_batch(&inputs, &output, px_mm, layer_height, buffer, connectivity,
+                    overlap, neighborhood, min_area, json),
+            IslandCommands::RleLabel { input, output, connectivity, json } =>
+                cmd_rle_label(&input, &output, connectivity, json),
+            IslandCommands::RleSubtract { mask_a, mask_b, output } =>
+                cmd_rle_subtract(&mask_a, &mask_b, &output),
+        },
+
+        Commands::Slice { command } => match command {
+            SliceCommands::Run { input, output, layer_height, build_width_mm, build_depth_mm,
+                source_width_px, source_height_px, png_compression, anti_aliasing,
+                mirror_x, mirror_y, format_version, min_aa_alpha, metadata_json, json } =>
+                cmd_slice_run(&input, &output, layer_height, build_width_mm, build_depth_mm,
+                    source_width_px, source_height_px, &png_compression, &anti_aliasing,
+                    mirror_x, mirror_y, &format_version, min_aa_alpha, &metadata_json, json),
+            SliceCommands::Formats => { cmd_slice_formats(); Ok(()) },
+            SliceCommands::PreviewLayer { input, layer, output } =>
+                extract_layer_png(&input, layer, &output),
+            SliceCommands::Info => { cmd_slice_info(); Ok(()) },
+        },
+
+        Commands::Print { command } => match command {
+            PrintCommands::Save { input, output } => cmd_print_save(&input, &output),
+            PrintCommands::ReadBytes { input, output } => cmd_print_read_bytes(&input, &output),
+            PrintCommands::ReadLayer { input, layer, output } =>
+                extract_layer_png(&input, layer, &output),
+            PrintCommands::Inspect { input, json } => cmd_print_inspect(&input, json),
+            PrintCommands::Cleanup { path, all, max_age_seconds } =>
+                cmd_print_cleanup(&path, all, max_age_seconds),
+        },
+
+        Commands::Info => { cmd_info(); Ok(()) },
+    };
+
+    let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+    match &result {
+        Ok(()) => eprintln!("  [{}] {:.1}ms", command_label, elapsed_ms),
+        Err(e) => {
+            eprintln!("  [{}] FAILED {:.1}ms", command_label, elapsed_ms);
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/rust/dragonfruit-islands/tests/worst_case.rs
+++ b/rust/dragonfruit-islands/tests/worst_case.rs
@@ -1,0 +1,398 @@
+//! Worst-case scenario property tests for the island detection pipeline.
+//!
+//! Each test generates adversarial geometry and verifies the pipeline
+//! produces valid, consistent output without panics or infinite loops.
+
+use dragonfruit_islands::model::*;
+use dragonfruit_islands::pipeline::run_island_scan;
+use dragonfruit_islands::rle::{rle_encode, rle_label_components};
+use proptest::prelude::*;
+
+fn make_job(width: i32, height: i32, num_layers: u32) -> IslandScanJob {
+    IslandScanJob {
+        px_mm: 0.1,
+        support_buffer_mm: 0.6,
+        connectivity: Connectivity::Four,
+        min_island_area_mm2: 0.0,
+        layer_height_mm: 0.05,
+        grid: GridRef {
+            origin_x: 0.0,
+            origin_z: 0.0,
+            width,
+            height,
+            px_mm: 0.1,
+        },
+        num_layers,
+        min_overlap_px: 1,
+        overlap_neighborhood_px: 1,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worst case 1: Many small disconnected islands (chain mail / Voronoi foam)
+//
+// Maximizes: CCL component count per layer, tracker map size.
+// Each layer has a grid of small isolated squares — N² islands.
+// ---------------------------------------------------------------------------
+
+fn gen_many_islands(w: i32, h: i32, layers: usize, count: i32) -> Vec<RleMask> {
+    let n = (count as f64).sqrt().ceil() as i32;
+    let dx = (w / n).max(3);
+    let dy = (h / n).max(3);
+    let pad = 1;
+
+    (0..layers)
+        .map(|_| {
+            let mut data = vec![0u8; (w * h) as usize];
+            for iy in 0..n {
+                for ix in 0..n {
+                    let x0 = ix * dx + pad;
+                    let y0 = iy * dy + pad;
+                    let x1 = ((ix + 1) * dx - pad).min(w);
+                    let y1 = ((iy + 1) * dy - pad).min(h);
+                    for y in y0..y1 {
+                        for x in x0..x1 {
+                            data[(y * w + x) as usize] = 1;
+                        }
+                    }
+                }
+            }
+            rle_encode(&data, w, h)
+        })
+        .collect()
+}
+
+proptest! {
+    /// Many small islands: pipeline must track N² islands correctly.
+    #[test]
+    fn many_islands_completes(
+        island_count in 4..100i32,
+        layers in 5..50usize,
+    ) {
+        let w = 200;
+        let h = 200;
+        let masks = gen_many_islands(w, h, layers, island_count);
+        let job = make_job(w, h, layers as u32);
+        let result = run_island_scan(&job, &masks, None);
+
+        // Must produce at least 1 island per unique block
+        let n = (island_count as f64).sqrt().ceil() as i32;
+        let expected_min = (n * n).min(island_count) as usize;
+        prop_assert!(
+            result.islands.len() >= expected_min / 2,
+            "Expected at least {} islands, got {}",
+            expected_min / 2,
+            result.islands.len()
+        );
+
+        // No island should span more layers than exist
+        for island in &result.islands {
+            prop_assert!(island.last_layer < layers as u32);
+            prop_assert!(island.first_layer <= island.last_layer);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worst case 2: Frequent merge/split (lattice that merges and splits)
+//
+// Maximizes: PendingMerge count, parent chain resolution.
+// Even layers: two separate blocks. Odd layers: blocks connected by bridge.
+// This forces merge on every odd layer and potential split on even layers.
+// ---------------------------------------------------------------------------
+
+fn gen_merge_split_lattice(w: i32, h: i32, layers: usize) -> Vec<RleMask> {
+    let mid = w / 2;
+    let gap = 4;
+    let h4 = h / 4;
+    let h34 = 3 * h / 4;
+
+    (0..layers)
+        .map(|l| {
+            let mut data = vec![0u8; (w * h) as usize];
+            // Two blocks always present
+            for y in h4..h34 {
+                for x in 2..(mid - gap) {
+                    data[(y * w + x) as usize] = 1;
+                }
+                for x in (mid + gap)..(w - 2) {
+                    data[(y * w + x) as usize] = 1;
+                }
+            }
+            // Bridge connecting blocks on odd layers
+            if l % 2 == 1 {
+                for y in (h / 2 - 1)..(h / 2 + 1) {
+                    for x in 2..(w - 2) {
+                        data[(y * w + x) as usize] = 1;
+                    }
+                }
+            }
+            rle_encode(&data, w, h)
+        })
+        .collect()
+}
+
+proptest! {
+    /// Merge/split thrash: pipeline must handle repeated merges without panic.
+    #[test]
+    fn merge_split_thrash_completes(
+        layers in 10..100usize,
+    ) {
+        let w = 100;
+        let h = 100;
+        let masks = gen_merge_split_lattice(w, h, layers);
+        let job = make_job(w, h, layers as u32);
+        let result = run_island_scan(&job, &masks, None);
+
+        // Must produce islands (at least the two blocks)
+        prop_assert!(result.islands.len() >= 2,
+            "Expected at least 2 islands, got {}", result.islands.len());
+
+        // Parent chains must be resolvable (no cycles)
+        for island in &result.islands {
+            if let Some(pid) = island.parent_id {
+                // Parent must exist
+                prop_assert!(
+                    result.islands.iter().any(|i| i.id == pid),
+                    "Island {} has parent {} which doesn't exist",
+                    island.id.0, pid.0
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worst case 3: Single pixel islands (maximum CCL overhead)
+//
+// Maximizes: CCL work per pixel, RLE run count.
+// Checkerboard pattern: every other pixel is solid, creating W*H/2 runs
+// and many tiny 1-pixel components.
+// ---------------------------------------------------------------------------
+
+fn gen_checkerboard(w: i32, h: i32, layers: usize) -> Vec<RleMask> {
+    (0..layers)
+        .map(|l| {
+            let mut data = vec![0u8; (w * h) as usize];
+            for y in 0..h {
+                for x in 0..w {
+                    // Shift pattern every other layer to create new islands
+                    let offset = (l % 2) as i32;
+                    if (x + y + offset) % 2 == 0 {
+                        data[(y * w + x) as usize] = 1;
+                    }
+                }
+            }
+            rle_encode(&data, w, h)
+        })
+        .collect()
+}
+
+proptest! {
+    /// Checkerboard: maximizes RLE run count and CCL component count.
+    ///
+    /// NOTE: Keep size small. With 4-connectivity, each pixel is its own island,
+    /// so a 20x20 grid has 200 islands. The tracker's overlap lookup is O(islands²)
+    /// per layer, making this O(size⁴ × layers). size=30 × 5 layers ≈ 1s.
+    #[test]
+    fn checkerboard_completes(
+        size in 10..20i32,
+        layers in 2..4usize,
+    ) {
+        let masks = gen_checkerboard(size, size, layers);
+        let job = make_job(size, size, layers as u32);
+        let result = run_island_scan(&job, &masks, None);
+
+        // With 4-connectivity, each pixel is its own island
+        prop_assert!(result.islands.len() > 0);
+
+        // Every island should have valid layer bounds
+        for island in &result.islands {
+            prop_assert!(island.first_layer <= island.last_layer);
+            prop_assert!(island.total_area_mm2 >= 0.0);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worst case 4: Growing overhang (area doubles each layer)
+//
+// Maximizes: per-layer candidate area growth, volume calculation.
+// Pyramid that widens by 2 pixels per layer on each side.
+// ---------------------------------------------------------------------------
+
+fn gen_growing_overhang(w: i32, h: i32, layers: usize) -> Vec<RleMask> {
+    (0..layers)
+        .map(|l| {
+            let mut data = vec![0u8; (w * h) as usize];
+            let margin = ((layers - l) as i32).max(0);
+            let x0 = (w / 2 - l as i32 * 2).max(0);
+            let x1 = (w / 2 + l as i32 * 2).min(w);
+            let y0 = (h / 2 - l as i32 * 2).max(0);
+            let y1 = (h / 2 + l as i32 * 2).min(h);
+            for y in y0..y1 {
+                for x in x0..x1 {
+                    data[(y * w + x) as usize] = 1;
+                }
+            }
+            rle_encode(&data, w, h)
+        })
+        .collect()
+}
+
+proptest! {
+    /// Growing overhang: each layer has more unsupported area than the last.
+    #[test]
+    fn growing_overhang_completes(
+        layers in 5..40usize,
+    ) {
+        let w = 200;
+        let h = 200;
+        let masks = gen_growing_overhang(w, h, layers);
+        let job = make_job(w, h, layers as u32);
+        let result = run_island_scan(&job, &masks, None);
+
+        // Layer 0 is fully unsupported (island)
+        prop_assert!(result.islands.len() >= 1);
+
+        // Islands should have positive volume
+        for island in &result.islands {
+            if island.volume_mm3.is_some() {
+                prop_assert!(island.volume_mm3.unwrap() >= 0.0);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worst case 5: Empty/degenerate layers interspersed
+//
+// Maximizes: edge cases in scan_layer (no prev, empty prev, empty current).
+// Random layers are completely empty, forcing the tracker to handle gaps.
+// ---------------------------------------------------------------------------
+
+fn gen_sparse_layers(w: i32, h: i32, layers: usize, seed: u64) -> Vec<RleMask> {
+    (0..layers)
+        .map(|l| {
+            // Deterministic pseudo-random: skip ~30% of layers
+            let is_empty = ((l as u64).wrapping_mul(seed).wrapping_add(7)) % 10 < 3;
+            if is_empty {
+                RleMask {
+                    width: w,
+                    height: h,
+                    rows: (0..h).map(|_| Vec::new()).collect(),
+                }
+            } else {
+                let mut data = vec![0u8; (w * h) as usize];
+                let block_size = 20;
+                let cx = w / 2;
+                let cy = h / 2;
+                for y in (cy - block_size).max(0)..(cy + block_size).min(h) {
+                    for x in (cx - block_size).max(0)..(cx + block_size).min(w) {
+                        data[(y * w + x) as usize] = 1;
+                    }
+                }
+                rle_encode(&data, w, h)
+            }
+        })
+        .collect()
+}
+
+proptest! {
+    /// Sparse layers: ~30% empty, tests gap handling in tracker.
+    #[test]
+    fn sparse_layers_completes(
+        layers in 10..60usize,
+        seed in 1..1000u64,
+    ) {
+        let w = 100;
+        let h = 100;
+        let masks = gen_sparse_layers(w, h, layers, seed);
+        let job = make_job(w, h, layers as u32);
+        let result = run_island_scan(&job, &masks, None);
+
+        // Pipeline should complete without panic
+        // Islands from non-empty layers should have valid bounds
+        for island in &result.islands {
+            prop_assert!(island.first_layer <= island.last_layer);
+            prop_assert!(island.last_layer < layers as u32);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worst case 6: Maximum RLE density (alternating pixels)
+//
+// Maximizes: RLE run count, intersect_dilated computation.
+// Every pixel alternates solid/empty — W/2 runs per row.
+// ---------------------------------------------------------------------------
+
+/// Max RLE density: alternating pixels create W/2 runs per row.
+/// CCL with 4-connectivity produces vertical stripe components.
+#[test]
+fn max_rle_density_ccl() {
+    let w = 100;
+    let h = 100;
+    let mut data = vec![0u8; (w * h) as usize];
+    for y in 0..h {
+        for x in 0..w {
+            if x % 2 == 0 {
+                data[y * w + x] = 1;
+            }
+        }
+    }
+    let mask = rle_encode(&data, w as i32, h as i32);
+
+    // Should have ~W/2 runs per row
+    for row in &mask.rows {
+        assert!(row.len() >= (w / 2 - 1));
+    }
+
+    // CCL: vertical stripes with 4-connectivity → W/2 components
+    let (labels, components) = rle_label_components(&mask, Connectivity::Four);
+    assert_eq!(labels.rows.len(), h);
+    assert!(components.len() >= w / 2 - 1);
+}
+
+// ---------------------------------------------------------------------------
+// Worst case 7: Determinism — same input must produce same output
+// ---------------------------------------------------------------------------
+
+/// Determinism: same input must produce same pixel-level output.
+/// Island IDs may differ due to merge ordering, but the label masks must be identical
+/// and the set of (first_layer, last_layer, total_area) tuples must match.
+#[test]
+fn pipeline_deterministic() {
+    let w = 100;
+    let h = 100;
+    let layers = 50;
+    let masks = gen_merge_split_lattice(w, h, layers);
+    let job = make_job(w, h, layers as u32);
+
+    let r1 = run_island_scan(&job, &masks, None);
+    let r2 = run_island_scan(&job, &masks, None);
+
+    assert_eq!(r1.islands.len(), r2.islands.len(), "island count differs");
+
+    // Compare island content as sorted tuples (ignoring ID assignment order)
+    // Round area to 0.01mm² to avoid float precision noise
+    let mut areas1: Vec<(u32, u32, i64)> = r1.islands.iter()
+        .map(|i| (i.first_layer, i.last_layer, (i.total_area_mm2 * 100.0).round() as i64))
+        .collect();
+    let mut areas2: Vec<(u32, u32, i64)> = r2.islands.iter()
+        .map(|i| (i.first_layer, i.last_layer, (i.total_area_mm2 * 100.0).round() as i64))
+        .collect();
+    areas1.sort();
+    areas2.sort();
+    assert_eq!(areas1, areas2, "island content differs between runs");
+
+    // Per-layer label masks: total labeled pixel count must match
+    for (l, (lab1, lab2)) in r1.island_labels_per_layer.iter()
+        .zip(r2.island_labels_per_layer.iter())
+        .enumerate()
+    {
+        let px1: i32 = lab1.rows.iter().flat_map(|r| r.iter().map(|run| run.length)).sum();
+        let px2: i32 = lab2.rows.iter().flat_map(|r| r.iter().map(|run| run.length)).sum();
+        assert_eq!(px1, px2, "labeled pixel count differs on layer {}", l);
+    }
+}

--- a/scripts/dragonfruit-ts-cli.ts
+++ b/scripts/dragonfruit-ts-cli.ts
@@ -1,0 +1,1520 @@
+#!/usr/bin/env npx tsx
+/**
+ * DragonFruit TS CLI — headless scene & support operations.
+ *
+ * Works at the VOXL file level (.voxl) — the same interchange format the GUI
+ * uses. Reads/writes VoxlDocumentV1 JSON, so the CLI and GUI share the same
+ * state format. No THREE.js or React dependencies.
+ *
+ * Usage:
+ *   npx tsx scripts/dragonfruit-ts-cli.ts scene create -o scene.voxl
+ *   npx tsx scripts/dragonfruit-ts-cli.ts scene add-model scene.voxl --mesh cube.stl --name Cube
+ *   npx tsx scripts/dragonfruit-ts-cli.ts scene list-models scene.voxl --json
+ *   npx tsx scripts/dragonfruit-ts-cli.ts support add-trunk scene.voxl --model-id m1 --position 10,20,0
+ *   npx tsx scripts/dragonfruit-ts-cli.ts support list scene.voxl --json
+ */
+
+import { readFileSync, writeFileSync, statSync } from 'fs';
+import { basename, resolve, dirname } from 'path';
+import { execSync } from 'child_process';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  parseVoxlDocument,
+  serializeVoxlDocument,
+  buildVoxlDocumentV1,
+} from '../src/features/scene/voxl/codec';
+import type {
+  VoxlDocumentV1,
+  VoxlModelEntry,
+  VoxlModelRuntimeLike,
+} from '../src/features/scene/voxl/types';
+import type {
+  DragonfruitImportFormat,
+  Roots,
+  Trunk,
+  Branch,
+  Leaf,
+  Brace,
+  Knot,
+  Vec3,
+  SupportEntity,
+} from '../src/supports/types';
+
+// ---------------------------------------------------------------------------
+// VOXL File I/O
+// ---------------------------------------------------------------------------
+
+function loadVoxl(path: string): VoxlDocumentV1 {
+  const raw = readFileSync(path, 'utf-8');
+  return parseVoxlDocument(raw);
+}
+
+function saveVoxl(path: string, doc: VoxlDocumentV1): void {
+  const json = serializeVoxlDocument(doc, true, { compression: 'auto' });
+  writeFileSync(path, json, 'utf-8');
+}
+
+function createEmptyDoc(): VoxlDocumentV1 {
+  const emptySupports: DragonfruitImportFormat = {
+    version: 1,
+    meta: { source: 'dragonfruit-ts-cli', objectCenter: { x: 0, y: 0, z: 0 } },
+    roots: [],
+    trunks: [],
+    branches: [],
+    leaves: [],
+    braces: [],
+    knots: [],
+  };
+
+  return buildVoxlDocumentV1({
+    models: [],
+    activeModelId: null,
+    selectedModelIds: [],
+    supports: emptySupports,
+    meta: { generator: 'dragonfruit-ts-cli' },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Parsing helpers
+// ---------------------------------------------------------------------------
+
+function parseVec3(s: string): Vec3 {
+  const parts = s.split(',').map((p) => parseFloat(p.trim()));
+  if (parts.length !== 3 || parts.some(isNaN)) {
+    throw new Error(`Expected x,y,z got '${s}'`);
+  }
+  return { x: parts[0], y: parts[1], z: parts[2] };
+}
+
+function parseArgs(argv: string[]): { command: string; subcommand: string; positional: string[]; flags: Record<string, string | boolean> } {
+  const command = argv[0] ?? '';
+  const subcommand = argv[1] ?? '';
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+
+  let i = 2;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        flags[key] = next;
+        i += 2;
+      } else {
+        flags[key] = true;
+        i += 1;
+      }
+    } else {
+      positional.push(arg);
+      i += 1;
+    }
+  }
+
+  return { command, subcommand, positional, flags };
+}
+
+function requireFlag(flags: Record<string, string | boolean>, key: string): string {
+  const val = flags[key];
+  if (val === undefined || val === true) {
+    throw new Error(`Missing required flag: --${key}`);
+  }
+  return val as string;
+}
+
+function optionalFlag(flags: Record<string, string | boolean>, key: string): string | undefined {
+  const val = flags[key];
+  if (val === true || val === undefined) return undefined;
+  return val as string;
+}
+
+function jsonOutput(flags: Record<string, string | boolean>): boolean {
+  return flags['json'] === true;
+}
+
+// ---------------------------------------------------------------------------
+// Scene commands
+// ---------------------------------------------------------------------------
+
+function sceneCreate(args: ReturnType<typeof parseArgs>): void {
+  const output = requireFlag(args.flags, 'o');
+  const doc = createEmptyDoc();
+  saveVoxl(output, doc);
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ created: output }, null, 2));
+  } else {
+    console.error(`scene create: ${output}`);
+  }
+}
+
+function sceneAddModel(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene add-model <scene.voxl> --mesh <path>');
+
+  const doc = loadVoxl(voxlPath);
+  const meshPath = requireFlag(args.flags, 'mesh');
+  const name = optionalFlag(args.flags, 'name') ?? basename(meshPath, '.stl');
+  const posStr = optionalFlag(args.flags, 'position');
+  const rotStr = optionalFlag(args.flags, 'rotate');
+  const scaleStr = optionalFlag(args.flags, 'scale');
+
+  const position = posStr ? parseVec3(posStr) : { x: 0, y: 0, z: 0 };
+  const rotation = rotStr ? parseVec3(rotStr) : { x: 0, y: 0, z: 0 };
+  const scale = scaleStr ? parseVec3(scaleStr) : { x: 1, y: 1, z: 1 };
+
+  let fileSizeBytes: number | undefined;
+  try { fileSizeBytes = statSync(meshPath).size; } catch { /* ignore */ }
+
+  const model: VoxlModelEntry = {
+    id: uuidv4(),
+    name,
+    visible: true,
+    color: '#a3a3a3',
+    polygonCount: 0,
+    fileSizeBytes,
+    transform: { position, rotation, scale },
+    mesh: { mode: 'external-file', fileName: basename(meshPath) },
+  };
+
+  doc.models.push(model);
+  doc.scene.activeModelId = model.id;
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify(model, null, 2));
+  } else {
+    console.error(`add-model: '${name}' id=${model.id}`);
+  }
+}
+
+function sceneRemoveModel(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene remove-model <scene.voxl> --id <id>');
+
+  const doc = loadVoxl(voxlPath);
+  const id = requireFlag(args.flags, 'id');
+
+  const before = doc.models.length;
+  doc.models = doc.models.filter((m) => m.id !== id);
+
+  // Clean supports referencing this model
+  const s = doc.supports;
+  s.roots = s.roots.filter((r) => r.modelId !== id);
+  s.trunks = s.trunks.filter((t) => t.modelId !== id);
+  s.branches = s.branches.filter((b) => b.modelId !== id);
+  s.leaves = s.leaves.filter((l) => l.modelId !== id);
+  s.braces = s.braces.filter((b) => b.modelId !== id);
+
+  if (doc.scene.activeModelId === id) doc.scene.activeModelId = null;
+  doc.scene.selectedModelIds = doc.scene.selectedModelIds.filter((sid) => sid !== id);
+
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ removed: id, models_before: before, models_after: doc.models.length }, null, 2));
+  } else {
+    console.error(`remove-model: ${id}`);
+  }
+}
+
+function sceneListModels(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene list-models <scene.voxl>');
+
+  const doc = loadVoxl(voxlPath);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({
+      count: doc.models.length,
+      activeModelId: doc.scene.activeModelId,
+      models: doc.models.map((m) => ({
+        id: m.id,
+        name: m.name,
+        visible: m.visible,
+        mesh: m.mesh.fileName ?? m.mesh.mode,
+        transform: m.transform,
+      })),
+    }, null, 2));
+  } else {
+    console.error(`${doc.models.length} models:`);
+    for (const m of doc.models) {
+      const p = m.transform.position;
+      console.error(`  ${m.id} '${m.name}' pos=(${p.x.toFixed(1)},${p.y.toFixed(1)},${p.z.toFixed(1)})`);
+    }
+  }
+}
+
+function sceneTransformModel(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene transform-model <scene.voxl> --id <id>');
+
+  const doc = loadVoxl(voxlPath);
+  const id = requireFlag(args.flags, 'id');
+  const model = doc.models.find((m) => m.id === id);
+  if (!model) throw new Error(`Model '${id}' not found`);
+
+  const posStr = optionalFlag(args.flags, 'position');
+  const rotStr = optionalFlag(args.flags, 'rotate');
+  const scaleStr = optionalFlag(args.flags, 'scale');
+
+  if (posStr) model.transform.position = parseVec3(posStr);
+  if (rotStr) model.transform.rotation = parseVec3(rotStr);
+  if (scaleStr) model.transform.scale = parseVec3(scaleStr);
+
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ id, transform: model.transform }, null, 2));
+  } else {
+    console.error(`transform-model: ${id}`);
+  }
+}
+
+function sceneDuplicate(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene duplicate <scene.voxl> --id <id>');
+
+  const doc = loadVoxl(voxlPath);
+  const id = requireFlag(args.flags, 'id');
+  const count = parseInt(optionalFlag(args.flags, 'count') ?? '1', 10);
+  const offsetStr = optionalFlag(args.flags, 'offset') ?? '20,0,0';
+  const offset = parseVec3(offsetStr);
+
+  const source = doc.models.find((m) => m.id === id);
+  if (!source) throw new Error(`Model '${id}' not found`);
+
+  const newIds: string[] = [];
+  for (let i = 1; i <= count; i++) {
+    const copy: VoxlModelEntry = JSON.parse(JSON.stringify(source));
+    copy.id = uuidv4();
+    copy.name = `${source.name} (${i})`;
+    copy.transform.position.x += offset.x * i;
+    copy.transform.position.y += offset.y * i;
+    copy.transform.position.z += offset.z * i;
+    doc.models.push(copy);
+    newIds.push(copy.id);
+  }
+
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ duplicated: newIds }, null, 2));
+  } else {
+    console.error(`duplicate: ${id} x${count} -> ${newIds.join(', ')}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Support commands — manipulates DragonfruitImportFormat inside VOXL
+// ---------------------------------------------------------------------------
+
+function supportAddTrunk(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: support add-trunk <scene.voxl> --model-id <id> --position x,y,z');
+
+  const doc = loadVoxl(voxlPath);
+  const modelId = requireFlag(args.flags, 'model-id');
+  const posStr = requireFlag(args.flags, 'position');
+  const pos = parseVec3(posStr);
+  const diameter = parseFloat(optionalFlag(args.flags, 'diameter') ?? '2.0');
+
+  const rootId = uuidv4();
+  const trunkId = uuidv4();
+  const segmentId = uuidv4();
+
+  const root: Roots = {
+    id: rootId,
+    modelId,
+    transform: { pos, rot: { x: 0, y: 0, z: 0, w: 1 } },
+    diameter,
+    diskHeight: 0.3,
+    coneHeight: 1.0,
+  };
+
+  const trunk: Trunk = {
+    id: trunkId,
+    modelId,
+    rootId,
+    segments: [{
+      id: segmentId,
+      diameter,
+      topJoint: undefined,
+      bottomJoint: undefined,
+    }],
+  };
+
+  doc.supports.roots.push(root);
+  doc.supports.trunks.push(trunk);
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ trunk_id: trunkId, root_id: rootId, position: pos }, null, 2));
+  } else {
+    console.error(`add-trunk: ${trunkId} at (${pos.x},${pos.y},${pos.z})`);
+  }
+}
+
+function supportAddBranch(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: support add-branch <scene.voxl> --model-id <id> --parent-knot-id <id>');
+
+  const doc = loadVoxl(voxlPath);
+  const modelId = requireFlag(args.flags, 'model-id');
+  const parentKnotId = requireFlag(args.flags, 'parent-knot-id');
+  const diameter = parseFloat(optionalFlag(args.flags, 'diameter') ?? '1.0');
+
+  const branchId = uuidv4();
+  const segmentId = uuidv4();
+
+  const branch: Branch = {
+    id: branchId,
+    modelId,
+    parentKnotId,
+    segments: [{
+      id: segmentId,
+      diameter,
+      topJoint: undefined,
+      bottomJoint: undefined,
+    }],
+  };
+
+  doc.supports.branches.push(branch);
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ branch_id: branchId }, null, 2));
+  } else {
+    console.error(`add-branch: ${branchId} on knot ${parentKnotId}`);
+  }
+}
+
+function supportAddLeaf(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: support add-leaf <scene.voxl> --model-id <id> --parent-knot-id <id> --contact x,y,z --normal x,y,z');
+
+  const doc = loadVoxl(voxlPath);
+  const modelId = requireFlag(args.flags, 'model-id');
+  const parentKnotId = requireFlag(args.flags, 'parent-knot-id');
+  const contact = parseVec3(requireFlag(args.flags, 'contact'));
+  const normal = parseVec3(optionalFlag(args.flags, 'normal') ?? '0,0,-1');
+  const tipDiameter = parseFloat(optionalFlag(args.flags, 'tip-diameter') ?? '0.3');
+
+  const leafId = uuidv4();
+  const leaf: Leaf = {
+    id: leafId,
+    modelId,
+    parentKnotId,
+    contactCone: {
+      pos: contact,
+      normal,
+      tipDiameterMm: tipDiameter,
+      bodyDiameterMm: tipDiameter + 0.5,
+      contactLengthMm: 0.3,
+      bodyLengthMm: 1.0,
+    } as any,
+  };
+
+  doc.supports.leaves.push(leaf);
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ leaf_id: leafId }, null, 2));
+  } else {
+    console.error(`add-leaf: ${leafId}`);
+  }
+}
+
+function supportAddBrace(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: support add-brace <scene.voxl> --model-id <id> --start-knot <id> --end-knot <id>');
+
+  const doc = loadVoxl(voxlPath);
+  const modelId = requireFlag(args.flags, 'model-id');
+  const startKnotId = requireFlag(args.flags, 'start-knot');
+  const endKnotId = requireFlag(args.flags, 'end-knot');
+  const diameter = parseFloat(optionalFlag(args.flags, 'diameter') ?? '0.5');
+
+  const braceId = uuidv4();
+  const brace: Brace = {
+    id: braceId,
+    modelId,
+    startKnotId,
+    endKnotId,
+    profile: { diameter },
+  };
+
+  doc.supports.braces.push(brace);
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ brace_id: braceId }, null, 2));
+  } else {
+    console.error(`add-brace: ${braceId} (${startKnotId} <-> ${endKnotId})`);
+  }
+}
+
+function supportAddKnot(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: support add-knot <scene.voxl> --parent-shaft-id <id> --position x,y,z');
+
+  const doc = loadVoxl(voxlPath);
+  const parentShaftId = requireFlag(args.flags, 'parent-shaft-id');
+  const pos = parseVec3(requireFlag(args.flags, 'position'));
+  const t = parseFloat(optionalFlag(args.flags, 't') ?? '0.5');
+
+  const knotId = uuidv4();
+  const knot: Knot = {
+    id: knotId,
+    parentShaftId,
+    t,
+    pos,
+  };
+
+  doc.supports.knots.push(knot);
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ knot_id: knotId }, null, 2));
+  } else {
+    console.error(`add-knot: ${knotId} on shaft ${parentShaftId} at t=${t}`);
+  }
+}
+
+function supportRemove(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: support remove <scene.voxl> --id <id>');
+
+  const doc = loadVoxl(voxlPath);
+  const id = requireFlag(args.flags, 'id');
+  const s = doc.supports;
+
+  // Cascading remove — mirrors state.ts removeTrunk/removeBranch logic
+  const cascadeRemoveByShaftIds = (shaftIds: string[]) => {
+    // Collect knots on these shafts
+    const knotIds = s.knots.filter((k) => shaftIds.includes(k.parentShaftId)).map((k) => k.id);
+    s.knots = s.knots.filter((k) => !shaftIds.includes(k.parentShaftId));
+    // Collect branches hanging off those knots, then recurse
+    const branchIds = s.branches.filter((b) => knotIds.includes(b.parentKnotId)).map((b) => b.id);
+    s.branches = s.branches.filter((b) => !knotIds.includes(b.parentKnotId));
+    s.leaves = s.leaves.filter((l) => !knotIds.includes(l.parentKnotId));
+    s.braces = s.braces.filter((b) => !knotIds.includes(b.startKnotId) && !knotIds.includes(b.endKnotId));
+    if (s.kickstands) s.kickstands = s.kickstands.filter((k: any) => !knotIds.includes(k.hostKnot?.id));
+    // Recurse: branches are shafts too
+    if (branchIds.length > 0) cascadeRemoveByShaftIds(branchIds);
+  };
+
+  const removedRoot = s.roots.find((r) => r.id === id);
+  const removedTrunk = !removedRoot ? s.trunks.find((t) => t.id === id) : undefined;
+  const removedBranch = !removedRoot && !removedTrunk ? s.branches.find((b) => b.id === id) : undefined;
+
+  if (removedRoot) {
+    const trunkIds = s.trunks.filter((t) => t.rootId === id).map((t) => t.id);
+    s.roots = s.roots.filter((r) => r.id !== id);
+    s.trunks = s.trunks.filter((t) => t.rootId !== id);
+    cascadeRemoveByShaftIds(trunkIds);
+  } else if (removedTrunk) {
+    s.trunks = s.trunks.filter((t) => t.id !== id);
+    // Also remove the root that owns this trunk
+    s.roots = s.roots.filter((r) => r.id !== removedTrunk.rootId);
+    cascadeRemoveByShaftIds([id]);
+  } else if (removedBranch) {
+    s.branches = s.branches.filter((b) => b.id !== id);
+    cascadeRemoveByShaftIds([id]);
+  } else {
+    // Simple remove for leaf, brace, knot, kickstand
+    s.leaves = s.leaves.filter((l) => l.id !== id);
+    s.braces = s.braces.filter((b) => b.id !== id);
+    s.knots = s.knots.filter((k) => k.id !== id);
+    if (s.kickstands) s.kickstands = s.kickstands.filter((k: any) =>
+      (k.kickstand?.id ?? k.id) !== id);
+  }
+
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ removed: id }, null, 2));
+  } else {
+    console.error(`remove: ${id}`);
+  }
+}
+
+function supportList(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: support list <scene.voxl>');
+
+  const doc = loadVoxl(voxlPath);
+  const s = doc.supports;
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({
+      roots: s.roots.length,
+      trunks: s.trunks.length,
+      branches: s.branches.length,
+      leaves: s.leaves.length,
+      braces: s.braces.length,
+      knots: s.knots.length,
+      kickstands: s.kickstands?.length ?? 0,
+      supports: s,
+    }, null, 2));
+  } else {
+    const total = s.roots.length + s.trunks.length + s.branches.length +
+      s.leaves.length + s.braces.length + s.knots.length + (s.kickstands?.length ?? 0);
+    console.error(`${total} support elements:`);
+    console.error(`  ${s.roots.length} roots, ${s.trunks.length} trunks, ${s.branches.length} branches`);
+    console.error(`  ${s.leaves.length} leaves, ${s.braces.length} braces, ${s.knots.length} knots`);
+    if (s.kickstands?.length) console.error(`  ${s.kickstands.length} kickstands`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scene load/save (raw VOXL dump)
+// ---------------------------------------------------------------------------
+
+function sceneLoad(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene load <scene.voxl>');
+
+  const doc = loadVoxl(voxlPath);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify(doc, null, 2));
+  } else {
+    console.error(`scene: ${doc.models.length} models, generator=${doc.meta.generator}`);
+    console.error(`  created: ${doc.meta.createdAt}`);
+    const s = doc.supports;
+    const total = s.roots.length + s.trunks.length + s.branches.length +
+      s.leaves.length + s.braces.length + s.knots.length;
+    console.error(`  supports: ${total} elements`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Support update — patch fields on any support element by ID
+// ---------------------------------------------------------------------------
+
+function supportUpdate(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: support update <scene.voxl> --id <id> [--diameter N] [--position x,y,z] [--tip-diameter N]');
+
+  const doc = loadVoxl(voxlPath);
+  const id = requireFlag(args.flags, 'id');
+  const s = doc.supports;
+  let found = false;
+
+  const diameterStr = optionalFlag(args.flags, 'diameter');
+  const positionStr = optionalFlag(args.flags, 'position');
+  const tipDiameterStr = optionalFlag(args.flags, 'tip-diameter');
+  const heightStr = optionalFlag(args.flags, 'height');
+
+  // Search across all collections
+  for (const root of s.roots) {
+    if (root.id === id) {
+      if (diameterStr) root.diameter = parseFloat(diameterStr);
+      if (positionStr) root.transform.pos = parseVec3(positionStr);
+      found = true; break;
+    }
+  }
+  if (!found) for (const trunk of s.trunks) {
+    if (trunk.id === id) {
+      if (diameterStr && trunk.segments.length > 0) trunk.segments[0].diameter = parseFloat(diameterStr);
+      found = true; break;
+    }
+  }
+  if (!found) for (const branch of s.branches) {
+    if (branch.id === id) {
+      if (diameterStr && branch.segments.length > 0) branch.segments[0].diameter = parseFloat(diameterStr);
+      found = true; break;
+    }
+  }
+  if (!found) for (const leaf of s.leaves) {
+    if (leaf.id === id) {
+      if (tipDiameterStr && leaf.contactCone) (leaf.contactCone as any).tipDiameterMm = parseFloat(tipDiameterStr);
+      found = true; break;
+    }
+  }
+  if (!found) for (const brace of s.braces) {
+    if (brace.id === id) {
+      if (diameterStr) brace.profile.diameter = parseFloat(diameterStr);
+      found = true; break;
+    }
+  }
+  if (!found) for (const knot of s.knots) {
+    if (knot.id === id) {
+      if (positionStr) knot.pos = parseVec3(positionStr);
+      found = true; break;
+    }
+  }
+  if (!found) for (const k of s.kickstands ?? []) {
+    if ((k as any).kickstand?.id === id || (k as any).id === id) {
+      found = true; break;
+    }
+  }
+
+  if (!found) throw new Error(`Support element '${id}' not found`);
+
+  saveVoxl(voxlPath, doc);
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ updated: id }, null, 2));
+  } else {
+    console.error(`update: ${id}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scene group / ungroup — stored in VOXL extensions
+// ---------------------------------------------------------------------------
+
+type VoxlGroup = { id: string; name: string; modelIds: string[] };
+
+function getGroups(doc: VoxlDocumentV1): VoxlGroup[] {
+  return ((doc.extensions as any)?.groups as VoxlGroup[]) ?? [];
+}
+
+function setGroups(doc: VoxlDocumentV1, groups: VoxlGroup[]): void {
+  if (!doc.extensions) doc.extensions = {};
+  (doc.extensions as any).groups = groups;
+}
+
+function sceneGroup(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene group <scene.voxl> --ids id1,id2 [--name "Group"]');
+
+  const doc = loadVoxl(voxlPath);
+  const idsStr = requireFlag(args.flags, 'ids');
+  const modelIds = idsStr.split(',').map((s) => s.trim());
+  const name = optionalFlag(args.flags, 'name') ?? 'Group';
+  const groupId = uuidv4();
+
+  const groups = getGroups(doc);
+  groups.push({ id: groupId, name, modelIds });
+  setGroups(doc, groups);
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ group_id: groupId, name, modelIds }, null, 2));
+  } else {
+    console.error(`group: ${groupId} '${name}' with ${modelIds.length} models`);
+  }
+}
+
+function sceneUngroup(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene ungroup <scene.voxl> --group-id <id>');
+
+  const doc = loadVoxl(voxlPath);
+  const groupId = requireFlag(args.flags, 'group-id');
+  const groups = getGroups(doc).filter((g) => g.id !== groupId);
+  setGroups(doc, groups);
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ ungrouped: groupId }, null, 2));
+  } else {
+    console.error(`ungroup: ${groupId}`);
+  }
+}
+
+function sceneListGroups(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene list-groups <scene.voxl>');
+
+  const doc = loadVoxl(voxlPath);
+  const groups = getGroups(doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ groups }, null, 2));
+  } else {
+    console.error(`${groups.length} groups:`);
+    for (const g of groups) {
+      console.error(`  ${g.id} '${g.name}' [${g.modelIds.join(', ')}]`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scene center-xy — wraps useModelTransform.ts centerXY logic
+// ---------------------------------------------------------------------------
+
+function sceneCenterXY(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene center-xy <scene.voxl> --id <model-id>');
+
+  const doc = loadVoxl(voxlPath);
+  const id = requireFlag(args.flags, 'id');
+  const model = doc.models.find((m) => m.id === id);
+  if (!model) throw new Error(`Model '${id}' not found`);
+
+  const oldX = model.transform.position.x;
+  const oldY = model.transform.position.y;
+  model.transform.position.x = 0;
+  model.transform.position.y = 0;
+
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({
+      id,
+      position: model.transform.position,
+      moved: { dx: -oldX, dy: -oldY },
+    }, null, 2));
+  } else {
+    console.error(`center-xy: ${id} (${oldX.toFixed(1)},${oldY.toFixed(1)}) -> (0, 0)`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Support straighten-segment — bezier→straight (wraps toggleSegmentCurve logic)
+// ---------------------------------------------------------------------------
+
+function supportStraightenSegment(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: support straighten-segment <scene.voxl> --id <segment-id>');
+
+  const doc = loadVoxl(voxlPath);
+  const segId = requireFlag(args.flags, 'id');
+  const s = doc.supports;
+  let found = false;
+
+  const straighten = (segments: any[]) => {
+    for (let i = 0; i < segments.length; i++) {
+      if (segments[i].id === segId) {
+        // Remove bezier fields, set to straight
+        delete segments[i].type;
+        delete segments[i].controlPoint1;
+        delete segments[i].controlPoint2;
+        delete segments[i].startTangent;
+        delete segments[i].endTangent;
+        delete segments[i].tension;
+        delete segments[i].bias;
+        delete segments[i].resolution;
+        found = true;
+        return;
+      }
+    }
+  };
+
+  for (const trunk of s.trunks) straighten(trunk.segments);
+  if (!found) for (const branch of s.branches) straighten(branch.segments);
+  if (!found) for (const twig of s.twigs ?? []) straighten((twig as any).segments ?? []);
+  if (!found) for (const stick of s.sticks ?? []) straighten((stick as any).segments ?? []);
+
+  if (!found) throw new Error(`Segment '${segId}' not found`);
+
+  saveVoxl(voxlPath, doc);
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ straightened: segId }, null, 2));
+  } else {
+    console.error(`straighten-segment: ${segId}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Support add-twig — model-to-model contact via disks
+// ---------------------------------------------------------------------------
+
+function supportAddTwig(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: support add-twig <scene.voxl> --model-id <id> --contact-a x,y,z --contact-b x,y,z');
+
+  const doc = loadVoxl(voxlPath);
+  const modelId = requireFlag(args.flags, 'model-id');
+  const contactA = parseVec3(requireFlag(args.flags, 'contact-a'));
+  const contactB = parseVec3(requireFlag(args.flags, 'contact-b'));
+  const diameter = parseFloat(optionalFlag(args.flags, 'diameter') ?? '0.5');
+
+  const twigId = uuidv4();
+  const twig = {
+    id: twigId,
+    modelId,
+    segments: [{ id: uuidv4(), diameter }],
+    contactDiskA: {
+      id: uuidv4(), pos: contactA,
+      surfaceNormal: { x: 0, y: 0, z: -1 }, coneAxis: { x: 0, y: 0, z: 1 },
+      profile: { type: 'default' }, contactDiameterMm: diameter,
+    },
+    contactDiskB: {
+      id: uuidv4(), pos: contactB,
+      surfaceNormal: { x: 0, y: 0, z: -1 }, coneAxis: { x: 0, y: 0, z: 1 },
+      profile: { type: 'default' }, contactDiameterMm: diameter,
+    },
+  };
+
+  if (!doc.supports.twigs) (doc.supports as any).twigs = [];
+  (doc.supports as any).twigs.push(twig);
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ twig_id: twigId }, null, 2));
+  } else {
+    console.error(`add-twig: ${twigId}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Support add-stick — model-to-model contact via cones
+// ---------------------------------------------------------------------------
+
+function supportAddStick(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: support add-stick <scene.voxl> --model-id <id> --contact-a x,y,z --contact-b x,y,z');
+
+  const doc = loadVoxl(voxlPath);
+  const modelId = requireFlag(args.flags, 'model-id');
+  const contactA = parseVec3(requireFlag(args.flags, 'contact-a'));
+  const contactB = parseVec3(requireFlag(args.flags, 'contact-b'));
+  const diameter = parseFloat(optionalFlag(args.flags, 'diameter') ?? '0.5');
+  const tipDiameter = parseFloat(optionalFlag(args.flags, 'tip-diameter') ?? '0.3');
+
+  const stickId = uuidv4();
+  const makeCone = (pos: Vec3) => ({
+    pos, normal: { x: 0, y: 0, z: -1 },
+    tipDiameterMm: tipDiameter, bodyDiameterMm: diameter,
+    contactLengthMm: 0.3, bodyLengthMm: 1.0,
+  });
+
+  const stick = {
+    id: stickId,
+    modelId,
+    segments: [{ id: uuidv4(), diameter }],
+    contactConeA: makeCone(contactA),
+    contactConeB: makeCone(contactB),
+  };
+
+  if (!doc.supports.sticks) (doc.supports as any).sticks = [];
+  (doc.supports as any).sticks.push(stick);
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ stick_id: stickId }, null, 2));
+  } else {
+    console.error(`add-stick: ${stickId}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Support add-kickstand / remove-kickstand
+// ---------------------------------------------------------------------------
+
+function supportAddKickstand(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: support add-kickstand <scene.voxl> --model-id <id> --base x,y,z --host-knot-id <id> --host-segment-id <id>');
+
+  const doc = loadVoxl(voxlPath);
+  const modelId = requireFlag(args.flags, 'model-id');
+  const basePos = parseVec3(requireFlag(args.flags, 'base'));
+  const hostKnotId = requireFlag(args.flags, 'host-knot-id');
+  const hostSegmentId = requireFlag(args.flags, 'host-segment-id');
+  const diameter = parseFloat(optionalFlag(args.flags, 'diameter') ?? '1.5');
+
+  const rootId = uuidv4();
+  const kickstandId = uuidv4();
+
+  const root = {
+    id: rootId, modelId,
+    transform: { pos: basePos, rot: { x: 0, y: 0, z: 0, w: 1 } },
+    diameter, diskHeight: 0.3, coneHeight: 1.0,
+  };
+
+  const hostKnot = {
+    id: hostKnotId,
+    parentShaftId: hostSegmentId,
+    pos: basePos, // placeholder — real position computed by GUI
+  };
+
+  const kickstand = {
+    root, hostKnot,
+    kickstand: {
+      id: kickstandId, modelId,
+      rootId, hostKnotId, hostSegmentId,
+      hostMinT: 0,
+      segments: [{ id: uuidv4(), diameter }],
+      profile: {
+        bodyDiameterMm: diameter,
+        terminalStartDiameterMm: diameter * 0.8,
+        terminalEndDiameterMm: diameter * 0.5,
+      },
+    },
+  };
+
+  if (!doc.supports.kickstands) (doc.supports as any).kickstands = [];
+  (doc.supports as any).kickstands.push(kickstand);
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ kickstand_id: kickstandId, root_id: rootId }, null, 2));
+  } else {
+    console.error(`add-kickstand: ${kickstandId}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scene place-on-platform — needs STL bbox Z
+// ---------------------------------------------------------------------------
+
+function scenePlace(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene place-on-platform <scene.voxl> --id <model-id> --mesh-dir <dir>');
+
+  const doc = loadVoxl(voxlPath);
+  const id = requireFlag(args.flags, 'id');
+  const meshDir = optionalFlag(args.flags, 'mesh-dir') ?? dirname(resolve(voxlPath));
+  const model = doc.models.find((m) => m.id === id);
+  if (!model) throw new Error(`Model '${id}' not found`);
+
+  const meshFileName = model.mesh.fileName ?? model.name + '.stl';
+  const candidates = [resolve(meshDir, meshFileName), meshFileName, resolve(meshFileName)];
+  let meshPath: string | null = null;
+  for (const c of candidates) {
+    try { statSync(c); meshPath = c; break; } catch { /* next */ }
+  }
+  if (!meshPath) throw new Error(`Mesh not found: ${candidates.join(', ')}`);
+
+  const positions = loadBinaryStl(meshPath);
+  let minZ = Infinity;
+  for (let i = 2; i < positions.length; i += 3) {
+    if (positions[i] < minZ) minZ = positions[i];
+  }
+
+  const oldZ = model.transform.position.z;
+  model.transform.position.z = -minZ;
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({ id, position: model.transform.position, mesh_min_z: minZ }, null, 2));
+  } else {
+    console.error(`place-on-platform: ${id} z=${oldZ.toFixed(2)} -> ${(-minZ).toFixed(2)} (mesh minZ=${minZ.toFixed(2)})`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scene export-stl — merge models + shell out to Rust mesh export-stl
+// ---------------------------------------------------------------------------
+
+function sceneExportStl(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene export-stl <scene.voxl> --o <output.stl> --mesh-dir <dir>');
+
+  const doc = loadVoxl(voxlPath);
+  const output = requireFlag(args.flags, 'o');
+  const meshDir = optionalFlag(args.flags, 'mesh-dir') ?? dirname(resolve(voxlPath));
+  const visibleModels = doc.models.filter((m) => m.visible);
+  if (visibleModels.length === 0) throw new Error('No visible models');
+
+  // Merge all model positions with translations
+  const allPositions: Float32Array[] = [];
+  for (const model of visibleModels) {
+    const meshFileName = model.mesh.fileName ?? model.name + '.stl';
+    const candidates = [resolve(meshDir, meshFileName), meshFileName, resolve(meshFileName)];
+    let meshPath: string | null = null;
+    for (const c of candidates) {
+      try { statSync(c); meshPath = c; break; } catch { /* next */ }
+    }
+    if (!meshPath) throw new Error(`Mesh not found for '${model.name}': ${candidates.join(', ')}`);
+
+    const positions = loadBinaryStl(meshPath);
+    applyVoxlTransform(positions, model.transform);
+    allPositions.push(positions);
+  }
+
+  // Merge + write positions.bin
+  const totalFloats = allPositions.reduce((sum, p) => sum + p.length, 0);
+  const merged = new Float32Array(totalFloats);
+  let off = 0;
+  for (const p of allPositions) { merged.set(p, off); off += p.length; }
+
+  const tmpDir = `/tmp/df-export-stl-${Date.now()}`;
+  execSync(`mkdir -p ${tmpDir}`);
+  const posPath = resolve(tmpDir, 'positions.bin');
+  writePositionsBin(posPath, merged);
+
+  // Shell out to Rust CLI
+  const rustCli = resolve(dirname(new URL(import.meta.url).pathname), '../rust/dragonfruit-cli/target/release/dragonfruit-cli');
+  execSync(`${rustCli} mesh export-stl -i ${tmpDir} -o ${resolve(output)}`, { stdio: 'inherit' });
+  execSync(`rm -rf ${tmpDir}`);
+
+  if (jsonOutput(args.flags)) {
+    console.log(JSON.stringify({
+      output: resolve(output),
+      models: visibleModels.length,
+      triangles: totalFloats / 9,
+    }, null, 2));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scene arrange — wraps highPrecisionArrange (same algo as GUI)
+// ---------------------------------------------------------------------------
+
+import * as THREE from 'three';
+import { quaternionFromGlobalEuler } from '../src/utils/rotation';
+import {
+  computeHighPrecisionArrangeUpdates,
+  type ArrangeModel,
+  type ArrangeTransform,
+  type HullCacheEntry,
+  type HighPrecisionArrangeInput,
+} from '../src/features/scene/arrange/highPrecisionArrange';
+import type { ArrangeAnchorMode } from '../src/components/controls/ArrangePanel';
+
+/**
+ * Build a THREE.BufferGeometry from flat f32 STL positions.
+ */
+function geometryFromPositions(positions: Float32Array): THREE.BufferGeometry {
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geom.computeBoundingBox();
+  geom.computeBoundingSphere();
+  return geom;
+}
+
+function sceneArrange(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene arrange <scene.voxl> [--spacing 2] [--build-width-mm 218] [--build-depth-mm 122] [--mesh-dir <dir>]');
+
+  const doc = loadVoxl(voxlPath);
+  const meshDir = optionalFlag(args.flags, 'mesh-dir') ?? dirname(resolve(voxlPath));
+  const spacing = parseFloat(optionalFlag(args.flags, 'spacing') ?? '2.0');
+  const plateW = parseFloat(optionalFlag(args.flags, 'build-width-mm') ?? '218.0');
+  const plateD = parseFloat(optionalFlag(args.flags, 'build-depth-mm') ?? '122.0');
+  const anchorMode = (optionalFlag(args.flags, 'anchor') ?? 'center') as ArrangeAnchorMode;
+
+  const visibleModels = doc.models.filter((m) => m.visible);
+  if (visibleModels.length === 0) throw new Error('No visible models to arrange');
+
+  // Build ArrangeModel[] for the existing arrange algo
+  const arrangeModels: ArrangeModel[] = [];
+  const geometryCache = new Map<string, { geom: THREE.BufferGeometry; center: THREE.Vector3 }>();
+
+  for (const model of visibleModels) {
+    const meshFileName = model.mesh.fileName ?? model.name + '.stl';
+    const candidates = [resolve(meshDir, meshFileName), meshFileName, resolve(meshFileName)];
+    let meshPath: string | null = null;
+    for (const c of candidates) {
+      try { statSync(c); meshPath = c; break; } catch { /* next */ }
+    }
+    if (!meshPath) throw new Error(`Mesh not found for '${model.name}': ${candidates.join(', ')}`);
+
+    // Cache geometry per mesh file (duplicates share the same geometry)
+    let cached = geometryCache.get(meshPath);
+    if (!cached) {
+      const positions = loadBinaryStl(meshPath);
+      const geom = geometryFromPositions(positions);
+      geom.computeBoundingBox();
+      const bb = geom.boundingBox!;
+      const center = new THREE.Vector3();
+      bb.getCenter(center);
+      cached = { geom, center };
+      geometryCache.set(meshPath, cached);
+    }
+
+    const t = model.transform;
+    const arrangeModel: ArrangeModel = {
+      id: model.id,
+      visible: model.visible,
+      transform: {
+        position: new THREE.Vector3(t.position.x, t.position.y, t.position.z),
+        rotation: new THREE.Euler(t.rotation.x, t.rotation.y, t.rotation.z, 'XYZ'),
+        scale: new THREE.Vector3(t.scale.x, t.scale.y, t.scale.z),
+      },
+      geometry: {
+        center: cached.center,
+        geometry: cached.geom,
+      },
+    };
+    arrangeModels.push(arrangeModel);
+  }
+
+  console.error(`arrange: ${arrangeModels.length} models on ${plateW}x${plateD}mm plate (anchor=${anchorMode}, spacing=${spacing}mm)`);
+
+  const hullCache = new Map<string, HullCacheEntry>();
+  const input: HighPrecisionArrangeInput = {
+    visibleModels: arrangeModels,
+    sceneModels: arrangeModels,
+    widthMm: plateW,
+    depthMm: plateD,
+    originMode: 'center',
+    arrangeSpacingMm: spacing,
+    arrangeAllowRotateOnZ: false,
+    arrangeAnchorMode: anchorMode,
+    getArrangeTransform: (model: ArrangeModel) => model.transform,
+    hullCache,
+  };
+
+  const updates = computeHighPrecisionArrangeUpdates(input);
+
+  // Apply updates back to the VOXL document
+  for (const update of updates) {
+    const model = doc.models.find((m) => m.id === update.id);
+    if (!model) continue;
+    model.transform.position.x = update.transform.position.x;
+    model.transform.position.y = update.transform.position.y;
+    model.transform.position.z = update.transform.position.z;
+    model.transform.rotation.x = update.transform.rotation.x;
+    model.transform.rotation.y = update.transform.rotation.y;
+    model.transform.rotation.z = update.transform.rotation.z;
+  }
+
+  saveVoxl(voxlPath, doc);
+
+  if (jsonOutput(args.flags)) {
+    const result = updates.map((u) => ({
+      id: u.id,
+      name: doc.models.find((m) => m.id === u.id)?.name,
+      position: { x: +u.transform.position.x.toFixed(2), y: +u.transform.position.y.toFixed(2), z: +u.transform.position.z.toFixed(2) },
+    }));
+    console.log(JSON.stringify({ arranged: result, plate: { width: plateW, depth: plateD } }, null, 2));
+  } else {
+    for (const update of updates) {
+      const name = doc.models.find((m) => m.id === update.id)?.name ?? update.id;
+      const p = update.transform.position;
+      console.error(`  ${name}: (${p.x.toFixed(1)}, ${p.y.toFixed(1)})`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scene slice — merge models from VOXL, shell out to Rust slicer
+// ---------------------------------------------------------------------------
+
+/**
+ * Load a binary STL and return flat f32 positions [x,y,z,...].
+ * Same logic as cli.rs load_binary_stl.
+ */
+function loadBinaryStl(path: string): Float32Array {
+  const data = readFileSync(path);
+  if (data.length < 84) throw new Error(`STL file too small: ${data.length} bytes`);
+
+  const numTriangles = data.readUInt32LE(80);
+  const expected = 84 + numTriangles * 50;
+  if (data.length < expected) throw new Error(`STL truncated: expected ${expected}, got ${data.length}`);
+
+  const positions = new Float32Array(numTriangles * 9);
+  let offset = 84;
+  let pi = 0;
+  for (let t = 0; t < numTriangles; t++) {
+    offset += 12; // skip normal
+    for (let v = 0; v < 3; v++) {
+      positions[pi++] = data.readFloatLE(offset);
+      positions[pi++] = data.readFloatLE(offset + 4);
+      positions[pi++] = data.readFloatLE(offset + 8);
+      offset += 12;
+    }
+    offset += 2; // attribute byte count
+  }
+  return positions;
+}
+
+/**
+ * Apply position offset to flat positions in-place.
+ * For VOXL scene slicing, rotation/scale in the scene transform are Euler radians.
+ * This handles translation; full matrix transform would need quaternion math.
+ */
+function applyTranslation(positions: Float32Array, tx: number, ty: number, tz: number): void {
+  for (let i = 0; i < positions.length; i += 3) {
+    positions[i] += tx;
+    positions[i + 1] += ty;
+    positions[i + 2] += tz;
+  }
+}
+
+/**
+ * Apply full VOXL transform (position + rotation + scale) to flat positions.
+ * Same transform pipeline as useIslandManager.ts::prepareTransformedGeom:
+ * 1. Center geometry at origin (subtract bbox center)
+ * 2. Apply rotation (Euler XYZ radians) + scale via Matrix4
+ * 3. Apply position translation
+ */
+function applyVoxlTransform(
+  positions: Float32Array,
+  transform: { position: { x: number; y: number; z: number }; rotation: { x: number; y: number; z: number }; scale: { x: number; y: number; z: number } },
+): void {
+  const { position: pos, rotation: rot, scale: scl } = transform;
+  const hasRotation = rot.x !== 0 || rot.y !== 0 || rot.z !== 0;
+  const hasScale = scl.x !== 1 || scl.y !== 1 || scl.z !== 1;
+
+  if (!hasRotation && !hasScale) {
+    // Translation only — fast path
+    if (pos.x !== 0 || pos.y !== 0 || pos.z !== 0) {
+      applyTranslation(positions, pos.x, pos.y, pos.z);
+    }
+    return;
+  }
+
+  // Compute bbox center for centering before rotation (matches GUI behavior)
+  let minX = Infinity, maxX = -Infinity;
+  let minY = Infinity, maxY = -Infinity;
+  let minZ = Infinity, maxZ = -Infinity;
+  for (let i = 0; i < positions.length; i += 3) {
+    const x = positions[i], y = positions[i + 1], z = positions[i + 2];
+    if (x < minX) minX = x; if (x > maxX) maxX = x;
+    if (y < minY) minY = y; if (y > maxY) maxY = y;
+    if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+  }
+  const cx = (minX + maxX) / 2, cy = (minY + maxY) / 2, cz = (minZ + maxZ) / 2;
+
+  // Build transform matrix: translate(pos) * rotate(rot) * scale(scl)
+  // Same as GUI: Matrix4.compose(position, quaternionFromGlobalEuler(rotation), scale)
+  const quaternion = quaternionFromGlobalEuler(rot);
+  const matrix = new THREE.Matrix4().compose(
+    new THREE.Vector3(pos.x, pos.y, pos.z),
+    quaternion,
+    new THREE.Vector3(scl.x, scl.y, scl.z),
+  );
+
+  const v = new THREE.Vector3();
+  for (let i = 0; i < positions.length; i += 3) {
+    // Center, then apply matrix
+    v.set(positions[i] - cx, positions[i + 1] - cy, positions[i + 2] - cz);
+    v.applyMatrix4(matrix);
+    positions[i] = v.x;
+    positions[i + 1] = v.y;
+    positions[i + 2] = v.z;
+  }
+}
+
+/**
+ * Write flat f32 positions to a binary file (same as cli.rs write_positions_bin).
+ */
+function writePositionsBin(path: string, positions: Float32Array): void {
+  writeFileSync(path, Buffer.from(positions.buffer, positions.byteOffset, positions.byteLength));
+}
+
+function sceneSlice(args: ReturnType<typeof parseArgs>): void {
+  const voxlPath = args.positional[0];
+  if (!voxlPath) throw new Error('Usage: scene slice <scene.voxl> --o <output.nanodlp> [--mesh-dir <dir>]');
+
+  const output = requireFlag(args.flags, 'o');
+  const meshDir = optionalFlag(args.flags, 'mesh-dir') ?? dirname(resolve(voxlPath));
+  const layerHeight = optionalFlag(args.flags, 'layer-height') ?? '0.05';
+  const buildWidth = optionalFlag(args.flags, 'build-width-mm') ?? '218.0';
+  const buildDepth = optionalFlag(args.flags, 'build-depth-mm') ?? '122.0';
+
+  const doc = loadVoxl(voxlPath);
+  const visibleModels = doc.models.filter((m) => m.visible);
+
+  if (visibleModels.length === 0) throw new Error('No visible models in scene');
+
+  console.error(`scene slice: ${visibleModels.length} visible models`);
+
+  // Phase 1: Load each model's STL, apply translation, collect all positions
+  const allPositions: Float32Array[] = [];
+  let totalTriangles = 0;
+
+  for (const model of visibleModels) {
+    const meshFileName = model.mesh.fileName ?? model.name + '.stl';
+    // Try mesh-dir, then absolute path, then cwd
+    let meshPath: string | null = null;
+    const candidates = [
+      resolve(meshDir, meshFileName),
+      meshFileName,
+      resolve(meshFileName),
+    ];
+    for (const c of candidates) {
+      try { statSync(c); meshPath = c; break; } catch { /* try next */ }
+    }
+    if (!meshPath) throw new Error(`Mesh file not found for model '${model.name}': tried ${candidates.join(', ')}`);
+
+    console.error(`  loading ${model.name}: ${meshPath}`);
+    const positions = loadBinaryStl(meshPath);
+
+    // Apply full scene transform (position + rotation + scale)
+    applyVoxlTransform(positions, model.transform);
+    const t = model.transform;
+    const hasRot = t.rotation.x !== 0 || t.rotation.y !== 0 || t.rotation.z !== 0;
+    const hasScl = t.scale.x !== 1 || t.scale.y !== 1 || t.scale.z !== 1;
+    const hasPos = t.position.x !== 0 || t.position.y !== 0 || t.position.z !== 0;
+    if (hasPos || hasRot || hasScl) {
+      console.error(`    transform: pos=(${t.position.x.toFixed(1)},${t.position.y.toFixed(1)},${t.position.z.toFixed(1)}) rot=(${t.rotation.x.toFixed(3)},${t.rotation.y.toFixed(3)},${t.rotation.z.toFixed(3)}) scale=(${t.scale.x},${t.scale.y},${t.scale.z})`);
+    }
+
+    allPositions.push(positions);
+    totalTriangles += positions.length / 9;
+  }
+
+  // Phase 2: Merge into single positions buffer
+  const totalFloats = allPositions.reduce((sum, p) => sum + p.length, 0);
+  const merged = new Float32Array(totalFloats);
+  let writeOffset = 0;
+  for (const p of allPositions) {
+    merged.set(p, writeOffset);
+    writeOffset += p.length;
+  }
+
+  // Phase 3: Write merged positions.bin
+  const tmpDir = `/tmp/df-scene-slice-${Date.now()}`;
+  execSync(`mkdir -p ${tmpDir}`);
+  const mergedPath = resolve(tmpDir, 'positions.bin');
+  writePositionsBin(mergedPath, merged);
+  console.error(`  merged: ${totalTriangles} triangles -> ${mergedPath}`);
+
+  // Phase 4: Shell out to Rust slicer
+  const rustCli = resolve(dirname(new URL(import.meta.url).pathname), '../rust/dragonfruit-cli/target/release/dragonfruit-cli');
+  const sliceCmd = [
+    rustCli,
+    'slice', 'run',
+    mergedPath,
+    '-o', resolve(output),
+    '--layer-height', layerHeight,
+    '--build-width-mm', buildWidth,
+    '--build-depth-mm', buildDepth,
+    '--json',
+  ].join(' ');
+
+  console.error(`  slicing: ${sliceCmd}`);
+  const result = execSync(sliceCmd, { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 });
+
+  // Cleanup temp
+  execSync(`rm -rf ${tmpDir}`);
+
+  if (jsonOutput(args.flags)) {
+    // Parse and augment the Rust output with scene info
+    const sliceResult = JSON.parse(result);
+    sliceResult.scene = {
+      voxl: resolve(voxlPath),
+      models: visibleModels.length,
+      total_triangles: totalTriangles,
+    };
+    console.log(JSON.stringify(sliceResult, null, 2));
+  } else {
+    // Rust already printed JSON to stdout, just pass it through
+    process.stdout.write(result);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+const USAGE = `dragonfruit-ts-cli — headless scene & support operations on .voxl files
+
+Usage: npx tsx scripts/dragonfruit-ts-cli.ts <command> <subcommand> [args]
+
+Commands:
+  scene create          Create empty .voxl scene
+  scene add-model       Add model to scene
+  scene remove-model    Remove model (cascades supports)
+  scene list-models     List models
+  scene transform-model Set model transform
+  scene duplicate       Duplicate a model
+  scene arrange         Auto-arrange models on build plate (SAT nesting)
+  scene slice           Merge scene models + slice via Rust engine
+  scene group           Group models
+  scene ungroup         Ungroup
+  scene list-groups     List groups
+  scene center-xy       Center model XY on plate
+  scene place-on-platform  Place model on platform (min Z = 0)
+  scene export-stl      Merge scene → binary STL via Rust
+  scene load            Dump full scene
+
+  support add-trunk     Add trunk + root support
+  support add-branch    Add branch to knot
+  support add-leaf      Add leaf to knot
+  support add-brace     Add brace between knots
+  support add-knot      Add knot on shaft
+  support add-twig      Add twig (model-to-model disk contact)
+  support add-stick     Add stick (model-to-model cone contact)
+  support add-kickstand Add kickstand support
+  support update        Update element fields (diameter, position, etc.)
+  support remove        Remove element (full cascading)
+  support straighten-segment  Convert bezier segment to straight
+  support list          List all supports
+
+Flags: --json for JSON stdout output
+
+Each command operates on a .voxl file — the same format the DragonFruit GUI uses.`;
+
+/**
+ * Wrap a command function with timing. Captures stdout JSON output and injects _perf.
+ */
+function withTiming(fn: (args: ReturnType<typeof parseArgs>) => void, args: ReturnType<typeof parseArgs>): void {
+  const t0 = performance.now();
+  const commandLabel = `${args.command} ${args.subcommand}`;
+
+  // Intercept console.log to capture JSON output and inject _perf
+  const originalLog = console.log;
+  let capturedJson: string | null = null;
+
+  if (jsonOutput(args.flags)) {
+    console.log = (...logArgs: unknown[]) => {
+      capturedJson = String(logArgs[0]);
+    };
+  }
+
+  fn(args);
+
+  const elapsed_ms = +(performance.now() - t0).toFixed(2);
+
+  if (jsonOutput(args.flags)) {
+    console.log = originalLog;
+    if (capturedJson) {
+      try {
+        const parsed = JSON.parse(capturedJson);
+        parsed._perf = { command: commandLabel, elapsed_ms };
+        console.log(JSON.stringify(parsed, null, 2));
+      } catch {
+        console.log(capturedJson);
+      }
+    }
+  } else {
+    console.error(`  [${commandLabel}] ${elapsed_ms}ms`);
+  }
+}
+
+function main(): void {
+  const rawArgs = process.argv.slice(2);
+  if (rawArgs.length === 0 || rawArgs[0] === '--help' || rawArgs[0] === '-h') {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  const args = parseArgs(rawArgs);
+
+  const dispatch = (fn: (a: ReturnType<typeof parseArgs>) => void) => withTiming(fn, args);
+
+  try {
+    if (args.command === 'scene') {
+      switch (args.subcommand) {
+        case 'create': dispatch(sceneCreate); break;
+        case 'add-model': dispatch(sceneAddModel); break;
+        case 'remove-model': dispatch(sceneRemoveModel); break;
+        case 'list-models': dispatch(sceneListModels); break;
+        case 'transform-model': dispatch(sceneTransformModel); break;
+        case 'duplicate': dispatch(sceneDuplicate); break;
+        case 'arrange': dispatch(sceneArrange); break;
+        case 'slice': dispatch(sceneSlice); break;
+        case 'group': dispatch(sceneGroup); break;
+        case 'ungroup': dispatch(sceneUngroup); break;
+        case 'list-groups': dispatch(sceneListGroups); break;
+        case 'center-xy': dispatch(sceneCenterXY); break;
+        case 'place-on-platform': dispatch(scenePlace); break;
+        case 'export-stl': dispatch(sceneExportStl); break;
+        case 'load': dispatch(sceneLoad); break;
+        default: throw new Error(`Unknown scene subcommand: ${args.subcommand}`);
+      }
+    } else if (args.command === 'support') {
+      switch (args.subcommand) {
+        case 'add-trunk': dispatch(supportAddTrunk); break;
+        case 'add-branch': dispatch(supportAddBranch); break;
+        case 'add-leaf': dispatch(supportAddLeaf); break;
+        case 'add-brace': dispatch(supportAddBrace); break;
+        case 'add-knot': dispatch(supportAddKnot); break;
+        case 'add-twig': dispatch(supportAddTwig); break;
+        case 'add-stick': dispatch(supportAddStick); break;
+        case 'add-kickstand': dispatch(supportAddKickstand); break;
+        case 'update': dispatch(supportUpdate); break;
+        case 'remove': dispatch(supportRemove); break;
+        case 'straighten-segment': dispatch(supportStraightenSegment); break;
+        case 'list': dispatch(supportList); break;
+        default: throw new Error(`Unknown support subcommand: ${args.subcommand}`);
+      }
+    } else {
+      throw new Error(`Unknown command: ${args.command}\n\n${USAGE}`);
+    }
+  } catch (err: any) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/island-compare-rs-ts.ts
+++ b/scripts/island-compare-rs-ts.ts
@@ -1,0 +1,444 @@
+#!/usr/bin/env npx tsx
+/**
+ * Compare Rust vs TypeScript island detection pipelines.
+ *
+ * Strategy: Use Rust-rasterized masks as ground truth input,
+ * then run BOTH the Rust and TS scan+track pipelines on the same masks.
+ * This isolates the scan/track/analyze logic from rasterization differences.
+ *
+ * Usage: npx tsx scripts/island-compare-rs-ts.ts /tmp/df-det-a
+ *   (where /tmp/df-det-a is output from: dragonfruit-cli island full model.stl -o /tmp/df-det-a)
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// ---------------------------------------------------------------------------
+// RLE types (same as island-bench.ts)
+// ---------------------------------------------------------------------------
+type RleRow = Int32Array;
+type RleMask = { rows: RleRow[]; width: number; height: number };
+type RleLabelRow = Int32Array;
+type RleLabels = { rows: RleLabelRow[]; width: number; height: number };
+type ComponentInfo = {
+  id: number; label: number; area_px: number; size: number;
+  centroidSumX: number; centroidSumY: number;
+};
+type Island = {
+  id: number; firstLayer: number; lastLayer: number;
+  status: 'active' | 'complete'; totalAreaMm2: number;
+  perLayerAreaMm2: Map<number, number>; parentId?: number;
+  childIds: number[]; volumeMm3?: number; maxAreaMm2?: number;
+  maxAreaLayer?: number; isMergedPlaceholder?: boolean;
+  centroidSumX: number; centroidSumY: number; centroidSumZ: number;
+  centroidCount: number;
+  centroid?: { x: number; y: number; z: number };
+  lastLayerCentroid?: { x: number; y: number; z: number };
+};
+
+// ---------------------------------------------------------------------------
+// RLE functions (copied from island-bench.ts — the TS reference impl)
+// ---------------------------------------------------------------------------
+function rleIntersectDilated(a: RleMask, b: RleMask, buffer: number): RleMask {
+  const { width, height } = a;
+  const resultRows: RleRow[] = new Array(height);
+  for (let y = 0; y < height; y++) {
+    const aRow = a.rows[y];
+    if (aRow.length === 0) { resultRows[y] = new Int32Array(0); continue; }
+    const relevantBRows: RleRow[] = [];
+    const startY = Math.max(0, y - buffer), endY = Math.min(height - 1, y + buffer);
+    for (let by = startY; by <= endY; by++) if (b.rows[by].length > 0) relevantBRows.push(b.rows[by]);
+    if (relevantBRows.length === 0) { resultRows[y] = new Int32Array(0); continue; }
+    const bIntervals: { start: number; end: number }[] = [];
+    for (const bRow of relevantBRows) {
+      for (let i = 0; i < bRow.length; i += 2) {
+        bIntervals.push({ start: Math.max(0, bRow[i] - buffer), end: Math.min(width, bRow[i] + bRow[i + 1] + buffer) });
+      }
+    }
+    bIntervals.sort((p, q) => p.start - q.start);
+    const mergedB: { start: number; end: number }[] = [];
+    if (bIntervals.length > 0) {
+      let curr = bIntervals[0];
+      for (let i = 1; i < bIntervals.length; i++) {
+        const next = bIntervals[i];
+        if (next.start <= curr.end) curr.end = Math.max(curr.end, next.end);
+        else { mergedB.push(curr); curr = next; }
+      }
+      mergedB.push(curr);
+    }
+    const resSpans: number[] = [];
+    let bIdx = 0;
+    for (let i = 0; i < aRow.length; i += 2) {
+      const aStart = aRow[i], aEnd = aStart + aRow[i + 1];
+      while (bIdx < mergedB.length && mergedB[bIdx].end <= aStart) bIdx++;
+      let tempBIdx = bIdx;
+      while (tempBIdx < mergedB.length && mergedB[tempBIdx].start < aEnd) {
+        const bInt = mergedB[tempBIdx];
+        const start = Math.max(aStart, bInt.start), end = Math.min(aEnd, bInt.end);
+        if (start < end) {
+          if (resSpans.length > 0 && resSpans[resSpans.length - 2] + resSpans[resSpans.length - 1] === start) resSpans[resSpans.length - 1] += end - start;
+          else resSpans.push(start, end - start);
+        }
+        tempBIdx++;
+      }
+    }
+    resultRows[y] = new Int32Array(resSpans);
+  }
+  return { rows: resultRows, width, height };
+}
+
+function rleSubtract(a: RleMask, b: RleMask): RleMask {
+  const { width, height } = a;
+  const resultRows: RleRow[] = new Array(height);
+  for (let y = 0; y < height; y++) {
+    const aRow = a.rows[y], bRow = b.rows[y];
+    if (aRow.length === 0) { resultRows[y] = new Int32Array(0); continue; }
+    if (bRow.length === 0) { resultRows[y] = aRow; continue; }
+    const resSpans: number[] = [];
+    let bIdx = 0;
+    for (let i = 0; i < aRow.length; i += 2) {
+      let currentStart = aRow[i];
+      const currentEnd = currentStart + aRow[i + 1];
+      while (bIdx < bRow.length && bRow[bIdx] + bRow[bIdx + 1] <= currentStart) bIdx += 2;
+      let tempBIdx = bIdx;
+      while (tempBIdx < bRow.length && bRow[tempBIdx] < currentEnd) {
+        const bStart = bRow[tempBIdx], bEnd = bStart + bRow[tempBIdx + 1];
+        if (bStart > currentStart) resSpans.push(currentStart, bStart - currentStart);
+        currentStart = Math.max(currentStart, bEnd);
+        tempBIdx += 2;
+      }
+      if (currentStart < currentEnd) resSpans.push(currentStart, currentEnd - currentStart);
+    }
+    resultRows[y] = new Int32Array(resSpans);
+  }
+  return { rows: resultRows, width, height };
+}
+
+function rleLabelComponents(mask: RleMask, connectivity: 4 | 8 = 4): { labels: RleLabels; components: ComponentInfo[] } {
+  const { rows, width, height } = mask;
+  const labelRows: RleLabelRow[] = new Array(height);
+  const parent: number[] = [0], area: number[] = [0], sumX: number[] = [0], sumY: number[] = [0];
+  let nextId = 1;
+  function find(i: number): number { if (parent[i] === i) return i; parent[i] = find(parent[i]); return parent[i]; }
+  function union(i: number, j: number) {
+    const ri = find(i), rj = find(j);
+    if (ri !== rj) { parent[rj] = ri; area[ri] += area[rj]; sumX[ri] += sumX[rj]; sumY[ri] += sumY[rj]; area[rj] = 0; sumX[rj] = 0; sumY[rj] = 0; }
+  }
+  function newLabel(a: number, sx: number, sy: number): number {
+    const id = nextId++; parent[id] = id; area[id] = a; sumX[id] = sx; sumY[id] = sy; return id;
+  }
+  for (let y = 0; y < height; y++) {
+    const row = rows[y], prevRow = y > 0 ? labelRows[y - 1] : null;
+    const cur: number[] = [];
+    for (let i = 0; i < row.length; i += 2) {
+      const start = row[i], len = row[i + 1], end = start + len;
+      const myId = newLabel(len, len * (start + (end - 1)) / 2, len * y);
+      cur.push(start, len, myId);
+      if (prevRow) {
+        const expand = connectivity === 8 ? 1 : 0;
+        const ss = start - expand, se = end + expand;
+        for (let j = 0; j < prevRow.length; j += 3) {
+          const ps = prevRow[j], pl = prevRow[j + 1], pid = prevRow[j + 2], pe = ps + pl;
+          if (Math.max(ss, ps) < Math.min(se, pe)) union(myId, pid);
+          if (ps >= se) break;
+        }
+      }
+    }
+    labelRows[y] = new Int32Array(cur);
+  }
+  const comps: ComponentInfo[] = [];
+  const idMap = new Map<number, number>();
+  let fid = 1;
+  for (let y = 0; y < height; y++) {
+    const row = labelRows[y];
+    for (let i = 0; i < row.length; i += 3) {
+      const root = find(row[i + 2]);
+      let f = idMap.get(root);
+      if (f === undefined) {
+        f = fid++;
+        idMap.set(root, f);
+        comps.push({ id: f, label: f, area_px: area[root], size: area[root], centroidSumX: sumX[root], centroidSumY: sumY[root] });
+      }
+      row[i + 2] = f;
+    }
+  }
+  return { labels: { rows: labelRows, width, height }, components: comps };
+}
+
+function scanLayer(current: RleMask, prev: RleMask | null, opts: { px_mm: number; support_buffer_mm: number; connectivity: 4 | 8 }) {
+  let candidates: RleMask;
+  if (!prev) { candidates = current; }
+  else {
+    const buf = Math.max(0, Math.round(opts.support_buffer_mm / opts.px_mm));
+    candidates = rleSubtract(current, rleIntersectDilated(current, prev, buf));
+  }
+  const { labels, components } = rleLabelComponents(candidates, opts.connectivity);
+  return { labels, components, solidMask: current };
+}
+
+// IslandTracker — same as island-bench.ts
+class IslandTracker {
+  private islands: Map<number, Island> = new Map();
+  private nextId = 1;
+  private px_mm: number;
+  private minOverlapPx: number;
+  private overlapNeighborhoodPx: number;
+  private pendingMerges: Array<{ mergeLayer: number; candidateIds: number[]; mergedIslandId: number; overlapCounts: Map<number, number>; preMergeLabels: RleLabels }> = [];
+  private readonly MERGE_EVAL_WINDOW = 30;
+  constructor(px_mm: number, opts?: { minOverlapPx?: number; overlapNeighborhoodPx?: number }) {
+    this.px_mm = px_mm;
+    this.minOverlapPx = Math.max(1, opts?.minOverlapPx ?? 1);
+    this.overlapNeighborhoodPx = Math.max(0, opts?.overlapNeighborhoodPx ?? 1);
+  }
+  processLayer(li: number, cl: RleLabels, cc: ComponentInfo[], pil: RleLabels | null, sm: RleMask): RleLabels {
+    const { width, height } = cl;
+    const ilr: Int32Array[] = new Array(height);
+    if (!pil) {
+      const m = new Map<number, number>();
+      for (const c of cc) { const a = c.area_px * this.px_mm * this.px_mm; m.set(c.id, this.createIsland(li, a, c)); }
+      for (let y = 0; y < height; y++) { const r = cl.rows[y], nr: number[] = []; for (let i = 0; i < r.length; i += 3) { const id = m.get(r[i + 2]) || 0; if (id > 0) nr.push(r[i], r[i + 1], id); } ilr[y] = new Int32Array(nr); }
+    } else {
+      const { labels: sl, components: sc } = rleLabelComponents(sm, 4);
+      const m = new Map<number, number>();
+      for (const comp of sc) {
+        const ov = this.findOverlaps(comp.id, sl, pil);
+        const prev = new Set<number>(); for (const [id, cnt] of ov) if (cnt >= this.minOverlapPx) prev.add(id);
+        const active = new Set<number>(); for (const id of prev) { const isl = this.islands.get(id); if (isl && isl.status === 'active') active.add(id); }
+        const rp = (sid: number): number => { let c = sid; const v = new Set<number>(); while (true) { if (v.has(c)) break; v.add(c); const i = this.islands.get(c); if (!i || i.parentId === undefined) break; c = i.parentId; } return c; };
+        const a = comp.area_px * this.px_mm * this.px_mm;
+        let aid: number;
+        if (active.size === 0) {
+          if (prev.size > 0) { aid = rp(prev.values().next().value as number); this.updateIsland(aid, li, a, comp); }
+          else aid = this.createIsland(li, a, comp);
+        } else if (active.size === 1) { aid = active.values().next().value as number; this.updateIsland(aid, li, a, comp); }
+        else { const rs = new Set<number>(); for (const id of active) rs.add(rp(id)); aid = this.mergeIslands(li, rs, pil, a, comp); }
+        m.set(comp.id, aid);
+        this.trackMergeOverlaps(li, comp.id, sl, pil);
+      }
+      for (let y = 0; y < height; y++) { const r = sl.rows[y], nr: number[] = []; for (let i = 0; i < r.length; i += 3) { const id = m.get(r[i + 2]) || 0; if (id > 0) nr.push(r[i], r[i + 1], id); } ilr[y] = new Int32Array(nr); }
+    }
+    this.evalMerges(li);
+    return { rows: ilr, width, height };
+  }
+  private findOverlaps(cid: number, sl: RleLabels, pil: RleLabels): Map<number, number> {
+    const counts = new Map<number, number>();
+    const { height } = sl;
+    for (let y = 0; y < height; y++) {
+      const sr = sl.rows[y]; if (sr.length === 0) continue;
+      for (let i = 0; i < sr.length; i += 3) {
+        if (sr[i + 2] !== cid) continue;
+        const s = sr[i], e = s + sr[i + 1], ss = s - this.overlapNeighborhoodPx, se = e + this.overlapNeighborhoodPx;
+        const ys = Math.max(0, y - this.overlapNeighborhoodPx), ye = Math.min(height - 1, y + this.overlapNeighborhoodPx);
+        for (let py = ys; py <= ye; py++) {
+          const pr = pil.rows[py]; if (pr.length === 0) continue;
+          for (let j = 0; j < pr.length; j += 3) {
+            const ps = pr[j], pe = ps + pr[j + 1], pid = pr[j + 2];
+            const os = Math.max(ss, ps), oe = Math.min(se, pe);
+            if (os < oe && pid > 0) counts.set(pid, (counts.get(pid) ?? 0) + (oe - os));
+            if (ps >= se) break;
+          }
+        }
+      }
+    }
+    return counts;
+  }
+  private trackMergeOverlaps(_li: number, cid: number, sl: RleLabels, _pil: RleLabels): void {
+    if (this.pendingMerges.length === 0) return;
+    for (const p of this.pendingMerges) {
+      const ov = this.findOverlaps(cid, sl, p.preMergeLabels);
+      for (const [id, cnt] of ov) if (p.overlapCounts.has(id)) p.overlapCounts.set(id, (p.overlapCounts.get(id) ?? 0) + cnt);
+    }
+  }
+  private createIsland(li: number, a: number, c?: ComponentInfo): number {
+    const id = this.nextId++;
+    this.islands.set(id, { id, firstLayer: li, lastLayer: li, status: 'active', totalAreaMm2: a,
+      perLayerAreaMm2: new Map([[li, a]]), childIds: [], maxAreaMm2: a, maxAreaLayer: li,
+      centroidSumX: c?.centroidSumX ?? 0, centroidSumY: c?.centroidSumY ?? 0,
+      centroidSumZ: c ? c.size * li : 0, centroidCount: c ? c.size : 0,
+      lastLayerCentroid: c && c.size > 0 ? { x: c.centroidSumX / c.size, y: c.centroidSumY / c.size, z: li } : undefined,
+    });
+    return id;
+  }
+  private updateIsland(id: number, li: number, a: number, c?: ComponentInfo): void {
+    const isl = this.islands.get(id); if (!isl) return;
+    isl.lastLayer = li; isl.totalAreaMm2 += a; isl.perLayerAreaMm2.set(li, a);
+    if (!isl.maxAreaMm2 || a > isl.maxAreaMm2) { isl.maxAreaMm2 = a; isl.maxAreaLayer = li; }
+    if (c) { isl.centroidSumX += c.centroidSumX; isl.centroidSumY += c.centroidSumY; isl.centroidSumZ += c.size * li; isl.centroidCount += c.size;
+      if (c.size > 0) isl.lastLayerCentroid = { x: c.centroidSumX / c.size, y: c.centroidSumY / c.size, z: li }; }
+  }
+  private mergeIslands(li: number, ids: Set<number>, pil: RleLabels, a: number, c?: ComponentInfo): number {
+    const pre: RleLabels = { width: pil.width, height: pil.height, rows: pil.rows.map(r => new Int32Array(r)) };
+    for (const id of ids) { const isl = this.islands.get(id); if (isl) { isl.status = 'complete'; isl.lastLayer = li - 1; } }
+    const mid = this.createIsland(li, a, c);
+    const mi = this.islands.get(mid)!; mi.isMergedPlaceholder = true;
+    const oc = new Map<number, number>(); for (const id of ids) oc.set(id, 0);
+    this.pendingMerges.push({ mergeLayer: li, candidateIds: Array.from(ids), mergedIslandId: mid, overlapCounts: oc, preMergeLabels: pre });
+    return mid;
+  }
+  private evalMerges(cl: number): void {
+    const tf: number[] = [];
+    for (let i = 0; i < this.pendingMerges.length; i++) {
+      const p = this.pendingMerges[i];
+      if (cl - p.mergeLayer >= this.MERGE_EVAL_WINDOW) {
+        let pid = 0, mx = -1;
+        for (const [id, cnt] of p.overlapCounts) if (cnt > mx) { mx = cnt; pid = id; }
+        for (const cid of p.candidateIds) if (cid !== pid) { const ch = this.islands.get(cid); if (ch) ch.parentId = pid; }
+        const mi = this.islands.get(p.mergedIslandId); if (mi) mi.parentId = pid;
+        const par = this.islands.get(pid);
+        if (par && mi) {
+          for (const cid of p.candidateIds) if (cid !== pid && !par.childIds.includes(cid)) par.childIds.push(cid);
+          if (!par.childIds.includes(p.mergedIslandId)) par.childIds.push(p.mergedIslandId);
+          par.lastLayer = mi.lastLayer; par.status = mi.status;
+          for (const [l, a] of mi.perLayerAreaMm2) { par.perLayerAreaMm2.set(l, a); par.totalAreaMm2 += a; if (!par.maxAreaMm2 || a > par.maxAreaMm2) { par.maxAreaMm2 = a; par.maxAreaLayer = l; } }
+          if (mi.centroidCount > 0) { par.centroidSumX += mi.centroidSumX; par.centroidSumY += mi.centroidSumY; par.centroidSumZ += mi.centroidSumZ; par.centroidCount += mi.centroidCount; }
+          if (mi.lastLayerCentroid) par.lastLayerCentroid = { ...mi.lastLayerCentroid };
+        }
+        tf.push(i);
+      }
+    }
+    for (let i = tf.length - 1; i >= 0; i--) this.pendingMerges.splice(tf[i], 1);
+  }
+  getIslands(): Island[] {
+    const islands = Array.from(this.islands.values());
+    for (const isl of islands) if (isl.centroidCount > 0) isl.centroid = { x: isl.centroidSumX / isl.centroidCount, y: isl.centroidSumY / isl.centroidCount, z: isl.centroidSumZ / isl.centroidCount };
+    return islands;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Load Rust-generated masks from disk
+// ---------------------------------------------------------------------------
+function loadMaskJson(path: string): RleMask {
+  const raw = JSON.parse(readFileSync(path, 'utf-8'));
+  return {
+    width: raw.width,
+    height: raw.height,
+    rows: raw.rows.map((r: number[]) => {
+      // Convert from [start, length, start, length, ...] pairs
+      const out: number[] = [];
+      for (let i = 0; i < r.length; i += 2) {
+        out.push(r[i], r[i + 1]);
+      }
+      return new Int32Array(out);
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+const rustDir = process.argv[2];
+if (!rustDir) {
+  console.error('Usage: npx tsx scripts/island-compare-rs-ts.ts <rust-island-output-dir>');
+  console.error('  Run: dragonfruit-cli island full model.stl -o <dir>');
+  process.exit(1);
+}
+
+const params = JSON.parse(readFileSync(join(rustDir, 'params.json'), 'utf-8'));
+const numLayers = params.num_layers as number;
+const px_mm = params.px_mm as number;
+const layerHeight = params.layer_height_mm as number;
+const bufferMm = params.support_buffer_mm as number;
+
+console.log(`Loading ${numLayers} Rust-rasterized masks from ${rustDir}`);
+console.log(`  grid: ${params.grid_width}x${params.grid_height}, px_mm=${px_mm}, layer_h=${layerHeight}, buffer=${bufferMm}`);
+
+// Load all masks
+const masks: RleMask[] = [];
+for (let l = 0; l < numLayers; l++) {
+  masks.push(loadMaskJson(join(rustDir, 'layers', `${String(l).padStart(3, '0')}.mask.rle.json`)));
+}
+
+// Run TS pipeline on Rust masks
+console.log('\nRunning TS scan+track pipeline on Rust-rasterized masks...');
+const tsT0 = performance.now();
+const opts = { px_mm, support_buffer_mm: bufferMm, connectivity: 4 as 4 | 8, min_island_area_mm2: 0.0, layer_height_mm: layerHeight };
+
+// Phase 1: per-layer scan
+const tsLayers: ReturnType<typeof scanLayer>[] = [];
+for (let i = 0; i < numLayers; i++) {
+  tsLayers.push(scanLayer(masks[i], i > 0 ? masks[i - 1] : null, opts));
+}
+
+// Phase 2: island tracking
+const tracker = new IslandTracker(px_mm, { minOverlapPx: params.min_overlap_px ?? 4, overlapNeighborhoodPx: params.overlap_neighborhood_px ?? 1 });
+const tsIslandLabels: RleLabels[] = [];
+for (let l = 0; l < numLayers; l++) {
+  const il = tracker.processLayer(l, tsLayers[l].labels, tsLayers[l].components, l > 0 ? tsIslandLabels[l - 1] : null, tsLayers[l].solidMask);
+  tsIslandLabels.push(il);
+}
+const tsIslands = tracker.getIslands();
+for (const isl of tsIslands) { let v = 0; for (const a of isl.perLayerAreaMm2.values()) v += a * layerHeight; isl.volumeMm3 = v; }
+const tsMs = performance.now() - tsT0;
+
+// Load Rust results
+const rustIslands: any[] = JSON.parse(readFileSync(join(rustDir, 'islands.json'), 'utf-8'));
+const rustResult: any = JSON.parse(readFileSync(join(rustDir, 'result.json'), 'utf-8'));
+
+// Also compare per-layer scan output
+console.log('\n=== PER-LAYER SCAN COMPARISON ===');
+let scanDiffLayers = 0;
+let totalTsCandPx = 0;
+let totalRsCandPx = 0;
+for (let l = 0; l < numLayers; l++) {
+  const tsCandPx = tsLayers[l].components.reduce((s, c) => s + c.area_px, 0);
+  totalTsCandPx += tsCandPx;
+
+  // Load Rust components for this layer
+  try {
+    const rsComps: any[] = JSON.parse(readFileSync(join(rustDir, 'layers', `${String(l).padStart(3, '0')}.components.json`), 'utf-8'));
+    const rsCandPx = rsComps.reduce((s: number, c: any) => s + c.area_px, 0);
+    totalRsCandPx += rsCandPx;
+    if (tsCandPx !== rsCandPx) {
+      scanDiffLayers++;
+      if (scanDiffLayers <= 5) {
+        console.log(`  layer ${l}: TS=${tsCandPx}px RS=${rsCandPx}px (delta=${tsCandPx - rsCandPx})`);
+      }
+    }
+  } catch { /* layer file missing */ }
+}
+console.log(`Scan: ${scanDiffLayers}/${numLayers} layers differ`);
+console.log(`  TS total candidate px: ${totalTsCandPx}`);
+console.log(`  RS total candidate px: ${totalRsCandPx}`);
+console.log(`  delta: ${totalTsCandPx - totalRsCandPx} (${((totalTsCandPx - totalRsCandPx) / Math.max(1, totalRsCandPx) * 100).toFixed(2)}%)`);
+
+// Compare island results
+console.log('\n=== ISLAND TRACKING COMPARISON ===');
+const tsReal = tsIslands.filter(i => !i.isMergedPlaceholder);
+const rsReal = rustIslands.filter((i: any) => !i.is_merged_placeholder);
+
+console.log(`  TS: ${tsIslands.length} total, ${tsReal.length} real`);
+console.log(`  RS: ${rustIslands.length} total, ${rsReal.length} real`);
+console.log(`  TS time: ${tsMs.toFixed(0)}ms`);
+
+// Sort both by total_area descending and compare top islands
+const tsSorted = tsReal.sort((a, b) => (b.totalAreaMm2) - (a.totalAreaMm2));
+const rsSorted = rsReal.sort((a: any, b: any) => (b.total_area_mm2) - (a.total_area_mm2));
+
+console.log(`\nTop 15 islands by area:`);
+console.log(`${'#'.padStart(3)} | ${'TS area'.padStart(10)} ${'TS layers'.padStart(12)} | ${'RS area'.padStart(10)} ${'RS layers'.padStart(12)} | ${'match?'.padStart(6)}`);
+console.log('-'.repeat(75));
+
+let matchCount = 0;
+for (let i = 0; i < Math.min(15, Math.max(tsSorted.length, rsSorted.length)); i++) {
+  const ts = tsSorted[i];
+  const rs = rsSorted[i];
+  const tsArea = ts ? ts.totalAreaMm2.toFixed(1) : '---';
+  const tsLayers = ts ? `${ts.firstLayer}-${ts.lastLayer}` : '---';
+  const rsArea = rs ? rs.total_area_mm2.toFixed(1) : '---';
+  const rsLayers = rs ? `${rs.first_layer}-${rs.last_layer}` : '---';
+
+  const areaMatch = ts && rs && Math.abs(ts.totalAreaMm2 - rs.total_area_mm2) < 0.01;
+  const layerMatch = ts && rs && ts.firstLayer === rs.first_layer && ts.lastLayer === rs.last_layer;
+  const match = areaMatch && layerMatch ? '  YES' : '   NO';
+  if (areaMatch && layerMatch) matchCount++;
+
+  console.log(`${String(i + 1).padStart(3)} | ${tsArea.padStart(10)} ${tsLayers.padStart(12)} | ${rsArea.padStart(10)} ${rsLayers.padStart(12)} | ${match}`);
+}
+
+console.log(`\nMatched: ${matchCount}/${Math.min(15, Math.max(tsSorted.length, rsSorted.length))} top islands`);
+
+// Total area comparison
+const tsTotalArea = tsReal.reduce((s, i) => s + i.totalAreaMm2, 0);
+const rsTotalArea = rsReal.reduce((s: number, i: any) => s + i.total_area_mm2, 0);
+console.log(`\nTotal area: TS=${tsTotalArea.toFixed(1)}mm² RS=${rsTotalArea.toFixed(1)}mm² delta=${(tsTotalArea - rsTotalArea).toFixed(1)}mm²`);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -75,9 +75,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -340,6 +340,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -606,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -616,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -628,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -719,9 +734,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
@@ -836,6 +851,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
 name = "cssparser-macros"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,9 +926,9 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "deflate64"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "deranged"
@@ -930,6 +958,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -967,12 +1016,6 @@ dependencies = [
  "redox_users",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "dispatch"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
@@ -1027,6 +1070,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dom_query"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
+dependencies = [
+ "bit-set",
+ "cssparser 0.36.0",
+ "foldhash 0.2.0",
+ "html5ever 0.38.0",
+ "precomputed-hash",
+ "selectors 0.36.1",
+ "tendril 0.5.0",
 ]
 
 [[package]]
@@ -1132,9 +1190,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embed-resource"
-version = "3.0.6"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a075fc573c64510038d7ee9abc7990635863992f83ebc52c8b433b8411a02e"
+checksum = "63a1d0de4f2249aa0ff5884d7080814f446bb241a559af6c170a41e878ed2d45"
 dependencies = [
  "cc",
  "memchr",
@@ -1194,9 +1252,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e8918065695684b2b0702da20382d5ae6065cf3327bc2d6436bd49a71ce9f3"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
 dependencies = [
  "serde",
  "serde_core",
@@ -1286,6 +1344,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1581,20 +1645,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1778,7 +1842,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1828,8 +1892,18 @@ checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.14.1",
  "match_token",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
@@ -2152,15 +2226,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -2174,9 +2248,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "javascriptcore-rs"
@@ -2210,7 +2284,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2219,9 +2293,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -2235,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2282,17 +2378,11 @@ version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
- "cssparser",
- "html5ever",
+ "cssparser 0.29.6",
+ "html5ever 0.29.1",
  "indexmap 2.13.0",
- "selectors",
+ "selectors 0.24.0",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -2326,9 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
@@ -2352,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
 ]
@@ -2422,9 +2512,20 @@ dependencies = [
  "log",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
- "tendril",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril 0.5.0",
+ "web_atoms",
 ]
 
 [[package]]
@@ -2541,7 +2642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.11.0",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys",
  "num_enum",
@@ -2561,7 +2662,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -2593,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -2603,11 +2704,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2631,38 +2732,8 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "libc",
  "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
  "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-text",
- "objc2-core-video",
- "objc2-foundation",
- "objc2-quartz-core",
-]
-
-[[package]]
-name = "objc2-cloud-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-data"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
  "objc2-foundation",
 ]
 
@@ -2691,41 +2762,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-core-image"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-text"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
-]
-
-[[package]]
-name = "objc2-core-video"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-io-surface",
-]
-
-[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,7 +2784,6 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2765,16 +2800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-javascript-core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
-dependencies = [
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,17 +2809,6 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-security"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2821,15 +2835,13 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
- "objc2-javascript-core",
- "objc2-security",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2839,9 +2851,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -2871,9 +2883,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -2998,6 +3010,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3038,16 @@ checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3048,6 +3081,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3069,6 +3112,19 @@ checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3097,6 +3153,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
 ]
@@ -3138,7 +3203,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3238,11 +3303,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.8+spec-1.1.0",
 ]
 
 [[package]]
@@ -3294,10 +3359,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.44"
+name = "quick-xml"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3307,6 +3381,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -3557,9 +3637,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3628,6 +3708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3673,9 +3759,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3705,9 +3791,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3805,14 +3891,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
- "cssparser",
- "derive_more",
+ "cssparser 0.29.6",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "phf 0.8.0",
  "phf_codegen 0.8.0",
  "precomputed-hash",
- "servo_arc",
+ "servo_arc 0.2.0",
+ "smallvec",
+]
+
+[[package]]
+name = "selectors"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser 0.36.0",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc 0.4.3",
  "smallvec",
 ]
 
@@ -3914,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -3997,6 +4102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4066,12 +4180,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4142,6 +4256,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "string_cache_codegen"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4149,6 +4275,18 @@ checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -4254,23 +4392,22 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.5"
+version = "0.34.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
+checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
- "dispatch",
+ "dispatch2",
  "dlopen2",
  "dpi",
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
  "jni",
- "lazy_static",
  "libc",
  "log",
  "ndk",
@@ -4282,7 +4419,6 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "raw-window-handle",
- "scopeguard",
  "tao-macros",
  "unicode-segmentation",
  "url",
@@ -4311,9 +4447,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.10.2"
+version = "2.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463ae8677aa6d0f063a900b9c41ecd4ac2b7ca82f0b058cc4491540e55b20129"
+checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4339,7 +4475,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.1",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4362,9 +4498,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.5"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7bd893329425df750813e95bd2b643d5369d929438da96d5bbb7cc2c918f74"
+checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4384,9 +4520,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac423e5859d9f9ccdd32e3cf6a5866a15bedbf25aa6630bcb2acde9468f6ae3"
+checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4411,9 +4547,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.4"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a1bd2861ff0c8766b1d38b32a6a410f6dc6532d4ef534c47cfb2236092f59"
+checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4440,9 +4576,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b885ffeac82b00f1f6fd292b6e5aabfa7435d537cef57d11e38a489956535651"
+checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
 dependencies = [
  "cookie",
  "dpi",
@@ -4465,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5204682391625e867d16584fedc83fc292fb998814c9f7918605c789cd876314"
+checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
 dependencies = [
  "gtk",
  "http",
@@ -4475,7 +4611,6 @@ dependencies = [
  "log",
  "objc2",
  "objc2-app-kit",
- "objc2-foundation",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -4492,9 +4627,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd169fccdff05eff2c1033210b9b94acd07a47e6fa9a3431cf09cfd4f01c87e"
+checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
 dependencies = [
  "anyhow",
  "brotli",
@@ -4502,7 +4637,7 @@ dependencies = [
  "ctor",
  "dunce",
  "glob",
- "html5ever",
+ "html5ever 0.29.1",
  "http",
  "infer",
  "json-patch",
@@ -4541,12 +4676,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -4560,6 +4695,16 @@ checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
 dependencies = [
  "futf",
  "mac",
+ "utf-8",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
  "utf-8",
 ]
 
@@ -4646,9 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -4711,11 +4856,11 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.14",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4732,6 +4877,15 @@ name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
@@ -4762,30 +4916,30 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
- "winnow 0.7.14",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow 0.7.14",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tower"
@@ -4923,13 +5077,13 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "uds_windows"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4987,9 +5141,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -5054,11 +5208,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5153,37 +5307,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -5192,9 +5334,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5202,22 +5344,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -5246,9 +5388,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -5271,9 +5413,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.12"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -5285,9 +5427,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.12"
+version = "0.31.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
 dependencies = [
  "bitflags 2.11.0",
  "rustix",
@@ -5297,9 +5439,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.10"
+version = "0.32.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -5309,20 +5451,20 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.8"
+version = "0.31.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.2",
  "quote",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.8"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
 dependencies = [
  "dlib",
  "log",
@@ -5331,12 +5473,24 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]
@@ -5941,9 +6095,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
@@ -6054,24 +6217,23 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.54.2"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb26159b420aa77684589a744ae9a9461a95395b848764ad12290a14d960a11a"
+checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
 dependencies = [
  "base64 0.22.1",
  "block2",
  "cookie",
  "crossbeam-channel",
  "dirs",
+ "dom_query",
  "dpi",
  "dunce",
  "gdkx11",
  "gtk",
- "html5ever",
  "http",
  "javascriptcore-rs",
  "jni",
- "kuchikiki",
  "libc",
  "ndk",
  "objc2",
@@ -6179,7 +6341,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 0.7.14",
+ "winnow 0.7.15",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -6191,7 +6353,7 @@ version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6207,24 +6369,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
- "winnow 0.7.14",
+ "winnow 0.7.15",
  "zvariant",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6403,7 +6565,7 @@ dependencies = [
  "enumflags2",
  "serde",
  "url",
- "winnow 0.7.14",
+ "winnow 0.7.15",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -6414,7 +6576,7 @@ version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6431,5 +6593,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow 0.7.14",
+ "winnow 0.7.15",
 ]


### PR DESCRIPTION
## Summary

Two CLI tools exposing the full DragonFruit pipeline for headless automation scripting. Every command produces JSON output (`--json`) and reports timing metrics. No new logic — only wrappers to existing functions.

Stacked on #82 (`feat/island-detection-rust`).

## Architecture

```
dragonfruit-cli (Rust)              dragonfruit-ts-cli (TypeScript)
Wraps existing Rust backend         Wraps existing TS modules
Same code paths as Tauri IPC        Same code paths as GUI

mesh -- read-stl, info,             scene -- create, add-model,
        export-stl, export-3mf               remove-model, list-models,
island -- rasterize, scan, track,            transform-model, duplicate,
           analyze, full, bench,             arrange (SAT nesting),
           rle-label, rle-subtract           slice, group, ungroup,
slice -- run, preview-layer, info            list-groups, center-xy,
print -- save, read-bytes,                   place-on-platform,
          read-layer, cleanup                export-stl, load
benchmark                           support -- add-trunk, add-branch,
info                                           add-leaf, add-brace,
                                               add-knot, add-twig,
                                               add-stick, add-kickstand,
                                               update, remove (cascading),
                                               straighten-segment, list
```

**57 total CLI commands** covering ~72% of all app operations.

## Rust CLI — `dragonfruit-cli`

Standalone crate at `rust/dragonfruit-cli/` wrapping existing Rust backend — same code as Tauri IPC commands.

### New Rust library functions

- `io::write_binary_stl(path, positions)` — extracted from inline CLI code
- `io::write_3mf(path, positions)` — minimal 3MF writer (ZIP + XML, uses existing `zip` crate)
- 7 new tests: STL roundtrip (unit + proptest), 3MF structure (unit + proptest + validation)

## TypeScript CLI — `dragonfruit-ts-cli`

Operates on `.voxl` files — the same scene format the GUI saves/loads. Imports existing TS modules directly (THREE.js works in Node.js).

## End-to-end pipeline example

```bash
# TS CLI: build scene
npx tsx scripts/dragonfruit-ts-cli.ts scene create --o scene.voxl
npx tsx scripts/dragonfruit-ts-cli.ts scene add-model scene.voxl --mesh model.stl
npx tsx scripts/dragonfruit-ts-cli.ts scene duplicate scene.voxl --id $ID --count 2
npx tsx scripts/dragonfruit-ts-cli.ts scene arrange scene.voxl --mesh-dir . --spacing 5

# TS CLI + Rust CLI: slice
npx tsx scripts/dragonfruit-ts-cli.ts scene slice scene.voxl --o out.nanodlp --mesh-dir .

# Rust CLI: inspect
dragonfruit-cli slice preview-layer out.nanodlp --layer 500 -o preview.png
dragonfruit-cli island full model.stl -o /tmp/islands --json
```

## Verification scripts

- `scripts/island-compare-rs-ts.ts` — runs TS and Rust island pipelines on same masks, compares per-layer scan output, island tracking, and total areas

## Files

- `rust/dragonfruit-cli/src/main.rs` (1,668 lines) — Rust CLI binary
- `rust/dragonfruit-cli/src/io.rs` (892 lines) — `write_binary_stl`, `write_3mf` + tests
- `rust/dragonfruit-cli/Cargo.toml` — Crate manifest
- `scripts/dragonfruit-ts-cli.ts` (1,520 lines) — TypeScript CLI
- `scripts/island-compare-rs-ts.ts` (444 lines) — TS vs Rust parity verification
- `rust/dragonfruit-cli/docs/CLI.md` — Full CLI reference + coverage audit
- `rust/dragonfruit-cli/docs/CLI_GAPS_PLAN.md` — Implementation plan
- `rust/dragonfruit-cli/docs/CLI_WONT_DO.md` — Won't-do list for review
- `rust/dragonfruit-islands/tests/worst_case.rs` (398 lines) — Worst-case island detection tests
