### PR TITLE
fix: Use proper support geometry for slicing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13103,15 +13103,15 @@ export default function Home() {
               <div className="rounded-md border p-3 space-y-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
                 <div className="flex items-start gap-2 text-xs" style={{ color: 'var(--text-muted)' }}>
                   <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" style={{ color: '#86efac' }} />
-                  <span>No foreign objects are on or near the build area.</span>
+                  <span>Build plate and resin vat are properly seated and secured.</span>
                 </div>
                 <div className="flex items-start gap-2 text-xs" style={{ color: 'var(--text-muted)' }}>
                   <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" style={{ color: '#86efac' }} />
-                  <span>The build plate is clear (no previous prints/debris left).</span>
+                  <span>Resin is mixed, sufficient for the print, and at operating temperature.</span>
                 </div>
                 <div className="flex items-start gap-2 text-xs" style={{ color: 'var(--text-muted)' }}>
                   <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" style={{ color: '#86efac' }} />
-                  <span>Resin vat and machine are in a safe, ready state.</span>
+                  <span>Build plate is clean and clear, and the printer cover is fully closed.</span>
                 </div>
               </div>
 

--- a/src/features/slicing/rasterLayerZipExport.ts
+++ b/src/features/slicing/rasterLayerZipExport.ts
@@ -809,6 +809,9 @@ function buildSupportAndRaftWorldTriangles(
   const supportState = getSupportSnapshot();
   const kickstandState = getKickstandSnapshot();
   const sink: TriangleSink = collector ?? out;
+  const raftSettings = getRaftSettings();
+  const hasSolidBottom = raftSettings.bottomMode === 'solid';
+  const raftThickness = raftSettings.thickness;
   const tessellation = resolveSupportSliceTessellation(supportState, kickstandState);
   const segmentTessellation = {
     shaftRadialSegments: tessellation.shaftRadialSegments,
@@ -853,10 +856,18 @@ function buildSupportAndRaftWorldTriangles(
     const rootVisibleByLink = visibleRootIds.has(root.id);
     if (!rootVisibleByModel && !rootVisibleByLink) continue;
 
-    const base = new THREE.Vector3(root.transform.pos.x, root.transform.pos.y, root.transform.pos.z);
+    // Mirror proxy hasSolidBottom logic: collapse disk height and shift root up so it
+    // sits flush on top of the solid raft rather than extending through it.
+    const effectiveDiskHeight = hasSolidBottom ? 0.05 : Math.max(0.01, root.diskHeight);
+    const verticalOffset = hasSolidBottom ? Math.max(raftThickness - effectiveDiskHeight, 0) : 0;
+    const base = new THREE.Vector3(
+      root.transform.pos.x,
+      root.transform.pos.y,
+      root.transform.pos.z + verticalOffset,
+    );
     const rootRadius = Math.max(0.05, root.diameter * 0.5);
     const topRadius = rootTopRadiusByRootId.get(root.id) ?? Math.max(0.05, rootRadius * 0.45);
-    const diskTop = base.clone().add(new THREE.Vector3(0, 0, Math.max(0.01, root.diskHeight)));
+    const diskTop = base.clone().add(new THREE.Vector3(0, 0, effectiveDiskHeight));
     const coneTop = diskTop.clone().add(new THREE.Vector3(0, 0, Math.max(0.01, root.coneHeight)));
 
     const diskGeom = createFrustumGeometryBetween(base, diskTop, rootRadius, rootRadius, tessellation.rootRadialSegments);
@@ -956,11 +967,16 @@ function buildSupportAndRaftWorldTriangles(
     const startKnot = supportState.knots[brace.startKnotId];
     const endKnot = supportState.knots[brace.endKnotId];
     if (!startKnot || !endKnot) continue;
+    // Mirror renderer: derive visual diameter from host knot diameters, not raw profile.diameter.
+    const profileDiameter = Math.max(0.001, brace.profile?.diameter ?? 1);
+    const startHostDia = Math.max(0.05, (startKnot.diameter ?? (profileDiameter + 0.1)) - 0.1);
+    const endHostDia = Math.max(0.05, (endKnot.diameter ?? (profileDiameter + 0.1)) - 0.1);
+    const braceDiameter = (startHostDia + endHostDia) * 0.5;
     appendSegmentPrimitive(
       sink,
       new THREE.Vector3(startKnot.pos.x, startKnot.pos.y, startKnot.pos.z),
       new THREE.Vector3(endKnot.pos.x, endKnot.pos.y, endKnot.pos.z),
-      Math.max(0.05, brace.profile?.diameter ?? 1),
+      braceDiameter,
       brace.curve as any,
       segmentTessellation,
     );
@@ -994,7 +1010,8 @@ function buildSupportAndRaftWorldTriangles(
     }
   }
 
-  const raft = getRaftSettings();
+  // raftSettings already resolved at top of function; reuse it.
+  const raft = raftSettings;
   if (raft.bottomMode !== 'off') {
     const rootsByModel = new Map<string, Array<{ x: number; y: number; r: number }>>();
     for (const root of Object.values(supportState.roots)) {

--- a/src/supports/SupportProxyMeshLayer.tsx
+++ b/src/supports/SupportProxyMeshLayer.tsx
@@ -547,13 +547,26 @@ export function SupportProxyMeshLayer({
       const endKnot = supportKnots[brace.endKnotId];
       if (!startKnot || !endKnot) continue;
 
+      // Mirror SupportRenderer: derive visual diameter from host knot diameters (= trunk segment
+      // diameter + 0.1mm offset). Using profile.diameter alone produces the thin brace setting
+      // value and loses the dynamic sizing that matches the attached trunk thickness.
+      const profileDiameter = Math.max(0.001, brace.profile?.diameter ?? 1);
+      const startHostDiameter = Math.max(
+        0.001,
+        (startKnot.diameter ?? (profileDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+      );
+      const endHostDiameter = Math.max(
+        0.001,
+        (endKnot.diameter ?? (profileDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+      );
+
       pushShaft({
         id: `braceSegment:${brace.id}`,
         supportId: brace.id,
         modelId: brace.modelId,
         start: startKnot.pos,
         end: endKnot.pos,
-        diameter: Math.max(0.1, brace.profile?.diameter ?? 1),
+        diameter: (startHostDiameter + endHostDiameter) * 0.5,
       });
     }
 

--- a/src/supports/SupportProxyMeshLayer.tsx
+++ b/src/supports/SupportProxyMeshLayer.tsx
@@ -41,7 +41,6 @@ interface SupportProxyMeshLayerProps {
 const DEFAULT_SUPPORT_COLOR = '#9a9a9a';
 const ACTIVE_SUPPORT_COLOR = '#c8752a';
 const PROXY_JOINT_DIAMETER_BLEND_MM = JOINT_DIAMETER_OFFSET_MM * 0.75;
-const PROXY_KNOT_DIAMETER_BLEND_MM = JOINT_DIAMETER_OFFSET_MM;
 
 type ProxyModelGeometry = {
   modelId?: string;
@@ -558,27 +557,9 @@ export function SupportProxyMeshLayer({
       });
     }
 
-    if (includeDetailedPrimitives) {
-      for (const knot of Object.values(supportKnots)) {
-        let modelId = segmentModelIdById.get(knot.parentShaftId);
-        let supportId = segmentSupportIdById.get(knot.parentShaftId);
-        const resolvedKnotDiameter = knot.diameter ?? 1.2;
-
-        if (!modelId && knot.parentShaftId.startsWith('leafCone:')) {
-          const leafId = knot.parentShaftId.slice('leafCone:'.length);
-          modelId = leafModelIdById.get(leafId);
-          supportId = leafSupportIdById.get(leafId);
-        }
-
-        pushJoint({
-          id: `knot:${knot.id}`,
-          pos: knot.pos,
-          diameter: Math.max(0.001, resolvedKnotDiameter),
-          supportId,
-          modelId,
-        }, `knot:${knot.id}`, PROXY_KNOT_DIAMETER_BLEND_MM);
-      }
-    }
+    // Knots are interaction affordances (branch/brace attachment point drag handles) rendered
+    // only for selected supports in the full SupportRenderer. Omitting them from the proxy
+    // avoids visible hemisphere bumps at every trunk segment split point.
 
     for (const kickstand of Object.values(kickstandKickstands)) {
       const root = kickstandRoots[kickstand.rootId];
@@ -637,21 +618,7 @@ export function SupportProxyMeshLayer({
       }
     }
 
-    if (includeDetailedPrimitives) {
-      for (const knot of Object.values(kickstandKnots)) {
-        const modelId = segmentModelIdById.get(knot.parentShaftId);
-        const supportId = segmentSupportIdById.get(knot.parentShaftId);
-        const resolvedKnotDiameter = knot.diameter ?? 1.2;
-
-        pushJoint({
-          id: `kickstand-knot:${knot.id}`,
-          pos: knot.pos,
-          diameter: Math.max(0.001, resolvedKnotDiameter),
-          supportId,
-          modelId,
-        }, `kickstand-knot:${knot.id}`, PROXY_KNOT_DIAMETER_BLEND_MM);
-      }
-    }
+    // Kickstand host knots are also interaction affordances — omitted from proxy for the same reason.
 
     sharedProxyCache = {
       supportTrunksRef: supportTrunks,


### PR DESCRIPTION
This PR ensures that slicing operations use the correct support geometry instead of incorrect default values