### PR TITLE
feat: Respect Safety Margin for Arrange and Duplicate

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10256,6 +10256,17 @@ export default function Home() {
     scene.setSelectedModelIds(visibleIds);
   }, [scene.mode, scene.activeModelId, scene.models, scene.setActiveModelId]);
 
+  // When entering arrange mode with exactly one visible model, auto-select it.
+  React.useEffect(() => {
+    if (scene.mode !== 'prepare') return;
+    if (transformMgr.transformMode !== 'arrange') return;
+    const visibleModels = scene.models.filter((m) => m.visible);
+    if (visibleModels.length !== 1) return;
+    const sole = visibleModels[0];
+    if (scene.activeModelId === sole.id && scene.selectedModelIds.includes(sole.id)) return;
+    scene.selectModel(sole.id, 'single');
+  }, [scene.mode, transformMgr.transformMode, scene.models, scene.activeModelId, scene.selectedModelIds, scene.selectModel]);
+
   React.useEffect(() => {
     if (!hasActivePrinterProfile) return;
     if (!allowPrepareWithoutPrinter) return;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11248,10 +11248,15 @@ export default function Home() {
       const totalCount = Math.max(1, duplicateTotalCopies);
       const spacing = Math.max(0, duplicateSpacingMm);
 
-      const minX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
-      const maxX = minX + scene.view3dSettings.widthMm;
-      const minY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
-      const maxY = minY + scene.view3dSettings.depthMm;
+      const rawDupMinX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
+      const rawDupMaxX = rawDupMinX + scene.view3dSettings.widthMm;
+      const rawDupMinY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
+      const rawDupMaxY = rawDupMinY + scene.view3dSettings.depthMm;
+      const dupSm = scene.view3dSettings.safetyMarginMm;
+      const minX = rawDupMinX + Math.max(0, dupSm?.left ?? 0);
+      const maxX = rawDupMaxX - Math.max(0, dupSm?.right ?? 0);
+      const minY = rawDupMinY + Math.max(0, dupSm?.front ?? 0);
+      const maxY = rawDupMaxY - Math.max(0, dupSm?.back ?? 0);
 
       const plateWidth = Math.max(1, maxX - minX);
       const plateDepth = Math.max(1, maxY - minY);
@@ -11409,6 +11414,7 @@ export default function Home() {
     scene.activeModel,
     scene.models,
     scene.mode,
+    scene.view3dSettings.safetyMarginMm,
     transformMgr.transformMode,
   ]);
 
@@ -11495,10 +11501,15 @@ export default function Home() {
     const depth = sourceDims.depth;
     const spacing = Math.max(0, duplicateSpacingMm);
 
-    const minX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
-    const maxX = minX + scene.view3dSettings.widthMm;
-    const minY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
-    const maxY = minY + scene.view3dSettings.depthMm;
+    const rawFillMinX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
+    const rawFillMaxX = rawFillMinX + scene.view3dSettings.widthMm;
+    const rawFillMinY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
+    const rawFillMaxY = rawFillMinY + scene.view3dSettings.depthMm;
+    const fillSm = scene.view3dSettings.safetyMarginMm;
+    const minX = rawFillMinX + Math.max(0, fillSm?.left ?? 0);
+    const maxX = rawFillMaxX - Math.max(0, fillSm?.right ?? 0);
+    const minY = rawFillMinY + Math.max(0, fillSm?.front ?? 0);
+    const maxY = rawFillMaxY - Math.max(0, fillSm?.back ?? 0);
 
     const plateWidth = Math.max(1, maxX - minX);
     const plateDepth = Math.max(1, maxY - minY);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9472,10 +9472,15 @@ export default function Home() {
         };
       });
 
-      const minX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
-      const maxX = minX + scene.view3dSettings.widthMm;
-      const minY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
-      const maxY = minY + scene.view3dSettings.depthMm;
+      const rawMinX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
+      const rawMaxX = rawMinX + scene.view3dSettings.widthMm;
+      const rawMinY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
+      const rawMaxY = rawMinY + scene.view3dSettings.depthMm;
+      const arrangeSm = scene.view3dSettings.safetyMarginMm;
+      const minX = rawMinX + Math.max(0, arrangeSm?.left ?? 0);
+      const maxX = rawMaxX - Math.max(0, arrangeSm?.right ?? 0);
+      const minY = rawMinY + Math.max(0, arrangeSm?.front ?? 0);
+      const maxY = rawMaxY - Math.max(0, arrangeSm?.back ?? 0);
       const plateWidth = Math.max(1, maxX - minX);
       const plateDepth = Math.max(1, maxY - minY);
 
@@ -9963,6 +9968,7 @@ export default function Home() {
         arrangeAnchorMode,
         getArrangeTransform: (model) => model.transform,
         hullCache: arrangeHullFootprintCacheRef.current,
+        safetyMarginMm: scene.view3dSettings.safetyMarginMm,
       });
 
       if (updates.length > 1) {
@@ -10029,10 +10035,15 @@ export default function Home() {
     const stepY = maxDepth + gapY;
     const stepZ = maxHeight + gapZ;
 
-    const minX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
-    const maxX = minX + scene.view3dSettings.widthMm;
-    const minY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
-    const maxY = minY + scene.view3dSettings.depthMm;
+    const rawMinX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
+    const rawMaxX = rawMinX + scene.view3dSettings.widthMm;
+    const rawMinY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
+    const rawMaxY = rawMinY + scene.view3dSettings.depthMm;
+    const arraySm = scene.view3dSettings.safetyMarginMm;
+    const minX = rawMinX + Math.max(0, arraySm?.left ?? 0);
+    const maxX = rawMaxX - Math.max(0, arraySm?.right ?? 0);
+    const minY = rawMinY + Math.max(0, arraySm?.front ?? 0);
+    const maxY = rawMaxY - Math.max(0, arraySm?.back ?? 0);
 
     const slotsPerLayer = countX * countY;
     const requiredLayers = Math.max(1, Math.ceil(visibleModels.length / slotsPerLayer));
@@ -10041,8 +10052,8 @@ export default function Home() {
     const totalWidth = (countX - 1) * stepX;
     const totalDepth = (countY - 1) * stepY;
 
-    let startX = (scene.view3dSettings.originMode === 'front_left' ? scene.view3dSettings.widthMm * 0.5 : 0) - (totalWidth * 0.5);
-    let startY = (scene.view3dSettings.originMode === 'front_left' ? scene.view3dSettings.depthMm * 0.5 : 0) - (totalDepth * 0.5);
+    let startX = (minX + maxX) * 0.5 - totalWidth * 0.5;
+    let startY = (minY + maxY) * 0.5 - totalDepth * 0.5;
 
     if (arrangeAnchorMode === 'front_left') {
       startX = minX + (maxWidth * 0.5);
@@ -10093,6 +10104,7 @@ export default function Home() {
     scene.selectedModelIds,
     scene.view3dSettings.depthMm,
     scene.view3dSettings.originMode,
+    scene.view3dSettings.safetyMarginMm,
     scene.view3dSettings.widthMm,
     getArrangeTransform,
     getModelSupportAwareDimensionsMm,

--- a/src/components/controls/ArrangePanel.tsx
+++ b/src/components/controls/ArrangePanel.tsx
@@ -360,7 +360,7 @@ export function ArrangePanel({
             </button>
           )}
 
-          <div className="grid grid-cols-2 gap-2">
+          <div className="flex flex-col gap-2">
             <Button
               onClick={onApplyAll}
               variant={isArrangeAllDisabled ? 'secondary' : 'primary'}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -2346,6 +2346,11 @@ export function SceneCanvas({
     return Array.from(new Set(arrangeArrayPreviewItems.map((item) => item.model.id)));
   }, [arrangeArrayPreviewItems]);
 
+  const arrangeArraySourceModelIdSet = React.useMemo(() => {
+    if (!arrangeArrayPreviewItems || arrangeArrayPreviewItems.length === 0) return new Set<string>();
+    return new Set(arrangeArrayPreviewItems.map((item) => item.model.id));
+  }, [arrangeArrayPreviewItems]);
+
   const supportBaseExcludeModelIds = React.useMemo(() => {
     const ids = [...multiGizmoSupportPreviewIds];
     if (arrangeSupportPreviewModelIds.length > 0) {
@@ -4265,6 +4270,7 @@ export function SceneCanvas({
                 // Use per-model visibility
                 if (!model.visible) return null;
                 if (shouldHideDuplicateSourceModel) return null;
+                if (arrangeArraySourceModelIdSet.has(model.id)) return null;
 
                 return (
                   <React.Fragment key={model.id}>

--- a/src/features/scene/arrange/highPrecisionArrange.ts
+++ b/src/features/scene/arrange/highPrecisionArrange.ts
@@ -69,6 +69,7 @@ export type HighPrecisionArrangeInput = {
   arrangeAnchorMode: ArrangeAnchorMode;
   getArrangeTransform: (model: ArrangeModel) => ArrangeTransform;
   hullCache: Map<string, HullCacheEntry>;
+  safetyMarginMm?: { front: number; back: number; left: number; right: number };
 };
 
 export type HighPrecisionArrangeUpdate = {
@@ -98,10 +99,14 @@ export function computeHighPrecisionArrangeUpdates(input: HighPrecisionArrangeIn
   const minSpacing = spacing + SAT_EPS_MM;
   const PERF_COMPLEX_SCENE = visibleModels.length >= 30;
 
-  const minX = originMode === 'front_left' ? 0 : -widthMm * 0.5;
-  const maxX = minX + widthMm;
-  const minY = originMode === 'front_left' ? 0 : -depthMm * 0.5;
-  const maxY = minY + depthMm;
+  const rawMinX = originMode === 'front_left' ? 0 : -widthMm * 0.5;
+  const rawMaxX = rawMinX + widthMm;
+  const rawMinY = originMode === 'front_left' ? 0 : -depthMm * 0.5;
+  const rawMaxY = rawMinY + depthMm;
+  const minX = rawMinX + Math.max(0, input.safetyMarginMm?.left ?? 0);
+  const maxX = rawMaxX - Math.max(0, input.safetyMarginMm?.right ?? 0);
+  const minY = rawMinY + Math.max(0, input.safetyMarginMm?.front ?? 0);
+  const maxY = rawMaxY - Math.max(0, input.safetyMarginMm?.back ?? 0);
 
   const modelTransformById = new Map(
     sceneModels.map((model) => [model.id, getArrangeTransform(model)] as const),

--- a/src/features/scene/arrange/highPrecisionArrange.worker.shared.ts
+++ b/src/features/scene/arrange/highPrecisionArrange.worker.shared.ts
@@ -36,6 +36,7 @@ export type HighPrecisionArrangeWorkerInput = {
   arrangeSpacingMm: number;
   arrangeAllowRotateOnZ: boolean;
   arrangeAnchorMode: 'center' | 'front_left' | 'front_right' | 'back_left' | 'back_right';
+  safetyMarginMm?: { front: number; back: number; left: number; right: number };
 };
 
 export type HighPrecisionArrangeWorkerRequest = {

--- a/src/features/scene/arrange/highPrecisionArrange.worker.ts
+++ b/src/features/scene/arrange/highPrecisionArrange.worker.ts
@@ -86,6 +86,7 @@ self.onmessage = (event: MessageEvent<HighPrecisionArrangeWorkerRequest>) => {
       arrangeSpacingMm: msg.input.arrangeSpacingMm,
       arrangeAllowRotateOnZ: msg.input.arrangeAllowRotateOnZ,
       arrangeAnchorMode: msg.input.arrangeAnchorMode,
+      safetyMarginMm: msg.input.safetyMarginMm,
       getArrangeTransform: (model) => model.transform,
       hullCache: new Map(),
     };

--- a/src/features/scene/arrange/highPrecisionArrangeWorkerClient.ts
+++ b/src/features/scene/arrange/highPrecisionArrangeWorkerClient.ts
@@ -111,6 +111,7 @@ const serializeInput = (input: HighPrecisionArrangeInput): HighPrecisionArrangeW
   arrangeSpacingMm: input.arrangeSpacingMm,
   arrangeAllowRotateOnZ: input.arrangeAllowRotateOnZ,
   arrangeAnchorMode: input.arrangeAnchorMode,
+  safetyMarginMm: input.safetyMarginMm,
 });
 
 export async function computeHighPrecisionArrangeUpdatesWorker(input: HighPrecisionArrangeInput): Promise<HighPrecisionArrangeUpdate[]> {


### PR DESCRIPTION
This PR ensures that Arranging and Duplication now respect the safety margins

- When only one model is on the plate and not selected, we assume to auto-select it upon opening the Arrange & Duplicate tab