### PR TITLE
fix: Increase Gizmo Priority

### DIFF
--- a/src/components/gizmo/TransformGizmo.tsx
+++ b/src/components/gizmo/TransformGizmo.tsx
@@ -82,6 +82,9 @@ export function TransformGizmo({
     gizmoRootRef.current.traverse((obj) => {
       obj.frustumCulled = false;
       obj.renderOrder = 2500;
+      // Mark every gizmo node so StlMesh pointer handlers can detect gizmo
+      // involvement directly from e.intersections (frame-accurate, unlike GPU pick).
+      obj.userData.isGizmoHandle = true;
 
       const material = (obj as THREE.Mesh).material;
       if (!material) return;

--- a/src/components/picking/PickingRenderer.tsx
+++ b/src/components/picking/PickingRenderer.tsx
@@ -34,6 +34,9 @@ function shouldExcludeFromPickClone(object: THREE.Object3D): boolean {
   return object.userData?.excludeFromPickingClone === true;
 }
 
+/** No-op override for Object3D.updateMatrixWorld — keeps our manually synced matrixWorld intact. */
+function noop() {}
+
 /**
  * PickingRenderer - Handles the offscreen render pass for GPU picking.
  * 
@@ -147,6 +150,22 @@ export function PickingRenderer({
     const pickObject = sourceObject.clone(true);
     pickObject.traverse((child) => {
       child.matrixAutoUpdate = false;
+      // Prevent Three.js from recomputing matrixWorld during gl.render(pickScene).
+      // Pick clones live directly under the pick scene root (identity transform), so
+      // Three.js would compute:  matrixWorld = identity × child.matrix = child.matrix
+      // But child.matrix is the SOURCE object's LOCAL matrix, not its world matrix.
+      // For meshes nested deep inside a gizmo hierarchy (positioned far from origin),
+      // this produces the wrong pick position. We manually copy source.matrixWorld in
+      // syncPickObjectTransforms and must prevent Three.js from overwriting it.
+      child.updateMatrixWorld = noop;
+      // Gizmo handles must always render after model geometry in the pick scene
+      // so their depthTest=false color wins regardless of depth values.
+      // This is set here (not relied on from the source) because React child
+      // effects fire before parent effects — the gizmo traverse that sets
+      // renderOrder=2500 on source objects hasn't run yet at registration time.
+      if (isGizmo) {
+        child.renderOrder = 9999;
+      }
       if (shouldExcludeFromPickClone(child)) {
         child.visible = false;
         return;
@@ -155,6 +174,8 @@ export function PickingRenderer({
         child.material = pickMaterial;
       }
     });
+    // Flag so syncPickSceneCache can skip the one-time renderOrder repair below.
+    if (isGizmo) pickObject.userData.renderOrderPatched = true;
 
     return pickObject;
   }, [getPickingMaterial]);
@@ -170,6 +191,9 @@ export function PickingRenderer({
 
       pick.visible = source.visible && !shouldExcludeFromPickClone(source);
       pick.matrixAutoUpdate = false;
+      // Also ensure the no-op guard is in place on every node we sync
+      // (covers clones created before this patch via hot-reload).
+      if (pick.updateMatrixWorld !== noop) pick.updateMatrixWorld = noop;
       pick.matrix.copy(source.matrix);
       pick.matrixWorld.copy(source.matrixWorld);
 
@@ -199,6 +223,12 @@ export function PickingRenderer({
 
       const cached = pickObjectCacheRef.current.get(pickId);
       if (cached && cached.sourceObject === registration.object) {
+        // One-time repair: clones created before the renderOrder=9999 fix
+        // (stale hot-reload survivors) need their renderOrder backfilled once.
+        if (registration.category === 'gizmo' && !cached.pickObject.userData.renderOrderPatched) {
+          cached.pickObject.traverse((child) => { child.renderOrder = 9999; });
+          cached.pickObject.userData.renderOrderPatched = true;
+        }
         continue;
       }
 

--- a/src/components/picking/pickingUtils.ts
+++ b/src/components/picking/pickingUtils.ts
@@ -56,12 +56,17 @@ export function decodePickIdFromBuffer(buffer: Uint8Array, pixelIndex: number): 
  * Returns the most common pick ID, with tie-breakers:
  * 1. Center pixel wins ties
  * 2. Previous winner wins ties (stability)
+ *
+ * If `isPriority` is provided, any pixel that satisfies it wins outright before
+ * the majority vote is considered. This ensures gizmo handles always beat model
+ * geometry even when the gizmo occupies only 1-2 pixels of the 3×3 patch.
  * 
  * @param buffer - RGBA pixel buffer (9 pixels = 36 bytes for 3x3)
  * @param previousWinner - Previous pick ID for tie-breaking
+ * @param isPriority - Optional predicate; matching IDs beat all others
  * @returns Winning pick ID
  */
-export function majorityVote(buffer: Uint8Array, previousWinner: number = PICK_ID.NONE): number {
+export function majorityVote(buffer: Uint8Array, previousWinner: number = PICK_ID.NONE, isPriority?: (id: number) => boolean): number {
   const size = RENDER_TARGET.SIZE; // 3
   const totalPixels = size * size; // 9
   
@@ -73,6 +78,26 @@ export function majorityVote(buffer: Uint8Array, previousWinner: number = PICK_I
     const id = decodePickIdFromBuffer(buffer, i);
     ids.push(id);
     counts.set(id, (counts.get(id) || 0) + 1);
+  }
+
+  // Priority pass: if any pixel satisfies the priority predicate, those IDs win
+  // outright before the majority vote. Gizmos should always beat model geometry
+  // even when only clipping 1-2 pixels of the 3×3 window.
+  if (isPriority) {
+    const priorityIds: number[] = [];
+    for (const id of ids) {
+      if (id !== PICK_ID.NONE && isPriority(id) && !priorityIds.includes(id)) {
+        priorityIds.push(id);
+      }
+    }
+    if (priorityIds.length > 0) {
+      if (priorityIds.length === 1) return priorityIds[0];
+      // Multiple priority IDs: prefer center pixel, then previous winner
+      const centerPriority = ids[4];
+      if (isPriority(centerPriority)) return centerPriority;
+      if (previousWinner !== PICK_ID.NONE && priorityIds.includes(previousWinner)) return previousWinner;
+      return priorityIds[0];
+    }
   }
   
   // Find the maximum count

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -529,8 +529,12 @@ function StlMeshComponent({
             }
 
             // Let gizmo handles (especially center XY disc) receive clicks without
-            // model-level event swallowing.
-            if (isGizmoHoverCategory) {
+            // model-level event swallowing. Check both GPU pick (may lag 1 frame)
+            // and the raw intersection list for immediate accuracy.
+            const hasGizmoIntersection = e.intersections.some(
+              (h) => h.object.userData?.isGizmoHandle === true,
+            );
+            if (isGizmoHoverCategory || hasGizmoIntersection) {
               return;
             }
             e.stopPropagation();
@@ -663,7 +667,13 @@ function StlMeshComponent({
 
             // If the pointer is over a gizmo handle, do not consume the event at
             // the model layer; let gizmo drag interactions win.
-            if (isGizmoHoverCategory) {
+            // Check both the GPU pick result (isGizmoHoverCategory) AND the raw
+            // intersection list (isGizmoHandle userData) to guard against the
+            // 1-frame lag where GPU pick hasn't updated yet at click time.
+            const hasGizmoIntersection = e.intersections.some(
+              (h) => h.object.userData?.isGizmoHandle === true,
+            );
+            if (isGizmoHoverCategory || hasGizmoIntersection) {
               return;
             }
 


### PR DESCRIPTION
Ensures that gizmo handles always have priority so don't accidentally click through them, at a model.