### PR TITLE
fix: Windows NO-OP: Tauri Build Flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:tauri": "next build && node scripts/prepare-tauri-frontend.mjs",
     "start": "next start",
     "tauri:dev": "tauri dev",
-    "tauri:build": "cross-env RUSTFLAGS=\"-C target-cpu=native\" tauri build",
+    "tauri:build": "cross-env RUSTFLAGS=\"-C target-feature=+avx2,+fma\" tauri build",
     "tauri:bundle": "node scripts/tauri-bundle-all.mjs",
     "tauri:bundle:windows": "tauri build --target x86_64-pc-windows-msvc --bundles msi,nsis",
     "tauri:bundle:linux": "tauri build --target x86_64-unknown-linux-gnu --bundles deb,rpm,appimage",

--- a/scripts/tauri-bundle-all.mjs
+++ b/scripts/tauri-bundle-all.mjs
@@ -74,7 +74,10 @@ for (const target of targets) {
 
       const result = spawnSync(npxCmd, cmdArgs, {
             stdio: "inherit",
-            env: process.env,
+            // Use +avx2 (supported on all CPUs since ~2013) for good vectorization
+            // without the illegal-instruction crashes that "target-cpu=native" causes
+            // on older hardware (STATUS_ILLEGAL_INSTRUCTION / 0xC000001D).
+            env: { ...process.env, RUSTFLAGS: "-C target-feature=+avx2,+fma" },
       });
 
       if (result.status !== 0) {


### PR DESCRIPTION
Update Tauri build flags for improved compatibility on older hardware.

Fixes #101 