### PR TITLE
fix: Re-Render Cross-Section Caps

### DIFF
--- a/src/components/scene/CrossSectionStencilCap.tsx
+++ b/src/components/scene/CrossSectionStencilCap.tsx
@@ -410,6 +410,17 @@ function CrossSectionStencilCapInner({
     return material;
   }, [color, glowColor, glowOpacity, glowThicknessMm]);
 
+  // R3F adds/removes meshes from the support group during the commit phase,
+  // AFTER React's render phase (where useMemo runs). To avoid traversing a
+  // stale group, we gate the traversal on a post-commit counter that is
+  // incremented by a useLayoutEffect after each version change. This ensures
+  // staticSourceEntries is recomputed on the render that follows the commit
+  // in which the scene graph was actually updated.
+  const [postCommitTraversalKey, setPostCommitTraversalKey] = React.useState(0);
+  React.useLayoutEffect(() => {
+    setPostCommitTraversalKey((k) => k + 1);
+  }, [sourceObjectVersion]);
+
   const staticSourceEntries = React.useMemo<StaticStencilEntry[]>(() => {
     if (!sourceObject) return [];
 
@@ -573,7 +584,7 @@ function CrossSectionStencilCapInner({
     });
 
     return results;
-  }, [skipSourceZBounds, sourceObject, sourceObjectVersion]);
+  }, [skipSourceZBounds, sourceObject, postCommitTraversalKey]);
 
   const modelStencilEntryCacheRef = React.useRef<Map<string, {
     signature: string;

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -2799,12 +2799,18 @@ export function SceneCanvas({
     raftWallEnabled: raftSettingsForBounds.wallEnabled,
     raftWallHeight: raftSettingsForBounds.wallHeight,
     raftChamferAngle: raftSettingsForBounds.chamferAngle,
+    // Model-level signals: ensure the cross-section rebuilds when models are
+    // added, removed, copied, or transformed (supports may be attached to a
+    // model whose transform drives their rendered world positions).
+    models,
+    transform,
   }), [
     effectiveHoldSupportDragDelta,
     isGizmoDragging,
     kickstandStateForBounds.kickstands,
     kickstandStateForBounds.knots,
     kickstandStateForBounds.roots,
+    models,
     raftSettingsForBounds.bottomMode,
     raftSettingsForBounds.chamferAngle,
     raftSettingsForBounds.lineHeightMm,
@@ -2821,6 +2827,7 @@ export function SceneCanvas({
     supportStateForBounds.twigs,
     supportDragTransactionId,
     supportRenderRefreshNonce,
+    transform,
   ]);
 
   const crossSectionPlaneWidthMm = Math.max(

--- a/src/supports/SupportRenderer.tsx
+++ b/src/supports/SupportRenderer.tsx
@@ -3585,7 +3585,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 applyMaterialGhostOpacity(mesh.material);
             }
         });
-    }, [clippingPlanes, ghostOpacityClamped, ghostTransparent, ghostRenderOrder]);
+    }, [clippingPlanes, ghostOpacityClamped, ghostTransparent, ghostRenderOrder, selectedId]);
 
     return (
         <group ref={groupRef}>


### PR DESCRIPTION
When editing models and/or supports, re-render cross-section caps to avoid displaying stale ones.