### PR TITLE
feat: Anchor support type for near-plate contacts

### DIFF
--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -2108,6 +2108,14 @@ export function SceneCanvas({
       pushIfProjectedInside(brace.id, points);
     }
 
+    for (const anchor of Object.values(supportStateForBounds.anchors)) {
+      const points: Array<{ x: number; y: number; z: number }> = [anchor.rootPos];
+      if (anchor.contactCone) {
+        points.push(anchor.contactCone.pos);
+      }
+      pushIfProjectedInside(anchor.id, points);
+    }
+
     for (const kickstand of Object.values(kickstandStateForBounds.kickstands)) {
       const points = segmentPoints(kickstand.segments);
       pushIfProjectedInside(kickstand.id, points);

--- a/src/features/scene/voxl/codec.ts
+++ b/src/features/scene/voxl/codec.ts
@@ -242,6 +242,7 @@ export function buildSupportExportFromStores(
     twigs: Object.values(supportState.twigs),
     sticks: Object.values(supportState.sticks),
     braces: Object.values(supportState.braces),
+    anchors: Object.values(supportState.anchors),
     knots: Object.values(supportState.knots),
     kickstands,
   };

--- a/src/features/supports/useSupportInteractionManager.ts
+++ b/src/features/supports/useSupportInteractionManager.ts
@@ -25,6 +25,7 @@ import {
   removeLeaf,
   removeTwig,
   removeStick,
+  removeAnchor,
   removeTrunk,
   removeKickstandCascade,
   removeJointById,
@@ -36,7 +37,7 @@ import {
 } from '@/supports/state';
 import { registerDeleteHandler } from '@/features/delete/deleteRegistry';
 import { pushHistory } from '@/history/historyStore';
-import { SUPPORT_REMOVE_BRANCH, SUPPORT_REMOVE_BRACE, SUPPORT_REMOVE_LEAF, SUPPORT_REMOVE_TRUNK, SUPPORT_UPDATE_TRUNK, SUPPORT_UPDATE_BRANCH, SUPPORT_REMOVE_TWIG, SUPPORT_REMOVE_STICK, SUPPORT_AUTO_BRACE_REPLACE, SUPPORT_REMOVE_KICKSTAND } from '@/supports/history/actionTypes';
+import { SUPPORT_REMOVE_ANCHOR, SUPPORT_REMOVE_BRANCH, SUPPORT_REMOVE_BRACE, SUPPORT_REMOVE_LEAF, SUPPORT_REMOVE_TRUNK, SUPPORT_UPDATE_TRUNK, SUPPORT_UPDATE_BRANCH, SUPPORT_REMOVE_TWIG, SUPPORT_REMOVE_STICK, SUPPORT_AUTO_BRACE_REPLACE, SUPPORT_REMOVE_KICKSTAND } from '@/supports/history/actionTypes';
 import { clearSupportSelection, getResolvedPrimarySelection, selectSupportIds } from '@/supports/interaction/shared/selection/selectionController';
 import { getKickstandSnapshot } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
@@ -68,6 +69,7 @@ function resolveSupportCategoryFromSnapshot(id: string) {
   if (snapshot.twigs[id]) return 'twig' as const;
   if (snapshot.sticks[id]) return 'stick' as const;
   if (snapshot.braces[id]) return 'brace' as const;
+  if (snapshot.anchors[id]) return 'anchor' as const;
   if (getKickstandSnapshot().kickstands[id]) return 'brace' as const;
   return null;
 }
@@ -83,6 +85,7 @@ function collectAllSupportIds() {
     ...Object.keys(snapshot.twigs),
     ...Object.keys(snapshot.sticks),
     ...Object.keys(snapshot.braces),
+    ...Object.keys(snapshot.anchors),
     ...Object.keys(kickstandSnapshot.kickstands),
   ];
 }
@@ -551,6 +554,19 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
           pushHistory({
             type: SUPPORT_REMOVE_STICK,
             payload: snapshots,
+          });
+        }
+        setSelectedId(null);
+        return true;
+      }
+
+      if (category === 'anchor') {
+        const snapshots = removeAnchor(id);
+        if (!snapshots) return false;
+        if (recordHistory) {
+          pushHistory({
+            type: SUPPORT_REMOVE_ANCHOR,
+            payload: { anchor: snapshots.anchor },
           });
         }
         setSelectedId(null);

--- a/src/supports/PlacementLogic/Grid/gridPlacement.ts
+++ b/src/supports/PlacementLogic/Grid/gridPlacement.ts
@@ -17,9 +17,11 @@ import { calculateKnotPositionOnSegmentFromT } from '../../SupportPrimitives/Kno
 import { checkShaftCollision } from '../CollisionUtils';
 import * as THREE from 'three';
 import { generateUuid } from '../../../utils/uuid';
+import { buildAnchorData } from '../../SupportTypes/Anchor/anchorBuilder';
 
 const MIN_TRUNK_CLEARANCE_MM = 0.5;
 const MAX_NEAREST_NODE_SEARCH_RINGS = 4;
+const ANCHOR_HEIGHT_THRESHOLD_MM = 5.0;
 
 function withResolvedSnappedRoute(
     candidate: TrunkBuildResult,
@@ -438,6 +440,12 @@ function trunkCollidesWithMesh(
 
 export function decideGridPlacement(args: DecideGridPlacementArgs): GridPlacementDecision {
     const { settings, snapshot, candidate, tipPos, tipNormal, modelId, mesh } = args;
+
+    // Near-plate contacts get a minimal anchor support instead of trunk/branch
+    if (tipPos.z < ANCHOR_HEIGHT_THRESHOLD_MM) {
+        const { anchor, supportData } = buildAnchorData({ tipPos, tipNormal, modelId });
+        return { kind: 'place_anchor', anchor, supportData };
+    }
 
     if (!settings.grid?.enabled) {
         return {

--- a/src/supports/PlacementLogic/Grid/types.ts
+++ b/src/supports/PlacementLogic/Grid/types.ts
@@ -1,4 +1,4 @@
-import type { Branch, Knot, SupportState, Vec3 } from '../../types';
+import type { Anchor, Branch, Knot, SupportState, Vec3 } from '../../types';
 import type { SupportData } from '../../rendering/SupportBuilder';
 import type { SupportSettings } from '../../Settings/types';
 import type { TrunkBuildResult } from '../../SupportTypes/Trunk/trunkBuilder';
@@ -35,6 +35,11 @@ export type GridPlacementDecision =
         hostTrunkId: string;
         knot: Knot;
         branch: Branch;
+        supportData: SupportData;
+    }
+    | {
+        kind: 'place_anchor';
+        anchor: Anchor;
         supportData: SupportData;
     }
     | {

--- a/src/supports/RaftProxyMeshLayer.tsx
+++ b/src/supports/RaftProxyMeshLayer.tsx
@@ -45,6 +45,7 @@ type VisibleRaftEntry = {
 
 type RaftProxyCacheEntry = {
   supportRootsRef: ReturnType<typeof getSnapshot>['roots'];
+  supportAnchorsRef: ReturnType<typeof getSnapshot>['anchors'];
   raftSignature: string;
   geometriesByModel: Map<string, CachedRaftGeometry>;
 };
@@ -161,7 +162,10 @@ function disposeGeneratedMeshes(meshes: Array<THREE.Mesh | null | undefined>) {
   }
 }
 
-function collectRootCirclesByModel(roots: ReturnType<typeof getSnapshot>['roots']): Map<string, SupportBaseCircle[]> {
+function collectRootCirclesByModel(
+  roots: ReturnType<typeof getSnapshot>['roots'],
+  anchors: ReturnType<typeof getSnapshot>['anchors'],
+): Map<string, SupportBaseCircle[]> {
   const byModel = new Map<string, SupportBaseCircle[]>();
 
   for (const root of Object.values(roots)) {
@@ -171,6 +175,17 @@ function collectRootCirclesByModel(roots: ReturnType<typeof getSnapshot>['roots'
       x: root.transform.pos.x,
       y: root.transform.pos.y,
       r: root.diameter / 2,
+    });
+    if (!byModel.has(modelKey)) byModel.set(modelKey, circles);
+  }
+
+  for (const anchor of Object.values(anchors)) {
+    const modelKey = toModelKey(anchor.modelId);
+    const circles = byModel.get(modelKey) ?? [];
+    circles.push({
+      x: anchor.rootPos.x,
+      y: anchor.rootPos.y,
+      r: anchor.rootBaseDiameter / 2,
     });
     if (!byModel.has(modelKey)) byModel.set(modelKey, circles);
   }
@@ -198,6 +213,7 @@ export function RaftProxyMeshLayer({
 }: RaftProxyMeshLayerProps) {
   const supportState = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   const supportRoots = supportState.roots;
+  const supportAnchors = supportState.anchors;
   const raft = useSyncExternalStore(subscribeToRaftStore, getRaftSettings, getRaftSettings);
 
   const selectedModelIdSet = React.useMemo(() => new Set(selectedModelIds), [selectedModelIds]);
@@ -222,12 +238,13 @@ export function RaftProxyMeshLayer({
     if (
       raftProxyCache
       && raftProxyCache.supportRootsRef === supportRoots
+      && raftProxyCache.supportAnchorsRef === supportAnchors
       && raftProxyCache.raftSignature === raftSignature
     ) {
       return raftProxyCache.geometriesByModel;
     }
 
-    const rootCirclesByModel = collectRootCirclesByModel(supportRoots);
+    const rootCirclesByModel = collectRootCirclesByModel(supportRoots, supportAnchors);
     const next = new Map<string, CachedRaftGeometry>();
 
     if (raft.bottomMode === 'solid') {
@@ -286,12 +303,13 @@ export function RaftProxyMeshLayer({
 
     raftProxyCache = {
       supportRootsRef: supportRoots,
+      supportAnchorsRef: supportAnchors,
       raftSignature,
       geometriesByModel: next,
     };
 
     return next;
-  }, [raft, raftSignature, supportRoots]);
+  }, [raft, raftSignature, supportRoots, supportAnchors]);
 
   const visibleEntries = React.useMemo<VisibleRaftEntry[]>(() => {
     const entries: VisibleRaftEntry[] = [];

--- a/src/supports/Rafts/Crenelated/rendering/FootprintBorderRenderer.tsx
+++ b/src/supports/Rafts/Crenelated/rendering/FootprintBorderRenderer.tsx
@@ -118,13 +118,22 @@ export default function FootprintBorderRenderer({
     const allPoints: THREE.Vector2[] = [];
 
     // 1. Add raft outer boundary points
-    const circles: SupportBaseCircle[] = Object.values(supportState.roots)
-      .filter((root) => !modelId || root.modelId === modelId)
-      .map(root => ({
-        x: root.transform.pos.x,
-        y: root.transform.pos.y,
-        r: root.diameter / 2,
-      }));
+    const circles: SupportBaseCircle[] = [
+      ...Object.values(supportState.roots)
+        .filter((root) => !modelId || root.modelId === modelId)
+        .map(root => ({
+          x: root.transform.pos.x,
+          y: root.transform.pos.y,
+          r: root.diameter / 2,
+        })),
+      ...Object.values(supportState.anchors)
+        .filter((anchor) => !modelId || anchor.modelId === modelId)
+        .map(anchor => ({
+          x: anchor.rootPos.x,
+          y: anchor.rootPos.y,
+          r: anchor.rootBaseDiameter / 2,
+        })),
+    ];
 
     if (circles.length > 0) {
       const baseProfile = computeFootprint(circles, { marginMm: 0.2, samplesPerCircle: 24 });

--- a/src/supports/Rafts/Crenelated/rendering/LineRaftRenderer.tsx
+++ b/src/supports/Rafts/Crenelated/rendering/LineRaftRenderer.tsx
@@ -249,6 +249,23 @@ export default function LineRaftRenderer({
       rootsByModel.get(key)!.push(root);
     }
 
+    // Include anchor roots for raft footprint
+    for (const anchor of Object.values(supportState.anchors)) {
+      if (excludeModelId && anchor.modelId === excludeModelId) continue;
+      if (anchor.modelId && excludedModelIdSet.has(anchor.modelId)) continue;
+      if (modelFilterId && anchor.modelId !== modelFilterId) continue;
+      const key = anchor.modelId || 'unknown';
+      if (!rootsByModel.has(key)) rootsByModel.set(key, []);
+      rootsByModel.get(key)!.push({
+        id: anchor.id,
+        modelId: anchor.modelId,
+        transform: { pos: anchor.rootPos, rot: { x: 0, y: 0, z: 0, w: 1 } },
+        diameter: anchor.rootBaseDiameter,
+        diskHeight: anchor.rootHeight,
+        coneHeight: 0,
+      });
+    }
+
     const blendColor = (baseHex: string, tintHex: string, strength: number) =>
       new THREE.Color(baseHex).lerp(new THREE.Color(tintHex), strength).getStyle();
 

--- a/src/supports/Rafts/Crenelated/rendering/RaftRenderer.tsx
+++ b/src/supports/Rafts/Crenelated/rendering/RaftRenderer.tsx
@@ -157,6 +157,23 @@ export default function RaftRenderer({
       rootsByModel.get(key)!.push(root);
     }
 
+    // Include anchor roots as synthetic Roots entries for raft footprint
+    for (const anchor of Object.values(supportState.anchors)) {
+      if (excludeModelId && anchor.modelId === excludeModelId) continue;
+      if (anchor.modelId && excludedModelIdSet.has(anchor.modelId)) continue;
+      if (modelFilterId && anchor.modelId !== modelFilterId) continue;
+      const key = anchor.modelId || 'unknown';
+      if (!rootsByModel.has(key)) rootsByModel.set(key, []);
+      rootsByModel.get(key)!.push({
+        id: anchor.id,
+        modelId: anchor.modelId,
+        transform: { pos: anchor.rootPos, rot: { x: 0, y: 0, z: 0, w: 1 } },
+        diameter: anchor.rootBaseDiameter,
+        diskHeight: anchor.rootHeight,
+        coneHeight: 0,
+      });
+    }
+
     const blendColor = (baseHex: string, tintHex: string, strength: number) =>
       new THREE.Color(baseHex).lerp(new THREE.Color(tintHex), strength).getStyle();
 

--- a/src/supports/SupportProxyMeshLayer.tsx
+++ b/src/supports/SupportProxyMeshLayer.tsx
@@ -73,6 +73,7 @@ type SharedProxyCacheEntry = {
   supportTwigsRef: ReturnType<typeof getSnapshot>['twigs'];
   supportSticksRef: ReturnType<typeof getSnapshot>['sticks'];
   supportBracesRef: ReturnType<typeof getSnapshot>['braces'];
+  supportAnchorsRef: ReturnType<typeof getSnapshot>['anchors'];
   kickstandKickstandsRef: ReturnType<typeof useKickstandStoreState>['kickstands'];
   kickstandRootsRef: ReturnType<typeof useKickstandStoreState>['roots'];
   kickstandKnotsRef: ReturnType<typeof useKickstandStoreState>['knots'];
@@ -233,6 +234,7 @@ export function SupportProxyMeshLayer({
       && sharedProxyCache.supportTwigsRef === supportTwigs
       && sharedProxyCache.supportSticksRef === supportSticks
       && sharedProxyCache.supportBracesRef === supportBraces
+      && sharedProxyCache.supportAnchorsRef === supportState.anchors
       && sharedProxyCache.kickstandKickstandsRef === kickstandKickstands
       && sharedProxyCache.kickstandRootsRef === kickstandRoots
       && sharedProxyCache.kickstandKnotsRef === kickstandKnots
@@ -574,6 +576,29 @@ export function SupportProxyMeshLayer({
     // only for selected supports in the full SupportRenderer. Omitting them from the proxy
     // avoids visible hemisphere bumps at every trunk segment split point.
 
+    // Anchors: root + contact cone, no shafts
+    const supportAnchors = supportState.anchors;
+    for (const anchor of Object.values(supportAnchors)) {
+      pushRoot({
+        id: `${anchor.id}:root`,
+        supportId: anchor.id,
+        modelId: anchor.modelId,
+        basePos: anchor.rootPos,
+        bottomRadius: Math.max(0.001, anchor.rootBaseDiameter / 2),
+        topRadius: Math.max(0.001, anchor.rootTopDiameter / 2),
+        effectiveDiskHeight: 0.1,
+        coneHeight: Math.max(0, anchor.rootHeight),
+      });
+
+      if (includeDetailedPrimitives && anchor.contactCone) {
+        pushCone({
+          ...anchor.contactCone,
+          supportId: anchor.id,
+          modelId: anchor.modelId,
+        });
+      }
+    }
+
     for (const kickstand of Object.values(kickstandKickstands)) {
       const root = kickstandRoots[kickstand.rootId];
       const hostKnot = kickstandKnots[kickstand.hostKnotId];
@@ -642,6 +667,7 @@ export function SupportProxyMeshLayer({
       supportTwigsRef: supportTwigs,
       supportSticksRef: supportSticks,
       supportBracesRef: supportBraces,
+      supportAnchorsRef: supportState.anchors,
       kickstandKickstandsRef: kickstandKickstands,
       kickstandRootsRef: kickstandRoots,
       kickstandKnotsRef: kickstandKnots,

--- a/src/supports/SupportRenderer.tsx
+++ b/src/supports/SupportRenderer.tsx
@@ -10,6 +10,7 @@ import { BraceRenderer } from './SupportTypes/Brace/BraceRenderer';
 import { TwigRenderer } from './SupportTypes/Twig/TwigRenderer';
 import { StickRenderer } from './SupportTypes/Stick/StickRenderer';
 import { KickstandRenderer } from './SupportTypes/Kickstand/KickstandRenderer';
+import { AnchorRenderer } from './SupportTypes/Anchor/AnchorRenderer';
 import { InstancedShaftGroup, type InstancedShaft } from './SupportPrimitives/Shaft/InstancedShaftGroup';
 import { InstancedJointGroup, type InstancedJoint } from './SupportPrimitives/Joint/InstancedJointGroup';
 import { InstancedRootsGroup, type InstancedRoot } from './SupportPrimitives/Roots/InstancedRootsGroup';
@@ -663,6 +664,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
     const twigList = useMemo(() => Object.values(state.twigs), [state.twigs]);
     const stickList = useMemo(() => Object.values(state.sticks), [state.sticks]);
     const braceList = useMemo(() => Object.values(state.braces), [state.braces]);
+    const anchorList = useMemo(() => Object.values(state.anchors), [state.anchors]);
     const kickstandList = useMemo(() => Object.values(kickstandState.kickstands), [kickstandState.kickstands]);
     const knotList = useMemo(() => Object.values(state.knots), [state.knots]);
     const kickstandKnotList = useMemo(() => Object.values(kickstandState.knots), [kickstandState.knots]);
@@ -945,8 +947,12 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
     const supportIdByContactDiskId = useMemo(() => {
         const map = new Map<string, string>();
         for (const [id, supportId] of Object.entries(supportRenderLookup.supportIdByContactDiskId)) map.set(id, supportId);
+        // Add anchor contact cones (not indexed by render lookup worker)
+        for (const anchor of anchorList) {
+            if (anchor.contactCone?.id) map.set(anchor.contactCone.id, anchor.id);
+        }
         return map;
-    }, [supportRenderLookup.supportIdByContactDiskId]);
+    }, [supportRenderLookup.supportIdByContactDiskId, anchorList]);
 
     const hoveredSupportIdFromPicking = useMemo(() => {
         return resolveHoveredSupportOwnerId(
@@ -1355,6 +1361,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             || selectedCategory === 'twig'
             || selectedCategory === 'stick'
             || selectedCategory === 'brace'
+            || selectedCategory === 'anchor'
         ) {
             return selectedId;
         }
@@ -1474,6 +1481,21 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
         return selected;
     }, [singleSelectedSupportId, selectedSupportIdSet, state.sticks, useMultiSelectionDetail]);
+
+    const selectedAnchorIds = useMemo(() => {
+        const selected = new Set<string>();
+        if (useMultiSelectionDetail) {
+            for (const supportId of selectedSupportIdSet) {
+                if (state.anchors[supportId]) selected.add(supportId);
+            }
+        }
+
+        if (singleSelectedSupportId && state.anchors[singleSelectedSupportId]) {
+            selected.add(singleSelectedSupportId);
+        }
+
+        return selected;
+    }, [singleSelectedSupportId, selectedSupportIdSet, state.anchors, useMultiSelectionDetail]);
 
     const selectedKickstandIds = useMemo(() => {
         const selected = new Set<string>();
@@ -4162,6 +4184,30 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                     />
                 </group>
             ))}
+
+            {/* Render Anchors */}
+            {anchorList.map(anchor => {
+                if (!isModelVisible(anchor.modelId, anchor.id)) return null;
+                const effectiveSelected = selectedAnchorIds.has(anchor.id);
+                const isAnchorHovered = hoveredSupportIdForVisual === anchor.id
+                    || marqueeHoveredSupportIdSet.has(anchor.id);
+
+                return (
+                    <group key={anchor.id}>
+                    <AnchorRenderer
+                        key={anchor.id}
+                        anchor={anchor}
+                        isSelected={effectiveSelected}
+                        selectedId={effectiveSelected ? selectedId : null}
+                        dimNonSelected={dimNonSelected}
+                        isHovered={isAnchorHovered}
+                        baseColor={resolveBaseColor(anchor.modelId)}
+                        suppressHover={suppressHover}
+                        isInteractable={isInteractable}
+                    />
+                    </group>
+                );
+            })}
 
             {/*
               Auto-bracing debug overlay mount point.

--- a/src/supports/SupportTypes/Anchor/AnchorRenderer.tsx
+++ b/src/supports/SupportTypes/Anchor/AnchorRenderer.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from 'react';
+import { useThree } from '@react-three/fiber';
+import type { Anchor, Roots } from '../../types';
+import type { ContactCone } from '../../SupportPrimitives/ContactCone/types';
+import { RootsRenderer } from '../../SupportPrimitives/Roots/RootsRenderer';
+import { ContactConeRenderer, getFinalSocketPosition } from '../../SupportPrimitives/ContactCone';
+import { recomputeContactConeForMovedDisk } from '../../SupportPrimitives/ContactDisk';
+import { isPrimaryPointerPress, startContactDiskDragSession, type ContactDiskDragHit, type ContactDiskDragSession } from '../../SupportPrimitives/ContactDisk/contactDiskDragController';
+import { handleSupportClick } from '../../interaction/clickHandlers';
+import { useHighlight } from '../../interaction/useHighlight';
+import { getSnapshot, updateAnchor } from '../../state';
+import { captureSupportEditSnapshot, pushSupportEditHistory } from '../../history/supportEditHistory';
+
+interface AnchorRendererProps {
+    anchor: Anchor;
+    isSelected?: boolean;
+    selectedId?: string | null;
+    dimNonSelected?: boolean;
+    isHovered?: boolean;
+    suppressHover?: boolean;
+    isInteractable?: boolean;
+    baseColor?: string;
+    deferContactConesToSceneBatch?: boolean;
+    onContactDiskHudHoverChange?: (hovered: boolean) => void;
+}
+
+export const AnchorRenderer = React.memo(function AnchorRenderer({
+    anchor,
+    isSelected,
+    selectedId,
+    dimNonSelected,
+    isHovered: propHovered,
+    suppressHover,
+    isInteractable = true,
+    baseColor = '#ff8800',
+    deferContactConesToSceneBatch = false,
+    onContactDiskHudHoverChange,
+}: AnchorRendererProps) {
+    const { camera, scene, gl } = useThree();
+    const dragSessionRef = React.useRef<ContactDiskDragSession | null>(null);
+    const liveDragConeRef = React.useRef<ContactCone | null>(null);
+    const beforeHistoryRef = React.useRef<ReturnType<typeof captureSupportEditSnapshot> | null>(null);
+    const [, setDragTick] = React.useState(0);
+
+    const { pickRef, visuals, isPickingHovered } = useHighlight({
+        id: anchor.id,
+        category: 'support',
+        enabled: !!isInteractable && !suppressHover && !isSelected,
+        isSelected,
+        suppressHover,
+        externalHover: propHovered,
+        baseColor: dimNonSelected && !isSelected ? '#666666' : baseColor,
+    });
+
+    // Build a synthetic Roots entity so RootsRenderer handles raft offset, sphere top, etc.
+    const syntheticRoot: Roots = useMemo(() => ({
+        id: `${anchor.id}:root`,
+        modelId: anchor.modelId,
+        transform: { pos: anchor.rootPos, rot: { x: 0, y: 0, z: 0, w: 1 } },
+        diameter: anchor.rootBaseDiameter,
+        diskHeight: 0.1,
+        coneHeight: anchor.rootHeight,
+    }), [anchor.id, anchor.modelId, anchor.rootPos, anchor.rootBaseDiameter, anchor.rootHeight]);
+
+    const handleClick = (e: any) => {
+        handleSupportClick(e, anchor.id, !!isInteractable);
+    };
+
+    const handleContactDiskHudPointerDown = React.useCallback((e: any) => {
+        if (!isSelected || !anchor.contactCone) return;
+        if (!isPrimaryPointerPress(e)) return;
+
+        const socketAnchor = getFinalSocketPosition(anchor.contactCone);
+        beforeHistoryRef.current = captureSupportEditSnapshot();
+
+        dragSessionRef.current?.stop();
+        dragSessionRef.current = startContactDiskDragSession({
+            camera,
+            domElement: gl.domElement,
+            scene,
+            initialEvent: e,
+            modelId: anchor.modelId,
+            onHit: ({ point, surfaceNormal }: ContactDiskDragHit) => {
+                const latest = getSnapshot().anchors[anchor.id];
+                if (!latest?.contactCone) return;
+                liveDragConeRef.current = recomputeContactConeForMovedDisk(latest.contactCone, point, surfaceNormal, socketAnchor);
+                setDragTick(t => t + 1);
+            },
+            onEnd: () => {
+                if (liveDragConeRef.current) {
+                    const latest = getSnapshot().anchors[anchor.id];
+                    if (latest) updateAnchor({ ...latest, contactCone: liveDragConeRef.current });
+                    if (beforeHistoryRef.current) {
+                        pushSupportEditHistory('Move anchor tip', beforeHistoryRef.current, captureSupportEditSnapshot());
+                    }
+                }
+                liveDragConeRef.current = null;
+                dragSessionRef.current = null;
+                beforeHistoryRef.current = null;
+            },
+        });
+    }, [camera, gl.domElement, isSelected, scene, anchor.id, anchor.contactCone, anchor.modelId]);
+
+    const handleContactDiskHudPointerUp = React.useCallback(() => {
+        dragSessionRef.current?.stop();
+        dragSessionRef.current = null;
+    }, []);
+
+    // Render contact cone
+    const effectiveCone = liveDragConeRef.current ?? anchor.contactCone;
+    let coneRender = null;
+    if (effectiveCone && !deferContactConesToSceneBatch) {
+        const isConeSelected = !!effectiveCone.id && selectedId === effectiveCone.id;
+        coneRender = (
+            <ContactConeRenderer
+                contactDiskId={effectiveCone.id}
+                pos={effectiveCone.pos}
+                normal={effectiveCone.normal}
+                surfaceNormal={effectiveCone.surfaceNormal}
+                diskLengthOverride={effectiveCone.diskLengthOverride}
+                profile={effectiveCone.profile}
+                color={visuals.color}
+                emissive={visuals.emissive}
+                emissiveIntensity={visuals.emissiveIntensity}
+                socketJointId={effectiveCone.socketJointId}
+                isInteractable={isInteractable}
+                isParentSelected={isSelected}
+                isContactDiskSelected={isConeSelected}
+                onDiskHudHoverChange={onContactDiskHudHoverChange}
+                onDiskHudPointerDown={handleContactDiskHudPointerDown}
+                onDiskHudPointerUp={handleContactDiskHudPointerUp}
+            />
+        );
+    }
+
+    return (
+        <group onClick={handleClick} ref={pickRef as any}>
+            <RootsRenderer
+                root={syntheticRoot}
+                shaftDiameter={anchor.rootTopDiameter}
+                color={visuals.color}
+                emissive={visuals.emissive}
+                emissiveIntensity={visuals.emissiveIntensity}
+            />
+            {coneRender}
+        </group>
+    );
+});
+
+AnchorRenderer.displayName = 'AnchorRenderer';

--- a/src/supports/SupportTypes/Anchor/anchorBuilder.ts
+++ b/src/supports/SupportTypes/Anchor/anchorBuilder.ts
@@ -1,0 +1,141 @@
+import type { Anchor, Joint, Vec3 } from '../../types';
+import type { ContactCone, SupportTipProfile } from '../../SupportPrimitives/ContactCone/types';
+import type { SupportData } from '../../rendering/SupportBuilder';
+import { calculateDiskThickness } from '../../SupportPrimitives/ContactDisk/contactDiskUtils';
+import { getSettings } from '../../Settings';
+import { resolveConeAxisPolicy } from '../../PlacementLogic/ConeAxisPolicy';
+import { encodeSupportSettingsHex } from '../../Settings/supportSettingsCodec';
+import { generateUuid } from '../../../utils/uuid';
+import { getRaftSettings } from '../../Rafts/Crenelated/RaftState';
+
+const ANCHOR_ROOT_BASE_DIAMETER_MM = 2.0;
+const ANCHOR_ROOT_TOP_DIAMETER_MM = 1.5;
+const ANCHOR_ROOT_HEIGHT_MM = 1.0;
+const ANCHOR_JOINT_DIAMETER_MM = 1.5;
+
+export interface AnchorBuildInput {
+    tipPos: Vec3;
+    tipNormal: Vec3;
+    modelId: string;
+}
+
+export interface AnchorBuildResult {
+    anchor: Anchor;
+    supportData: SupportData;
+}
+
+export function buildAnchorData(input: AnchorBuildInput): AnchorBuildResult {
+    const { tipPos, tipNormal, modelId } = input;
+
+    const settings = getSettings();
+    const settingsCodeHex = encodeSupportSettingsHex(settings);
+    const coneAngleMode = settings.tip.coneAngleMode ?? 'normal';
+    const adaptiveConeAngleOffsetDeg = settings.tip.adaptiveConeAngleOffsetDeg ?? 30;
+
+    const { coneAxis } = resolveConeAxisPolicy({
+        surfaceNormal: tipNormal,
+        coneAngleMode,
+        adaptiveConeAngleOffsetDeg,
+    });
+
+    const effectiveConeAxis = coneAxis ?? tipNormal;
+    const tipProfile: SupportTipProfile = {
+        type: 'disk',
+        contactDiameterMm: settings.tip.contactDiameterMm,
+        bodyDiameterMm: settings.tip.bodyDiameterMm,
+        lengthMm: settings.tip.lengthMm,
+        penetrationMm: settings.tip.penetrationMm,
+        diskThicknessMm: 0.1,
+        maxStandoffMm: 1.5,
+        standoffAngleThreshold: Math.PI / 4,
+    };
+
+    // Contact cone disk offset
+    const diskThickness = tipProfile.type === 'disk'
+        ? calculateDiskThickness(tipNormal, effectiveConeAxis, tipProfile)
+        : 0;
+
+    const coneStartPos: Vec3 = {
+        x: tipPos.x + tipNormal.x * diskThickness,
+        y: tipPos.y + tipNormal.y * diskThickness,
+        z: tipPos.z + tipNormal.z * diskThickness,
+    };
+
+    // Compute raft vertical offset (must match RootsRenderer logic)
+    const raft = getRaftSettings();
+    const hasSolidBottom = raft.bottomMode === 'solid';
+    const raftThickness = raft.thickness ?? 0;
+    const ANCHOR_DISK_HEIGHT_MM = 0.1;
+    const effectiveDiskHeight = hasSolidBottom ? 0.05 : ANCHOR_DISK_HEIGHT_MM;
+    const verticalOffset = hasSolidBottom ? Math.max(raftThickness - effectiveDiskHeight, 0) : 0;
+
+    // Sphere center Z = verticalOffset + effectiveDiskHeight + coneHeight
+    // (sphere center is at top of cone, not offset by radius)
+    const targetSocketZ = verticalOffset + effectiveDiskHeight + ANCHOR_ROOT_HEIGHT_MM;
+    const dzPerUnit = effectiveConeAxis.z;
+    const coneLength = Math.abs(dzPerUnit) > 1e-6
+        ? (targetSocketZ - coneStartPos.z) / dzPerUnit
+        : tipProfile.lengthMm; // fallback if cone axis is nearly horizontal
+
+    // Use the stretched length (but never shorter than the default)
+    const effectiveConeLength = Math.max(coneLength, tipProfile.lengthMm);
+
+    const socketPos: Vec3 = {
+        x: coneStartPos.x + effectiveConeAxis.x * effectiveConeLength,
+        y: coneStartPos.y + effectiveConeAxis.y * effectiveConeLength,
+        z: coneStartPos.z + effectiveConeAxis.z * effectiveConeLength,
+    };
+
+    // Root and joint are positioned at the socket XY, vertical stack
+    const rootPos: Vec3 = { x: socketPos.x, y: socketPos.y, z: 0 };
+    const jointPos: Vec3 = { x: socketPos.x, y: socketPos.y, z: targetSocketZ };
+    const joint: Joint = {
+        id: generateUuid(),
+        pos: jointPos,
+        diameter: ANCHOR_JOINT_DIAMETER_MM,
+    };
+
+    const socketJoint: Joint = {
+        id: generateUuid(),
+        pos: socketPos,
+        diameter: ANCHOR_JOINT_DIAMETER_MM,
+    };
+
+    // Override profile: stretched length + body diameter matches joint
+    const anchorTipProfile: SupportTipProfile = {
+        ...tipProfile,
+        lengthMm: effectiveConeLength,
+        bodyDiameterMm: ANCHOR_JOINT_DIAMETER_MM - 0.1,
+    };
+
+    const contactCone: ContactCone = {
+        id: generateUuid(),
+        pos: tipPos,
+        normal: effectiveConeAxis,
+        surfaceNormal: tipNormal,
+        profile: anchorTipProfile,
+        socketJointId: socketJoint.id,
+    };
+
+    const anchorId = generateUuid();
+    const anchor: Anchor = {
+        id: anchorId,
+        modelId,
+        settingsCodeHex,
+        rootPos,
+        rootBaseDiameter: ANCHOR_ROOT_BASE_DIAMETER_MM,
+        rootTopDiameter: ANCHOR_ROOT_TOP_DIAMETER_MM,
+        rootHeight: ANCHOR_ROOT_HEIGHT_MM,
+        joint,
+        segments: [],
+        contactCone,
+    };
+
+    const supportData: SupportData = {
+        id: anchorId,
+        segments: [],
+        contactCone,
+    };
+
+    return { anchor, supportData };
+}

--- a/src/supports/SupportTypes/Anchor/index.ts
+++ b/src/supports/SupportTypes/Anchor/index.ts
@@ -1,0 +1,2 @@
+export { buildAnchorData } from './anchorBuilder';
+export type { AnchorBuildInput, AnchorBuildResult } from './anchorBuilder';

--- a/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
+++ b/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
@@ -1,8 +1,8 @@
 import { useCallback, useState, useEffect, useRef } from 'react';
 import * as THREE from 'three';
-import { addBranch, addKnot, addRoot, addTrunk, getSnapshot, setSnapshot, updateKnot, updateTrunk } from '../../state';
+import { addAnchor, addBranch, addKnot, addRoot, addTrunk, getSnapshot, setSnapshot, updateKnot, updateTrunk } from '../../state';
 import { pushHistory } from '@/history/historyStore';
-import { SUPPORT_ADD_BRANCH, SUPPORT_ADD_TRUNK } from '../../history/actionTypes';
+import { SUPPORT_ADD_ANCHOR, SUPPORT_ADD_BRANCH, SUPPORT_ADD_TRUNK } from '../../history/actionTypes';
 import { useInteractionStatus } from '../../interaction/useInteractionStatus';
 import { buildTrunkData } from './trunkBuilder';
 import { applyTrunkReplacement, computeAndApplyTrunkDiameterProfile, planTrunkReplacement } from './TrunkReplacement';
@@ -165,6 +165,13 @@ export function useTrunkPlacementV2() {
             return;
         }
 
+        if (decision.kind === 'place_anchor') {
+            setPreviewData(decision.supportData);
+            setPreviewError(null);
+            setPreviewWarning(null);
+            return;
+        }
+
         // reject
         if (decision.trunkBuild) {
             setPreviewData(decision.trunkBuild.supportData);
@@ -220,6 +227,16 @@ export function useTrunkPlacementV2() {
             modelId,
             mesh,
         });
+
+        if (decision.kind === 'place_anchor') {
+            addAnchor(decision.anchor);
+            pushHistory({
+                type: SUPPORT_ADD_ANCHOR,
+                payload: { anchor: decision.anchor },
+            });
+            clearSupportSelection();
+            return;
+        }
 
         if (decision.kind === 'place_branch') {
             addKnot(decision.knot);

--- a/src/supports/__tests__/autoBraceGeneration.test.ts
+++ b/src/supports/__tests__/autoBraceGeneration.test.ts
@@ -47,6 +47,7 @@ function createEmptySnapshot(): SupportState {
         twigs: {},
         sticks: {},
         braces: {},
+        anchors: {},
         knots: {},
         selectedId: null,
         selectedCategory: null,

--- a/src/supports/__tests__/gridPlacementIntegration.test.ts
+++ b/src/supports/__tests__/gridPlacementIntegration.test.ts
@@ -39,6 +39,7 @@ function makeEmptySnapshot(): SupportState {
         twigs: {},
         sticks: {},
         braces: {},
+        anchors: {},
         knots: {},
         selectedId: null,
         hoveredId: null,

--- a/src/supports/__tests__/kickstandDeletionCascade.test.ts
+++ b/src/supports/__tests__/kickstandDeletionCascade.test.ts
@@ -125,6 +125,7 @@ function makeState(): SupportState {
         },
       },
     },
+    anchors: {},
     knots: {
       'kickstand-host-knot': {
         id: 'kickstand-host-knot',

--- a/src/supports/history/actionTypes.ts
+++ b/src/supports/history/actionTypes.ts
@@ -1,4 +1,4 @@
-import type { Roots, Trunk, Leaf, Knot, Branch, Brace, Twig, Stick, SupportState } from '../types';
+import type { Anchor, Roots, Trunk, Leaf, Knot, Branch, Brace, Twig, Stick, SupportState } from '../types';
 import type { KickstandBuildResult, KickstandRemoveResult, KickstandState } from '../SupportTypes/Kickstand/types';
 
 export const SUPPORT_ADD_TRUNK = 'support:add-trunk' as const;
@@ -20,6 +20,9 @@ export const SUPPORT_REMOVE_STICK = 'support:remove-stick' as const;
 
 export const SUPPORT_ADD_BRACE = 'support:add-brace' as const;
 export const SUPPORT_REMOVE_BRACE = 'support:remove-brace' as const;
+
+export const SUPPORT_ADD_ANCHOR = 'support:add-anchor' as const;
+export const SUPPORT_REMOVE_ANCHOR = 'support:remove-anchor' as const;
 
 export const SUPPORT_ADD_KICKSTAND = 'support:add-kickstand' as const;
 export const SUPPORT_REMOVE_KICKSTAND = 'support:remove-kickstand' as const;
@@ -43,6 +46,8 @@ export type SupportHistoryActionType =
   | typeof SUPPORT_REMOVE_STICK
   | typeof SUPPORT_ADD_BRACE
   | typeof SUPPORT_REMOVE_BRACE
+  | typeof SUPPORT_ADD_ANCHOR
+  | typeof SUPPORT_REMOVE_ANCHOR
   | typeof SUPPORT_ADD_KICKSTAND
   | typeof SUPPORT_REMOVE_KICKSTAND
   | typeof SUPPORT_REPLACE_TRUNK
@@ -115,6 +120,10 @@ export interface BraceLinkPayload {
   brace: Brace;
   startKnot?: Knot | null;
   endKnot?: Knot | null;
+}
+
+export interface SupportAnchorPayload {
+  anchor: Anchor;
 }
 
 export interface SupportKickstandPayload {

--- a/src/supports/history/useSupportHistoryHandlers.ts
+++ b/src/supports/history/useSupportHistoryHandlers.ts
@@ -7,6 +7,8 @@ import {
   SUPPORT_ADD_TWIG,
   SUPPORT_ADD_STICK,
   SUPPORT_ADD_BRACE,
+  SUPPORT_ADD_ANCHOR,
+  SUPPORT_REMOVE_ANCHOR,
   SUPPORT_REMOVE_TRUNK,
   SUPPORT_REMOVE_LEAF,
   SUPPORT_REMOVE_BRANCH,
@@ -31,10 +33,11 @@ import {
   SupportBranchUpdatePayload,
   SupportReplaceTrunkPayload,
   SupportReplaceStatePayload,
+  SupportAnchorPayload,
   SupportKickstandPayload,
   SupportKickstandRemovePayload,
 } from './actionTypes';
-import { addKnot, addLeaf, addRoot, addTrunk, addBranch, addTwig, addStick, addBrace, removeLeaf, removeTrunk, removeBranch, removeTwig, removeStick, removeBrace, removeKickstandCascade, updateTrunk, updateBranch, updateKnot, setSnapshot } from '../state';
+import { addAnchor, addKnot, addLeaf, addRoot, addTrunk, addBranch, addTwig, addStick, addBrace, removeAnchor, removeLeaf, removeTrunk, removeBranch, removeTwig, removeStick, removeBrace, removeKickstandCascade, updateTrunk, updateBranch, updateKnot, setSnapshot } from '../state';
 import { addKickstand, setKickstandSnapshot } from '../SupportTypes/Kickstand/kickstandStore';
 import { clearSupportSelection } from '../interaction/shared/selection/selectionController';
 
@@ -132,6 +135,26 @@ export function useSupportHistoryHandlers(enabled = true) {
           if (payload.startKnot) addKnot(payload.startKnot);
           if (payload.endKnot) addKnot(payload.endKnot);
           addBrace(payload.brace);
+        }
+        return true;
+      }),
+      registerHistoryHandler(SUPPORT_ADD_ANCHOR, (action, direction) => {
+        const payload = action.payload as SupportAnchorPayload | undefined;
+        if (!payload?.anchor) return false;
+        if (direction === 'undo') {
+          removeAnchor(payload.anchor.id);
+        } else {
+          addAnchor(payload.anchor);
+        }
+        return true;
+      }),
+      registerHistoryHandler(SUPPORT_REMOVE_ANCHOR, (action, direction) => {
+        const payload = action.payload as SupportAnchorPayload | undefined;
+        if (!payload?.anchor) return false;
+        if (direction === 'undo') {
+          addAnchor(payload.anchor);
+        } else {
+          removeAnchor(payload.anchor.id);
         }
         return true;
       }),

--- a/src/supports/interaction/shared/selection/selectionController.ts
+++ b/src/supports/interaction/shared/selection/selectionController.ts
@@ -14,6 +14,7 @@ const SUPPORT_SELECTION_CATEGORIES = new Set([
     'twig',
     'stick',
     'brace',
+    'anchor',
     'root',
 ]);
 

--- a/src/supports/interaction/supportMultiSelection.ts
+++ b/src/supports/interaction/supportMultiSelection.ts
@@ -4,7 +4,7 @@ const listeners = new Set<() => void>();
 const selectedSupportIds = new Set<string>();
 const EMPTY_SELECTION: readonly string[] = Object.freeze([]);
 
-const SUPPORT_SELECTION_CATEGORIES = new Set(['trunk', 'branch', 'leaf', 'twig', 'stick', 'brace', 'root']);
+const SUPPORT_SELECTION_CATEGORIES = new Set(['trunk', 'branch', 'leaf', 'twig', 'stick', 'brace', 'anchor', 'root']);
 
 let syncedPrimarySelection = false;
 let lastPrimarySelectedId: string | null = null;

--- a/src/supports/state.ts
+++ b/src/supports/state.ts
@@ -1,4 +1,4 @@
-import { SupportState, DragonfruitImportFormat, Trunk, Roots, Segment, BezierSegment, StraightSegment, Branch, Knot, Vec3, Leaf, Brace, Twig, Stick } from './types';
+import { SupportState, DragonfruitImportFormat, Trunk, Roots, Segment, BezierSegment, StraightSegment, Branch, Knot, Vec3, Leaf, Brace, Twig, Stick, Anchor } from './types';
 import { calculateBezierControlPoints, getBezierPointAtT, toVector3, toVec3 } from './Curves/BezierUtils';
 import { getBranchSegmentEndpoints, getTrunkSegmentEndpoints, calculateKnotPositionOnSegmentFromT } from './SupportPrimitives/Knot/knotUtils';
 import type { SupportTipProfile } from './SupportPrimitives/ContactCone/types';
@@ -49,6 +49,7 @@ const initialState: SupportState = {
     twigs: {},
     sticks: {},
     braces: {},
+    anchors: {},
     knots: {},
     selectedId: null,
     hoveredId: null,
@@ -65,7 +66,7 @@ let supportSettingsHexCache: SupportSettingsHexCache = {
     leaf: {},
 };
 
-type SelectionCategory = 'trunk' | 'branch' | 'leaf' | 'twig' | 'stick' | 'brace' | 'root' | 'joint' | 'knot' | 'segment' | 'contactDisk' | null;
+type SelectionCategory = 'trunk' | 'branch' | 'leaf' | 'twig' | 'stick' | 'brace' | 'anchor' | 'root' | 'joint' | 'knot' | 'segment' | 'contactDisk' | null;
 
 interface SelectionLookupCache {
     trunksRef: SupportState['trunks'];
@@ -73,6 +74,7 @@ interface SelectionLookupCache {
     leavesRef: SupportState['leaves'];
     twigsRef: SupportState['twigs'];
     sticksRef: SupportState['sticks'];
+    anchorsRef: SupportState['anchors'];
     kickstandsRef: Record<string, Kickstand>;
     jointIds: Set<string>;
     segmentIds: Set<string>;
@@ -93,6 +95,7 @@ function getSelectionLookupCache(): SelectionLookupCache {
         && selectionLookupCache.leavesRef === state.leaves
         && selectionLookupCache.twigsRef === state.twigs
         && selectionLookupCache.sticksRef === state.sticks
+        && selectionLookupCache.anchorsRef === state.anchors
         && selectionLookupCache.kickstandsRef === kickstands
     ) {
         return selectionLookupCache;
@@ -155,6 +158,12 @@ function getSelectionLookupCache(): SelectionLookupCache {
         if (stick.contactConeB?.id) contactDiskIds.add(stick.contactConeB.id);
     }
 
+    for (const anchor of Object.values(state.anchors)) {
+        if (anchor.contactCone?.id) {
+            contactDiskIds.add(anchor.contactCone.id);
+        }
+    }
+
     for (const kickstand of Object.values(kickstands)) {
         kickstandIds.add(kickstand.id);
         for (const segment of kickstand.segments) {
@@ -170,6 +179,7 @@ function getSelectionLookupCache(): SelectionLookupCache {
         leavesRef: state.leaves,
         twigsRef: state.twigs,
         sticksRef: state.sticks,
+        anchorsRef: state.anchors,
         kickstandsRef: kickstands,
         jointIds,
         segmentIds,
@@ -190,6 +200,7 @@ function resolveSelectionCategory(id: string): SelectionCategory {
     if (state.twigs[id]) return 'twig';
     if (state.sticks[id]) return 'stick';
     if (state.braces[id]) return 'brace';
+    if (state.anchors[id]) return 'anchor';
 
     const lookup = getSelectionLookupCache();
     if (lookup.kickstandIds.has(id)) return 'brace';
@@ -1015,6 +1026,7 @@ export function reassignAllSupportModelIds(modelId: string): boolean {
     let nextTwigs = state.twigs;
     let nextSticks = state.sticks;
     let nextBraces = state.braces;
+    let nextAnchors = state.anchors;
 
     for (const root of Object.values(state.roots)) {
         if (root.modelId === modelId) continue;
@@ -1079,6 +1091,15 @@ export function reassignAllSupportModelIds(modelId: string): boolean {
         nextBraces[brace.id] = { ...brace, modelId };
     }
 
+    for (const anchor of Object.values(state.anchors)) {
+        if (anchor.modelId === modelId) continue;
+        if (!changed) {
+            nextAnchors = { ...state.anchors };
+            changed = true;
+        }
+        nextAnchors[anchor.id] = { ...anchor, modelId };
+    }
+
     if (changed) {
         state = {
             ...state,
@@ -1089,6 +1110,7 @@ export function reassignAllSupportModelIds(modelId: string): boolean {
             twigs: nextTwigs,
             sticks: nextSticks,
             braces: nextBraces,
+            anchors: nextAnchors,
         };
         notify();
     }
@@ -1566,6 +1588,25 @@ export function transformSupportsForModel(
         };
     }
 
+    let nextAnchors = state.anchors;
+    for (const anchor of Object.values(state.anchors)) {
+        if (anchor.modelId !== modelId) continue;
+        if (!changed) {
+            nextAnchors = { ...state.anchors };
+            changed = true;
+        }
+        nextAnchors[anchor.id] = {
+            ...anchor,
+            rootPos: transformVec3(anchor.rootPos, deltaMatrix),
+            joint: {
+                ...anchor.joint,
+                pos: transformVec3(anchor.joint.pos, deltaMatrix),
+            },
+            segments: anchor.segments.map((segment) => transformSegment(segment, deltaMatrix, normalMatrix)),
+            contactCone: transformContactCone(anchor.contactCone, deltaMatrix, normalMatrix),
+        };
+    }
+
     for (const knot of Object.values(state.knots)) {
         const parentShaftId = knot.parentShaftId;
         const isLeafConeKnot = parentShaftId.startsWith('leafCone:')
@@ -1600,6 +1641,7 @@ export function transformSupportsForModel(
             twigs: nextTwigs,
             sticks: nextSticks,
             braces: nextBraces,
+            anchors: nextAnchors,
             knots: nextKnots,
         };
         notify();
@@ -1725,6 +1767,20 @@ export function transformAllSupportsForSingleModel(
         };
     }
 
+    const nextAnchors: Record<string, Anchor> = {};
+    for (const anchor of Object.values(state.anchors)) {
+        nextAnchors[anchor.id] = {
+            ...anchor,
+            rootPos: transformVec3(anchor.rootPos, deltaMatrix),
+            joint: {
+                ...anchor.joint,
+                pos: transformVec3(anchor.joint.pos, deltaMatrix),
+            },
+            segments: anchor.segments.map((segment) => transformSegment(segment, deltaMatrix, normalMatrix)),
+            contactCone: transformContactCone(anchor.contactCone, deltaMatrix, normalMatrix),
+        };
+    }
+
     const nextKnots: Record<string, Knot> = {};
     for (const knot of Object.values(state.knots)) {
         nextKnots[knot.id] = {
@@ -1742,6 +1798,7 @@ export function transformAllSupportsForSingleModel(
         twigs: nextTwigs,
         sticks: nextSticks,
         braces: nextBraces,
+        anchors: nextAnchors,
         knots: nextKnots,
     };
     notify();
@@ -2030,6 +2087,7 @@ export function loadFromLychee(data: DragonfruitImportFormat) {
         twigs: {},
         sticks: {},
         braces: {},
+        anchors: {},
         knots: {},
         selectedId: null,
         hoveredId: null,
@@ -2077,6 +2135,13 @@ export function loadFromLychee(data: DragonfruitImportFormat) {
         newState.braces[br.id] = br;
     });
 
+    // Populate Anchors
+    if (data.anchors) {
+        data.anchors.forEach(a => {
+            newState.anchors[a.id] = a;
+        });
+    }
+
     // Populate Knots
     if (data.knots) {
         data.knots.forEach(k => {
@@ -2103,6 +2168,7 @@ export function loadFromLychee(data: DragonfruitImportFormat) {
         twigs: Object.keys(state.twigs).length,
         sticks: Object.keys(state.sticks).length,
         braces: Object.keys(state.braces).length,
+        anchors: Object.keys(state.anchors).length,
         knots: Object.keys(state.knots).length,
         kickstands: Object.keys(getKickstandSnapshot().kickstands).length,
     });
@@ -2389,6 +2455,7 @@ export function mergeFromLychee(data: DragonfruitImportFormat) {
         twigs: { ...state.twigs },
         sticks: { ...state.sticks },
         braces: { ...state.braces },
+        anchors: { ...state.anchors },
         knots: { ...state.knots },
     };
 
@@ -2399,6 +2466,7 @@ export function mergeFromLychee(data: DragonfruitImportFormat) {
     if (isolated.twigs) { isolated.twigs.forEach(t => { merged.twigs[t.id] = t; }); }
     if (isolated.sticks) { isolated.sticks.forEach(s => { merged.sticks[s.id] = s; }); }
     isolated.braces.forEach(br => { merged.braces[br.id] = br; });
+    if (isolated.anchors) { isolated.anchors.forEach(a => { merged.anchors[a.id] = a; }); }
     if (isolated.knots) { isolated.knots.forEach(k => { merged.knots[k.id] = k; }); }
 
     for (const kickstandBuild of isolated.kickstands ?? []) {
@@ -2420,6 +2488,7 @@ export function mergeFromLychee(data: DragonfruitImportFormat) {
         twigs: Object.keys(state.twigs).length,
         sticks: Object.keys(state.sticks).length,
         braces: Object.keys(state.braces).length,
+        anchors: Object.keys(state.anchors).length,
         knots: Object.keys(state.knots).length,
         kickstands: Object.keys(getKickstandSnapshot().kickstands).length,
     });
@@ -2633,6 +2702,32 @@ export function addStick(stick: Stick) {
         sticks: { ...state.sticks, [stick.id]: stick },
     };
     notify();
+}
+
+export function addAnchor(anchor: Anchor) {
+    state = {
+        ...state,
+        anchors: { ...state.anchors, [anchor.id]: anchor },
+    };
+    notify();
+}
+
+export function updateAnchor(anchor: Anchor) {
+    if (!state.anchors[anchor.id]) return;
+    state = {
+        ...state,
+        anchors: { ...state.anchors, [anchor.id]: anchor },
+    };
+    notify();
+}
+
+export function removeAnchor(anchorId: string): { anchor: Anchor } | null {
+    const anchor = state.anchors[anchorId];
+    if (!anchor) return null;
+    const { [anchorId]: _, ...rest } = state.anchors;
+    state = { ...state, anchors: rest };
+    notify();
+    return { anchor };
 }
 
 export function updateTwig(twig: Twig) {
@@ -3641,6 +3736,14 @@ export function getBraces() {
     return Object.values(state.braces);
 }
 
+export function getAnchors() {
+    return Object.values(state.anchors);
+}
+
+export function getAnchorById(anchorId: string) {
+    return state.anchors[anchorId] ?? null;
+}
+
 export function getKnotsMap() {
     return state.knots;
 }
@@ -3684,6 +3787,7 @@ export function getModelIdForSupportEntityId(id: string | null | undefined): str
     if (state.twigs[id]) return state.twigs[id].modelId ?? null;
     if (state.sticks[id]) return state.sticks[id].modelId ?? null;
     if (state.braces[id]) return state.braces[id].modelId ?? null;
+    if (state.anchors[id]) return state.anchors[id].modelId ?? null;
 
     const kickstandState = getKickstandSnapshot();
     const directKickstand = kickstandState.kickstands[id];

--- a/src/supports/types.ts
+++ b/src/supports/types.ts
@@ -171,6 +171,21 @@ export type BraceCurve = {
 };
 
 /**
+ * Anchor: A minimal near-plate support for contact points below 5mm.
+ * Bypasses grid system entirely. Not a target for branches, leaves, or braces.
+ * Geometry: frustum root → joint → single segment → contact cone.
+ */
+export interface Anchor extends SupportEntity {
+    rootPos: Vec3;
+    rootBaseDiameter: number;
+    rootTopDiameter: number;
+    rootHeight: number;
+    joint: Joint;
+    segments: Segment[];
+    contactCone: ContactCone;
+}
+
+/**
  * Brace: A stabilizer bar connecting two supports.
  */
 export interface Brace extends SupportEntity {
@@ -192,10 +207,11 @@ export interface SupportState {
     twigs: Record<string, Twig>;
     sticks: Record<string, Stick>;
     braces: Record<string, Brace>;
+    anchors: Record<string, Anchor>;
     knots: Record<string, Knot>;
     // Interaction State
     selectedId: string | null;
-    selectedCategory?: 'trunk' | 'branch' | 'leaf' | 'twig' | 'stick' | 'brace' | 'root' | 'joint' | 'knot' | 'segment' | 'contactDisk' | null;
+    selectedCategory?: 'trunk' | 'branch' | 'leaf' | 'twig' | 'stick' | 'brace' | 'anchor' | 'root' | 'joint' | 'knot' | 'segment' | 'contactDisk' | null;
     hoveredId: string | null;
     hoveredCategory?: 'model' | 'support' | 'contactDisk' | 'segment' | 'joint' | 'knot' | 'raft' | 'gizmo' | 'none';
     interactionWarning?: WarningCode | null;
@@ -216,6 +232,7 @@ export interface DragonfruitImportFormat {
     twigs?: Twig[];
     sticks?: Stick[];
     braces: Brace[];
+    anchors?: Anchor[];
     knots: Knot[];
     kickstands?: KickstandBuildResult[];
 }


### PR DESCRIPTION
## Summary

- Adds a new **Anchor** support type that replaces trunk/branch generation when model contact points are below 5mm from the build plate, fixing malformed geometry from grid snapping on low surfaces
- Anchor geometry: frustum root (2mm base → 1.5mm top, 1mm tall) with spherical top, connected directly to a variable-length contact cone that stretches along the configured cone angle to reach the model surface
- Anchors are fully standalone — they bypass the grid system and cannot be targets for branches, leaves, or braces

## What changed

- **New files:** `src/supports/SupportTypes/Anchor/` — builder, renderer, index
- **Grid placement:** 5mm threshold in `decideGridPlacement()` returns `place_anchor` decision before any grid logic
- **Store:** Anchor CRUD, transforms, model ID reassignment, selection category registration
- **Rendering:** Uses `RootsRenderer` for raft-aware root geometry; `ContactConeRenderer` with hover, selection, and draggable contact disk
- **Selection:** Single-click, shift-multi-select, marquee select, contact disk sub-selection, delete
- **Raft:** Anchor roots included in footprint generation across all raft renderers + proxy layer
- **Proxy mesh layer:** Anchors registered for non-support tab rendering
- **History:** `SUPPORT_ADD_ANCHOR` / `SUPPORT_REMOVE_ANCHOR` with full undo/redo
- **Import/Export:** Anchors serialized in `DragonfruitImportFormat`

Closes #113