### PR TITLE
feat: Internal Supports

### DIFF
--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -23,9 +23,13 @@ if (isLinux) {
 
 console.log(`[tauri-build] ${npxCmd} ${cmdArgs.join(" ")}`);
 
+// Set RUSTFLAGS in the environment.
+process.env.RUSTFLAGS = "-C target-feature=+avx2,+fma";
+
+// Use shell:true to work around Windows spawnSync EINVAL issues with npx.cmd
 const result = spawnSync(npxCmd, cmdArgs, {
   stdio: "inherit",
-  env: { ...process.env, RUSTFLAGS: "-C target-feature=+avx2,+fma" },
+  shell: true,
 });
 
 process.exit(result.status ?? 1);

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -21,15 +21,16 @@ if (isLinux) {
   cmdArgs.push("--", "--no-default-features", "--features", "custom-protocol,tauri-cef");
 }
 
-console.log(`[tauri-build] ${npxCmd} ${cmdArgs.join(" ")}`);
+const rustflags = "-C target-feature=+avx2,+fma";
+console.log(`[tauri-build] ${npxCmd} ${cmdArgs.join(" ")} (RUSTFLAGS=${rustflags})`);
 
-// Set RUSTFLAGS in the environment.
-process.env.RUSTFLAGS = "-C target-feature=+avx2,+fma";
-
-// Use shell:true to work around Windows spawnSync EINVAL issues with npx.cmd
+// On Windows, .cmd files cannot be spawned directly — they require the shell
+// (cmd.exe) to execute them. Pass RUSTFLAGS explicitly through env so it is
+// guaranteed to reach cargo/rustc regardless of inherited process.env state.
 const result = spawnSync(npxCmd, cmdArgs, {
   stdio: "inherit",
-  shell: true,
+  shell: process.platform === "win32",
+  env: { ...process.env, RUSTFLAGS: rustflags },
 });
 
 process.exit(result.status ?? 1);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.9.2",
+ "rand 0.9.3",
  "raw-window-handle",
  "serde",
  "serde_repr",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -571,6 +571,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,14 +667,38 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cef"
+version = "146.4.1+146.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5dad6495c583fedab04a24f6fc08274c59a28b33967ca87709398e1f11c2ebe"
+dependencies = [
+ "cef-dll-sys",
+ "libloading 0.9.0",
+ "objc2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cef-dll-sys"
+version = "146.4.1+146.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6616217417da12da57bb7650acc3c8be0fc26e7120892ab926d2ba8d84c8c9c2"
+dependencies = [
+ "anyhow",
+ "cmake",
+ "download-cef",
+ "serde_json",
 ]
 
 [[package]]
@@ -770,6 +803,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +837,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,8 +866,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1107,6 +1180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dioxus-debug-cell"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ea539174bb236e0e7dc9c12b19b88eae3cb574dedbd0252a2d43ea7e6de13e2"
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dom_query"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,6 +1290,25 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "download-cef"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7471a7d5d3bd8df1b3b75871f0317d8a6dd73270ab861cc97ae7907ee63e554"
+dependencies = [
+ "bzip2 0.6.1",
+ "clap",
+ "indicatif",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha1_smol",
+ "tar",
+ "thiserror 2.0.18",
+ "ureq",
+]
 
 [[package]]
 name = "dpi"
@@ -1245,7 +1352,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "dragonfruit-slicing-engine",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rayon",
  "serde",
  "serde_json",
@@ -1335,6 +1442,12 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1432,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -1456,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-sidecar"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f076483fb6efcf02e4abcf3e9388d30123346f85b9a96e8fe834718951b945ed"
+checksum = "42bc8b8df567bc8a9dcf9004a22be12c4e0766649b2116b2397dd04f25c8f2fe"
 dependencies = [
  "anyhow",
  "tar",
@@ -1756,33 +1869,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gdkx11"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3caa00e14351bebbc8183b3c36690327eb77c49abc2268dd4bd36b856db3fbfe"
-dependencies = [
- "gdk",
- "gdkx11-sys",
- "gio",
- "glib",
- "libc",
- "x11",
-]
-
-[[package]]
-name = "gdkx11-sys"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d"
-dependencies = [
- "gdk-sys",
- "glib-sys",
- "libc",
- "system-deps",
- "x11",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,7 +2087,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2028,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -2128,9 +2214,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2142,7 +2228,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2241,12 +2326,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2254,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2267,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2281,15 +2367,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2301,15 +2387,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2376,14 +2462,27 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -2413,9 +2512,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2512,10 +2611,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2561,7 +2662,7 @@ checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
  "cssparser 0.29.6",
  "html5ever 0.29.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "selectors 0.24.0",
 ]
 
@@ -2572,34 +2673,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "libappindicator"
-version = "0.9.0"
+name = "libbz2-rs-sys"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a"
-dependencies = [
- "glib",
- "gtk",
- "gtk-sys",
- "libappindicator-sys",
- "log",
-]
-
-[[package]]
-name = "libappindicator-sys"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
-dependencies = [
- "gtk-sys",
- "libloading 0.7.4",
- "once_cell",
-]
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libdeflate-sys"
@@ -2621,16 +2704,6 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
-name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
@@ -2640,15 +2713,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.15"
+name = "libloading"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2659,9 +2742,15 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -2793,9 +2882,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -2804,9 +2893,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2946,8 +3035,38 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2976,6 +3095,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,6 +3152,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3014,6 +3169,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-javascript-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3023,6 +3188,17 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3049,6 +3225,8 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+ "objc2-javascript-core",
+ "objc2-security",
 ]
 
 [[package]]
@@ -3387,12 +3565,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3422,7 +3594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "quick-xml 0.38.4",
  "serde",
  "time",
@@ -3462,10 +3634,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
-name = "potential_utf"
-version = "0.1.4"
+name = "portable-atomic"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3527,7 +3705,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3661,9 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3781,9 +3959,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -4019,9 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4071,9 +4249,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4112,21 +4290,6 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "indexmap 1.9.3",
- "schemars_derive",
- "serde",
- "serde_json",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -4145,15 +4308,18 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+ "url",
+ "uuid",
 ]
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4241,9 +4407,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -4308,6 +4474,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -4337,9 +4504,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4366,7 +4533,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -4440,6 +4607,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4468,9 +4641,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
@@ -4510,6 +4683,17 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4729,7 +4913,6 @@ dependencies = [
  "dlopen2",
  "dpi",
  "gdkwayland-sys",
- "gdkx11-sys",
  "gtk",
  "jni",
  "libc",
@@ -4749,7 +4932,6 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
  "windows-version",
- "x11-dl",
 ]
 
 [[package]]
@@ -4789,8 +4971,7 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 [[package]]
 name = "tauri"
 version = "2.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
+source = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#a94e1b8595d9bb49328451dfe151d8499c712d44"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4825,11 +5006,11 @@ dependencies = [
  "tauri-build",
  "tauri-macros",
  "tauri-runtime",
+ "tauri-runtime-cef",
  "tauri-runtime-wry",
  "tauri-utils",
  "thiserror 2.0.18",
  "tokio",
- "tray-icon",
  "url",
  "webkit2gtk",
  "webview2-com",
@@ -4840,16 +5021,16 @@ dependencies = [
 [[package]]
 name = "tauri-build"
 version = "2.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
+source = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#a94e1b8595d9bb49328451dfe151d8499c712d44"
 dependencies = [
  "anyhow",
  "cargo_toml",
+ "cef-dll-sys",
  "dirs",
  "glob",
  "heck 0.5.0",
  "json-patch",
- "schemars 0.8.22",
+ "schemars 1.2.1",
  "semver",
  "serde",
  "serde_json",
@@ -4862,8 +5043,7 @@ dependencies = [
 [[package]]
 name = "tauri-codegen"
 version = "2.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
+source = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#a94e1b8595d9bb49328451dfe151d8499c712d44"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4889,8 +5069,7 @@ dependencies = [
 [[package]]
 name = "tauri-macros"
 version = "2.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
+source = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#a94e1b8595d9bb49328451dfe151d8499c712d44"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4902,14 +5081,13 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692a77abd8b8773e107a42ec0e05b767b8d2b7ece76ab36c6c3947e34df9f53f"
+version = "2.5.4"
+source = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#a94e1b8595d9bb49328451dfe151d8499c712d44"
 dependencies = [
  "anyhow",
  "glob",
  "plist",
- "schemars 0.8.22",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tauri-utils",
@@ -4954,9 +5132,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-single-instance"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+checksum = "a33a5b7d78f0dec4406b003ea87c40bf928d801b6fd9323a556172c91d8712c1"
 dependencies = [
  "serde",
  "serde_json",
@@ -4970,8 +5148,7 @@ dependencies = [
 [[package]]
 name = "tauri-runtime"
 version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
+source = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#a94e1b8595d9bb49328451dfe151d8499c712d44"
 dependencies = [
  "cookie",
  "dpi",
@@ -4980,23 +5157,47 @@ dependencies = [
  "jni",
  "objc2",
  "objc2-ui-kit",
- "objc2-web-kit",
  "raw-window-handle",
  "serde",
  "serde_json",
  "tauri-utils",
  "thiserror 2.0.18",
  "url",
- "webkit2gtk",
- "webview2-com",
  "windows",
+]
+
+[[package]]
+name = "tauri-runtime-cef"
+version = "0.1.0"
+source = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#a94e1b8595d9bb49328451dfe151d8499c712d44"
+dependencies = [
+ "base64 0.22.1",
+ "cef",
+ "cef-dll-sys",
+ "dioxus-debug-cell",
+ "dirs",
+ "gtk",
+ "html5ever 0.29.1",
+ "http",
+ "kuchikiki",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "raw-window-handle",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tauri-runtime",
+ "tauri-utils",
+ "url",
+ "windows",
+ "x11-dl",
 ]
 
 [[package]]
 name = "tauri-runtime-wry"
 version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
+source = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#a94e1b8595d9bb49328451dfe151d8499c712d44"
 dependencies = [
  "gtk",
  "http",
@@ -5004,6 +5205,7 @@ dependencies = [
  "log",
  "objc2",
  "objc2-app-kit",
+ "objc2-web-kit",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -5021,8 +5223,7 @@ dependencies = [
 [[package]]
 name = "tauri-utils"
 version = "2.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
+source = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#a94e1b8595d9bb49328451dfe151d8499c712d44"
 dependencies = [
  "anyhow",
  "brotli",
@@ -5041,7 +5242,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "schemars 0.8.22",
+ "schemars 1.2.1",
  "semver",
  "serde",
  "serde-untagged",
@@ -5176,9 +5377,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5201,9 +5402,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -5264,9 +5465,9 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.1.0",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -5293,9 +5494,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -5306,7 +5507,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -5317,7 +5518,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -5326,30 +5527,30 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -5425,28 +5626,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tray-icon"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
-dependencies = [
- "crossbeam-channel",
- "dirs",
- "libappindicator",
- "muda",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation",
- "once_cell",
- "png",
- "serde",
- "thiserror 2.0.18",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5556,10 +5735,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"
@@ -5574,11 +5765,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
  "flate2",
  "log",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
  "ureq-proto",
  "utf8-zero",
  "webpki-roots",
@@ -5659,9 +5854,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5764,9 +5959,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5777,23 +5972,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5801,9 +5992,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5814,9 +6005,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -5838,7 +6029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5864,15 +6055,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -5884,9 +6075,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.13"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.11.0",
  "rustix",
@@ -5896,9 +6087,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.11"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -5908,9 +6099,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.9"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml 0.39.2",
@@ -5919,9 +6110,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
@@ -5930,9 +6121,19 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6570,9 +6771,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -6615,7 +6816,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -6646,7 +6847,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -6665,7 +6866,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -6677,9 +6878,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
@@ -6695,7 +6896,6 @@ dependencies = [
  "dom_query",
  "dpi",
  "dunce",
- "gdkx11",
  "gtk",
  "http",
  "javascriptcore-rs",
@@ -6722,7 +6922,6 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
  "windows-version",
- "x11-dl",
 ]
 
 [[package]]
@@ -6732,16 +6931,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "x11"
-version = "2.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
-dependencies = [
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -6776,9 +6965,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6787,9 +6976,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6860,18 +7049,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6880,18 +7069,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6921,9 +7110,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6932,9 +7121,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6943,9 +7132,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6972,7 +7161,7 @@ checksum = "84e9a772a54b54236b9b744aaaf8d7be01b4d6e99725523cb82cb32d1c81b1d7"
 dependencies = [
  "aes",
  "arbitrary",
- "bzip2",
+ "bzip2 0.5.2",
  "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
@@ -6981,7 +7170,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.4",
  "hmac",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",
@@ -7003,7 +7192,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
  "zopfli",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -58,6 +58,17 @@ tauri-utils = { git = "https://github.com/tauri-apps/tauri", branch = "feat/cef"
 tauri-codegen = { git = "https://github.com/tauri-apps/tauri", branch = "feat/cef" }
 tauri-plugin = { git = "https://github.com/tauri-apps/tauri", branch = "feat/cef" }
 
+# Maximum release optimisation: fat LTO collapses all codegen units into one
+# link step, enabling inlining and dead-code elimination across crate boundaries.
+# Critical for the slicing engine — cross-crate SIMD and rayon dispatch paths
+# are 15-30% faster with fat LTO than the default thin/no-LTO build.
+[profile.release]
+lto = "fat"
+codegen-units = 1
+opt-level = 3
+panic = "abort"
+strip = "none"  # keep debug info for crash reports; strip handled by Tauri bundler
+
 # Compile ALL dependencies with full optimizations in dev builds.
 # The slicer and its deps (flate2, crc32fast, png, zip, rayon) are
 # 50-200x slower in debug mode due to heavy numerical/compression work.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1232,6 +1232,7 @@ export default function Home() {
   const [isHistoryPreviewActive, setIsHistoryPreviewActive] = React.useState(false);
   const historyPreviewBaselineRef = React.useRef<{ undo: number; redo: number } | null>(null);
   const [isSelectAllModelsActive, setIsSelectAllModelsActive] = React.useState(false);
+  const [isTemporarilyDisablingCrossSectionForThumbnail, setIsTemporarilyDisablingCrossSectionForThumbnail] = React.useState(false);
   const [arrangeSpacingMm, setArrangeSpacingMm] = React.useState(0.5);
   const [arrangePrecisionMode, setArrangePrecisionMode] = React.useState<ArrangePrecisionMode>('standard');
   const [arrangeAllowRotateOnZ, setArrangeAllowRotateOnZ] = React.useState(false);
@@ -6395,10 +6396,17 @@ export default function Home() {
     // Capture a thumbnail from the live scene canvas — same path as the export panel.
     let exportThumbnailPng: Uint8Array | null = null;
     try {
+      // Temporarily disable cross-section clipping while taking the scene thumbnail.
+      setIsTemporarilyDisablingCrossSectionForThumbnail(true);
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
       const runCapture = exportThumbnailCaptureRunnerRef.current;
       if (runCapture) exportThumbnailPng = await runCapture();
     } catch {
       // Non-fatal: save proceeds without thumbnail.
+    } finally {
+      setIsTemporarilyDisablingCrossSectionForThumbnail(false);
     }
 
     const savedPath = await ExportManager.exportScene(
@@ -11194,14 +11202,16 @@ export default function Home() {
   const isTransitioningOutOfPrinting = scene.mode !== 'printing' && previousSceneModeRef.current === 'printing';
 
   const sceneClipLower = React.useMemo(() => {
+    if (isTemporarilyDisablingCrossSectionForThumbnail) return null;
     if (scene.mode === 'printing' || isTransitioningOutOfPrinting) return null;
     return slicing.clipLower;
-  }, [isTransitioningOutOfPrinting, scene.mode, slicing.clipLower]);
+  }, [isTemporarilyDisablingCrossSectionForThumbnail, isTransitioningOutOfPrinting, scene.mode, slicing.clipLower]);
 
   const sceneClipUpper = React.useMemo(() => {
+    if (isTemporarilyDisablingCrossSectionForThumbnail) return null;
     if (scene.mode === 'printing' || isTransitioningOutOfPrinting) return null;
     return slicing.clipUpper;
-  }, [isTransitioningOutOfPrinting, scene.mode, slicing.clipUpper]);
+  }, [isTemporarilyDisablingCrossSectionForThumbnail, isTransitioningOutOfPrinting, scene.mode, slicing.clipUpper]);
 
   const effectiveHoverTintStrengthForScene = React.useMemo(() => {
     return scene.mode === 'printing' ? 0 : scene.hoverTintStrength;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,7 +40,7 @@ import { MeshSmoothingSettingsPanel } from '@/features/mesh-smoothing/MeshSmooth
 import { MeshSmoothingBrushCursor } from '@/features/mesh-smoothing/MeshSmoothingBrushCursor';
 import { PlaceOnFaceTool } from '@/features/placeOnFace/PlaceOnFaceTool';
 import { RtspRelayCanvasPlayer } from '@/components/monitoring/RtspRelayCanvasPlayer';
-import { IconButton } from '@/components/ui/primitives';
+import { IconButton, Toast, ToastViewport } from '@/components/ui/primitives';
 import { EditorContextMenu, type EditorMenuAction } from '@/components/ui/EditorContextMenu';
 import { DiagnosticsModal } from '@/components/modals/DiagnosticsModal';
 import { HistoryDebugModal } from '@/components/modals/HistoryDebugModal';
@@ -16338,37 +16338,21 @@ export default function Home() {
       )}
 
       {(isSceneSaveInProgress || isAutosaving) && (
-        <div className="pointer-events-none fixed inset-x-0 bottom-5 z-[126] flex justify-center px-3">
-          <div
-            className="flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold shadow-lg"
-            style={{
-              borderColor: 'color-mix(in srgb, #60a5fa, var(--border-subtle) 50%)',
-              background: 'color-mix(in srgb, #60a5fa, var(--surface-0) 90%)',
-              color: 'var(--text-strong)',
-            }}
-          >
+        <ToastViewport zIndex={126} offset="1.25rem">
+          <Toast tone="info" className="flex items-center gap-2">
             <RefreshCw className="h-4 w-4 animate-spin" />
             {isSceneSaveInProgress ? 'Saving…' : 'Autosaving…'}
-          </div>
-        </div>
+          </Toast>
+        </ToastViewport>
       )}
 
       {historyActionToast && (
-        <div className="pointer-events-none fixed inset-x-0 bottom-5 z-[125] flex justify-center px-3">
-          <div
-            className="flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold shadow-lg"
-            style={{
-              borderColor: historyActionToast.direction === 'undo'
-                ? 'color-mix(in srgb, #fbbf24, var(--border-subtle) 50%)'
-                : 'color-mix(in srgb, #60a5fa, var(--border-subtle) 50%)',
-              background: historyActionToast.direction === 'undo'
-                ? 'color-mix(in srgb, #fbbf24, var(--surface-0) 90%)'
-                : 'color-mix(in srgb, #60a5fa, var(--surface-0) 90%)',
-              color: 'var(--text-strong)',
-              opacity: isHistoryActionToastVisible ? 1 : 0,
-              transform: `translateY(${isHistoryActionToastVisible ? '0px' : '8px'})`,
-              transition: 'opacity 220ms ease, transform 220ms ease',
-            }}
+        <ToastViewport zIndex={125} offset="1.25rem">
+          <Toast
+            tone={historyActionToast.direction === 'undo' ? 'warning' : 'info'}
+            animated
+            visible={isHistoryActionToastVisible}
+            className="flex items-center gap-2"
           >
             {historyActionToast.direction === 'undo' ? (
               <Undo2 className="h-4 w-4 motion-safe:animate-pulse" />
@@ -16376,74 +16360,51 @@ export default function Home() {
               <Redo2 className="h-4 w-4 motion-safe:animate-pulse" />
             )}
             {historyActionToast.text}
-          </div>
-        </div>
+          </Toast>
+        </ToastViewport>
       )}
 
       {printingMonitorErrorToast && (
-        <div
-          className="pointer-events-none fixed inset-x-0 z-[126] flex justify-center px-3"
-          style={{ bottom: (historyActionToast || scene.sceneImportReport) ? '4.5rem' : '1.25rem' }}
+        <ToastViewport
+          zIndex={126}
+          offset={(historyActionToast || scene.sceneImportReport) ? '4.5rem' : '1.25rem'}
         >
-          <div
-            className="flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold shadow-lg"
-            style={{
-              borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 50%)',
-              background: 'color-mix(in srgb, #ef4444, var(--surface-0) 90%)',
-              color: 'var(--text-strong)',
-              opacity: isPrintingMonitorErrorToastVisible ? 1 : 0,
-              transform: `translateY(${isPrintingMonitorErrorToastVisible ? '0px' : '8px'})`,
-              transition: 'opacity 220ms ease, transform 220ms ease',
-            }}
+          <Toast
+            tone="error"
+            animated
+            visible={isPrintingMonitorErrorToastVisible}
+            className="flex items-center gap-2"
           >
             <AlertTriangle className="h-4 w-4 motion-safe:animate-pulse" />
             {printingMonitorErrorToast.text}
-          </div>
-        </div>
+          </Toast>
+        </ToastViewport>
       )}
 
       {scene.sceneImportReport && (
-        <div className="pointer-events-none fixed inset-x-0 bottom-5 z-[125] flex justify-center px-3">
-          <div
-            className="rounded-full border px-4 py-2 text-sm font-semibold shadow-lg"
-            style={{
-              borderColor: scene.sceneImportReport.tone === 'error'
-                ? 'color-mix(in srgb, #ef4444, var(--border-subtle) 50%)'
+        <ToastViewport zIndex={125} offset="1.25rem">
+          <Toast
+            tone={
+              scene.sceneImportReport.tone === 'error'
+                ? 'error'
                 : scene.sceneImportReport.tone === 'warning'
-                  ? 'color-mix(in srgb, #f59e0b, var(--border-subtle) 50%)'
-                  : 'color-mix(in srgb, #22c55e, var(--border-subtle) 50%)',
-              background: scene.sceneImportReport.tone === 'error'
-                ? 'color-mix(in srgb, #ef4444, var(--surface-0) 90%)'
-                : scene.sceneImportReport.tone === 'warning'
-                  ? 'color-mix(in srgb, #f59e0b, var(--surface-0) 90%)'
-                  : 'color-mix(in srgb, #22c55e, var(--surface-0) 90%)',
-              color: 'var(--text-strong)',
-              opacity: isSceneImportToastVisible ? 1 : 0,
-              transform: `translateY(${isSceneImportToastVisible ? '0px' : '8px'})`,
-              transition: 'opacity 220ms ease, transform 220ms ease',
-            }}
+                  ? 'warning'
+                  : 'success'
+            }
+            animated
+            visible={isSceneImportToastVisible}
           >
             {scene.sceneImportReport.text}
-          </div>
-        </div>
+          </Toast>
+        </ToastViewport>
       )}
 
       {exportSuccessToast && (
-        <div className="pointer-events-none fixed inset-x-0 bottom-5 z-[125] flex justify-center px-3">
-          <div
-            className="rounded-full border px-4 py-2 text-sm font-semibold shadow-lg"
-            style={{
-              borderColor: 'color-mix(in srgb, #22c55e, var(--border-subtle) 50%)',
-              background: 'color-mix(in srgb, #22c55e, var(--surface-0) 90%)',
-              color: 'var(--text-strong)',
-              opacity: isExportSuccessToastVisible ? 1 : 0,
-              transform: `translateY(${isExportSuccessToastVisible ? '0px' : '8px'})`,
-              transition: 'opacity 220ms ease, transform 220ms ease',
-            }}
-          >
+        <ToastViewport zIndex={125} offset="1.25rem">
+          <Toast tone="success" animated visible={isExportSuccessToastVisible}>
             Saved to: {exportSuccessToast.path}
-          </div>
-        </div>
+          </Toast>
+        </ToastViewport>
       )}
 
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -774,6 +774,9 @@ export default function Home() {
   const [exportSuccessToast, setExportSuccessToast] = React.useState<{ id: number; path: string } | null>(null);
   const [isExportSuccessToastVisible, setIsExportSuccessToastVisible] = React.useState(false);
   const [isSceneSaveInProgress, setIsSceneSaveInProgress] = React.useState(false);
+  const [isSaveToastVisible, setIsSaveToastVisible] = React.useState(false);
+  const [isSaveToastAnimatedVisible, setIsSaveToastAnimatedVisible] = React.useState(false);
+  const [saveToastLabel, setSaveToastLabel] = React.useState<'Saving…' | 'Autosaving…'>('Autosaving…');
   const [showLysImportWarningModal, setShowLysImportWarningModal] = React.useState(false);
   const [suppressLysImportWarning, setSuppressLysImportWarning] = React.useState(false);
   const [lysImportWarningSkipFuture, setLysImportWarningSkipFuture] = React.useState(false);
@@ -810,6 +813,10 @@ export default function Home() {
   const printingMonitorErrorToastClearTimeoutRef = React.useRef<number | null>(null);
   const sceneImportToastFadeTimeoutRef = React.useRef<number | null>(null);
   const exportSuccessToastFadeTimeoutRef = React.useRef<number | null>(null);
+  const saveToastHideTimeoutRef = React.useRef<number | null>(null);
+  const saveToastClearTimeoutRef = React.useRef<number | null>(null);
+  const saveToastEnterRafRef = React.useRef<number | null>(null);
+  const saveToastShownAtRef = React.useRef<number | null>(null);
   const sceneSaveKickoffTimerRef = React.useRef<number | null>(null);
   const sceneSaveInFlightRef = React.useRef(false);
   const sceneSaveQueuedRef = React.useRef(false);
@@ -825,6 +832,84 @@ export default function Home() {
     capMs: sceneAutosaveSettings.capMs,
     preferredSavePath: preferredOverwriteScenePathRef.current,
   });
+
+  React.useEffect(() => {
+    const MIN_SAVE_TOAST_VISIBLE_MS = 2000;
+    const TOAST_ANIMATION_MS = 220;
+    const hasActiveSaveWork = isSceneSaveInProgress || isAutosaving;
+
+    if (hasActiveSaveWork) {
+      if (saveToastHideTimeoutRef.current !== null) {
+        window.clearTimeout(saveToastHideTimeoutRef.current);
+        saveToastHideTimeoutRef.current = null;
+      }
+      if (saveToastClearTimeoutRef.current !== null) {
+        window.clearTimeout(saveToastClearTimeoutRef.current);
+        saveToastClearTimeoutRef.current = null;
+      }
+      if (saveToastEnterRafRef.current !== null) {
+        window.cancelAnimationFrame(saveToastEnterRafRef.current);
+        saveToastEnterRafRef.current = null;
+      }
+
+      setSaveToastLabel(isSceneSaveInProgress ? 'Saving…' : 'Autosaving…');
+
+      if (!isSaveToastVisible) {
+        saveToastShownAtRef.current = Date.now();
+        setIsSaveToastVisible(true);
+        setIsSaveToastAnimatedVisible(false);
+        saveToastEnterRafRef.current = window.requestAnimationFrame(() => {
+          saveToastEnterRafRef.current = null;
+          setIsSaveToastAnimatedVisible(true);
+        });
+      } else if (!isSaveToastAnimatedVisible) {
+        setIsSaveToastAnimatedVisible(true);
+      }
+      return;
+    }
+
+    if (!isSaveToastVisible) {
+      saveToastShownAtRef.current = null;
+      return;
+    }
+
+    const shownAt = saveToastShownAtRef.current ?? Date.now();
+    const elapsed = Date.now() - shownAt;
+    const remaining = Math.max(0, MIN_SAVE_TOAST_VISIBLE_MS - elapsed);
+
+    if (saveToastHideTimeoutRef.current !== null) {
+      window.clearTimeout(saveToastHideTimeoutRef.current);
+    }
+    saveToastHideTimeoutRef.current = window.setTimeout(() => {
+      saveToastHideTimeoutRef.current = null;
+      setIsSaveToastAnimatedVisible(false);
+      if (saveToastClearTimeoutRef.current !== null) {
+        window.clearTimeout(saveToastClearTimeoutRef.current);
+      }
+      saveToastClearTimeoutRef.current = window.setTimeout(() => {
+        saveToastClearTimeoutRef.current = null;
+        saveToastShownAtRef.current = null;
+        setIsSaveToastVisible(false);
+      }, TOAST_ANIMATION_MS);
+    }, remaining);
+  }, [isAutosaving, isSaveToastAnimatedVisible, isSaveToastVisible, isSceneSaveInProgress]);
+
+  React.useEffect(() => {
+    return () => {
+      if (saveToastHideTimeoutRef.current !== null) {
+        window.clearTimeout(saveToastHideTimeoutRef.current);
+        saveToastHideTimeoutRef.current = null;
+      }
+      if (saveToastClearTimeoutRef.current !== null) {
+        window.clearTimeout(saveToastClearTimeoutRef.current);
+        saveToastClearTimeoutRef.current = null;
+      }
+      if (saveToastEnterRafRef.current !== null) {
+        window.cancelAnimationFrame(saveToastEnterRafRef.current);
+        saveToastEnterRafRef.current = null;
+      }
+    };
+  }, []);
 
   const [sessionShaderOverride, setSessionShaderOverride] = React.useState<MeshShaderType | null>(null);
   const effectiveShaderType = sessionShaderOverride ?? scene.shaderType;
@@ -16337,11 +16422,11 @@ export default function Home() {
         </div>
       )}
 
-      {(isSceneSaveInProgress || isAutosaving) && (
+      {isSaveToastVisible && (
         <ToastViewport zIndex={126} offset="1.25rem">
-          <Toast tone="info" className="flex items-center gap-2">
+          <Toast tone="info" animated visible={isSaveToastAnimatedVisible} className="flex items-center gap-2">
             <RefreshCw className="h-4 w-4 animate-spin" />
-            {isSceneSaveInProgress ? 'Saving…' : 'Autosaving…'}
+            {saveToastLabel}
           </Toast>
         </ToastViewport>
       )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1233,6 +1233,8 @@ export default function Home() {
   const historyPreviewBaselineRef = React.useRef<{ undo: number; redo: number } | null>(null);
   const [isSelectAllModelsActive, setIsSelectAllModelsActive] = React.useState(false);
   const [isTemporarilyDisablingCrossSectionForThumbnail, setIsTemporarilyDisablingCrossSectionForThumbnail] = React.useState(false);
+  const [isCrossSectionEnabled, setIsCrossSectionEnabled] = React.useState(true);
+  const handleToggleCrossSection = React.useCallback(() => setIsCrossSectionEnabled((prev) => !prev), []);
   const [arrangeSpacingMm, setArrangeSpacingMm] = React.useState(0.5);
   const [arrangePrecisionMode, setArrangePrecisionMode] = React.useState<ArrangePrecisionMode>('standard');
   const [arrangeAllowRotateOnZ, setArrangeAllowRotateOnZ] = React.useState(false);
@@ -11203,15 +11205,17 @@ export default function Home() {
 
   const sceneClipLower = React.useMemo(() => {
     if (isTemporarilyDisablingCrossSectionForThumbnail) return null;
+    if (!isCrossSectionEnabled) return null;
     if (scene.mode === 'printing' || isTransitioningOutOfPrinting) return null;
     return slicing.clipLower;
-  }, [isTemporarilyDisablingCrossSectionForThumbnail, isTransitioningOutOfPrinting, scene.mode, slicing.clipLower]);
+  }, [isCrossSectionEnabled, isTemporarilyDisablingCrossSectionForThumbnail, isTransitioningOutOfPrinting, scene.mode, slicing.clipLower]);
 
   const sceneClipUpper = React.useMemo(() => {
     if (isTemporarilyDisablingCrossSectionForThumbnail) return null;
+    if (!isCrossSectionEnabled) return null;
     if (scene.mode === 'printing' || isTransitioningOutOfPrinting) return null;
     return slicing.clipUpper;
-  }, [isTemporarilyDisablingCrossSectionForThumbnail, isTransitioningOutOfPrinting, scene.mode, slicing.clipUpper]);
+  }, [isCrossSectionEnabled, isTemporarilyDisablingCrossSectionForThumbnail, isTransitioningOutOfPrinting, scene.mode, slicing.clipUpper]);
 
   const effectiveHoverTintStrengthForScene = React.useMemo(() => {
     return scene.mode === 'printing' ? 0 : scene.hoverTintStrength;
@@ -12967,6 +12971,8 @@ export default function Home() {
             lowerLayerIndex={slicing.lowerLayerIndex}
             onLowerLayerIndexChange={slicing.setLowerLayerIndex}
             lowerCurrentHeightMm={slicing.lowerCurrentHeightMm}
+            crossSectionEnabled={isCrossSectionEnabled}
+            onToggleCrossSection={handleToggleCrossSection}
           />
         )}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12869,6 +12869,9 @@ export default function Home() {
             currentHeightMm={slicing.currentHeightMm}
             maxHeightMm={slicing.heightMm}
             crossSectionMode={slicing.crossSectionMode}
+            lowerLayerIndex={slicing.lowerLayerIndex}
+            onLowerLayerIndexChange={slicing.setLowerLayerIndex}
+            lowerCurrentHeightMm={slicing.lowerCurrentHeightMm}
           />
         )}
 

--- a/src/components/controls/LayerSlider.tsx
+++ b/src/components/controls/LayerSlider.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import React from 'react';
 
@@ -20,9 +20,12 @@ type LayerSliderProps = {
   embedded?: boolean;
   expandToContainer?: boolean;
   dragBatchMode?: 'raf' | 'immediate';
+  lowerValue?: number;
+  onLowerChange?: (next: number) => void;
+  lowerCurrentHeightMm?: number;
 };
 
-export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onScrubEnd, onCrossSectionModeChange, currentHeightMm, maxHeightMm, className, showValue = false, crossSectionMode = 'smooth', docked = false, embedded = false, expandToContainer = false, dragBatchMode = 'raf' }: LayerSliderProps) {
+export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onScrubEnd, onCrossSectionModeChange, currentHeightMm, maxHeightMm, className, showValue = false, crossSectionMode = 'smooth', docked = false, embedded = false, expandToContainer = false, dragBatchMode = 'raf', lowerValue, onLowerChange, lowerCurrentHeightMm }: LayerSliderProps) {
   const isMinimalRail = embedded && docked;
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const errorTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
@@ -32,6 +35,8 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
   const [isShiftHeld, setIsShiftHeld] = React.useState(false);
   const [isDraggingThumb, setIsDraggingThumb] = React.useState(false);
   const dragShiftModeRef = React.useRef<boolean>(false); // Lock shift mode for entire drag
+  const lowerValueRef = React.useRef(0);
+  const activeDraggingThumbRef = React.useRef<'upper' | 'lower'>('upper');
 
   const formatMm = React.useCallback((mm: number) => {
     if (!Number.isFinite(mm)) return '0';
@@ -66,6 +71,18 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
     onChange(next);
   }, [clamp, onChange, snap]);
 
+  // Keep lowerValueRef in sync
+  React.useEffect(() => {
+    lowerValueRef.current = lowerValue ?? min;
+  }, [lowerValue, min]);
+
+  const emitLowerChange = React.useCallback((rawNext: number) => {
+    if (!onLowerChange) return;
+    const next = Math.min(clamp(snap(rawNext)), valueRef.current);
+    if (next === lowerValueRef.current) return;
+    onLowerChange(next);
+  }, [clamp, onLowerChange, snap]);
+
   const setByClientY = React.useCallback((clientY: number, shiftKey: boolean = false) => {
     const el = containerRef.current;
     if (!el) return;
@@ -88,6 +105,23 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
     }
   }, [emitChange, max, min]);
 
+  const setLowerByClientY = React.useCallback((clientY: number, shiftKey: boolean = false) => {
+    const el = containerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const rel = (clientY - rect.top) / rect.height;
+    const inv = 1 - rel;
+    const span = Math.max(1e-6, max - min);
+    if (shiftKey) {
+      const currentPercent = (lowerValueRef.current - min) / span;
+      const delta = (inv - currentPercent) * 0.1;
+      const newPercent = currentPercent + delta;
+      emitLowerChange(min + newPercent * span);
+    } else {
+      emitLowerChange(min + inv * span);
+    }
+  }, [emitLowerChange, max, min]);
+
   const onPointerDown = React.useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -96,14 +130,41 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
     setIsDraggingThumb(true);
     dragShiftModeRef.current = e.shiftKey;
     setIsShiftHeld(e.shiftKey);
-    setByClientY(e.clientY, e.shiftKey);
+    // Determine which thumb to drag based on proximity
+    if (lowerValue != null && onLowerChange != null) {
+      const el = containerRef.current;
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        const clickInv = 1 - (e.clientY - rect.top) / rect.height;
+        const span = Math.max(1e-6, max - min);
+        const upperPos = (valueRef.current - min) / span;
+        const lowerPos = (lowerValueRef.current - min) / span;
+        if (Math.abs(clickInv - lowerPos) < Math.abs(clickInv - upperPos)) {
+          activeDraggingThumbRef.current = 'lower';
+          setLowerByClientY(e.clientY, e.shiftKey);
+        } else {
+          activeDraggingThumbRef.current = 'upper';
+          setByClientY(e.clientY, e.shiftKey);
+        }
+      } else {
+        activeDraggingThumbRef.current = 'upper';
+        setByClientY(e.clientY, e.shiftKey);
+      }
+    } else {
+      activeDraggingThumbRef.current = 'upper';
+      setByClientY(e.clientY, e.shiftKey);
+    }
 
     let rafId: number | null = null;
     let pendingClientY = e.clientY;
 
     const flushMove = () => {
       rafId = null;
-      setByClientY(pendingClientY, dragShiftModeRef.current);
+      if (activeDraggingThumbRef.current === 'lower') {
+        setLowerByClientY(pendingClientY, dragShiftModeRef.current);
+      } else {
+        setByClientY(pendingClientY, dragShiftModeRef.current);
+      }
     };
     
     const onMove = (ev: MouseEvent) => {
@@ -114,7 +175,11 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
       }
 
       if (dragBatchMode === 'immediate') {
-        setByClientY(ev.clientY, dragShiftModeRef.current);
+        if (activeDraggingThumbRef.current === 'lower') {
+          setLowerByClientY(ev.clientY, dragShiftModeRef.current);
+        } else {
+          setByClientY(ev.clientY, dragShiftModeRef.current);
+        }
         return;
       }
 
@@ -148,7 +213,7 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
     window.addEventListener('blur', settleDrag);
-  }, [dragBatchMode, onScrubEnd, onScrubStart, setByClientY]);
+  }, [dragBatchMode, onScrubEnd, onScrubStart, setByClientY, setLowerByClientY]);
 
   const nudge = React.useCallback((dir: 1 | -1) => {
     const s = step || 1;
@@ -239,6 +304,9 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
   }, []);
 
   const percent = Math.min(100, Math.max(0, ((value - min) / Math.max(1, (max - min))) * 100));
+  const lowerPercent = lowerValue != null
+    ? Math.min(100, Math.max(0, ((lowerValue - min) / Math.max(1, (max - min))) * 100))
+    : null;
   const railBadgeClass = 'inline-flex items-center rounded-md border px-1 py-0.5 text-[9px] font-semibold tabular-nums';
   const railBadgeStyle: React.CSSProperties = {
     color: 'var(--text-muted)',
@@ -291,7 +359,7 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
                 background: 'color-mix(in srgb, var(--surface-1), transparent 12%)',
               }}
             >
-              {typeof currentHeightMm === 'number' ? `${formatMm(currentHeightMm)} mm` : '—'}
+              {typeof currentHeightMm === 'number' ? `${formatMm(currentHeightMm)} mm` : 'ΓÇö'}
             </div>
             {typeof maxHeightMm === 'number' && !embedded && (
               <div className="text-[10px] tabular-nums" style={{ color: 'var(--text-muted)' }}>
@@ -322,7 +390,7 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
           tabIndex={0}
           onKeyDown={onKeyDown}
           title={isMinimalRail
-            ? `Layer ${value} • ${typeof currentHeightMm === 'number' ? `${formatMm(currentHeightMm)} mm` : '—'} • Right-click to toggle ${crossSectionMode === 'smooth' ? 'rasterized' : 'smooth'}`
+            ? `Layer ${value} ΓÇó ${typeof currentHeightMm === 'number' ? `${formatMm(currentHeightMm)} mm` : 'ΓÇö'} ΓÇó Right-click to toggle ${crossSectionMode === 'smooth' ? 'rasterized' : 'smooth'}`
             : undefined}
         >
           {!isMinimalRail && (
@@ -353,15 +421,71 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
 
             {/* Progress fill */}
             <div
-              className="absolute left-1/2 -translate-x-1/2 bottom-0 w-1.5 rounded-full"
+              className="absolute left-1/2 -translate-x-1/2 w-1.5 rounded-full"
               style={{
-                height: `${percent}%`,
+                bottom: `${lowerPercent ?? 0}%`,
+                height: `${percent - (lowerPercent ?? 0)}%`,
                 background: 'linear-gradient(180deg, color-mix(in srgb, var(--accent), white 14%), var(--accent))',
                 boxShadow: '0 0 10px color-mix(in srgb, var(--accent), transparent 65%)',
               }}
             />
 
-            {/* Thumb */}
+            {/* Lower thumb */}
+            {lowerPercent != null && (
+              <div
+                className="absolute left-1/2 -translate-x-1/2 -translate-y-1/2"
+                style={{
+                  top: `${100 - lowerPercent}%`,
+                  transition: isDraggingThumb ? 'none' : 'top 170ms cubic-bezier(0.22, 1, 0.36, 1)',
+                }}
+              >
+                <div className="relative">
+                  {showValue && typeof lowerCurrentHeightMm === 'number' && (
+                    <div
+                      className={isMinimalRail
+                        ? `absolute left-1/2 -translate-x-1/2 whitespace-nowrap ${railBadgeClass} pointer-events-none top-3`
+                        : 'absolute right-full mr-2 top-1/2 -translate-y-1/2 whitespace-nowrap rounded border px-1.5 py-0.5 text-[10px] shadow tabular-nums pointer-events-none'}
+                      style={isMinimalRail
+                        ? railCurrentBadgeStyle
+                        : {
+                            borderColor: 'var(--border-subtle)',
+                            background: 'color-mix(in srgb, var(--surface-0), transparent 12%)',
+                            color: 'var(--text-strong)',
+                          }}
+                    >
+                      {isMinimalRail ? `${lowerValue}` : `${formatMm(lowerCurrentHeightMm)} mm`}
+                    </div>
+                  )}
+                  {crossSectionMode === 'rasterized' ? (
+                    <div
+                      className={`h-[9px] w-[24px] rounded-[3px] border ${isDraggingThumb ? 'scale-105' : 'scale-100'} transition-transform duration-150`}
+                      style={{
+                        borderColor: 'color-mix(in srgb, white, var(--accent) 20%)',
+                        background: 'repeating-linear-gradient(90deg, color-mix(in srgb, var(--accent), white 8%) 0 4px, color-mix(in srgb, var(--accent), black 8%) 4px 8px)',
+                        boxShadow: isDraggingThumb
+                          ? '0 0 0 2px color-mix(in srgb, var(--accent), transparent 65%), 0 6px 14px rgba(0,0,0,0.38)'
+                          : '0 0 0 2px color-mix(in srgb, var(--accent), transparent 80%), 0 4px 10px rgba(0,0,0,0.35)',
+                        opacity: 0.75,
+                      }}
+                    />
+                  ) : (
+                    <div
+                      className={`h-[9px] w-[24px] rounded-full border ${isDraggingThumb ? 'scale-105' : 'scale-100'} transition-transform duration-150`}
+                      style={{
+                        borderColor: 'color-mix(in srgb, white, var(--accent) 20%)',
+                        background: 'linear-gradient(90deg, color-mix(in srgb, var(--accent), white 20%), var(--accent), color-mix(in srgb, var(--accent), white 20%))',
+                        boxShadow: isDraggingThumb
+                          ? '0 0 0 2px color-mix(in srgb, var(--accent), transparent 65%), 0 6px 14px rgba(0,0,0,0.38)'
+                          : '0 0 0 2px color-mix(in srgb, var(--accent), transparent 80%), 0 4px 10px rgba(0,0,0,0.35)',
+                        opacity: 0.75,
+                      }}
+                    />
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Upper thumb */}
             <div
               className="absolute left-1/2 -translate-x-1/2 -translate-y-1/2"
               style={{
@@ -388,7 +512,6 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
                       : `${formatMm(currentHeightMm)} mm`}
                   </div>
                 )}
-
             {crossSectionMode === 'rasterized' ? (
               <div
                 className={`h-[9px] w-[24px] rounded-[3px] border ${isDraggingThumb ? 'scale-105' : 'scale-100'} transition-transform duration-150`}

--- a/src/components/controls/LayerSlider.tsx
+++ b/src/components/controls/LayerSlider.tsx
@@ -23,9 +23,10 @@ type LayerSliderProps = {
   lowerValue?: number;
   onLowerChange?: (next: number) => void;
   lowerCurrentHeightMm?: number;
+  showModeIndicator?: boolean;
 };
 
-export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onScrubEnd, onCrossSectionModeChange, currentHeightMm, maxHeightMm, className, showValue = false, crossSectionMode = 'smooth', docked = false, embedded = false, expandToContainer = false, dragBatchMode = 'raf', lowerValue, onLowerChange, lowerCurrentHeightMm }: LayerSliderProps) {
+export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onScrubEnd, onCrossSectionModeChange, currentHeightMm, maxHeightMm, className, showValue = false, crossSectionMode = 'smooth', docked = false, embedded = false, expandToContainer = false, dragBatchMode = 'raf', lowerValue, onLowerChange, lowerCurrentHeightMm, showModeIndicator = true }: LayerSliderProps) {
   const isMinimalRail = embedded && docked;
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const errorTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
@@ -36,7 +37,10 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
   const [isDraggingThumb, setIsDraggingThumb] = React.useState(false);
   const dragShiftModeRef = React.useRef<boolean>(false); // Lock shift mode for entire drag
   const lowerValueRef = React.useRef(0);
-  const activeDraggingThumbRef = React.useRef<'upper' | 'lower'>('upper');
+  const activeDraggingThumbRef = React.useRef<'upper' | 'lower' | 'window'>('upper');
+  const windowDragStartClientYRef = React.useRef(0);
+  const windowDragStartUpperRef = React.useRef(0);
+  const windowDragStartLowerRef = React.useRef(0);
 
   const formatMm = React.useCallback((mm: number) => {
     if (!Number.isFinite(mm)) return '0';
@@ -82,6 +86,52 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
     if (next === lowerValueRef.current) return;
     onLowerChange(next);
   }, [clamp, onLowerChange, snap]);
+
+  const emitWindowChange = React.useCallback((rawLower: number, rawUpper: number) => {
+    if (!onLowerChange) return;
+
+    const minMaxSpan = Math.max(0, max - min);
+    let targetLower = rawLower;
+    let targetUpper = rawUpper;
+
+    // Keep ordered and within range.
+    if (targetLower > targetUpper) {
+      const swap = targetLower;
+      targetLower = targetUpper;
+      targetUpper = swap;
+    }
+
+    const windowSpan = Math.min(minMaxSpan, Math.max(0, targetUpper - targetLower));
+
+    if (targetLower < min) {
+      targetLower = min;
+      targetUpper = min + windowSpan;
+    }
+    if (targetUpper > max) {
+      targetUpper = max;
+      targetLower = max - windowSpan;
+    }
+
+    const snappedLower = clamp(snap(targetLower));
+    let snappedUpper = snappedLower + windowSpan;
+
+    if (snappedUpper > max) {
+      snappedUpper = max;
+    }
+    if (snappedUpper < snappedLower) {
+      snappedUpper = snappedLower;
+    }
+
+    const finalUpper = clamp(snap(snappedUpper));
+    const finalLower = Math.min(clamp(snap(snappedLower)), finalUpper);
+
+    if (finalLower !== lowerValueRef.current) {
+      onLowerChange(finalLower);
+    }
+    if (finalUpper !== valueRef.current) {
+      onChange(finalUpper);
+    }
+  }, [clamp, max, min, onChange, onLowerChange, snap]);
 
   const setByClientY = React.useCallback((clientY: number, shiftKey: boolean = false) => {
     const el = containerRef.current;
@@ -139,7 +189,19 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
         const span = Math.max(1e-6, max - min);
         const upperPos = (valueRef.current - min) / span;
         const lowerPos = (lowerValueRef.current - min) / span;
-        if (Math.abs(clickInv - lowerPos) < Math.abs(clickInv - upperPos)) {
+        const lowerDistance = Math.abs(clickInv - lowerPos);
+        const upperDistance = Math.abs(clickInv - upperPos);
+        const thumbGrabThreshold = 0.035;
+        const inWindowRegion = clickInv >= Math.min(lowerPos, upperPos) && clickInv <= Math.max(lowerPos, upperPos);
+
+        // If user grabs the pink region between thumbs (not near either handle),
+        // move the entire window while preserving its thickness.
+        if (inWindowRegion && lowerDistance > thumbGrabThreshold && upperDistance > thumbGrabThreshold) {
+          activeDraggingThumbRef.current = 'window';
+          windowDragStartClientYRef.current = e.clientY;
+          windowDragStartLowerRef.current = lowerValueRef.current;
+          windowDragStartUpperRef.current = valueRef.current;
+        } else if (lowerDistance < upperDistance) {
           activeDraggingThumbRef.current = 'lower';
           setLowerByClientY(e.clientY, e.shiftKey);
         } else {
@@ -162,6 +224,30 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
       rafId = null;
       if (activeDraggingThumbRef.current === 'lower') {
         setLowerByClientY(pendingClientY, dragShiftModeRef.current);
+      } else if (activeDraggingThumbRef.current === 'window') {
+        const el = containerRef.current;
+        if (!el) return;
+
+        const rect = el.getBoundingClientRect();
+        const span = Math.max(1e-6, max - min);
+        const dragDeltaInv = -((pendingClientY - windowDragStartClientYRef.current) / Math.max(1, rect.height));
+        const precisionFactor = dragShiftModeRef.current ? 0.1 : 1;
+        const deltaValue = dragDeltaInv * span * precisionFactor;
+
+        const windowSpan = windowDragStartUpperRef.current - windowDragStartLowerRef.current;
+        let nextLower = windowDragStartLowerRef.current + deltaValue;
+        let nextUpper = nextLower + windowSpan;
+
+        if (nextLower < min) {
+          nextLower = min;
+          nextUpper = min + windowSpan;
+        }
+        if (nextUpper > max) {
+          nextUpper = max;
+          nextLower = max - windowSpan;
+        }
+
+        emitWindowChange(nextLower, nextUpper);
       } else {
         setByClientY(pendingClientY, dragShiftModeRef.current);
       }
@@ -177,6 +263,30 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
       if (dragBatchMode === 'immediate') {
         if (activeDraggingThumbRef.current === 'lower') {
           setLowerByClientY(ev.clientY, dragShiftModeRef.current);
+        } else if (activeDraggingThumbRef.current === 'window') {
+          const el = containerRef.current;
+          if (!el) return;
+
+          const rect = el.getBoundingClientRect();
+          const span = Math.max(1e-6, max - min);
+          const dragDeltaInv = -((ev.clientY - windowDragStartClientYRef.current) / Math.max(1, rect.height));
+          const precisionFactor = dragShiftModeRef.current ? 0.1 : 1;
+          const deltaValue = dragDeltaInv * span * precisionFactor;
+
+          const windowSpan = windowDragStartUpperRef.current - windowDragStartLowerRef.current;
+          let nextLower = windowDragStartLowerRef.current + deltaValue;
+          let nextUpper = nextLower + windowSpan;
+
+          if (nextLower < min) {
+            nextLower = min;
+            nextUpper = min + windowSpan;
+          }
+          if (nextUpper > max) {
+            nextUpper = max;
+            nextLower = max - windowSpan;
+          }
+
+          emitWindowChange(nextLower, nextUpper);
         } else {
           setByClientY(ev.clientY, dragShiftModeRef.current);
         }
@@ -213,7 +323,7 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
     window.addEventListener('mousemove', onMove);
     window.addEventListener('mouseup', onUp);
     window.addEventListener('blur', settleDrag);
-  }, [dragBatchMode, onScrubEnd, onScrubStart, setByClientY, setLowerByClientY]);
+  }, [dragBatchMode, emitWindowChange, max, min, onLowerChange, onScrubEnd, onScrubStart, setByClientY, setLowerByClientY]);
 
   const nudge = React.useCallback((dir: 1 | -1) => {
     const s = step || 1;
@@ -307,6 +417,11 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
   const lowerPercent = lowerValue != null
     ? Math.min(100, Math.max(0, ((lowerValue - min) / Math.max(1, (max - min))) * 100))
     : null;
+  const EDGE_BADGE_HIDE_EPS = 1e-6;
+  const hideUpperFloatingBadge = percent <= EDGE_BADGE_HIDE_EPS || percent >= (100 - EDGE_BADGE_HIDE_EPS);
+  const hideLowerFloatingBadge = lowerPercent != null
+    ? (lowerPercent <= EDGE_BADGE_HIDE_EPS || lowerPercent >= (100 - EDGE_BADGE_HIDE_EPS))
+    : false;
   const railBadgeClass = 'inline-flex items-center rounded-md border px-1 py-0.5 text-[9px] font-semibold tabular-nums';
   const railBadgeStyle: React.CSSProperties = {
     color: 'var(--text-muted)',
@@ -440,7 +555,7 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
                 }}
               >
                 <div className="relative">
-                  {showValue && typeof lowerCurrentHeightMm === 'number' && (
+                  {showValue && typeof lowerCurrentHeightMm === 'number' && !hideLowerFloatingBadge && (
                     <div
                       className={isMinimalRail
                         ? `absolute left-1/2 -translate-x-1/2 whitespace-nowrap ${railBadgeClass} pointer-events-none top-3`
@@ -494,7 +609,7 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
               }}
             >
               <div className="relative">
-                {showValue && typeof currentHeightMm === 'number' && (
+                {showValue && typeof currentHeightMm === 'number' && !hideUpperFloatingBadge && (
                   <div
                     className={isMinimalRail
                       ? `absolute left-1/2 -translate-x-1/2 whitespace-nowrap ${railBadgeClass} pointer-events-none ${shouldPlaceCurrentBadgeBelowThumb ? 'top-3' : '-top-5'}`
@@ -627,13 +742,15 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
             >
               {min}
             </div>
-            <div
-              className={railBadgeClass}
-              style={railBadgeStyle}
-              title={`Current cross-section mode: ${crossSectionMode}. Right-click slider to toggle.`}
-            >
-              {crossSectionMode === 'smooth' ? 'S' : 'R'}
-            </div>
+            {showModeIndicator && (
+              <div
+                className={railBadgeClass}
+                style={railBadgeStyle}
+                title={`Current cross-section mode: ${crossSectionMode}. Right-click slider to toggle.`}
+              >
+                {crossSectionMode === 'smooth' ? 'S' : 'R'}
+              </div>
+            )}
           </div>
         )}
 

--- a/src/components/controls/LayerSlider.tsx
+++ b/src/components/controls/LayerSlider.tsx
@@ -24,9 +24,11 @@ type LayerSliderProps = {
   onLowerChange?: (next: number) => void;
   lowerCurrentHeightMm?: number;
   showModeIndicator?: boolean;
+  crossSectionEnabled?: boolean;
+  onToggleCrossSection?: () => void;
 };
 
-export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onScrubEnd, onCrossSectionModeChange, currentHeightMm, maxHeightMm, className, showValue = false, crossSectionMode = 'smooth', docked = false, embedded = false, expandToContainer = false, dragBatchMode = 'raf', lowerValue, onLowerChange, lowerCurrentHeightMm, showModeIndicator = true }: LayerSliderProps) {
+export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onScrubEnd, onCrossSectionModeChange, currentHeightMm, maxHeightMm, className, showValue = false, crossSectionMode = 'smooth', docked = false, embedded = false, expandToContainer = false, dragBatchMode = 'raf', lowerValue, onLowerChange, lowerCurrentHeightMm, showModeIndicator = true, crossSectionEnabled = true, onToggleCrossSection }: LayerSliderProps) {
   const isMinimalRail = embedded && docked;
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const errorTimeoutRef = React.useRef<NodeJS.Timeout | null>(null);
@@ -413,6 +415,7 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
     }
   }, []);
 
+  const thumbColor = crossSectionEnabled ? 'var(--accent)' : 'var(--text-muted)';
   const percent = Math.min(100, Math.max(0, ((value - min) / Math.max(1, (max - min))) * 100));
   const lowerPercent = lowerValue != null
     ? Math.min(100, Math.max(0, ((lowerValue - min) / Math.max(1, (max - min))) * 100))
@@ -496,6 +499,12 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
           data-no-drag="true"
           className={`relative mx-auto ${embedded ? (expandToContainer ? (isMinimalRail ? 'flex-1 h-full min-h-[300px]' : 'flex-1 h-full min-h-[300px]') : 'h-[46vh]') : 'h-[56vh]'} ${embedded ? (isMinimalRail ? 'w-5' : 'w-7') : 'w-10'} cursor-pointer`}
           onMouseDown={onPointerDown}
+          onDoubleClick={(e) => {
+            if (!onToggleCrossSection) return;
+            e.preventDefault();
+            e.stopPropagation();
+            onToggleCrossSection();
+          }}
           onContextMenu={(e) => {
             if (!onCrossSectionModeChange) return;
             e.preventDefault();
@@ -536,12 +545,17 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
 
             {/* Progress fill */}
             <div
-              className="absolute left-1/2 -translate-x-1/2 w-1.5 rounded-full"
+              className="absolute left-1/2 -translate-x-1/2 w-1.5 rounded-full transition-[background,box-shadow] duration-200"
               style={{
                 bottom: `${lowerPercent ?? 0}%`,
                 height: `${percent - (lowerPercent ?? 0)}%`,
-                background: 'linear-gradient(180deg, color-mix(in srgb, var(--accent), white 14%), var(--accent))',
-                boxShadow: '0 0 10px color-mix(in srgb, var(--accent), transparent 65%)',
+                background: crossSectionEnabled
+                  ? 'linear-gradient(180deg, color-mix(in srgb, var(--accent), white 14%), var(--accent))'
+                  : 'linear-gradient(180deg, color-mix(in srgb, var(--text-muted), white 10%), var(--text-muted))',
+                boxShadow: crossSectionEnabled
+                  ? '0 0 10px color-mix(in srgb, var(--accent), transparent 65%)'
+                  : 'none',
+                opacity: crossSectionEnabled ? 1 : 0.45,
               }}
             />
 
@@ -573,25 +587,25 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
                   )}
                   {crossSectionMode === 'rasterized' ? (
                     <div
-                      className={`h-[9px] w-[24px] rounded-[3px] border ${isDraggingThumb ? 'scale-105' : 'scale-100'} transition-transform duration-150`}
+                      className={`h-[9px] w-[24px] rounded-[3px] border ${isDraggingThumb ? 'scale-105' : 'scale-100'} transition-[transform,background,box-shadow] duration-150`}
                       style={{
-                        borderColor: 'color-mix(in srgb, white, var(--accent) 20%)',
-                        background: 'repeating-linear-gradient(90deg, color-mix(in srgb, var(--accent), white 8%) 0 4px, color-mix(in srgb, var(--accent), black 8%) 4px 8px)',
+                        borderColor: `color-mix(in srgb, white, ${thumbColor} 20%)`,
+                        background: `repeating-linear-gradient(90deg, color-mix(in srgb, ${thumbColor}, white 8%) 0 4px, color-mix(in srgb, ${thumbColor}, black 8%) 4px 8px)`,
                         boxShadow: isDraggingThumb
-                          ? '0 0 0 2px color-mix(in srgb, var(--accent), transparent 65%), 0 6px 14px rgba(0,0,0,0.38)'
-                          : '0 0 0 2px color-mix(in srgb, var(--accent), transparent 80%), 0 4px 10px rgba(0,0,0,0.35)',
+                          ? `0 0 0 2px color-mix(in srgb, ${thumbColor}, transparent 65%), 0 6px 14px rgba(0,0,0,0.38)`
+                          : `0 0 0 2px color-mix(in srgb, ${thumbColor}, transparent 80%), 0 4px 10px rgba(0,0,0,0.35)`,
                         opacity: 0.75,
                       }}
                     />
                   ) : (
                     <div
-                      className={`h-[9px] w-[24px] rounded-full border ${isDraggingThumb ? 'scale-105' : 'scale-100'} transition-transform duration-150`}
+                      className={`h-[9px] w-[24px] rounded-full border ${isDraggingThumb ? 'scale-105' : 'scale-100'} transition-[transform,background,box-shadow] duration-150`}
                       style={{
-                        borderColor: 'color-mix(in srgb, white, var(--accent) 20%)',
-                        background: 'linear-gradient(90deg, color-mix(in srgb, var(--accent), white 20%), var(--accent), color-mix(in srgb, var(--accent), white 20%))',
+                        borderColor: `color-mix(in srgb, white, ${thumbColor} 20%)`,
+                        background: `linear-gradient(90deg, color-mix(in srgb, ${thumbColor}, white 20%), ${thumbColor}, color-mix(in srgb, ${thumbColor}, white 20%))`,
                         boxShadow: isDraggingThumb
-                          ? '0 0 0 2px color-mix(in srgb, var(--accent), transparent 65%), 0 6px 14px rgba(0,0,0,0.38)'
-                          : '0 0 0 2px color-mix(in srgb, var(--accent), transparent 80%), 0 4px 10px rgba(0,0,0,0.35)',
+                          ? `0 0 0 2px color-mix(in srgb, ${thumbColor}, transparent 65%), 0 6px 14px rgba(0,0,0,0.38)`
+                          : `0 0 0 2px color-mix(in srgb, ${thumbColor}, transparent 80%), 0 4px 10px rgba(0,0,0,0.35)`,
                         opacity: 0.75,
                       }}
                     />
@@ -629,24 +643,24 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
                 )}
             {crossSectionMode === 'rasterized' ? (
               <div
-                className={`h-[9px] w-[24px] rounded-[3px] border ${isDraggingThumb ? 'scale-105' : 'scale-100'} transition-transform duration-150`}
+                className={`h-[9px] w-[24px] rounded-[3px] border ${isDraggingThumb ? 'scale-105' : 'scale-100'} transition-[transform,background,box-shadow] duration-150`}
                 style={{
-                  borderColor: 'color-mix(in srgb, white, var(--accent) 20%)',
-                  background: 'repeating-linear-gradient(90deg, color-mix(in srgb, var(--accent), white 8%) 0 4px, color-mix(in srgb, var(--accent), black 8%) 4px 8px)',
+                  borderColor: `color-mix(in srgb, white, ${thumbColor} 20%)`,
+                  background: `repeating-linear-gradient(90deg, color-mix(in srgb, ${thumbColor}, white 8%) 0 4px, color-mix(in srgb, ${thumbColor}, black 8%) 4px 8px)`,
                   boxShadow: isDraggingThumb
-                    ? '0 0 0 2px color-mix(in srgb, var(--accent), transparent 65%), 0 6px 14px rgba(0,0,0,0.38)'
-                    : '0 0 0 2px color-mix(in srgb, var(--accent), transparent 80%), 0 4px 10px rgba(0,0,0,0.35)',
+                    ? `0 0 0 2px color-mix(in srgb, ${thumbColor}, transparent 65%), 0 6px 14px rgba(0,0,0,0.38)`
+                    : `0 0 0 2px color-mix(in srgb, ${thumbColor}, transparent 80%), 0 4px 10px rgba(0,0,0,0.35)`,
                 }}
               />
             ) : (
               <div
-                className={`h-[9px] w-[24px] rounded-full border ${isDraggingThumb ? 'scale-105' : 'scale-100'} transition-transform duration-150`}
+                className={`h-[9px] w-[24px] rounded-full border ${isDraggingThumb ? 'scale-105' : 'scale-100'} transition-[transform,background,box-shadow] duration-150`}
                 style={{
-                  borderColor: 'color-mix(in srgb, white, var(--accent) 20%)',
-                  background: 'linear-gradient(90deg, color-mix(in srgb, var(--accent), white 20%), var(--accent), color-mix(in srgb, var(--accent), white 20%))',
+                  borderColor: `color-mix(in srgb, white, ${thumbColor} 20%)`,
+                  background: `linear-gradient(90deg, color-mix(in srgb, ${thumbColor}, white 20%), ${thumbColor}, color-mix(in srgb, ${thumbColor}, white 20%))`,
                   boxShadow: isDraggingThumb
-                    ? '0 0 0 2px color-mix(in srgb, var(--accent), transparent 65%), 0 6px 14px rgba(0,0,0,0.38)'
-                    : '0 0 0 2px color-mix(in srgb, var(--accent), transparent 80%), 0 4px 10px rgba(0,0,0,0.35)',
+                    ? `0 0 0 2px color-mix(in srgb, ${thumbColor}, transparent 65%), 0 6px 14px rgba(0,0,0,0.38)`
+                    : `0 0 0 2px color-mix(in srgb, ${thumbColor}, transparent 80%), 0 4px 10px rgba(0,0,0,0.35)`,
                 }}
               />
             )}

--- a/src/components/controls/VisualSettingsPanel.tsx
+++ b/src/components/controls/VisualSettingsPanel.tsx
@@ -14,6 +14,9 @@ type VisualSettingsPanelProps = {
   currentHeightMm?: number;
   maxHeightMm?: number;
   crossSectionMode: 'smooth' | 'rasterized';
+  lowerLayerIndex?: number;
+  onLowerLayerIndexChange?: (value: number) => void;
+  lowerCurrentHeightMm?: number;
 };
 
 export function VisualSettingsPanel({
@@ -26,6 +29,9 @@ export function VisualSettingsPanel({
   currentHeightMm,
   maxHeightMm,
   crossSectionMode,
+  lowerLayerIndex,
+  onLowerLayerIndexChange,
+  lowerCurrentHeightMm,
 }: VisualSettingsPanelProps) {
   const handleLayerChange = React.useCallback((nextValue: number) => {
     onLayerIndexChange(Math.round(nextValue));
@@ -48,6 +54,9 @@ export function VisualSettingsPanel({
             maxHeightMm={maxHeightMm}
             showValue={true}
             crossSectionMode={crossSectionMode}
+            lowerValue={lowerLayerIndex}
+            onLowerChange={onLowerLayerIndexChange}
+            lowerCurrentHeightMm={lowerCurrentHeightMm}
             docked
             embedded
             expandToContainer

--- a/src/components/controls/VisualSettingsPanel.tsx
+++ b/src/components/controls/VisualSettingsPanel.tsx
@@ -17,6 +17,8 @@ type VisualSettingsPanelProps = {
   lowerLayerIndex?: number;
   onLowerLayerIndexChange?: (value: number) => void;
   lowerCurrentHeightMm?: number;
+  crossSectionEnabled?: boolean;
+  onToggleCrossSection?: () => void;
 };
 
 export function VisualSettingsPanel({
@@ -32,6 +34,8 @@ export function VisualSettingsPanel({
   lowerLayerIndex,
   onLowerLayerIndexChange,
   lowerCurrentHeightMm,
+  crossSectionEnabled,
+  onToggleCrossSection,
 }: VisualSettingsPanelProps) {
   const handleLayerChange = React.useCallback((nextValue: number) => {
     onLayerIndexChange(Math.round(nextValue));
@@ -58,6 +62,8 @@ export function VisualSettingsPanel({
             onLowerChange={onLowerLayerIndexChange}
             lowerCurrentHeightMm={lowerCurrentHeightMm}
             showModeIndicator={false}
+            crossSectionEnabled={crossSectionEnabled}
+            onToggleCrossSection={onToggleCrossSection}
             docked
             embedded
             expandToContainer

--- a/src/components/controls/VisualSettingsPanel.tsx
+++ b/src/components/controls/VisualSettingsPanel.tsx
@@ -57,6 +57,7 @@ export function VisualSettingsPanel({
             lowerValue={lowerLayerIndex}
             onLowerChange={onLowerLayerIndexChange}
             lowerCurrentHeightMm={lowerCurrentHeightMm}
+            showModeIndicator={false}
             docked
             embedded
             expandToContainer

--- a/src/components/gizmo/TransformGizmo.tsx
+++ b/src/components/gizmo/TransformGizmo.tsx
@@ -81,7 +81,9 @@ export function TransformGizmo({
 
     gizmoRootRef.current.traverse((obj) => {
       obj.frustumCulled = false;
-      obj.renderOrder = 2500;
+      // Cross-section stencil cap renders at ~9800. Gizmo must be above
+      // that so handles are never obscured by the cap fill.
+      obj.renderOrder = 9900;
       // Mark only renderable gizmo handle geometry so pointer handlers can detect
       // gizmo involvement from intersections. Do NOT tag lights/targets; those
       // should not be hidden during thumbnail capture because it changes lighting.
@@ -276,7 +278,7 @@ export function TransformGizmo({
   }, [suppressHover]);
 
   return (
-    <group ref={setGizmoRootRef} position={posArray} rotation={rotArray} scale={size} renderOrder={2500}>
+    <group ref={setGizmoRootRef} position={posArray} rotation={rotArray} scale={size} renderOrder={9900}>
       {enableMove && showCenter && (
         <GizmoCenter
           isHovered={!suppressHover && hoveredPart === 'center'}

--- a/src/components/layout/FloatingPanelStack.tsx
+++ b/src/components/layout/FloatingPanelStack.tsx
@@ -72,7 +72,7 @@ const PANEL_GAP = 12;
 const DEFAULT_PANEL_WIDTH = 320;
 const DEFAULT_PANEL_HEIGHT = 150;
 const PANEL_WIDTH_OVERRIDES: Record<string, number> = {
-  'visual-settings': 72,
+  'visual-settings': 56,
   'prepare-smoothing-settings': 340,
   'transform-debug-overlay': 420,
 };
@@ -721,13 +721,13 @@ export function FloatingPanelStack({ children }: { children: React.ReactNode }) 
       const supportUltrawideBoost = panelId === 'support-settings'
         ? (panelWidthScale >= 1.14 ? 1.1 : panelWidthScale >= 1.08 ? 1.06 : 1)
         : 1;
-      return Math.max(72, Math.round(baseWidth * panelWidthScale * supportUltrawideBoost));
+      return Math.max(panelId === 'visual-settings' ? 52 : 72, Math.round(baseWidth * panelWidthScale * supportUltrawideBoost));
     }
     const analysisCompactFactor = panelId.startsWith('analysis-')
       ? (panelWidthScale < 1 ? 0.88 : 1)
       : 1;
     const scaledWidth = Math.round(baseWidth * panelWidthScale * analysisCompactFactor);
-    return Math.max(72, scaledWidth);
+    return Math.max(panelId === 'visual-settings' ? 52 : 72, scaledWidth);
   }, [panelWidthScale]);
 
   const getPanelSize = React.useCallback((panelId: string): PanelSize => {

--- a/src/components/picking/PickingRenderer.tsx
+++ b/src/components/picking/PickingRenderer.tsx
@@ -197,6 +197,22 @@ export function PickingRenderer({
       pick.matrix.copy(source.matrix);
       pick.matrixWorld.copy(source.matrixWorld);
 
+      // Sync clipping planes from the source material so the model's cross-
+      // section clip is respected in the pick render.  Without this, the
+      // full unclipped model occludes support geometry behind it.
+      if ((source as THREE.Mesh).isMesh && (pick as THREE.Mesh).isMesh) {
+        const srcMatRaw = (source as THREE.Mesh).material;
+        const srcMat = (Array.isArray(srcMatRaw) ? srcMatRaw[0] : srcMatRaw) as THREE.Material & { clippingPlanes?: THREE.Plane[] | null } | undefined;
+        const pickMat = (pick as THREE.Mesh).material as THREE.Material & { clippingPlanes?: THREE.Plane[] | null };
+        if (srcMat && pickMat) {
+          const srcPlanes = srcMat.clippingPlanes ?? null;
+          if (pickMat.clippingPlanes !== srcPlanes) {
+            pickMat.clippingPlanes = srcPlanes;
+            pickMat.needsUpdate = true;
+          }
+        }
+      }
+
       const sourceChildren = source.children;
       const pickChildren = pick.children;
       const childCount = Math.min(sourceChildren.length, pickChildren.length);

--- a/src/components/picking/PickingRenderer.tsx
+++ b/src/components/picking/PickingRenderer.tsx
@@ -13,6 +13,7 @@ import { useThree, useFrame } from '@react-three/fiber';
 import { RENDER_TARGET, TIMING } from './constants';
 import { majorityVote, encodePickId } from './pickingUtils';
 import { reportPickingRenderSample } from './pickingDiagnostics';
+import { getClipBounds } from '@/components/scene/SceneCanvas/clipBoundsStore';
 import type { PickableRegistration, PickingConfig } from './types';
 
 interface PickingRendererProps {
@@ -197,22 +198,6 @@ export function PickingRenderer({
       pick.matrix.copy(source.matrix);
       pick.matrixWorld.copy(source.matrixWorld);
 
-      // Sync clipping planes from the source material so the model's cross-
-      // section clip is respected in the pick render.  Without this, the
-      // full unclipped model occludes support geometry behind it.
-      if ((source as THREE.Mesh).isMesh && (pick as THREE.Mesh).isMesh) {
-        const srcMatRaw = (source as THREE.Mesh).material;
-        const srcMat = (Array.isArray(srcMatRaw) ? srcMatRaw[0] : srcMatRaw) as THREE.Material & { clippingPlanes?: THREE.Plane[] | null } | undefined;
-        const pickMat = (pick as THREE.Mesh).material as THREE.Material & { clippingPlanes?: THREE.Plane[] | null };
-        if (srcMat && pickMat) {
-          const srcPlanes = srcMat.clippingPlanes ?? null;
-          if (pickMat.clippingPlanes !== srcPlanes) {
-            pickMat.clippingPlanes = srcPlanes;
-            pickMat.needsUpdate = true;
-          }
-        }
-      }
-
       const sourceChildren = source.children;
       const pickChildren = pick.children;
       const childCount = Math.min(sourceChildren.length, pickChildren.length);
@@ -310,6 +295,13 @@ export function PickingRenderer({
     
     pickCameraRef.current = pickCamera;
     
+    // When cross-section clip bounds are active, exclude the model from
+    // the pick scene entirely so it cannot occlude supports, joints, or
+    // gizmos inside the cavity.  Support placement uses R3F raycasting
+    // (not GPU picking), so it is unaffected.
+    const { clipLower, clipUpper } = getClipBounds();
+    const crossSectionActive = clipLower != null || clipUpper != null;
+
     // Sync cached transforms and dynamic visibility.
     let visiblePickObjects = 0;
     for (const [pickId, registration] of registrations.entries()) {
@@ -318,7 +310,9 @@ export function PickingRenderer({
 
       const hasAllowedCategories = Array.isArray(config.allowedCategories) && config.allowedCategories.length > 0;
       const categoryAllowed = !hasAllowedCategories || config.allowedCategories!.includes(registration.category);
-      const includeCategory = categoryAllowed && !(registration.category === 'gizmo' && !config.includeGizmo);
+      const includeCategory = categoryAllowed
+        && !(registration.category === 'gizmo' && !config.includeGizmo)
+        && !(crossSectionActive && registration.category === 'model');
       cached.pickObject.visible = includeCategory;
       if (!includeCategory) continue;
 

--- a/src/components/scene/CrossSectionCap.tsx
+++ b/src/components/scene/CrossSectionCap.tsx
@@ -323,6 +323,9 @@ type CrossSectionCapProps = {
   projectedContextVersion?: unknown;
   y: number;
   color?: string;
+  side?: THREE.Side;
+  offsetMm?: number;
+  depthTest?: boolean;
   transformMatrix?: THREE.Matrix4;
   mode?: 'smooth' | 'rasterized';
   pxMm?: number;
@@ -345,6 +348,9 @@ function CrossSectionCapInner({
   projectedContextVersion,
   y,
   color = '#ffffff',
+  side = THREE.FrontSide,
+  offsetMm = 1e-4,
+  depthTest = true,
   transformMatrix,
   mode = 'smooth',
   pxMm = 0.1,
@@ -438,7 +444,7 @@ function CrossSectionCapInner({
     );
 
     if (projectedModels && projectedModels.length > 0) {
-      const cacheKey = `${projectedContextVersionKey}|${projectedModelSignature}|${effectiveY.toFixed(3)}`;
+      const cacheKey = `${projectedContextVersionKey}|${projectedModelSignature}|${effectiveY.toFixed(3)}|off:${offsetMm.toFixed(4)}`;
       if (canUseProjectedCaches) {
         projectedCacheKey = cacheKey;
       }
@@ -578,16 +584,16 @@ function CrossSectionCapInner({
             transparent: true,
             alphaTest: 0.5,
             depthWrite: true,
-            depthTest: true,
+            depthTest,
             opacity: 1.0,
-            side: THREE.FrontSide,
+            side,
             polygonOffset: true,
             polygonOffsetFactor: -1,
             polygonOffsetUnits: -1,
           });
 
           const plane = new THREE.Mesh(planeGeom, mat);
-          plane.position.set(originX + ((width - 1) * pxMm * 0.5), originY + ((height - 1) * pxMm * 0.5), effectiveY + 1e-4);
+          plane.position.set(originX + ((width - 1) * pxMm * 0.5), originY + ((height - 1) * pxMm * 0.5), effectiveY + offsetMm);
           group.add(plane);
         }
       }
@@ -607,7 +613,7 @@ function CrossSectionCapInner({
           });
 
           shapeGeom = new THREE.ShapeGeometry(shapes);
-          shapeGeom.translate(0, 0, effectiveY + 1e-4);
+          shapeGeom.translate(0, 0, effectiveY + offsetMm);
           projectedShapeGeometryCacheRef.current.set(projectedCacheKey, shapeGeom);
           if (projectedShapeGeometryCacheRef.current.size > SHAPE_GEOMETRY_CACHE_LIMIT) {
             const oldestKey = projectedShapeGeometryCacheRef.current.keys().next().value;
@@ -628,16 +634,16 @@ function CrossSectionCapInner({
         });
 
         shapeGeom = new THREE.ShapeGeometry(shapes);
-        shapeGeom.translate(0, 0, effectiveY + 1e-4);
+        shapeGeom.translate(0, 0, effectiveY + offsetMm);
       }
 
       const mat = new THREE.MeshBasicMaterial({
         color,
         depthWrite: true,
-        depthTest: true,
+        depthTest,
         transparent: false,
         opacity: 1.0,
-        side: THREE.FrontSide,
+        side,
         polygonOffset: true,
         polygonOffsetFactor: -1,
         polygonOffsetUnits: -1,
@@ -649,14 +655,17 @@ function CrossSectionCapInner({
     return group;
   }, [
     color,
+    depthTest,
     geometry,
     interactive,
     interactiveZStepMm,
     mode,
+    offsetMm,
     preferProjectedOnlyDuringInteractive,
     projectedModelSignature,
     projectedContextVersionKey,
     pxMm,
+    side,
     sourceObject,
     transformMatrix,
     visible,
@@ -680,6 +689,9 @@ const areCrossSectionCapPropsEqual = (
     && prev.projectedModels === next.projectedModels
     && prev.projectedContextVersion === next.projectedContextVersion
     && prev.color === next.color
+    && prev.side === next.side
+    && prev.offsetMm === next.offsetMm
+    && prev.depthTest === next.depthTest
     && prev.transformMatrix === next.transformMatrix
     && prev.mode === next.mode
     && prev.pxMm === next.pxMm

--- a/src/components/scene/CrossSectionStencilCap.tsx
+++ b/src/components/scene/CrossSectionStencilCap.tsx
@@ -428,13 +428,17 @@ function CrossSectionStencilCapInner({
   const stencilBack = React.useMemo(() => {
     const material = stencilBase.clone();
     material.side = THREE.BackSide;
+    // IMPORTANT: Keep stencil source clipped by the PRIMARY plane only.
+    // Clipping stencil source by both boundaries makes the source geometry
+    // open at both ends, which can corrupt winding parity (e.g. bottom cap
+    // appearing both up into the model and down out of it).
     material.clippingPlanes = [clipPlaneRef.current];
     const op = effectiveStencilMode === 'mirrored' ? THREE.DecrementWrapStencilOp : THREE.IncrementWrapStencilOp;
     material.stencilFail = op;
     material.stencilZFail = op;
     material.stencilZPass = op;
     return material;
-  }, [effectiveStencilMode, stencilBase]);
+  }, [clipPlaneRef, effectiveStencilMode, stencilBase]);
 
   const stencilFront = React.useMemo(() => {
     const material = stencilBase.clone();
@@ -445,7 +449,7 @@ function CrossSectionStencilCapInner({
     material.stencilZFail = op;
     material.stencilZPass = op;
     return material;
-  }, [effectiveStencilMode, stencilBase]);
+  }, [clipPlaneRef, effectiveStencilMode, stencilBase]);
 
   const capPlaneGeometry = React.useMemo(() => {
     return new THREE.PlaneGeometry(

--- a/src/components/scene/CrossSectionStencilCap.tsx
+++ b/src/components/scene/CrossSectionStencilCap.tsx
@@ -20,6 +20,11 @@ type CrossSectionStencilCapProps = {
   sourceObjectVersion?: unknown;
   skipSourceZBounds?: boolean;
   y: number;
+  /** The y position of the OTHER clip boundary (if dual-cut is active).
+   *  When provided, the stencil geometry is clipped by both planes so
+   *  the stencil count matches the actual clipped model — eliminating
+   *  stencil bleed at the opposing cut. */
+  otherClipY?: number | null;
   color?: string;
   planeWidthMm: number;
   planeHeightMm: number;
@@ -30,6 +35,21 @@ type CrossSectionStencilCapProps = {
   glowOpacity?: number;
   glowColor?: string;
   direction?: 'top' | 'bottom';
+  renderOrderOffset?: number;
+  debugOverrides?: CrossSectionCapDebugOverrides;
+};
+
+export type CrossSectionCapDebugSide = 'front' | 'back' | 'double';
+export type CrossSectionCapDebugClipMode = 'upper' | 'lower';
+export type CrossSectionCapDebugStencilMode = 'standard' | 'mirrored';
+
+export type CrossSectionCapDebugOverrides = {
+  side?: CrossSectionCapDebugSide;
+  offsetMm?: number;
+  rotationXDeg?: number;
+  clipMode?: CrossSectionCapDebugClipMode;
+  stencilMode?: CrossSectionCapDebugStencilMode;
+  depthTest?: boolean;
 };
 
 type StaticStencilMeshEntry = {
@@ -153,10 +173,14 @@ function ModelStencilPass({
   entry,
   backMaterial,
   frontMaterial,
+  backRenderOrder,
+  frontRenderOrder,
 }: {
   entry: ModelStencilPassEntry;
   backMaterial: THREE.Material;
   frontMaterial: THREE.Material;
+  backRenderOrder: number;
+  frontRenderOrder: number;
 }) {
   return (
     <group key={`stencil-cap-${entry.id}`}>
@@ -165,7 +189,7 @@ function ModelStencilPass({
           geometry={entry.geometry}
           position={entry.offset}
           material={backMaterial}
-          renderOrder={STENCIL_MODEL_BACK_ORDER}
+          renderOrder={backRenderOrder}
           frustumCulled
           raycast={() => null}
         />
@@ -173,7 +197,7 @@ function ModelStencilPass({
           geometry={entry.geometry}
           position={entry.offset}
           material={frontMaterial}
-          renderOrder={STENCIL_MODEL_FRONT_ORDER}
+          renderOrder={frontRenderOrder}
           frustumCulled
           raycast={() => null}
         />
@@ -188,6 +212,8 @@ const ModelStencilPassMemo = React.memo(
     prev.entry === next.entry
     && prev.backMaterial === next.backMaterial
     && prev.frontMaterial === next.frontMaterial
+    && prev.backRenderOrder === next.backRenderOrder
+    && prev.frontRenderOrder === next.frontRenderOrder
   ),
 );
 ModelStencilPassMemo.displayName = 'ModelStencilPassMemo';
@@ -196,10 +222,14 @@ function StaticSingleStencilPass({
   entry,
   backMaterial,
   frontMaterial,
+  backRenderOrder,
+  frontRenderOrder,
 }: {
   entry: StaticStencilMeshEntry;
   backMaterial: THREE.Material;
   frontMaterial: THREE.Material;
+  backRenderOrder: number;
+  frontRenderOrder: number;
 }) {
   return (
     <group key={`stencil-source-pass-${entry.key}`}>
@@ -207,14 +237,14 @@ function StaticSingleStencilPass({
         <mesh
           geometry={entry.geometry}
           material={backMaterial}
-          renderOrder={STENCIL_SOURCE_BACK_ORDER}
+          renderOrder={backRenderOrder}
           frustumCulled
           raycast={() => null}
         />
         <mesh
           geometry={entry.geometry}
           material={frontMaterial}
-          renderOrder={STENCIL_SOURCE_FRONT_ORDER}
+          renderOrder={frontRenderOrder}
           frustumCulled
           raycast={() => null}
         />
@@ -229,6 +259,8 @@ const StaticSingleStencilPassMemo = React.memo(
     prev.entry === next.entry
     && prev.backMaterial === next.backMaterial
     && prev.frontMaterial === next.frontMaterial
+    && prev.backRenderOrder === next.backRenderOrder
+    && prev.frontRenderOrder === next.frontRenderOrder
   ),
 );
 StaticSingleStencilPassMemo.displayName = 'StaticSingleStencilPassMemo';
@@ -286,10 +318,6 @@ function composeCenteredGeometryMatrix(matrix: THREE.Matrix4, center: THREE.Vect
   return new THREE.Matrix4().multiplyMatrices(matrix, centerOffset);
 }
 
-function intersectsMinMaxZ(minZ: number, maxZ: number, clipZ: number): boolean {
-  return clipZ >= minZ - 1e-4 && clipZ <= maxZ + 1e-4;
-}
-
 const INSTANCED_STENCIL_Z_BUCKET_MM = 6;
 const STENCIL_RENDER_ORDER_BASE = 9800;
 const STENCIL_MODEL_BACK_ORDER = STENCIL_RENDER_ORDER_BASE + 0.1;
@@ -306,6 +334,7 @@ function CrossSectionStencilCapInner({
   sourceObjectVersion,
   skipSourceZBounds = false,
   y,
+  otherClipY,
   color = '#ffffff',
   planeWidthMm,
   planeHeightMm,
@@ -316,23 +345,69 @@ function CrossSectionStencilCapInner({
   glowOpacity = 0,
   glowColor,
   direction = 'top',
+  renderOrderOffset = 0,
+  debugOverrides,
 }: CrossSectionStencilCapProps) {
   const isBottom = direction === 'bottom';
+
+  const effectiveClipMode: CrossSectionCapDebugClipMode = debugOverrides?.clipMode ?? (isBottom ? 'lower' : 'upper');
+  const effectiveStencilMode: CrossSectionCapDebugStencilMode = debugOverrides?.stencilMode ?? 'standard';
+  const effectiveSide: CrossSectionCapDebugSide = debugOverrides?.side ?? (isBottom ? 'back' : 'front');
+  // Top cap sits slightly above the cut plane; bottom cap sits slightly below.
+  const effectiveOffsetMm = debugOverrides?.offsetMm ?? (isBottom ? -1e-4 : 1e-4);
+  const effectiveRotationXDeg = debugOverrides?.rotationXDeg ?? 0;
+
+  const MODEL_BACK_ORDER = STENCIL_MODEL_BACK_ORDER + renderOrderOffset;
+  const MODEL_FRONT_ORDER = STENCIL_MODEL_FRONT_ORDER + renderOrderOffset;
+  const SOURCE_BACK_ORDER = STENCIL_SOURCE_BACK_ORDER + renderOrderOffset;
+  const SOURCE_FRONT_ORDER = STENCIL_SOURCE_FRONT_ORDER + renderOrderOffset;
+  const GLOW_BACK_ORDER = STENCIL_GLOW_BACK_ORDER + renderOrderOffset;
+  const GLOW_FRONT_ORDER = STENCIL_GLOW_FRONT_ORDER + renderOrderOffset;
+  const CAP_ORDER = STENCIL_CAP_ORDER + renderOrderOffset;
+  const GROUP_ORDER = STENCIL_RENDER_ORDER_BASE + renderOrderOffset;
+
+  // Primary clip plane for this cap's stencil pass.
+  //   • Top cap:    Plane(0,0,-1, y)  → keeps z ≤ y (same as model's clipUpper)
+  //   • Bottom cap: Plane(0,0,1, -y)  → keeps z ≥ y (same as model's clipLower)
+  // As in Three.js clipping-stencil example, stencil geometry uses only this
+  // primary plane. The cap plane itself is clipped by the other boundary.
   const clipPlaneRef = React.useRef(
-    isBottom
+    effectiveClipMode === 'lower'
       ? new THREE.Plane(new THREE.Vector3(0, 0, 1), -y)
       : new THREE.Plane(new THREE.Vector3(0, 0, -1), y)
   );
 
+  // The "other" clip plane constrains the stencil geometry to the same
+  // region the real model is clipped to.  For the top cap (upper clip mode),
+  // the other plane is the lower boundary and vice-versa.
+  // Uses the same mutate-in-place ref pattern as the primary clip plane
+  // so slider dragging doesn't recreate materials every frame.
+  const otherClipPlaneRef = React.useRef(new THREE.Plane());
+  const hasOtherClip = otherClipY != null;
+
   React.useLayoutEffect(() => {
-    if (isBottom) {
+    if (effectiveClipMode === 'lower') {
       clipPlaneRef.current.normal.set(0, 0, 1);
       clipPlaneRef.current.constant = -y;
     } else {
       clipPlaneRef.current.normal.set(0, 0, -1);
       clipPlaneRef.current.constant = y;
     }
-  }, [isBottom, y]);
+  }, [effectiveClipMode, y]);
+
+  React.useLayoutEffect(() => {
+    if (otherClipY == null) return;
+    // The other boundary is the opposite direction from this cap's clip.
+    // Top cap (upper) → other boundary is lower: Plane(0,0,1, -otherClipY)
+    // Bottom cap (lower) → other boundary is upper: Plane(0,0,-1, otherClipY)
+    if (effectiveClipMode === 'upper') {
+      otherClipPlaneRef.current.normal.set(0, 0, 1);
+      otherClipPlaneRef.current.constant = -otherClipY;
+    } else {
+      otherClipPlaneRef.current.normal.set(0, 0, -1);
+      otherClipPlaneRef.current.constant = otherClipY;
+    }
+  }, [effectiveClipMode, otherClipY]);
 
   const stencilBase = React.useMemo(() => {
     const material = new THREE.MeshBasicMaterial();
@@ -344,25 +419,33 @@ function CrossSectionStencilCapInner({
     return material;
   }, []);
 
+  // Secondary clip plane for the cap plane itself when dual-cutting.
+  const capClipPlanes = React.useMemo(() => {
+    if (!hasOtherClip) return null;
+    return [otherClipPlaneRef.current];
+  }, [hasOtherClip]);
+
   const stencilBack = React.useMemo(() => {
     const material = stencilBase.clone();
     material.side = THREE.BackSide;
     material.clippingPlanes = [clipPlaneRef.current];
-    material.stencilFail = THREE.IncrementWrapStencilOp;
-    material.stencilZFail = THREE.IncrementWrapStencilOp;
-    material.stencilZPass = THREE.IncrementWrapStencilOp;
+    const op = effectiveStencilMode === 'mirrored' ? THREE.DecrementWrapStencilOp : THREE.IncrementWrapStencilOp;
+    material.stencilFail = op;
+    material.stencilZFail = op;
+    material.stencilZPass = op;
     return material;
-  }, [stencilBase]);
+  }, [effectiveStencilMode, stencilBase]);
 
   const stencilFront = React.useMemo(() => {
     const material = stencilBase.clone();
     material.side = THREE.FrontSide;
     material.clippingPlanes = [clipPlaneRef.current];
-    material.stencilFail = THREE.DecrementWrapStencilOp;
-    material.stencilZFail = THREE.DecrementWrapStencilOp;
-    material.stencilZPass = THREE.DecrementWrapStencilOp;
+    const op = effectiveStencilMode === 'mirrored' ? THREE.IncrementWrapStencilOp : THREE.DecrementWrapStencilOp;
+    material.stencilFail = op;
+    material.stencilZFail = op;
+    material.stencilZPass = op;
     return material;
-  }, [stencilBase]);
+  }, [effectiveStencilMode, stencilBase]);
 
   const capPlaneGeometry = React.useMemo(() => {
     return new THREE.PlaneGeometry(
@@ -374,28 +457,34 @@ function CrossSectionStencilCapInner({
   const capPlaneMaterial = React.useMemo(() => {
     const resolvedOpacity = Math.max(0, Math.min(1, capOpacity));
     const isOpaqueCap = resolvedOpacity >= 0.999;
+    const resolvedSide = effectiveSide === 'back'
+      ? THREE.BackSide
+      : effectiveSide === 'double'
+        ? THREE.DoubleSide
+        : THREE.FrontSide;
     const material = new THREE.MeshBasicMaterial({
       color,
-      side: THREE.DoubleSide,
+      side: resolvedSide,
+      clippingPlanes: capClipPlanes,
       transparent: !isOpaqueCap,
       opacity: resolvedOpacity,
       // Opaque caps must contribute depth so later transparent passes
       // (e.g. build plate helpers) don't overdraw and make the cap look
       // like it's rendering behind the plate.
       depthWrite: isOpaqueCap,
-      depthTest: capDepthTest,
+      depthTest: debugOverrides?.depthTest ?? capDepthTest,
       polygonOffset: true,
       polygonOffsetFactor: -1,
       polygonOffsetUnits: -1,
       stencilWrite: true,
       stencilRef: 0,
       stencilFunc: THREE.NotEqualStencilFunc,
-      stencilFail: THREE.KeepStencilOp,
-      stencilZFail: THREE.KeepStencilOp,
-      stencilZPass: THREE.KeepStencilOp,
+      stencilFail: THREE.ReplaceStencilOp,
+      stencilZFail: THREE.ReplaceStencilOp,
+      stencilZPass: THREE.ReplaceStencilOp,
     });
     return material;
-  }, [capDepthTest, capOpacity, color]);
+  }, [capClipPlanes, capDepthTest, capOpacity, color, debugOverrides?.depthTest, effectiveSide]);
 
   const glowPlaneMaterial = React.useMemo(() => {
     if (glowThicknessMm <= 0 || glowOpacity <= 0) return null;
@@ -403,6 +492,7 @@ function CrossSectionStencilCapInner({
     const material = new THREE.MeshBasicMaterial({
       color: glowColor ?? color,
       side: THREE.DoubleSide,
+      clippingPlanes: capClipPlanes,
       transparent: true,
       opacity: Math.max(0, Math.min(1, glowOpacity)),
       depthWrite: false,
@@ -415,13 +505,13 @@ function CrossSectionStencilCapInner({
       stencilWrite: true,
       stencilRef: 0,
       stencilFunc: THREE.NotEqualStencilFunc,
-      stencilFail: THREE.KeepStencilOp,
-      stencilZFail: THREE.KeepStencilOp,
-      stencilZPass: THREE.KeepStencilOp,
+      stencilFail: THREE.ReplaceStencilOp,
+      stencilZFail: THREE.ReplaceStencilOp,
+      stencilZPass: THREE.ReplaceStencilOp,
     });
 
     return material;
-  }, [color, glowColor, glowOpacity, glowThicknessMm]);
+  }, [capClipPlanes, color, glowColor, glowOpacity, glowThicknessMm]);
 
   // R3F adds/removes meshes from the support group during the commit phase,
   // AFTER React's render phase (where useMemo runs). To avoid traversing a
@@ -676,25 +766,27 @@ function CrossSectionStencilCapInner({
   }, [entries]);
 
   const visibleModelStencilEntries = React.useMemo(() => {
-    return modelStencilEntries.filter((entry) => intersectsMinMaxZ(entry.minZ, entry.maxZ, y));
-  }, [modelStencilEntries, y]);
+    // IMPORTANT: Do not z-filter here. Cached world bounds can be stale or
+    // conservative while transforms/support primitives update, which can
+    // incorrectly suppress an entire cap pass (especially the lower cap).
+    // Stencil clipping planes already constrain actual fragments precisely.
+    return modelStencilEntries;
+  }, [modelStencilEntries]);
 
   const visibleStaticSingleEntries = React.useMemo(() => {
     const visibleSingles: StaticStencilMeshEntry[] = [];
     for (const entry of staticSourceEntries) {
       if (entry.kind !== 'single') continue;
-      if (!intersectsMinMaxZ(entry.minZ, entry.maxZ, y)) continue;
       visibleSingles.push(entry);
     }
     return visibleSingles;
-  }, [staticSourceEntries, y]);
+  }, [staticSourceEntries]);
 
   const visibleStaticInstancedEntries = React.useMemo<VisibleStaticStencilInstancedEntry[]>(() => {
     const visibleInstanced: VisibleStaticStencilInstancedEntry[] = [];
 
     for (const entry of staticSourceEntries) {
       if (entry.kind !== 'instanced') continue;
-      if (!intersectsMinMaxZ(entry.minZ, entry.maxZ, y)) continue;
 
       visibleInstanced.push({
         key: entry.key,
@@ -705,7 +797,7 @@ function CrossSectionStencilCapInner({
     }
 
     return visibleInstanced;
-  }, [staticSourceEntries, y]);
+  }, [staticSourceEntries]);
 
   const hasVisibleStaticSource = visibleStaticSingleEntries.length > 0 || visibleStaticInstancedEntries.length > 0;
 
@@ -727,9 +819,11 @@ function CrossSectionStencilCapInner({
         entry={entry}
         backMaterial={stencilBack}
         frontMaterial={stencilFront}
+        backRenderOrder={MODEL_BACK_ORDER}
+        frontRenderOrder={MODEL_FRONT_ORDER}
       />
     ));
-  }, [stencilBack, stencilFront, visibleModelStencilEntries]);
+  }, [stencilBack, stencilFront, visibleModelStencilEntries, MODEL_BACK_ORDER, MODEL_FRONT_ORDER]);
 
   const staticSingleStencilPassNodes = React.useMemo(() => {
     return visibleStaticSingleEntries.map((entry) => (
@@ -738,9 +832,11 @@ function CrossSectionStencilCapInner({
         entry={entry}
         backMaterial={stencilBack}
         frontMaterial={stencilFront}
+        backRenderOrder={SOURCE_BACK_ORDER}
+        frontRenderOrder={SOURCE_FRONT_ORDER}
       />
     ));
-  }, [stencilBack, stencilFront, visibleStaticSingleEntries]);
+  }, [stencilBack, stencilFront, visibleStaticSingleEntries, SOURCE_BACK_ORDER, SOURCE_FRONT_ORDER]);
 
   const staticInstancedStencilPassNodes = React.useMemo(() => {
     return visibleStaticInstancedEntries.map((entry) => (
@@ -751,8 +847,8 @@ function CrossSectionStencilCapInner({
         matrixElements={entry.matrixElements}
         backMaterial={stencilBack}
         frontMaterial={stencilFront}
-        backRenderOrder={STENCIL_SOURCE_BACK_ORDER}
-        frontRenderOrder={STENCIL_SOURCE_FRONT_ORDER}
+        backRenderOrder={SOURCE_BACK_ORDER}
+        frontRenderOrder={SOURCE_FRONT_ORDER}
       />
     ));
   }, [stencilBack, stencilFront, visibleStaticInstancedEntries]);
@@ -760,7 +856,7 @@ function CrossSectionStencilCapInner({
   if (!visible || (visibleModelStencilEntries.length === 0 && !hasVisibleStaticSource)) return null;
 
   return (
-    <group renderOrder={STENCIL_RENDER_ORDER_BASE}>
+    <group renderOrder={GROUP_ORDER}>
       {modelStencilPassNodes}
 
       {staticSingleStencilPassNodes}
@@ -773,7 +869,7 @@ function CrossSectionStencilCapInner({
             geometry={capPlaneGeometry}
             material={glowPlaneMaterial}
             position={[0, 0, y + Math.max(1e-4, glowThicknessMm)]}
-            renderOrder={STENCIL_GLOW_BACK_ORDER}
+            renderOrder={GLOW_BACK_ORDER}
             frustumCulled
             raycast={() => null}
           />
@@ -781,7 +877,7 @@ function CrossSectionStencilCapInner({
             geometry={capPlaneGeometry}
             material={glowPlaneMaterial}
             position={[0, 0, y - Math.max(1e-4, glowThicknessMm)]}
-            renderOrder={STENCIL_GLOW_FRONT_ORDER}
+            renderOrder={GLOW_FRONT_ORDER}
             frustumCulled
             raycast={() => null}
           />
@@ -791,8 +887,9 @@ function CrossSectionStencilCapInner({
       <mesh
         geometry={capPlaneGeometry}
         material={capPlaneMaterial}
-        position={[0, 0, isBottom ? y - 1e-4 : y + 1e-4]}
-        renderOrder={STENCIL_CAP_ORDER}
+        position={[0, 0, y + effectiveOffsetMm]}
+        rotation={effectiveRotationXDeg !== 0 ? [THREE.MathUtils.degToRad(effectiveRotationXDeg), 0, 0] : undefined}
+        renderOrder={CAP_ORDER}
         frustumCulled
         raycast={() => null}
         onAfterRender={(renderer) => {
@@ -813,6 +910,7 @@ const areCrossSectionStencilCapPropsEqual = (
     && prev.sourceObjectVersion === next.sourceObjectVersion
     && prev.skipSourceZBounds === next.skipSourceZBounds
     && prev.y === next.y
+    && prev.otherClipY === next.otherClipY
     && prev.color === next.color
     && prev.planeWidthMm === next.planeWidthMm
     && prev.planeHeightMm === next.planeHeightMm
@@ -823,6 +921,13 @@ const areCrossSectionStencilCapPropsEqual = (
     && prev.glowOpacity === next.glowOpacity
     && prev.glowColor === next.glowColor
     && prev.direction === next.direction
+    && prev.renderOrderOffset === next.renderOrderOffset
+    && prev.debugOverrides?.side === next.debugOverrides?.side
+    && prev.debugOverrides?.offsetMm === next.debugOverrides?.offsetMm
+    && prev.debugOverrides?.rotationXDeg === next.debugOverrides?.rotationXDeg
+    && prev.debugOverrides?.clipMode === next.debugOverrides?.clipMode
+    && prev.debugOverrides?.stencilMode === next.debugOverrides?.stencilMode
+    && prev.debugOverrides?.depthTest === next.debugOverrides?.depthTest
   );
 };
 

--- a/src/components/scene/CrossSectionStencilCap.tsx
+++ b/src/components/scene/CrossSectionStencilCap.tsx
@@ -29,6 +29,7 @@ type CrossSectionStencilCapProps = {
   glowThicknessMm?: number;
   glowOpacity?: number;
   glowColor?: string;
+  direction?: 'top' | 'bottom';
 };
 
 type StaticStencilMeshEntry = {
@@ -314,12 +315,24 @@ function CrossSectionStencilCapInner({
   glowThicknessMm = 0,
   glowOpacity = 0,
   glowColor,
+  direction = 'top',
 }: CrossSectionStencilCapProps) {
-  const clipPlaneRef = React.useRef(new THREE.Plane(new THREE.Vector3(0, 0, -1), y));
-  
+  const isBottom = direction === 'bottom';
+  const clipPlaneRef = React.useRef(
+    isBottom
+      ? new THREE.Plane(new THREE.Vector3(0, 0, 1), -y)
+      : new THREE.Plane(new THREE.Vector3(0, 0, -1), y)
+  );
+
   React.useLayoutEffect(() => {
-    clipPlaneRef.current.constant = y;
-  }, [y]);
+    if (isBottom) {
+      clipPlaneRef.current.normal.set(0, 0, 1);
+      clipPlaneRef.current.constant = -y;
+    } else {
+      clipPlaneRef.current.normal.set(0, 0, -1);
+      clipPlaneRef.current.constant = y;
+    }
+  }, [isBottom, y]);
 
   const stencilBase = React.useMemo(() => {
     const material = new THREE.MeshBasicMaterial();
@@ -778,7 +791,7 @@ function CrossSectionStencilCapInner({
       <mesh
         geometry={capPlaneGeometry}
         material={capPlaneMaterial}
-        position={[0, 0, y + 1e-4]}
+        position={[0, 0, isBottom ? y - 1e-4 : y + 1e-4]}
         renderOrder={STENCIL_CAP_ORDER}
         frustumCulled
         raycast={() => null}
@@ -809,6 +822,7 @@ const areCrossSectionStencilCapPropsEqual = (
     && prev.glowThicknessMm === next.glowThicknessMm
     && prev.glowOpacity === next.glowOpacity
     && prev.glowColor === next.glowColor
+    && prev.direction === next.direction
   );
 };
 

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -77,6 +77,7 @@ import { PickingEmptySpaceHoverResetter, SceneRenderBindings } from './SceneCanv
 import { PickingProviderWrapper, SelectionSync, useInteractionWarning } from './SceneSelectionAndPicking';
 import { CameraClipPlaneStabilizer, CameraProvider, EnableLocalClipping, Helpers, Lights, LoggingHelper, SceneMoodOverlay } from './SceneEnvironment';
 import { StlMesh } from './StlMesh';
+import { setClipBounds } from './clipBoundsStore';
 import {
   DEFAULT_CAMERA_PROJECTION_SETTINGS,
   getSavedCameraProjectionSettings,
@@ -477,6 +478,10 @@ export function SceneCanvas({
   );
   const sceneHoveredSupportId = useSceneHoveredSupportId();
   const [contactDiskHudInteractionActive, setContactDiskHudInteractionActive] = React.useState(() => isContactDiskHudInteractionActive());
+
+  // Sync clip bounds to the module-level store so BranchPlacementController
+  // (and other independent raycasters) can skip hits on clipped geometry.
+  setClipBounds(clipLower, clipUpper);
 
   React.useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -4883,7 +4883,10 @@ export function SceneCanvas({
                   entries={crossSectionCapEntries}
                   sourceObject={supportDragGroupRef?.current ?? null}
                   sourceObjectVersion={clipUpper != null ? crossSectionStencilSourceVersion : undefined}
-                  skipSourceZBounds={clipUpper == null}
+                  // During slider scrubbing, avoid expensive source z-bound
+                  // traversal/bucketing work. Stencil clipping still constrains
+                  // fragments correctly, so this is a safe CPU optimization.
+                  skipSourceZBounds={clipUpper == null || isLayerScrubbing}
                   y={(clipUpper ?? indicatorPlaneZ)!}
                   otherClipY={clipLower}
                   color={clipUpper != null ? '#FFFFFF' : (indicatorPlaneColor ?? '#ec2a77')}
@@ -4911,7 +4914,12 @@ export function SceneCanvas({
                   offsetMm={bottomCpuCapOffsetMm}
                   depthTest={bottomCpuCapDepthTest}
                   mode="smooth"
-                  interactive={false}
+                  // Keep CPU bottom-cap winding/offset semantics untouched; only
+                  // enable quantized interactive updates while scrubbing so the
+                  // expensive loop/shape rebuild path doesn't run every tick.
+                  interactive={isLayerScrubbing}
+                  interactiveZStepMm={Math.max(0.1, layerHeightMm ?? 0.05)}
+                  preferProjectedOnlyDuringInteractive
                   visible={!hideCrossSectionCap}
                 />
               )}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -4,7 +4,12 @@ import React, { useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import * as THREE from 'three';
 import { OrbitControls } from '@react-three/drei';
-import { CrossSectionStencilCap, type CrossSectionStencilCapEntry } from '@/components/scene/CrossSectionStencilCap';
+import {
+  CrossSectionStencilCap,
+  type CrossSectionCapDebugOverrides,
+  type CrossSectionStencilCapEntry,
+} from '@/components/scene/CrossSectionStencilCap';
+import { CrossSectionCap } from '@/components/scene/CrossSectionCap';
 import { IslandOverlay } from '@/components/scene/IslandOverlay';
 import { IslandVoxelVisualization } from '@/components/scene/IslandVoxelVisualization';
 import { IslandExpansionVisualization } from '@/components/scene/IslandExpansionVisualization';
@@ -182,6 +187,35 @@ function GhostPreviewInstances({
     </instancedMesh>
   );
 }
+
+type CrossSectionCapDebugPanelState = {
+  enabled: boolean;
+  top: CrossSectionCapDebugOverrides;
+  bottom: CrossSectionCapDebugOverrides;
+};
+
+const CROSS_SECTION_CAP_DEBUG_STORAGE_KEY = 'df:cross-section-cap-debug:v4';
+const CROSS_SECTION_CAP_DEBUG_HOTKEY_ENABLED = false;
+
+const DEFAULT_CROSS_SECTION_CAP_DEBUG_STATE: CrossSectionCapDebugPanelState = {
+  enabled: false,
+  top: {
+    side: 'front',
+    offsetMm: 1e-4,
+    rotationXDeg: 0,
+    clipMode: 'upper',
+    stencilMode: 'standard',
+    depthTest: true,
+  },
+  bottom: {
+    side: 'back',
+    offsetMm: -1e-4,
+    rotationXDeg: 0,
+    clipMode: 'lower',
+    stencilMode: 'standard',
+    depthTest: false,
+  },
+};
 
 export function SceneCanvas({
   models: modelsProp = [],
@@ -4247,6 +4281,70 @@ export function SceneCanvas({
     };
   }, []);
 
+  const [showCrossSectionCapDebugPanel, setShowCrossSectionCapDebugPanel] = React.useState(false);
+  const [crossSectionCapDebugState, setCrossSectionCapDebugState] = React.useState<CrossSectionCapDebugPanelState>(
+    DEFAULT_CROSS_SECTION_CAP_DEBUG_STATE,
+  );
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const raw = window.localStorage.getItem(CROSS_SECTION_CAP_DEBUG_STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as Partial<CrossSectionCapDebugPanelState>;
+      setCrossSectionCapDebugState((prev) => ({
+        enabled: typeof parsed.enabled === 'boolean' ? parsed.enabled : prev.enabled,
+        top: { ...prev.top, ...(parsed.top ?? {}) },
+        bottom: { ...prev.bottom, ...(parsed.bottom ?? {}) },
+      }));
+    } catch {
+      // Ignore malformed debug state.
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(CROSS_SECTION_CAP_DEBUG_STORAGE_KEY, JSON.stringify(crossSectionCapDebugState));
+    } catch {
+      // Ignore storage write failures in temporary debug tooling.
+    }
+  }, [crossSectionCapDebugState]);
+
+  React.useEffect(() => {
+    if (!CROSS_SECTION_CAP_DEBUG_HOTKEY_ENABLED) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const isToggle = event.ctrlKey
+        && event.shiftKey
+        && (event.code === 'KeyK' || event.key.toLowerCase() === 'k');
+      if (!isToggle) return;
+      event.preventDefault();
+      event.stopPropagation();
+      setShowCrossSectionCapDebugPanel((prev) => !prev);
+    };
+
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, true);
+    };
+  }, []);
+
+  const topCapDebugOverrides = crossSectionCapDebugState.enabled
+    ? crossSectionCapDebugState.top
+    : undefined;
+  const bottomCapDebugOverrides = crossSectionCapDebugState.enabled
+    ? crossSectionCapDebugState.bottom
+    : undefined;
+  const bottomCpuCapSide = React.useMemo<THREE.Side>(() => {
+    const side = bottomCapDebugOverrides?.side ?? 'back';
+    if (side === 'back') return THREE.BackSide;
+    if (side === 'double') return THREE.DoubleSide;
+    return THREE.FrontSide;
+  }, [bottomCapDebugOverrides?.side]);
+  const bottomCpuCapOffsetMm = bottomCapDebugOverrides?.offsetMm ?? -1e-4;
+  const bottomCpuCapDepthTest = bottomCapDebugOverrides?.depthTest ?? false;
+
   return (
     <div
       style={{ width: '100%', height: '100%', position: 'relative' }}
@@ -4781,11 +4879,13 @@ export function SceneCanvas({
 
               {(clipUpper != null || indicatorPlaneZ != null) && !hideCrossSectionCap && (
                 <CrossSectionStencilCap
+                  key="cross-section-cap-top"
                   entries={crossSectionCapEntries}
                   sourceObject={supportDragGroupRef?.current ?? null}
                   sourceObjectVersion={clipUpper != null ? crossSectionStencilSourceVersion : undefined}
                   skipSourceZBounds={clipUpper == null}
                   y={(clipUpper ?? indicatorPlaneZ)!}
+                  otherClipY={clipLower}
                   color={clipUpper != null ? '#FFFFFF' : (indicatorPlaneColor ?? '#ec2a77')}
                   planeWidthMm={crossSectionPlaneWidthMm}
                   planeHeightMm={crossSectionPlaneHeightMm}
@@ -4795,21 +4895,23 @@ export function SceneCanvas({
                   glowOpacity={clipUpper != null ? 0 : 0.44}
                   glowColor={clipUpper != null ? undefined : (indicatorPlaneColor ?? '#ec2a77')}
                   visible={!hideCrossSectionCap && (clipUpper != null || indicatorPlaneZ != null)}
+                  debugOverrides={topCapDebugOverrides}
                 />
               )}
 
               {clipLower != null && !hideCrossSectionCap && (
-                <CrossSectionStencilCap
-                  entries={crossSectionCapEntries}
+                <CrossSectionCap
+                  key="cross-section-cap-bottom-cpu"
+                  projectedModels={models}
+                  projectedContextVersion={crossSectionStencilSourceVersion}
                   sourceObject={supportDragGroupRef?.current ?? null}
-                  sourceObjectVersion={crossSectionStencilSourceVersion}
                   y={clipLower}
-                  direction="bottom"
                   color="#FFFFFF"
-                  planeWidthMm={crossSectionPlaneWidthMm}
-                  planeHeightMm={crossSectionPlaneHeightMm}
-                  capOpacity={1}
-                  capDepthTest={true}
+                  side={bottomCpuCapSide}
+                  offsetMm={bottomCpuCapOffsetMm}
+                  depthTest={bottomCpuCapDepthTest}
+                  mode="smooth"
+                  interactive={false}
                   visible={!hideCrossSectionCap}
                 />
               )}
@@ -5685,6 +5787,162 @@ export function SceneCanvas({
 
       {/* GPU Picking Debug Overlay - shows what's under cursor */}
       {gpuPickingTest && <PickingDebugOverlay position="top-right" />}
+
+      {showCrossSectionCapDebugPanel && (
+        <div
+          className="absolute right-3 top-3 z-[70] w-[360px] rounded-lg border p-3 shadow-xl"
+          style={{
+            pointerEvents: 'auto',
+            borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+            background: 'color-mix(in srgb, var(--surface-0), black 6%)',
+            color: 'var(--text-strong)',
+          }}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-xs font-semibold">Cross-Section Cap Debug (temporary)</div>
+            <button
+              type="button"
+              className="rounded border px-2 py-1 text-[10px]"
+              style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+              onClick={() => setShowCrossSectionCapDebugPanel(false)}
+            >
+              Close
+            </button>
+          </div>
+
+          <div className="mt-2 flex items-center justify-between gap-2 rounded border p-2" style={{ borderColor: 'var(--border-subtle)' }}>
+            <label className="flex items-center gap-2 text-[11px]">
+              <input
+                type="checkbox"
+                checked={crossSectionCapDebugState.enabled}
+                onChange={(e) => {
+                  const enabled = e.target.checked;
+                  setCrossSectionCapDebugState((prev) => ({ ...prev, enabled }));
+                }}
+              />
+              Enable overrides
+            </label>
+            <button
+              type="button"
+              className="rounded border px-2 py-1 text-[10px]"
+              style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+              onClick={() => setCrossSectionCapDebugState(DEFAULT_CROSS_SECTION_CAP_DEBUG_STATE)}
+            >
+              Reset defaults
+            </button>
+          </div>
+
+          {(['top', 'bottom'] as const).map((which) => {
+            const settings = crossSectionCapDebugState[which];
+            const setSettings = (partial: Partial<CrossSectionCapDebugOverrides>) => {
+              setCrossSectionCapDebugState((prev) => ({
+                ...prev,
+                [which]: { ...prev[which], ...partial },
+              }));
+            };
+
+            return (
+              <div key={which} className="mt-2 rounded border p-2" style={{ borderColor: 'var(--border-subtle)' }}>
+                <div className="mb-1 text-[11px] font-semibold uppercase" style={{ color: 'var(--text-muted)' }}>
+                  {which} cap
+                </div>
+
+                <div className="grid grid-cols-2 gap-2 text-[11px]">
+                  <label className="flex flex-col gap-1">
+                    <span>Side</span>
+                    <select
+                      value={settings.side ?? 'front'}
+                      onChange={(e) => setSettings({ side: e.target.value as 'front' | 'back' | 'double' })}
+                      className="rounded border px-1.5 py-1"
+                      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+                    >
+                      <option value="front">front</option>
+                      <option value="back">back</option>
+                      <option value="double">double</option>
+                    </select>
+                  </label>
+
+                  <label className="flex flex-col gap-1">
+                    <span>Depth test</span>
+                    <select
+                      value={settings.depthTest ? 'on' : 'off'}
+                      onChange={(e) => setSettings({ depthTest: e.target.value === 'on' })}
+                      className="rounded border px-1.5 py-1"
+                      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+                    >
+                      <option value="on">on</option>
+                      <option value="off">off</option>
+                    </select>
+                  </label>
+
+                  <label className="flex flex-col gap-1">
+                    <span>Clip mode</span>
+                    <select
+                      value={settings.clipMode ?? (which === 'bottom' ? 'lower' : 'upper')}
+                      onChange={(e) => setSettings({ clipMode: e.target.value as 'upper' | 'lower' })}
+                      disabled={which === 'bottom'}
+                      className="rounded border px-1.5 py-1"
+                      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+                    >
+                      <option value="upper">upper (z ≤ y)</option>
+                      <option value="lower">lower (z ≥ y)</option>
+                    </select>
+                  </label>
+
+                  <label className="flex flex-col gap-1">
+                    <span>Stencil mode</span>
+                    <select
+                      value={settings.stencilMode ?? 'standard'}
+                      onChange={(e) => setSettings({ stencilMode: e.target.value as 'standard' | 'mirrored' })}
+                      disabled={which === 'bottom'}
+                      className="rounded border px-1.5 py-1"
+                      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+                    >
+                      <option value="standard">standard</option>
+                      <option value="mirrored">mirrored</option>
+                    </select>
+                  </label>
+
+                  <label className="flex flex-col gap-1">
+                    <span>Offset (mm)</span>
+                    <input
+                      type="number"
+                      step="0.0001"
+                      value={settings.offsetMm ?? (which === 'bottom' ? -0.0001 : 0.0001)}
+                      onChange={(e) => setSettings({ offsetMm: Number(e.target.value) })}
+                      className="rounded border px-1.5 py-1"
+                      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+                    />
+                  </label>
+
+                  <label className="flex flex-col gap-1">
+                    <span>Rotation X (deg)</span>
+                    <input
+                      type="number"
+                      step="1"
+                      value={settings.rotationXDeg ?? 0}
+                      onChange={(e) => setSettings({ rotationXDeg: Number(e.target.value) })}
+                      disabled={which === 'bottom'}
+                      className="rounded border px-1.5 py-1"
+                      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+                    />
+                  </label>
+                </div>
+
+                {which === 'bottom' && (
+                  <div className="mt-1 text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                    Bottom cap uses CPU slice loops right now (side/offset/depth-test apply; clip/stencil/rotation ignored).
+                  </div>
+                )}
+              </div>
+            );
+          })}
+
+          <div className="mt-2 text-[10px]" style={{ color: 'var(--text-muted)' }}>
+            Toggle panel: Ctrl+Shift+K · Settings persist locally.
+          </div>
+        </div>
+      )}
 
       {marqueeSelection && (
         <div

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import React, { useEffect } from 'react';
 import dynamic from 'next/dynamic';
@@ -3646,7 +3646,7 @@ export function SceneCanvas({
       }
 
       benchmarkRunIdRef.current = requestId;
-      dispatchProgress({ requestId, status: 'started', message: `Preparing ${stressProfile} 3D orbit sweeps…` });
+      dispatchProgress({ requestId, status: 'started', message: `Preparing ${stressProfile} 3D orbit sweepsΓÇª` });
 
       const startedAt = performance.now();
       const startedAtIso = new Date().toISOString();
@@ -4798,6 +4798,22 @@ export function SceneCanvas({
                 />
               )}
 
+              {clipLower != null && !hideCrossSectionCap && (
+                <CrossSectionStencilCap
+                  entries={crossSectionCapEntries}
+                  sourceObject={supportDragGroupRef?.current ?? null}
+                  sourceObjectVersion={crossSectionStencilSourceVersion}
+                  y={clipLower}
+                  direction="bottom"
+                  color="#FFFFFF"
+                  planeWidthMm={crossSectionPlaneWidthMm}
+                  planeHeightMm={crossSectionPlaneHeightMm}
+                  capOpacity={1}
+                  capDepthTest={true}
+                  visible={!hideCrossSectionCap}
+                />
+              )}
+
               {!hideRaftPrimitives
                 && !thumbnailCaptureActive
                 && !isGizmoDragging
@@ -5629,7 +5645,7 @@ export function SceneCanvas({
           }}
         >
           <div className="rounded border border-neutral-700 bg-neutral-900/70 px-3 py-2 text-sm text-neutral-100">
-            Loading brush…
+            Loading brushΓÇª
           </div>
         </div>
       )}
@@ -5646,7 +5662,7 @@ export function SceneCanvas({
           }}
         >
           <div className="rounded border border-neutral-700 bg-neutral-900/70 px-3 py-2 text-sm text-neutral-100">
-            Smoothing… {Math.round((smoothingProcessing.progress ?? 0) * 100)}%
+            SmoothingΓÇª {Math.round((smoothingProcessing.progress ?? 0) * 100)}%
           </div>
         </div>
       )}
@@ -5699,7 +5715,7 @@ export function SceneCanvas({
           }}
           title={outOfBoundsModels.map((m) => m.name).join(', ')}
         >
-          <span style={{ marginRight: 6 }}>⚠</span>
+          <span style={{ marginRight: 6 }}>ΓÜá</span>
           {outOfBoundsModels.length} model{outOfBoundsModels.length === 1 ? '' : 's'} out of build volume
         </div>
       )}

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -77,8 +77,9 @@ function hasVisibleNonModelIntersection(
   for (const int of intersections) {
     // Skip the model mesh itself (can appear multiple times for inner wall)
     if (int.object === modelObject) continue;
-    // Skip gizmo handles
-    if (int.object.userData?.isGizmoHandle) continue;
+    // Gizmo handles don't need the clip-bounds check — they are always
+    // rendered in their own layer and should be treated as visible.
+    if (int.object.userData?.isGizmoHandle) return true;
     // Check the hit is within visible clip bounds
     if (clipUpper != null && int.point.z > clipUpper) continue;
     if (clipLower != null && int.point.z < clipLower) continue;
@@ -868,7 +869,12 @@ if (uDitherAmount > 0.0) {
             return;
           }
 
-          if (shouldSuppressModelInteraction || isGizmoHoverCategory) {
+          // Check both GPU pick (may lag 1 frame) and raw intersection list
+          // so gizmo hover works even when gizmos are excluded from picking.
+          const hasGizmoIntersection = e.intersections.some(
+            (h) => h.object.userData?.isGizmoHandle === true,
+          );
+          if (shouldSuppressModelInteraction || isGizmoHoverCategory || hasGizmoIntersection) {
             if (!hasExternalHoverSource) schedulePointerHover(false);
             onModelHoverPointChange?.(null);
             onModelHoverModelChange?.(null);

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -25,12 +25,32 @@ import { emitImmediateModelHover } from '@/supports/interaction/pointerOcclusion
 // Scratch raycaster reused for clip-zone fallback raycasts.
 const _clipFallbackRaycaster = new THREE.Raycaster();
 
+// Mini-cache for clip-aware fallback raycasts.  Near the clip boundary the
+// primary hit oscillates between visible/clipped zones, causing a BVH
+// raycast on ~50% of pointer-move frames.  Caching the previous fallback
+// result by quantised ray origin + direction eliminates redundant raycasts
+// when the pointer hasn't moved meaningfully.
+const _clipCacheQuant = 0.15; // mm position quantisation
+let _clipCacheKey = '';
+let _clipCacheResult: THREE.Intersection | null = null;
+
+function clipRayCacheKey(ray: THREE.Ray): string {
+    const Q = _clipCacheQuant;
+    const o = ray.origin;
+    const d = ray.direction;
+    // Quantise origin (position) and direction (unit vector × 1000 for precision).
+    return `${Math.round(o.x / Q)},${Math.round(o.y / Q)},${Math.round(o.z / Q)},${Math.round(d.x * 1000)},${Math.round(d.y * 1000)},${Math.round(d.z * 1000)}`;
+}
+
 /**
  * When the primary ray hit falls in the clipped (hidden) portion of a mesh,
  * find the nearest hit within the visible Z range by raycasting with `near`
  * set just past the clipped surface. This skips the outer wall entirely and
  * uses firstHitOnly=true so the BVH stops at the very first triangle hit —
  * O(log n) instead of scanning all faces.
+ *
+ * Results are cached by quantised ray so near-duplicate pointer moves
+ * (common at clip boundaries) skip the BVH entirely.
  */
 function findClipAwareHit(
   ray: THREE.Ray,
@@ -39,6 +59,12 @@ function findClipAwareHit(
   clipUpper: number | null | undefined,
   primaryDistance: number,
 ): THREE.Intersection | null {
+  // Check ray cache — skip BVH if the ray hasn't changed meaningfully.
+  const cacheKey = clipRayCacheKey(ray) + `,${clipLower ?? ''},${clipUpper ?? ''}`;
+  if (cacheKey === _clipCacheKey) {
+    return _clipCacheResult;
+  }
+
   const rc = _clipFallbackRaycaster;
   rc.ray.copy(ray);
   // Skip past the already-found clipped surface.
@@ -52,14 +78,22 @@ function findClipAwareHit(
   rc.near = 0;
   rc.far = Infinity;
   (rc as any).firstHitOnly = false;
-  if (hits.length === 0) return null;
+  if (hits.length === 0) {
+    _clipCacheKey = cacheKey;
+    _clipCacheResult = null;
+    return null;
+  }
   const hit = hits[0];
   if (
     (clipUpper != null && hit.point.z > clipUpper) ||
     (clipLower != null && hit.point.z < clipLower)
   ) {
+    _clipCacheKey = cacheKey;
+    _clipCacheResult = null;
     return null;
   }
+  _clipCacheKey = cacheKey;
+  _clipCacheResult = hit;
   return hit;
 }
 

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -63,6 +63,30 @@ function findClipAwareHit(
   return hit;
 }
 
+/**
+ * Check whether any non-model intersection exists in the visible clip zone.
+ * Used to decide if a clipped model-mesh hit should let events propagate
+ * through to support objects behind the clipped surface.
+ */
+function hasVisibleNonModelIntersection(
+  intersections: THREE.Intersection[],
+  modelObject: THREE.Object3D,
+  clipLower: number | null | undefined,
+  clipUpper: number | null | undefined,
+): boolean {
+  for (const int of intersections) {
+    // Skip the model mesh itself (can appear multiple times for inner wall)
+    if (int.object === modelObject) continue;
+    // Skip gizmo handles
+    if (int.object.userData?.isGizmoHandle) continue;
+    // Check the hit is within visible clip bounds
+    if (clipUpper != null && int.point.z > clipUpper) continue;
+    if (clipLower != null && int.point.z < clipLower) continue;
+    return true;
+  }
+  return false;
+}
+
 function StlMeshComponent({
   geometry,
   clipLower,
@@ -813,6 +837,11 @@ if (uDitherAmount > 0.0) {
               (clipUpper != null && e.point.z > clipUpper) ||
               (clipLower != null && e.point.z < clipLower)
             ) {
+              // If a visible support is behind the clipped surface, let the
+              // click propagate to it instead of consuming it for placement.
+              if (hasVisibleNonModelIntersection(e.intersections, e.object, clipLower, clipUpper)) {
+                return; // Don't stop propagation — support will handle the click.
+              }
               // Primary hit is in the clipped (hidden) zone. Cast directly
               // against this mesh to find the nearest visible-zone hit.
               const fallback = findClipAwareHit(e.ray, e.object, clipLower, clipUpper, e.distance);
@@ -846,6 +875,24 @@ if (uDitherAmount > 0.0) {
           const isTopMostIntersection = e.intersections[0]?.object === e.object;
           if (!isTopMostIntersection) {
             if (!hasExternalHoverSource) schedulePointerHover(false);
+            return;
+          }
+
+          // If the primary hit is in the clipped (invisible) zone and there is a
+          // visible support (or other non-model object) behind it, let the event
+          // propagate so the support can receive its hover event instead.
+          const primaryClipped =
+            (clipUpper != null && e.point.z > clipUpper) ||
+            (clipLower != null && e.point.z < clipLower);
+          if (primaryClipped && hasVisibleNonModelIntersection(e.intersections, e.object, clipLower, clipUpper)) {
+            // Don't stop propagation — support behind the clipped surface will handle it.
+            if (!hasExternalHoverSource) schedulePointerHover(false);
+            onModelHoverPointChange?.(null);
+            onModelHoverModelChange?.(null);
+            emitImmediateModelHover(null);
+            if (mode === 'support' && onSupportHover) {
+              onSupportHover(null);
+            }
             return;
           }
 

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -832,16 +832,20 @@ if (uDitherAmount > 0.0) {
           // Support placement in support mode
           if (mode === 'support' && onSupportClick) {
             if (blockSupportPlacement) return;
+
+            // When cross-section is active and a visible support is behind
+            // the model surface, let the click propagate to the support
+            // instead of consuming it for placement.
+            const crossSectionActiveClick = clipUpper != null || clipLower != null;
+            if (crossSectionActiveClick && hasVisibleNonModelIntersection(e.intersections, e.object, clipLower, clipUpper)) {
+              return; // Don't stop propagation — support will handle the click.
+            }
+
             let clickHit: THREE.Intersection = e as unknown as THREE.Intersection;
             if (
               (clipUpper != null && e.point.z > clipUpper) ||
               (clipLower != null && e.point.z < clipLower)
             ) {
-              // If a visible support is behind the clipped surface, let the
-              // click propagate to it instead of consuming it for placement.
-              if (hasVisibleNonModelIntersection(e.intersections, e.object, clipLower, clipUpper)) {
-                return; // Don't stop propagation — support will handle the click.
-              }
               // Primary hit is in the clipped (hidden) zone. Cast directly
               // against this mesh to find the nearest visible-zone hit.
               const fallback = findClipAwareHit(e.ray, e.object, clipLower, clipUpper, e.distance);
@@ -878,13 +882,13 @@ if (uDitherAmount > 0.0) {
             return;
           }
 
-          // If the primary hit is in the clipped (invisible) zone and there is a
-          // visible support (or other non-model object) behind it, let the event
-          // propagate so the support can receive its hover event instead.
-          const primaryClipped =
-            (clipUpper != null && e.point.z > clipUpper) ||
-            (clipLower != null && e.point.z < clipLower);
-          if (primaryClipped && hasVisibleNonModelIntersection(e.intersections, e.object, clipLower, clipUpper)) {
+          // When cross-section is active and a visible support (or other
+          // non-model object) exists behind the model surface, let the event
+          // propagate so the support can receive hover — even if the model
+          // hit itself is in the visible zone (the ray may graze the outer
+          // wall on the way to a support visible through the opening).
+          const crossSectionActive = clipUpper != null || clipLower != null;
+          if (crossSectionActive && hasVisibleNonModelIntersection(e.intersections, e.object, clipLower, clipUpper)) {
             // Don't stop propagation — support behind the clipped surface will handle it.
             if (!hasExternalHoverSource) schedulePointerHover(false);
             onModelHoverPointChange?.(null);

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -893,9 +893,23 @@ if (uDitherAmount > 0.0) {
           // propagate so the support can receive hover — even if the model
           // hit itself is in the visible zone (the ray may graze the outer
           // wall on the way to a support visible through the opening).
+          //
+          // Also propagate when the primary model hit is in the clipped
+          // (invisible) zone — supports & instanced meshes inside the cavity
+          // must receive hover events even if they don't appear in the R3F
+          // intersection list at this stage.  In that case we still fall
+          // through to the placement-preview logic below so the clip-aware
+          // inner-wall hover preview can show.
           const crossSectionActive = clipUpper != null || clipLower != null;
-          if (crossSectionActive && hasVisibleNonModelIntersection(e.intersections, e.object, clipLower, clipUpper)) {
-            // Don't stop propagation — support behind the clipped surface will handle it.
+          const primaryInClippedZone = crossSectionActive && (
+            (clipUpper != null && e.point.z > clipUpper) ||
+            (clipLower != null && e.point.z < clipLower)
+          );
+          // Let events propagate when non-model geometry is behind the model.
+          const propagateForNonModel = crossSectionActive && hasVisibleNonModelIntersection(e.intersections, e.object, clipLower, clipUpper);
+          if (propagateForNonModel && !primaryInClippedZone) {
+            // Non-model is visible but model hit is in visible zone — suppress
+            // model hover and don't consume the event.
             if (!hasExternalHoverSource) schedulePointerHover(false);
             onModelHoverPointChange?.(null);
             onModelHoverModelChange?.(null);
@@ -906,12 +920,25 @@ if (uDitherAmount > 0.0) {
             return;
           }
 
-          e.stopPropagation();
+          // For clipped-zone hits, don't stop propagation but fall through
+          // to the placement-preview section so inner-wall hover still works.
+          if (!primaryInClippedZone) {
+            e.stopPropagation();
+          }
 
-          if (!hasExternalHoverSource) schedulePointerHover(true);
-          onModelHoverPointChange?.(e.point.clone());
-          onModelHoverModelChange?.(modelId);
-          emitImmediateModelHover(modelId);
+          if (primaryInClippedZone) {
+            // Primary hit is invisible — suppress model hover highlight but
+            // continue to the placement-preview section below.
+            if (!hasExternalHoverSource) schedulePointerHover(false);
+            onModelHoverPointChange?.(null);
+            onModelHoverModelChange?.(null);
+            emitImmediateModelHover(null);
+          } else {
+            if (!hasExternalHoverSource) schedulePointerHover(true);
+            onModelHoverPointChange?.(e.point.clone());
+            onModelHoverModelChange?.(modelId);
+            emitImmediateModelHover(modelId);
+          }
 
           if (mode === 'prepare' && transformMode === 'smoothing' && isActiveModel) {
             if (isGizmoHoverCategory || isSupportLikeHoverCategory) {

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -703,7 +703,6 @@ if (uDitherAmount > 0.0) {
       depthTest: true,
       depthWrite: false,
       clippingPlanes: planes,
-      clipIntersection: true,
       side: THREE.FrontSide,
       polygonOffset: true,
       polygonOffsetFactor: -1,
@@ -1135,7 +1134,6 @@ if (uDitherAmount > 0.0) {
             roughness={materialRoughness ?? 0.9}
             metalness={0.0}
             clippingPlanes={planes}
-            clipIntersection
             side={THREE.FrontSide}
           />
         ) : (

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -22,6 +22,47 @@ import type { SupportMode } from '@/supports/types';
 import { quaternionFromGlobalEuler } from '@/utils/rotation';
 import { emitImmediateModelHover } from '@/supports/interaction/pointerOcclusion';
 
+// Scratch raycaster reused for clip-zone fallback raycasts.
+const _clipFallbackRaycaster = new THREE.Raycaster();
+
+/**
+ * When the primary ray hit falls in the clipped (hidden) portion of a mesh,
+ * find the nearest hit within the visible Z range by raycasting with `near`
+ * set just past the clipped surface. This skips the outer wall entirely and
+ * uses firstHitOnly=true so the BVH stops at the very first triangle hit —
+ * O(log n) instead of scanning all faces.
+ */
+function findClipAwareHit(
+  ray: THREE.Ray,
+  mesh: THREE.Object3D,
+  clipLower: number | null | undefined,
+  clipUpper: number | null | undefined,
+  primaryDistance: number,
+): THREE.Intersection | null {
+  const rc = _clipFallbackRaycaster;
+  rc.ray.copy(ray);
+  // Skip past the already-found clipped surface.
+  rc.near = primaryDistance + 0.05;
+  // Bound the search — models fit within the build volume.
+  rc.far = primaryDistance + 500;
+  (rc as any).firstHitOnly = true;
+  const hits: THREE.Intersection[] = [];
+  (mesh as THREE.Mesh).raycast(rc, hits);
+  // Reset to safe defaults.
+  rc.near = 0;
+  rc.far = Infinity;
+  (rc as any).firstHitOnly = false;
+  if (hits.length === 0) return null;
+  const hit = hits[0];
+  if (
+    (clipUpper != null && hit.point.z > clipUpper) ||
+    (clipLower != null && hit.point.z < clipLower)
+  ) {
+    return null;
+  }
+  return hit;
+}
+
 function StlMeshComponent({
   geometry,
   clipLower,
@@ -767,8 +808,19 @@ if (uDitherAmount > 0.0) {
           // Support placement in support mode
           if (mode === 'support' && onSupportClick) {
             if (blockSupportPlacement) return;
+            let clickHit: THREE.Intersection = e as unknown as THREE.Intersection;
+            if (
+              (clipUpper != null && e.point.z > clipUpper) ||
+              (clipLower != null && e.point.z < clipLower)
+            ) {
+              // Primary hit is in the clipped (hidden) zone. Cast directly
+              // against this mesh to find the nearest visible-zone hit.
+              const fallback = findClipAwareHit(e.ray, e.object, clipLower, clipUpper, e.distance);
+              if (!fallback) return;
+              clickHit = fallback;
+            }
             e.stopPropagation();
-            onSupportClick(e as unknown as THREE.Intersection);
+            onSupportClick(clickHit);
           }
         }}
         onPointerMove={(e) => {
@@ -843,7 +895,24 @@ if (uDitherAmount > 0.0) {
               return;
             }
 
-            onSupportHover(e);
+            let hoverHit: THREE.Intersection = e as unknown as THREE.Intersection;
+            if (
+              (clipUpper != null && e.point.z > clipUpper) ||
+              (clipLower != null && e.point.z < clipLower)
+            ) {
+              // Primary hit is in the clipped (hidden) zone. Cast directly
+              // against this mesh to find the nearest visible-zone hit.
+              // (R3F + BVH may only provide one intersection per mesh via
+              // firstHitOnly, so we cannot rely on e.intersections here.)
+              const fallback = findClipAwareHit(e.ray, e.object, clipLower, clipUpper, e.distance);
+              if (!fallback) {
+                onSupportHover(null);
+                return;
+              }
+              hoverHit = fallback;
+            }
+
+            onSupportHover(hoverHit);
           }
         }}
         onPointerOut={(e) => {

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -1093,7 +1093,7 @@ if (uDitherAmount > 0.0) {
             depthWrite={false}
           />
         ) : typeof supportNonSelectedOpacity === 'number' ? (
-          <primitive object={supportDimMaterialObj} attach="material" />
+          supportDimMaterialObj ? <primitive object={supportDimMaterialObj} attach="material" /> : null
         ) : interactionLodActive ? (
           <meshStandardMaterial
             vertexColors={hasVertexColorAttribute}

--- a/src/components/scene/SceneCanvas/clipBoundsStore.ts
+++ b/src/components/scene/SceneCanvas/clipBoundsStore.ts
@@ -1,0 +1,19 @@
+/**
+ * Module-level store for the active cross-section clip bounds.
+ *
+ * Updated by SceneCanvas when clipUpper/clipLower props change.
+ * Read by BranchPlacementController (and any other code that does
+ * independent raycasting) to skip hits on clipped geometry.
+ */
+
+let _clipLower: number | null = null;
+let _clipUpper: number | null = null;
+
+export function setClipBounds(lower: number | null | undefined, upper: number | null | undefined): void {
+    _clipLower = lower ?? null;
+    _clipUpper = upper ?? null;
+}
+
+export function getClipBounds(): { clipLower: number | null; clipUpper: number | null } {
+    return { clipLower: _clipLower, clipUpper: _clipUpper };
+}

--- a/src/components/ui/SupportToasts.tsx
+++ b/src/components/ui/SupportToasts.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
+import { Toast } from '@/components/ui/primitives';
 
 export function SupportToasts({ message }: { message: string | null }) {
   if (!message) return null;
   return (
-    <div 
-      className="absolute top-4 left-1/2 -translate-x-1/2 bg-red-600 text-white px-4 py-2 rounded-lg shadow-lg text-sm font-medium z-50 transition-all duration-200 ease-out"
-      style={{ animation: 'fadeIn 0.2s ease-out' }}
-    >
-      {message}
+    <div className="absolute top-4 left-1/2 z-50 -translate-x-1/2">
+      <Toast
+        tone="error"
+        shape="rounded"
+        className="transition-all duration-200 ease-out"
+        style={{ animation: 'fadeIn 0.2s ease-out' }}
+      >
+        {message}
+      </Toast>
     </div>
   );
 }

--- a/src/components/ui/primitives/Toast.tsx
+++ b/src/components/ui/primitives/Toast.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { cn } from './cn';
+
+export type ToastTone = 'neutral' | 'info' | 'success' | 'warning' | 'error';
+
+const toastToneStyle: Record<ToastTone, React.CSSProperties> = {
+  neutral: {
+    borderColor: 'var(--border-subtle)',
+    background: 'var(--surface-0)',
+    color: 'var(--text-strong)',
+  },
+  info: {
+    borderColor: 'color-mix(in srgb, #60a5fa, var(--border-subtle) 50%)',
+    background: 'color-mix(in srgb, #60a5fa, var(--surface-0) 90%)',
+    color: 'var(--text-strong)',
+  },
+  success: {
+    borderColor: 'color-mix(in srgb, #22c55e, var(--border-subtle) 50%)',
+    background: 'color-mix(in srgb, #22c55e, var(--surface-0) 90%)',
+    color: 'var(--text-strong)',
+  },
+  warning: {
+    borderColor: 'color-mix(in srgb, #f59e0b, var(--border-subtle) 50%)',
+    background: 'color-mix(in srgb, #f59e0b, var(--surface-0) 90%)',
+    color: 'var(--text-strong)',
+  },
+  error: {
+    borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 50%)',
+    background: 'color-mix(in srgb, #ef4444, var(--surface-0) 90%)',
+    color: 'var(--text-strong)',
+  },
+};
+
+type ToastShape = 'pill' | 'rounded';
+
+export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
+  tone?: ToastTone;
+  shape?: ToastShape;
+  animated?: boolean;
+  visible?: boolean;
+  enterOffsetPx?: number;
+  pulse?: boolean;
+}
+
+export function Toast({
+  tone = 'info',
+  shape = 'pill',
+  animated = false,
+  visible = true,
+  enterOffsetPx = 8,
+  pulse = false,
+  className,
+  style,
+  children,
+  ...props
+}: ToastProps) {
+  const animationStyle: React.CSSProperties | undefined = animated
+    ? {
+        opacity: visible ? 1 : 0,
+        transform: `translateY(${visible ? '0px' : `${enterOffsetPx}px`})`,
+        transition: 'opacity 220ms ease, transform 220ms ease',
+      }
+    : undefined;
+
+  return (
+    <div
+      className={cn(
+        'border px-4 py-2 text-sm font-semibold shadow-lg',
+        shape === 'pill' ? 'rounded-full' : 'rounded-lg',
+        pulse ? 'motion-safe:animate-pulse' : '',
+        className,
+      )}
+      style={{
+        ...toastToneStyle[tone],
+        ...animationStyle,
+        ...style,
+      }}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+type ToastViewportPosition = 'bottom-center' | 'top-center';
+
+export interface ToastViewportProps extends React.HTMLAttributes<HTMLDivElement> {
+  position?: ToastViewportPosition;
+  offset?: number | string;
+  zIndex?: number;
+}
+
+function resolveOffsetValue(offset: number | string | undefined, fallback: string): string {
+  if (typeof offset === 'number' && Number.isFinite(offset)) {
+    return `${offset}px`;
+  }
+
+  if (typeof offset === 'string' && offset.trim().length > 0) {
+    return offset;
+  }
+
+  return fallback;
+}
+
+export function ToastViewport({
+  position = 'bottom-center',
+  offset,
+  zIndex,
+  className,
+  style,
+  children,
+  ...props
+}: ToastViewportProps) {
+  const offsetValue = resolveOffsetValue(
+    offset,
+    position === 'top-center' ? '1rem' : '1.25rem',
+  );
+
+  const positionStyle: React.CSSProperties = position === 'top-center'
+    ? { top: offsetValue }
+    : { bottom: offsetValue };
+
+  return (
+    <div
+      className={cn('pointer-events-none fixed inset-x-0 flex justify-center px-3', className)}
+      style={{
+        ...positionStyle,
+        ...(zIndex != null ? { zIndex } : null),
+        ...style,
+      }}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/primitives/index.ts
+++ b/src/components/ui/primitives/index.ts
@@ -3,4 +3,5 @@ export { IconButton } from './IconButton';
 export { Input } from './Input';
 export { Select } from './Select';
 export { Card, CardHeader } from './Card';
+export { Toast, ToastViewport } from './Toast';
 export { cn } from './cn';

--- a/src/features/shaders/mesh/flatUnlit.tsx
+++ b/src/features/shaders/mesh/flatUnlit.tsx
@@ -41,7 +41,6 @@ export function FlatUnlitMaterial({
       vertexColors={useVertexColors ?? true}
       color={useVertexColors ?? true ? tintColor : flatColor}
       clippingPlanes={clippingPlanes}
-      clipIntersection
       side={THREE.FrontSide}
     />
   );

--- a/src/features/shaders/mesh/matcap.tsx
+++ b/src/features/shaders/mesh/matcap.tsx
@@ -98,7 +98,6 @@ export function MatcapMaterial({
       color={tintColor}
       matcap={matcap}
       clippingPlanes={clippingPlanes}
-      clipIntersection
       side={THREE.FrontSide}
     />
   );

--- a/src/features/shaders/mesh/normalDebug.tsx
+++ b/src/features/shaders/mesh/normalDebug.tsx
@@ -8,7 +8,6 @@ export function NormalDebugMaterial({
   return (
     <meshNormalMaterial
       clippingPlanes={clippingPlanes}
-      clipIntersection
       side={THREE.FrontSide}
     />
   );

--- a/src/features/shaders/mesh/opaqueWireMesh.tsx
+++ b/src/features/shaders/mesh/opaqueWireMesh.tsx
@@ -9,7 +9,6 @@ export function OpaqueWireOverlayMaterial({
     <meshBasicMaterial
       color="#AAAAAA"
       clippingPlanes={clippingPlanes}
-      clipIntersection
       side={THREE.DoubleSide}
       wireframe
       polygonOffset

--- a/src/features/shaders/mesh/overhangHeatmap.tsx
+++ b/src/features/shaders/mesh/overhangHeatmap.tsx
@@ -69,7 +69,6 @@ export function OverhangHeatmapMaterial({
             roughness={materialRoughness ?? 0.9}
             envMapIntensity={0.34}
             clippingPlanes={clippingPlanes}
-            clipIntersection
             side={THREE.FrontSide}
             flatShading={false}
             onBeforeCompile={(shader) => {

--- a/src/features/shaders/mesh/softClay.tsx
+++ b/src/features/shaders/mesh/softClay.tsx
@@ -46,7 +46,6 @@ export function SoftClayMaterial({
       roughness={materialRoughness ?? 0.9}
       envMapIntensity={0.34}
       clippingPlanes={clippingPlanes}
-      clipIntersection
       side={THREE.FrontSide}
       flatShading={false}
       onBeforeCompile={(shader) => {

--- a/src/features/shaders/mesh/toon.tsx
+++ b/src/features/shaders/mesh/toon.tsx
@@ -76,7 +76,6 @@ export function ToonMaterial({
       emissive="#000000"
       emissiveIntensity={0}
       clippingPlanes={clippingPlanes}
-      clipIntersection
       side={THREE.FrontSide}
     />
   );

--- a/src/features/shaders/mesh/wireframe.tsx
+++ b/src/features/shaders/mesh/wireframe.tsx
@@ -33,7 +33,6 @@ export function WireframeMaterial({
     <meshBasicMaterial
       color={wireColor}
       clippingPlanes={clippingPlanes}
-      clipIntersection
       side={THREE.FrontSide}
       wireframe
       polygonOffset

--- a/src/features/shaders/mesh/xray.tsx
+++ b/src/features/shaders/mesh/xray.tsx
@@ -47,7 +47,6 @@ export function XrayMaterial({
       opacity={opacity ?? 0.25}
       depthWrite={false}
       clippingPlanes={clippingPlanes}
-      clipIntersection
       side={THREE.DoubleSide}
     />
   );

--- a/src/features/slicing/useSlicingManager.ts
+++ b/src/features/slicing/useSlicingManager.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useMemo, useCallback, type SetStateAction } from 'react';
-import type { GeometryWithBounds } from '@/hooks/useStlGeometry';
 
 interface SlicingStateProps {
   hasGeometry: boolean;
@@ -10,6 +9,7 @@ export function useSlicingManager({ hasGeometry, zRange }: SlicingStateProps) {
   const [layerHeightMicron, setLayerHeightMicron] = useState<number>(50);
   const [crossSectionMode, setCrossSectionMode] = useState<'smooth' | 'rasterized'>('smooth');
   const [layerIndex, setLayerIndexState] = useState<number>(0);
+  const [lowerLayerIndex, setLowerLayerIndexState] = useState<number>(0);
 
   const layerHeightMm = useMemo(() => layerHeightMicron / 1000, [layerHeightMicron]);
 
@@ -29,7 +29,7 @@ export function useSlicingManager({ hasGeometry, zRange }: SlicingStateProps) {
     heightMm > 0 && layerHeightMm > 0 ? Math.ceil(heightMm / layerHeightMm) : 0
   ), [heightMm, layerHeightMm]);
 
-  const clampLayerIndex = useCallback((value: number) => {
+  const clampLayerIndex = useCallback((value: number): number => {
     const safeValue = Number.isFinite(value) ? Math.round(value) : 0;
     const maxLayer = Math.max(0, numLayers);
     return Math.max(0, Math.min(maxLayer, safeValue));
@@ -45,6 +45,16 @@ export function useSlicingManager({ hasGeometry, zRange }: SlicingStateProps) {
     });
   }, [clampLayerIndex]);
 
+  const setLowerLayerIndex = useCallback((next: SetStateAction<number>) => {
+    setLowerLayerIndexState((previous) => {
+      const resolved = typeof next === 'function'
+        ? (next as (prevState: number) => number)(previous)
+        : next;
+      const clamped = clampLayerIndex(resolved);
+      return previous === clamped ? previous : clamped;
+    });
+  }, [clampLayerIndex]);
+
   useEffect(() => {
     setLayerIndexState((previous) => {
       const clamped = clampLayerIndex(previous);
@@ -52,20 +62,46 @@ export function useSlicingManager({ hasGeometry, zRange }: SlicingStateProps) {
     });
   }, [clampLayerIndex]);
 
+  useEffect(() => {
+    setLowerLayerIndexState((previous) => {
+      const clamped = clampLayerIndex(previous);
+      return previous === clamped ? previous : clamped;
+    });
+  }, [clampLayerIndex]);
+
+  // Derive an ordered layer pair for clipping so lower-slider drags cannot
+  // accidentally invalidate clipping (e.g. transient lower > upper).
+  const orderedLayerRange = useMemo(() => {
+    const upper = Math.max(layerIndex, lowerLayerIndex);
+    const lower = Math.min(layerIndex, lowerLayerIndex);
+    return { lower, upper };
+  }, [layerIndex, lowerLayerIndex]);
+
   const currentHeightMm = useMemo(() => {
     if (!hasGeometry) return 0;
-    const height = layerIndex * layerHeightMm;
+    const height = orderedLayerRange.upper * layerHeightMm;
     return Math.min(Math.max(height, 0), Math.max(heightMm, 0));
-  }, [hasGeometry, layerIndex, layerHeightMm, heightMm]);
+  }, [hasGeometry, orderedLayerRange.upper, layerHeightMm, heightMm]);
 
-  const clipLower = useMemo(() => null, []); // Always show from bottom
+  const lowerCurrentHeightMm = useMemo(() => {
+    if (!hasGeometry) return 0;
+    const height = orderedLayerRange.lower * layerHeightMm;
+    return Math.min(Math.max(height, 0), Math.max(heightMm, 0));
+  }, [hasGeometry, orderedLayerRange.lower, layerHeightMm, heightMm]);
+
+  const clipLower = useMemo(() => {
+    if (!hasGeometry || orderedLayerRange.lower === 0) return null;
+    const EPS = 1e-6;
+    const lower = zRange.min + (orderedLayerRange.lower * layerHeightMm) - EPS;
+    return Math.min(Math.max(lower, zRange.min - EPS), zRange.max);
+  }, [hasGeometry, orderedLayerRange.lower, zRange, layerHeightMm]);
 
   const clipUpper = useMemo(() => {
-    if (!hasGeometry || layerIndex === 0) return null;
+    if (!hasGeometry || orderedLayerRange.upper === 0) return null;
     const EPS = 1e-6;
-    const upper = zRange.min + (layerIndex * layerHeightMm) + EPS;
+    const upper = zRange.min + (orderedLayerRange.upper * layerHeightMm) + EPS;
     return Math.min(Math.max(upper, zRange.min), zRange.max + EPS);
-  }, [hasGeometry, layerIndex, zRange, layerHeightMm]);
+  }, [hasGeometry, orderedLayerRange.upper, zRange, layerHeightMm]);
 
   return {
     layerHeightMicron,
@@ -74,9 +110,12 @@ export function useSlicingManager({ hasGeometry, zRange }: SlicingStateProps) {
     setCrossSectionMode,
     layerIndex,
     setLayerIndex,
+    lowerLayerIndex,
+    setLowerLayerIndex,
     layerHeightMm,
     heightMm,
     currentHeightMm,
+    lowerCurrentHeightMm,
     numLayers,
     clipLower,
     clipUpper

--- a/src/features/slicing/useSlicingManager.ts
+++ b/src/features/slicing/useSlicingManager.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback, type SetStateAction } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef, type SetStateAction } from 'react';
 
 interface SlicingStateProps {
   hasGeometry: boolean;
@@ -10,6 +10,7 @@ export function useSlicingManager({ hasGeometry, zRange }: SlicingStateProps) {
   const [crossSectionMode, setCrossSectionMode] = useState<'smooth' | 'rasterized'>('smooth');
   const [layerIndex, setLayerIndexState] = useState<number>(0);
   const [lowerLayerIndex, setLowerLayerIndexState] = useState<number>(0);
+  const topSliderInitializedRef = useRef(false);
 
   const layerHeightMm = useMemo(() => layerHeightMicron / 1000, [layerHeightMicron]);
 
@@ -69,6 +70,28 @@ export function useSlicingManager({ hasGeometry, zRange }: SlicingStateProps) {
     });
   }, [clampLayerIndex]);
 
+  // Default UX: on a fresh geometry session, keep bottom slider at 0 and
+  // initialize the top slider to max so users start with full-height view.
+  // Do this once per "no-geometry -> geometry" transition only.
+  useEffect(() => {
+    if (!hasGeometry) {
+      topSliderInitializedRef.current = false;
+      return;
+    }
+
+    if (numLayers <= 0) return;
+    if (topSliderInitializedRef.current) return;
+
+    // Respect pre-existing/restored layer state if it was already set.
+    if (layerIndex !== 0 || lowerLayerIndex !== 0) {
+      topSliderInitializedRef.current = true;
+      return;
+    }
+
+    setLayerIndexState(numLayers);
+    topSliderInitializedRef.current = true;
+  }, [hasGeometry, layerIndex, lowerLayerIndex, numLayers]);
+
   // Derive an ordered layer pair for clipping so lower-slider drags cannot
   // accidentally invalidate clipping (e.g. transient lower > upper).
   const orderedLayerRange = useMemo(() => {
@@ -97,11 +120,18 @@ export function useSlicingManager({ hasGeometry, zRange }: SlicingStateProps) {
   }, [hasGeometry, orderedLayerRange.lower, zRange, layerHeightMm]);
 
   const clipUpper = useMemo(() => {
-    if (!hasGeometry || orderedLayerRange.upper === 0) return null;
+    if (!hasGeometry) return null;
+
+    // Disable upper clipping at either edge of the slider range.
+    // - upper=0: historical behavior
+    // - upper=max: new default-rest behavior (top slider parked at max)
+    const maxLayer = Math.max(0, numLayers);
+    if (orderedLayerRange.upper === 0 || orderedLayerRange.upper >= maxLayer) return null;
+
     const EPS = 1e-6;
     const upper = zRange.min + (orderedLayerRange.upper * layerHeightMm) + EPS;
     return Math.min(Math.max(upper, zRange.min), zRange.max + EPS);
-  }, [hasGeometry, orderedLayerRange.upper, zRange, layerHeightMm]);
+  }, [hasGeometry, numLayers, orderedLayerRange.upper, zRange, layerHeightMm]);
 
   return {
     layerHeightMicron,

--- a/src/supports/PlacementLogic/Grid/gridPlacement.ts
+++ b/src/supports/PlacementLogic/Grid/gridPlacement.ts
@@ -417,6 +417,9 @@ function findNearestReachableHostTrunkAttachment(args: {
         : null;
 }
 
+// Reusable raycaster for trunk collision checks — avoids allocating one per call.
+const _trunkCollisionRaycaster = new THREE.Raycaster();
+
 function trunkCollidesWithMesh(
     candidate: TrunkBuildResult,
     settings: DecideGridPlacementArgs['settings'],
@@ -425,7 +428,7 @@ function trunkCollidesWithMesh(
     const trunk = candidate.trunk;
     const root = candidate.root;
     const collisionRadius = settings.shaft.diameterMm / 2 + MIN_TRUNK_CLEARANCE_MM;
-    const raycaster = new THREE.Raycaster();
+    const raycaster = _trunkCollisionRaycaster;
 
     for (let segIndex = 0; segIndex < trunk.segments.length; segIndex++) {
         const endpoints = getTrunkSegmentEndpointsWithSettings(trunk, root, segIndex, settings);

--- a/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
+++ b/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
@@ -51,6 +51,26 @@ export interface GridAStarOptions {
      * rejects those positions so the A* keeps searching.
      */
     goalValidator?: (wx: number, wy: number, wz: number) => boolean;
+    /**
+     * When true, each neighbor edge collision check uses `sdf.isBlocked` on
+     * the endpoint cell only instead of the full `sdf.segmentBlocked` sweep.
+     *
+     * **Why this matters for preview performance:**
+     * The A* grid step is 2mm but the SDF cell size is 0.5mm. `segmentBlocked`
+     * samples at 0.5mm intervals, generating 5–8 BVH queries per edge. The
+     * intermediate sample points are never grid-aligned → they can NEVER hit
+     * the SDF cache → permanent cold BVH misses on every A* frame. With 26
+     * neighbors × 600 expansions this means ~30,000–60,000 uncacheable BVH
+     * queries per hover frame regardless of how warm the cache is.
+     *
+     * With endpoint-only checks, each neighbor issues exactly 1 BVH query at a
+     * grid-aligned position that IS cached after first visit. Cold cost drops
+     * from ~30k to ~600 BVH calls on first approach to a new region.
+     *
+     * Trade-off: geometry thinner than the grid step (2mm) is not detected.
+     * Acceptable for hover preview — click-time always uses full resolution.
+     */
+    endpointOnlyCollisionCheck?: boolean;
 }
 
 export interface GridAStarResult {
@@ -307,10 +327,13 @@ export function gridAStar(
             }
             // n.dz > 0 (upward) — no angle constraint, always allowed if within climb limit
 
-            // SDF collision check: validate the entire edge from current → neighbor
-            // using fine-resolution segment checks (SDF cellSize intervals).
-            // The pathfinding grid is coarser than the SDF grid, so we must
-            // check intermediate points to catch geometry between grid cells.
+            // SDF collision check.
+            // Full mode: fine-resolution segment check at SDF cellSize intervals.
+            // Endpoint-only mode (preview): just check the destination cell.
+            //   The intermediate sample points in segmentBlocked are NOT grid-aligned
+            //   and can never hit the SDF cache, producing permanent cold BVH misses
+            //   on every frame. Endpoint cells ARE on the 2mm grid and are cached
+            //   after first visit, so preview A* becomes cheap on revisits.
             const cwx = current.x * step;
             const cwy = current.y * step;
             const cwz = current.z * step;
@@ -318,7 +341,10 @@ export function gridAStar(
             const wy = ny * step;
             const wz = nz * step;
 
-            if (sdf.segmentBlocked(cwx, cwy, cwz, wx, wy, wz, clearance)) continue;
+            if (opts.endpointOnlyCollisionCheck
+                ? sdf.isBlocked(wx, wy, wz, clearance)
+                : sdf.segmentBlocked(cwx, cwy, cwz, wx, wy, wz, clearance)
+            ) continue;
 
             // Support occupancy check
             if (occupancy && occupancy.isOccupied(wx, wy, wz, ignoreSupportId)) continue;

--- a/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
+++ b/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
@@ -12,6 +12,11 @@
  *   protrusions — without this, any geometry below the socket is impassable
  * - **Goal validation**: roots collision check integrated into goal acceptance
  * - **Frame-coherent warm-start**: reuses open set between frames
+ *
+ * Cost priorities (in order):
+ * 1. **Shortest collision-free path** — base euclidean distance (moveCost)
+ * 2. **Greatest verticality**         — lateral XY movement is penalised
+ * 3. **Least shallow angles**         — quadratic penalty on lateral/drop ratio
  */
 
 import { Vec3 } from '../../types';
@@ -184,7 +189,7 @@ export function gridAStar(
 
     // Maximum upward climb in grid cells — allows routing over protrusions
     // but prevents the path from going far above the socket
-    const maxClimbCells = Math.max(3, Math.ceil(10 / step)); // up to ~10mm above start
+    const maxClimbCells = Math.max(5, Math.ceil(20 / step)); // up to ~20mm above start
 
     const q = (v: number) => Math.round(v / step);
 
@@ -230,7 +235,7 @@ export function gridAStar(
     // and the expansion count when it last improved. If 250 expansions pass
     // without any Z improvement, the search is stuck and will never reach
     // the goal — abort instead of burning the full 2000-expansion budget.
-    const STAGNATION_LIMIT = 100;
+    const STAGNATION_LIMIT = 250;
     let bestZReached = sqz;
     let lastZProgressAt = 0;
 
@@ -314,13 +319,41 @@ export function gridAStar(
             // Support occupancy check
             if (occupancy && occupancy.isOccupied(wx, wy, wz, ignoreSupportId)) continue;
 
-            // Cost: base movement cost + proximity penalty (prefer paths with more clearance)
+            // ---- Priority-based cost function ----
+            //
+            // 1. Shortest collision-free path (base euclidean distance)
+            // 2. Greatest verticality   (penalise lateral XY movement)
+            // 3. Least shallow angles   (penalise high lateral-to-drop ratio)
+
+            // (1) Base movement cost — euclidean distance in mm
+            const moveCost = n.cost * step;
+
+            // (2) Verticality penalty — pure-vertical moves are free;
+            //     lateral component is penalised proportionally.
+            const lateralCells = Math.sqrt(n.dx * n.dx + n.dy * n.dy);
+            const verticalityPenalty = lateralCells * step * 1.5;
+
+            // (3) Shallow-angle penalty — quadratic in lateral/drop ratio
+            //     so near-vertical moves are cheap; near-horizontal expensive.
+            let shallowAnglePenalty = 0;
+            if (lateralCells > 0) {
+                if (n.dz !== 0) {
+                    const ratio = lateralCells / Math.abs(n.dz);
+                    shallowAnglePenalty = ratio * ratio * step * 0.8;
+                } else {
+                    // Pure horizontal: maximum angle penalty
+                    shallowAnglePenalty = step * 4.0;
+                }
+            }
+
+            // Proximity penalty — prefer paths with more clearance from mesh
             const dist = sdf.distanceAt(wx, wy, wz);
             const clearancePenalty = dist < clearance * 2 ? (clearance * 2 - dist) * 0.5 : 0;
-            // Penalize upward movement heavily to prefer downward paths
+
+            // Climb penalty — heavily discourage upward movement
             const climbPenalty = n.dz > 0 ? step * 3 : 0;
-            const moveCost = n.cost * step;
-            const tentativeG = current.g + moveCost + clearancePenalty + climbPenalty;
+
+            const tentativeG = current.g + moveCost + verticalityPenalty + shallowAnglePenalty + clearancePenalty + climbPenalty;
 
             const existingG = gScore.get(nKey);
             if (existingG !== undefined && tentativeG >= existingG) continue;

--- a/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
+++ b/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
@@ -62,6 +62,10 @@ export interface GridAStarResult {
     reached: boolean;
     /** True if the search was terminated early due to lack of Z progress (cavity). */
     stagnated: boolean;
+    /** True if the search exhausted its expansion budget without reaching the goal.
+     *  Distinct from stagnated: the search was making progress but ran out of budget.
+     *  When true, V1 raycast fallback is also very unlikely to succeed. */
+    hitExpansionLimit: boolean;
     /** Reusable warm-start state for the next frame. */
     warmState: WarmStartState | null;
 }
@@ -368,6 +372,7 @@ export function gridAStar(
 
     // ---- Reconstruct path ----
     const stagnated = !goalEntry && (expansions - lastZProgressAt > STAGNATION_LIMIT);
+    const hitExpansionLimit = !goalEntry && !stagnated && expansions >= maxExp;
 
     if (!goalEntry) {
         return {
@@ -375,9 +380,10 @@ export function gridAStar(
             expansions,
             reached: false,
             stagnated,
+            hitExpansionLimit,
             warmState: stagnated ? null : {
                 socketPos: { ...startPos },
-                openEntries: openSet.slice(0, 64), // keep top entries for next frame
+                openEntries: openSet.slice(0, 64),
                 gScores: gScore,
                 cameFrom,
             },
@@ -430,6 +436,7 @@ export function gridAStar(
         expansions,
         reached: true,
         stagnated: false,
+        hitExpansionLimit: false,
         warmState: {
             socketPos: { ...startPos },
             openEntries: [], // search complete, no reuse needed

--- a/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
+++ b/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
@@ -230,7 +230,7 @@ export function gridAStar(
     // and the expansion count when it last improved. If 250 expansions pass
     // without any Z improvement, the search is stuck and will never reach
     // the goal — abort instead of burning the full 2000-expansion budget.
-    const STAGNATION_LIMIT = 250;
+    const STAGNATION_LIMIT = 100;
     let bestZReached = sqz;
     let lastZProgressAt = 0;
 

--- a/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
+++ b/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
@@ -55,6 +55,8 @@ export interface GridAStarResult {
     expansions: number;
     /** Whether the path reached the goal region. */
     reached: boolean;
+    /** True if the search was terminated early due to lack of Z progress (cavity). */
+    stagnated: boolean;
     /** Reusable warm-start state for the next frame. */
     warmState: WarmStartState | null;
 }
@@ -223,11 +225,27 @@ export function gridAStar(
     let expansions = 0;
     let goalEntry: AStarEntry | null = null;
 
+    // Stagnation detection: bail early when the search is trapped in a
+    // cavity and cannot make downward progress. Track the lowest Z reached
+    // and the expansion count when it last improved. If 250 expansions pass
+    // without any Z improvement, the search is stuck and will never reach
+    // the goal — abort instead of burning the full 2000-expansion budget.
+    const STAGNATION_LIMIT = 250;
+    let bestZReached = sqz;
+    let lastZProgressAt = 0;
+
     while (openSet.length > 0 && expansions < maxExp) {
         const current = heapPop(openSet)!;
         if (closedSet.has(current.key)) continue;
         closedSet.add(current.key);
         expansions++;
+
+        // Track Z progress for stagnation detection
+        if (current.z < bestZReached) {
+            bestZReached = current.z;
+            lastZProgressAt = expansions;
+        }
+        if (expansions - lastZProgressAt > STAGNATION_LIMIT) break;
 
         // Goal check: reached the target Z layer
         if (current.z <= gqz) {
@@ -316,12 +334,15 @@ export function gridAStar(
     }
 
     // ---- Reconstruct path ----
+    const stagnated = !goalEntry && (expansions - lastZProgressAt > STAGNATION_LIMIT);
+
     if (!goalEntry) {
         return {
             path: [],
             expansions,
             reached: false,
-            warmState: {
+            stagnated,
+            warmState: stagnated ? null : {
                 socketPos: { ...startPos },
                 openEntries: openSet.slice(0, 64), // keep top entries for next frame
                 gScores: gScore,
@@ -375,6 +396,7 @@ export function gridAStar(
         path: simplified,
         expansions,
         reached: true,
+        stagnated: false,
         warmState: {
             socketPos: { ...startPos },
             openEntries: [], // search complete, no reuse needed

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -211,7 +211,7 @@ export function calculateSmartPlacementV2(
     const diskHeight = settings.roots.diskHeightMm;
     const coneHeight = settings.roots.coneHeightMm;
     const minRoutedTrunkAngleDeg = settings.grid.minRoutedTrunkAngleDeg;
-    const maxTotalLateralMm = Math.max(18, settings.grid.spacingMm * 5);
+    const maxTotalLateralMm = Math.max(30, settings.grid.spacingMm * 8);
 
     // 1. Standard placement (baseline — no collision check)
     const standard = calculateStandardPlacement(input);
@@ -252,15 +252,13 @@ export function calculateSmartPlacementV2(
         return { ...standard, error: 'COLLISION_WITH_MODEL', stagnated: true };
     }
 
-    // 3c. Quick vertical solvability check: sample a few points along the
-    //     straight-down axis. If the majority are deeply inside the mesh
-    //     (negative SDF), the A* has no realistic chance of finding a path
-    //     around the obstruction — bail early to avoid burning expansions.
-    //     This catches thick-walled cavities before any A* work.
+    // 3c. Quick vertical solvability check: sample points along the
+    //     straight-down axis AND at lateral offsets.  Only bail if the
+    //     obstruction is thick AND there's no lateral escape route.
     const vertSpan = socketPos.z - rootTopZ;
     if (vertSpan > 1) {
-        const VERT_SAMPLES = 5;
-        const deepThreshold = -clearance * 2;
+        const VERT_SAMPLES = 7;
+        const deepThreshold = -clearance * 3;
         let deeplyBlockedCount = 0;
         for (let i = 1; i <= VERT_SAMPLES; i++) {
             const t = i / (VERT_SAMPLES + 1);
@@ -269,9 +267,24 @@ export function calculateSmartPlacementV2(
                 deeplyBlockedCount++;
             }
         }
-        if (deeplyBlockedCount >= 3) {
-            recordStagnation(mesh.uuid, socketPos);
-            return { ...standard, error: 'COLLISION_WITH_MODEL', stagnated: true };
+        // Only bail if almost ALL samples are deeply blocked — meaning true
+        // cavity with no thin-wall escape.  Also probe a few lateral offsets
+        // to confirm there's no nearby gap the A* could exploit.
+        if (deeplyBlockedCount >= 6) {
+            const PROBE_OFFSETS = [clearance * 4, -clearance * 4];
+            let anyLateralClear = false;
+            const probeZ = socketPos.z - vertSpan * 0.5;
+            for (const off of PROBE_OFFSETS) {
+                if (sdf.distanceAt(socketPos.x + off, socketPos.y, probeZ) > clearance ||
+                    sdf.distanceAt(socketPos.x, socketPos.y + off, probeZ) > clearance) {
+                    anyLateralClear = true;
+                    break;
+                }
+            }
+            if (!anyLateralClear) {
+                recordStagnation(mesh.uuid, socketPos);
+                return { ...standard, error: 'COLLISION_WITH_MODEL', stagnated: true };
+            }
         }
     }
 

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -48,6 +48,10 @@ export interface SmartPlacementV2Context {
     /** Override the A* expansion budget (default 2000). Pass a lower value for
      *  hover preview to reduce first-frame cost at transition-zone positions. */
     maxExpansions?: number;
+    /** When true, enables the preview-exhausted spatial cache so positions where A*
+     *  exhausts its reduced preview budget are fast-failed on subsequent hover frames.
+     *  Must NOT be set for click-time placement — only for hover preview. */
+    isPreview?: boolean;
 }
 
 // ---------- Constants ----------
@@ -58,6 +62,84 @@ const MAX_NEAREST_NODE_SEARCH_RINGS = 4;
 const ROOTS_DISK_PERIMETER_SAMPLES = 16;
 /** Safety margin in mm added to all roots volume checks. */
 const ROOTS_DISK_SAFETY_MM = 0.5;
+
+/**
+ * Preview-mode coarse sampling constants.
+ *
+ * The SDF cache cell size is 0.5mm; segmentBlocked samples at that interval,
+ * so a 50mm straight-down shaft triggers ~100 BVH closestPointToPoint calls
+ * on first hover (cold cache). rootsDiskBlocked compounds it with up to 170
+ * more per check. On cold cache every call is a full BVH traversal (~0.1ms
+ * on complex meshes), causing a visible hitch on the very first hover over
+ * any new area of the model.
+ *
+ * For hover preview we use 2mm steps (matching A* step size) for segment
+ * checks and a 3-slice/6-point roots sweep. This reduces first-hover BVH
+ * queries from ~270 to ~50 — a 5× reduction — while keeping accuracy
+ * sufficient for preview (click-time always uses full resolution).
+ */
+const PREVIEW_SEGMENT_STEP_MM = 2.0;   // matches A* step size
+const ROOTS_DISK_QUICK_Z_SLICES = 3;   // vs max(4, ceil(rootTopZ/0.5)) ≈ 10
+const ROOTS_DISK_QUICK_PERIMETER_SAMPLES = 6;  // vs 16
+
+/**
+ * Coarse segment-blocked check for hover preview.
+ * Samples at `stepMm` intervals instead of the SDF cell size (0.5mm),
+ * trading the ability to detect very thin (< 2mm) geometry for ~4× fewer
+ * BVH queries. Acceptable for preview; click-time uses the full sdf method.
+ */
+function segmentBlockedCoarse(
+    sdf: SDFCache,
+    ax: number, ay: number, az: number,
+    bx: number, by: number, bz: number,
+    clearance: number,
+    stepMm: number,
+): boolean {
+    const dx = bx - ax, dy = by - ay, dz = bz - az;
+    const len = Math.sqrt(dx * dx + dy * dy + dz * dz);
+    if (len < 0.01) return sdf.isBlocked(ax, ay, az, clearance);
+    const steps = Math.max(1, Math.ceil(len / stepMm));
+    const inv = 1 / steps;
+    for (let i = 0; i <= steps; i++) {
+        const t = i * inv;
+        if (sdf.isBlocked(ax + dx * t, ay + dy * t, az + dz * t, clearance)) return true;
+    }
+    return false;
+}
+
+/**
+ * Quick (reduced-sample) roots-disk blocked check for hover preview.
+ * Uses 3 Z slices and 6 perimeter points vs the full sweep (~10 slices × 17
+ * points). Reduces first-hover BVH calls from ~170 to ~28 for this check.
+ */
+function quickRootsDiskBlocked(
+    sdf: SDFCache,
+    centerX: number,
+    centerY: number,
+    diskHeight: number,
+    coneHeight: number,
+    rootsRadius: number,
+    shaftRadius: number,
+): boolean {
+    const safety = ROOTS_DISK_SAFETY_MM;
+    const rootTopZ = diskHeight + coneHeight;
+    for (let zi = 0; zi <= ROOTS_DISK_QUICK_Z_SLICES; zi++) {
+        const z = (zi / ROOTS_DISK_QUICK_Z_SLICES) * rootTopZ;
+        let radiusAtZ: number;
+        if (z <= diskHeight) {
+            radiusAtZ = rootsRadius;
+        } else {
+            const t = coneHeight > 0 ? (z - diskHeight) / coneHeight : 1;
+            radiusAtZ = rootsRadius + t * (shaftRadius - rootsRadius);
+        }
+        if (sdf.isBlocked(centerX, centerY, z, safety)) return true;
+        for (let i = 0; i < ROOTS_DISK_QUICK_PERIMETER_SAMPLES; i++) {
+            const angle = (i / ROOTS_DISK_QUICK_PERIMETER_SAMPLES) * Math.PI * 2;
+            if (sdf.isBlocked(centerX + Math.cos(angle) * radiusAtZ, centerY + Math.sin(angle) * radiusAtZ, z, safety)) return true;
+        }
+    }
+    return false;
+}
 
 // ---------- Roots cone volume check ----------
 
@@ -139,12 +221,14 @@ export function clearSDFCacheForMesh(meshUuid: string): void {
         sdfCachePool.delete(meshUuid);
     }
     stagnationCache.delete(meshUuid);
+    previewExhaustedCache.delete(meshUuid);
 }
 
 export function clearAllSDFCaches(): void {
     for (const cache of sdfCachePool.values()) cache.clear();
     sdfCachePool.clear();
     stagnationCache.clear();
+    previewExhaustedCache.clear();
 }
 
 // ---------- Main API ----------
@@ -168,8 +252,19 @@ const STAGNATION_RADIUS_SQ = STAGNATION_RADIUS_MM * STAGNATION_RADIUS_MM;
 const MAX_STAGNATION_ENTRIES = 512;
 const stagnationCache = new Map<string, Vec3[]>();
 
-function isNearStagnationPoint(meshUuid: string, pos: Vec3): boolean {
-    const points = stagnationCache.get(meshUuid);
+/**
+ * Preview-exhausted cache — records socketPos positions where the A* exhausted
+ * its REDUCED preview budget (≠ true stagnation) so that subsequent hover frames
+ * at similar positions skip the 600-expansion A* run entirely.
+ *
+ * Separate from stagnationCache so click-time placement (full 2000-expansion
+ * budget) is never affected — only hover preview fast-paths through this cache.
+ * Keyed by mesh uuid; cleared alongside stagnationCache.
+ */
+const previewExhaustedCache = new Map<string, Vec3[]>();
+
+function isNearSpatialPoint(cache: Map<string, Vec3[]>, meshUuid: string, pos: Vec3): boolean {
+    const points = cache.get(meshUuid);
     if (!points || points.length === 0) return false;
     for (let i = 0; i < points.length; i++) {
         const p = points[i];
@@ -181,19 +276,25 @@ function isNearStagnationPoint(meshUuid: string, pos: Vec3): boolean {
     return false;
 }
 
-function recordStagnation(meshUuid: string, pos: Vec3): void {
-    let points = stagnationCache.get(meshUuid);
+function recordSpatialPoint(cache: Map<string, Vec3[]>, meshUuid: string, pos: Vec3): void {
+    let points = cache.get(meshUuid);
     if (!points) {
         points = [];
-        stagnationCache.set(meshUuid, points);
+        cache.set(meshUuid, points);
     }
-    // Don't add if already near an existing entry
-    if (isNearStagnationPoint(meshUuid, pos)) return;
+    if (isNearSpatialPoint(cache, meshUuid, pos)) return;
     if (points.length >= MAX_STAGNATION_ENTRIES) {
-        // Evict oldest entries
         points.splice(0, points.length - MAX_STAGNATION_ENTRIES + 1);
     }
     points.push({ x: pos.x, y: pos.y, z: pos.z });
+}
+
+function isNearStagnationPoint(meshUuid: string, pos: Vec3): boolean {
+    return isNearSpatialPoint(stagnationCache, meshUuid, pos);
+}
+
+function recordStagnation(meshUuid: string, pos: Vec3): void {
+    recordSpatialPoint(stagnationCache, meshUuid, pos);
 }
 
 /**
@@ -230,30 +331,36 @@ export function calculateSmartPlacementV2(
     // 3. Quick check: is the straight-down path clear AND do the roots fit at the base?
     const rootTopZ = input.rootsTopZ;
     const socketPos = standard.socketPos;
+    const isPreview = context?.isPreview ?? false;
 
-    const straightClear = !sdf.segmentBlocked(
-        socketPos.x, socketPos.y, socketPos.z,
-        socketPos.x, socketPos.y, rootTopZ,
-        clearance,
-    );
-    // Volumetric roots check at the standard base position: sweeps the full
-    // roots disk+cone geometry with cone-accurate radius at each Z slice.
+    // For hover preview, use coarse sampling (2mm steps) to cut first-hover
+    // BVH cache-miss queries from ~100 to ~25 for the shaft check, and from
+    // ~170 to ~28 for the roots check.  Click-time always uses full resolution.
+    const straightClear = isPreview
+        ? !segmentBlockedCoarse(sdf, socketPos.x, socketPos.y, socketPos.z, socketPos.x, socketPos.y, rootTopZ, clearance, PREVIEW_SEGMENT_STEP_MM)
+        : !sdf.segmentBlocked(socketPos.x, socketPos.y, socketPos.z, socketPos.x, socketPos.y, rootTopZ, clearance);
+
+    // Volumetric roots check at the standard base position.
     const baseXY = standard.basePos;
-    const rootsFitStandard = !rootsDiskBlocked(
-        sdf, baseXY.x, baseXY.y, diskHeight, coneHeight, rootsRadius, shaftRadius,
-    );
+    const rootsFitStandard = isPreview
+        ? !quickRootsDiskBlocked(sdf, baseXY.x, baseXY.y, diskHeight, coneHeight, rootsRadius, shaftRadius)
+        : !rootsDiskBlocked(sdf, baseXY.x, baseXY.y, diskHeight, coneHeight, rootsRadius, shaftRadius);
 
     if (straightClear && rootsFitStandard) {
         return standard; // Shaft is clear and roots fit — no routing needed
     }
 
-    // 3b. Spatial stagnation cache: if a previous search from a nearby
-    //     socketPos already stagnated (cavity), skip entirely.
-    //     This is the primary performance win for cavity hovers — turns
-    //     repeated probes at similar positions from ~150 A* expansions to
-    //     a single distance check.
+    // 3b. Spatial caches: skip A* if a previous search from a nearby socketPos
+    //     already stagnated (cavity) or exhausted the preview budget.
+    //     This turns repeated probes at similar positions from ~600 A* expansions
+    //     to a single distance check — the primary performance win for interior hovers.
     if (isNearStagnationPoint(mesh.uuid, socketPos)) {
         return { ...standard, error: 'COLLISION_WITH_MODEL', stagnated: true };
+    }
+    // Preview-exhausted fast-fail: if this is a preview call and a nearby position
+    // already exhausted the reduced budget, skip A* for this frame too.
+    if (context?.isPreview && isNearSpatialPoint(previewExhaustedCache, mesh.uuid, socketPos)) {
+        return { ...standard, error: 'COLLISION_WITH_MODEL', exhaustedBudget: true };
     }
 
     // 3c. Quick vertical solvability check: sample points along the
@@ -299,8 +406,12 @@ export function calculateSmartPlacementV2(
     //    to find a valid position — proper 3D pathfinding for the whole support.
     const warmStart = context?.warmStart ?? warmStartByModel.get(modelId) ?? null;
 
+    // For preview: use the quick (reduced-sample) roots check in the goal validator.
+    // The full-resolution check is reserved for click-time placement.
     const goalValidator = (wx: number, wy: number, _wz: number) => {
-        return !rootsDiskBlocked(sdf, wx, wy, diskHeight, coneHeight, rootsRadius, shaftRadius);
+        return isPreview
+            ? !quickRootsDiskBlocked(sdf, wx, wy, diskHeight, coneHeight, rootsRadius, shaftRadius)
+            : !rootsDiskBlocked(sdf, wx, wy, diskHeight, coneHeight, rootsRadius, shaftRadius);
     };
 
     const result = gridAStar(sdf, socketPos, rootTopZ, {
@@ -312,6 +423,13 @@ export function calculateSmartPlacementV2(
         maxExpansions: context?.maxExpansions ?? 2000,
         stepMm: 2.0, // Coarse grid for pathfinding; fine SDF checking at cellSize
         goalValidator,
+        // For hover preview, use endpoint-only SDF checks in the A* neighbor loop.
+        // The default segmentBlocked samples at 0.5mm intervals on a 2mm grid — all
+        // intermediate sub-grid points are permanent cold BVH cache misses, causing
+        // ~30k–60k uncacheable BVH queries per hover frame on interior surfaces.
+        // Endpoint-only checks hit grid-aligned cells that ARE cached after first
+        // visit, dropping first-frame cold cost from ~30k to ~600 BVH calls.
+        endpointOnlyCollisionCheck: isPreview,
     }, warmStart);
 
     // Store warm-start for next frame (don't save stagnated searches)
@@ -323,6 +441,12 @@ export function calculateSmartPlacementV2(
         warmStartByModel.delete(modelId);
         // Record this position so future hovers skip the A* entirely
         recordStagnation(mesh.uuid, socketPos);
+    }
+    // Preview-exhausted: record budget-exhausted positions so subsequent preview
+    // hover frames at similar positions skip the A* instead of re-running it.
+    // Only recorded for isPreview calls — doesn't affect click-time placement.
+    if (result.hitExpansionLimit && context?.isPreview) {
+        recordSpatialPoint(previewExhaustedCache, mesh.uuid, socketPos);
     }
 
     if (!result.reached || result.path.length < 2) {

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -38,13 +38,16 @@ export interface SmartPlacementV2Input extends TrunkPlacementInput {
 
 export interface SmartPlacementV2Context {
     /** Cached SDF for the model mesh. Reuse across placements for same model. */
-    sdfCache: SDFCache;
+    sdfCache?: SDFCache;
     /** Tracks placed support geometry. Optional — omit to skip support-to-support avoidance. */
     occupancy?: SupportOccupancy;
     /** Warm-start state from previous frame's search. Pass null for first frame. */
     warmStart?: WarmStartState | null;
     /** Support ID being placed (to ignore self in occupancy). */
     placingSupportId?: string;
+    /** Override the A* expansion budget (default 2000). Pass a lower value for
+     *  hover preview to reduce first-frame cost at transition-zone positions. */
+    maxExpansions?: number;
 }
 
 // ---------- Constants ----------
@@ -227,6 +230,7 @@ export function calculateSmartPlacementV2(
     // 3. Quick check: is the straight-down path clear AND do the roots fit at the base?
     const rootTopZ = input.rootsTopZ;
     const socketPos = standard.socketPos;
+
     const straightClear = !sdf.segmentBlocked(
         socketPos.x, socketPos.y, socketPos.z,
         socketPos.x, socketPos.y, rootTopZ,
@@ -305,7 +309,7 @@ export function calculateSmartPlacementV2(
         minAngleFromVerticalDeg: 90 - minRoutedTrunkAngleDeg,
         occupancy: context?.occupancy,
         ignoreSupportId: context?.placingSupportId,
-        maxExpansions: 2000,
+        maxExpansions: context?.maxExpansions ?? 2000,
         stepMm: 2.0, // Coarse grid for pathfinding; fine SDF checking at cellSize
         goalValidator,
     }, warmStart);
@@ -326,6 +330,7 @@ export function calculateSmartPlacementV2(
             ...standard,
             error: 'COLLISION_WITH_MODEL',
             stagnated: result.stagnated,
+            exhaustedBudget: result.hitExpansionLimit,
         };
     }
 
@@ -448,7 +453,7 @@ export function calculateSmartPlacementV2(
     }
 
     // 9. Build the result
-    return {
+    const finalResult: TrunkPlacementResult = {
         socketPos,
         joints: simplifiedJoints,
         constructionJoints: [],
@@ -459,6 +464,8 @@ export function calculateSmartPlacementV2(
         angle: standard.angle,
         coneAxis: standard.coneAxis,
     };
+
+    return finalResult;
 }
 
 // ---------- SDF-based joint simplification ----------

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -135,17 +135,63 @@ export function clearSDFCacheForMesh(meshUuid: string): void {
         cache.clear();
         sdfCachePool.delete(meshUuid);
     }
+    stagnationCache.delete(meshUuid);
 }
 
 export function clearAllSDFCaches(): void {
     for (const cache of sdfCachePool.values()) cache.clear();
     sdfCachePool.clear();
+    stagnationCache.clear();
 }
 
 // ---------- Main API ----------
 
 /** Warm-start storage keyed by modelId for frame-coherent preview. */
 const warmStartByModel = new Map<string, WarmStartState>();
+
+/**
+ * Spatial stagnation cache — records socketPos positions where the A*
+ * search stagnated (trapped in a cavity). On subsequent hover frames,
+ * if the socketPos is within STAGNATION_RADIUS_MM of a cached point,
+ * the search is skipped entirely, turning cavity hover from ~150
+ * A* expansions to a single distance check.
+ *
+ * Keyed by mesh uuid so it auto-invalidates when the model changes.
+ * Entries are cleared when the model matrix changes (SDF refresh),
+ * when SDF caches are cleared, or when warm-starts are cleared.
+ */
+const STAGNATION_RADIUS_MM = 3;
+const STAGNATION_RADIUS_SQ = STAGNATION_RADIUS_MM * STAGNATION_RADIUS_MM;
+const MAX_STAGNATION_ENTRIES = 512;
+const stagnationCache = new Map<string, Vec3[]>();
+
+function isNearStagnationPoint(meshUuid: string, pos: Vec3): boolean {
+    const points = stagnationCache.get(meshUuid);
+    if (!points || points.length === 0) return false;
+    for (let i = 0; i < points.length; i++) {
+        const p = points[i];
+        const dx = pos.x - p.x;
+        const dy = pos.y - p.y;
+        const dz = pos.z - p.z;
+        if (dx * dx + dy * dy + dz * dz < STAGNATION_RADIUS_SQ) return true;
+    }
+    return false;
+}
+
+function recordStagnation(meshUuid: string, pos: Vec3): void {
+    let points = stagnationCache.get(meshUuid);
+    if (!points) {
+        points = [];
+        stagnationCache.set(meshUuid, points);
+    }
+    // Don't add if already near an existing entry
+    if (isNearStagnationPoint(meshUuid, pos)) return;
+    if (points.length >= MAX_STAGNATION_ENTRIES) {
+        // Evict oldest entries
+        points.splice(0, points.length - MAX_STAGNATION_ENTRIES + 1);
+    }
+    points.push({ x: pos.x, y: pos.y, z: pos.z });
+}
 
 /**
  * Calculates smart placement using grid A* pathfinding.
@@ -197,13 +243,20 @@ export function calculateSmartPlacementV2(
         return standard; // Shaft is clear and roots fit — no routing needed
     }
 
-    // 3b. Quick vertical solvability check: sample a few points along the
+    // 3b. Spatial stagnation cache: if a previous search from a nearby
+    //     socketPos already stagnated (cavity), skip entirely.
+    //     This is the primary performance win for cavity hovers — turns
+    //     repeated probes at similar positions from ~150 A* expansions to
+    //     a single distance check.
+    if (isNearStagnationPoint(mesh.uuid, socketPos)) {
+        return { ...standard, error: 'COLLISION_WITH_MODEL', stagnated: true };
+    }
+
+    // 3c. Quick vertical solvability check: sample a few points along the
     //     straight-down axis. If the majority are deeply inside the mesh
     //     (negative SDF), the A* has no realistic chance of finding a path
-    //     around the obstruction — bail early to avoid burning 2000 expansions.
-    //     This is the common case for contact points on interior cavity walls,
-    //     where the support path must cross through solid mesh to reach the
-    //     build plate.
+    //     around the obstruction — bail early to avoid burning expansions.
+    //     This catches thick-walled cavities before any A* work.
     const vertSpan = socketPos.z - rootTopZ;
     if (vertSpan > 1) {
         const VERT_SAMPLES = 5;
@@ -217,7 +270,8 @@ export function calculateSmartPlacementV2(
             }
         }
         if (deeplyBlockedCount >= 3) {
-            return { ...standard, error: 'COLLISION_WITH_MODEL' };
+            recordStagnation(mesh.uuid, socketPos);
+            return { ...standard, error: 'COLLISION_WITH_MODEL', stagnated: true };
         }
     }
 
@@ -243,9 +297,15 @@ export function calculateSmartPlacementV2(
         goalValidator,
     }, warmStart);
 
-    // Store warm-start for next frame
+    // Store warm-start for next frame (don't save stagnated searches)
     if (result.warmState) {
         warmStartByModel.set(modelId, result.warmState);
+    }
+    if (result.stagnated) {
+        // Clear warm-start so the next nearby search starts fresh
+        warmStartByModel.delete(modelId);
+        // Record this position so future hovers skip the A* entirely
+        recordStagnation(mesh.uuid, socketPos);
     }
 
     if (!result.reached || result.path.length < 2) {
@@ -450,4 +510,13 @@ export function clearWarmStart(modelId: string): void {
 
 export function clearAllWarmStarts(): void {
     warmStartByModel.clear();
+    stagnationCache.clear();
+}
+
+export function clearStagnationCache(meshUuid?: string): void {
+    if (meshUuid) {
+        stagnationCache.delete(meshUuid);
+    } else {
+        stagnationCache.clear();
+    }
 }

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -197,6 +197,30 @@ export function calculateSmartPlacementV2(
         return standard; // Shaft is clear and roots fit — no routing needed
     }
 
+    // 3b. Quick vertical solvability check: sample a few points along the
+    //     straight-down axis. If the majority are deeply inside the mesh
+    //     (negative SDF), the A* has no realistic chance of finding a path
+    //     around the obstruction — bail early to avoid burning 2000 expansions.
+    //     This is the common case for contact points on interior cavity walls,
+    //     where the support path must cross through solid mesh to reach the
+    //     build plate.
+    const vertSpan = socketPos.z - rootTopZ;
+    if (vertSpan > 1) {
+        const VERT_SAMPLES = 5;
+        const deepThreshold = -clearance * 2;
+        let deeplyBlockedCount = 0;
+        for (let i = 1; i <= VERT_SAMPLES; i++) {
+            const t = i / (VERT_SAMPLES + 1);
+            const sz = socketPos.z - t * vertSpan;
+            if (sdf.distanceAt(socketPos.x, socketPos.y, sz) < deepThreshold) {
+                deeplyBlockedCount++;
+            }
+        }
+        if (deeplyBlockedCount >= 3) {
+            return { ...standard, error: 'COLLISION_WITH_MODEL' };
+        }
+    }
+
     // 4. Run grid A* from socket down to rootTopZ.
     //    The goalValidator integrates roots collision into the search:
     //    when A* reaches a cell at rootTopZ, it checks that the full roots
@@ -228,6 +252,7 @@ export function calculateSmartPlacementV2(
         return {
             ...standard,
             error: 'COLLISION_WITH_MODEL',
+            stagnated: result.stagnated,
         };
     }
 

--- a/src/supports/PlacementLogic/Pathfinding/index.ts
+++ b/src/supports/PlacementLogic/Pathfinding/index.ts
@@ -14,5 +14,6 @@ export {
     clearAllSDFCaches,
     clearWarmStart,
     clearAllWarmStarts,
+    clearStagnationCache,
 } from './SmartPlacementV2';
 export type { SmartPlacementV2Input, SmartPlacementV2Context } from './SmartPlacementV2';

--- a/src/supports/PlacementLogic/StandardPlacement.ts
+++ b/src/supports/PlacementLogic/StandardPlacement.ts
@@ -25,6 +25,9 @@ export interface TrunkPlacementResult {
     coneAxis?: Vec3; // Cone axis used for socket placement (may differ from surface normal)
     /** True if the pathfinder stagnated (trapped in cavity). Signals that fallback searches are futile. */
     stagnated?: boolean;
+    /** True if A* exhausted its expansion budget without reaching the goal.
+     *  When true, the V1 raycast fallback is very unlikely to succeed and can be skipped. */
+    exhaustedBudget?: boolean;
 }
 
 /**

--- a/src/supports/PlacementLogic/StandardPlacement.ts
+++ b/src/supports/PlacementLogic/StandardPlacement.ts
@@ -23,6 +23,8 @@ export interface TrunkPlacementResult {
     warning?: WarningCode; // Allow with warning
     angle?: number; // Surface angle in degrees (0=Up, 90=Vert, 180=Down)
     coneAxis?: Vec3; // Cone axis used for socket placement (may differ from surface normal)
+    /** True if the pathfinder stagnated (trapped in cavity). Signals that fallback searches are futile. */
+    stagnated?: boolean;
 }
 
 /**

--- a/src/supports/SupportPrimitives/ContactCone/ContactConeRenderer.tsx
+++ b/src/supports/SupportPrimitives/ContactCone/ContactConeRenderer.tsx
@@ -7,6 +7,7 @@ import { getConeCenterPosition, getConeQuaternion } from './contactConeUtils';
 import { handleContactDiskClick } from '../../interaction/clickHandlers';
 import { setHoveredState } from '../../state';
 import { emitImmediateModelHover, getFrontBlockingModelId } from '../../interaction/pointerOcclusion';
+import { useJointDragPosition } from '../../interaction/jointDragPosition';
 
 // Primitives
 import { ContactDiskRenderer, calculateDiskThickness } from '../ContactDisk';
@@ -78,9 +79,9 @@ export function ContactConeRenderer({
     const groupRef = React.useRef<any>(null);
     const pickIdRef = React.useRef<number | null>(null);
     const { register, unregister } = usePicking();
+    const liveSocketJointPos = useJointDragPosition(socketJointId ?? '');
     const contactRadius = profile.contactDiameterMm / 2;
     const bodyRadius = profile.bodyDiameterMm / 2;
-    const length = profile.lengthMm;
     const penetrationMm = profile.penetrationMm ?? 0;
     const [isHovered, setIsHovered] = useState(false);
     const hoverVisible = isHovered && isInteractable && isParentSelected;
@@ -92,40 +93,84 @@ export function ContactConeRenderer({
     // Fallback: If no surfaceNormal provided, assume it aligns with cone axis
     const effectiveSurfaceNormal = surfaceNormal || normal;
 
-    // --- 1. Determine Primitive Offset ---
-    // If we are using a Disk, the cone body must start *behind* the disk.
-    const primitiveThickness = useMemo(() => {
+    const renderGeometry = useMemo(() => {
+        let renderNormal = { ...normal };
+        let renderThickness = 0;
+        let renderLength = profile.lengthMm;
+
         if (profile.type === 'disk') {
-            if (diskLengthOverride !== undefined) {
-                return diskLengthOverride;
-            }
-            return calculateDiskThickness(effectiveSurfaceNormal, normal, profile);
+            renderThickness = diskLengthOverride !== undefined
+                ? diskLengthOverride
+                : calculateDiskThickness(effectiveSurfaceNormal, renderNormal, profile);
         }
-        return 0; // No offset for legacy/undefined
-    }, [normal, effectiveSurfaceNormal, profile, diskLengthOverride]);
 
-    // --- 2. Calculate Geometry Positions ---
+        // While dragging the socket joint, solve against the *live* joint position so
+        // the cone socket stays visually pinned to the joint center in the same frame.
+        if (liveSocketJointPos) {
+            const contactPos = new THREE.Vector3(pos.x, pos.y, pos.z);
+            const socketPos = new THREE.Vector3(liveSocketJointPos.x, liveSocketJointPos.y, liveSocketJointPos.z);
+            const surfaceNormalVec = new THREE.Vector3(
+                effectiveSurfaceNormal.x,
+                effectiveSurfaceNormal.y,
+                effectiveSurfaceNormal.z,
+            );
+            if (surfaceNormalVec.lengthSq() < 0.000001) surfaceNormalVec.set(0, 0, 1);
+            surfaceNormalVec.normalize();
 
-    // Effective Start Position for the Cone Body
-    // It starts at: pos + (normal * primitiveThickness)
-    // Note: 'normal' here is the Cone Axis. We push along the Cone Axis.
-    // Wait, if the disk is extended, do we push along Surface Normal or Cone Axis?
-    // The disk extends along the SURFACE NORMAL.
-    // So the cone start position is: pos + (surfaceNormal * primitiveThickness)
-    // But the cone connects to the BACK of the disk.
-    // If the disk is a cylinder along surfaceNormal, its back face center is at pos + surfaceNormal * thickness.
+            let axis = new THREE.Vector3(renderNormal.x, renderNormal.y, renderNormal.z);
+            if (axis.lengthSq() < 0.000001) {
+                axis.copy(socketPos).sub(contactPos);
+            }
+            if (axis.lengthSq() < 0.000001) axis.set(0, 0, 1);
+            axis.normalize();
 
-    const coneStartPos = useMemo(() => {
-        return {
-            x: pos.x + effectiveSurfaceNormal.x * primitiveThickness,
-            y: pos.y + effectiveSurfaceNormal.y * primitiveThickness,
-            z: pos.z + effectiveSurfaceNormal.z * primitiveThickness,
+            for (let i = 0; i < 4; i += 1) {
+                const thickness = profile.type === 'disk'
+                    ? (diskLengthOverride !== undefined
+                        ? diskLengthOverride
+                        : calculateDiskThickness(
+                            { x: surfaceNormalVec.x, y: surfaceNormalVec.y, z: surfaceNormalVec.z },
+                            { x: axis.x, y: axis.y, z: axis.z },
+                            profile,
+                        ))
+                    : 0;
+
+                const startPos = contactPos.clone().add(surfaceNormalVec.clone().multiplyScalar(thickness));
+                const coneVec = socketPos.clone().sub(startPos);
+                const len = coneVec.length();
+                renderThickness = thickness;
+                if (len > 0.0001) {
+                    axis.copy(coneVec).normalize();
+                    renderLength = Math.max(0.1, len);
+                }
+            }
+
+            renderNormal = { x: axis.x, y: axis.y, z: axis.z };
+        }
+
+        const coneStartPos = {
+            x: pos.x + effectiveSurfaceNormal.x * renderThickness,
+            y: pos.y + effectiveSurfaceNormal.y * renderThickness,
+            z: pos.z + effectiveSurfaceNormal.z * renderThickness,
         };
-    }, [pos, effectiveSurfaceNormal, primitiveThickness]);
 
-    // Calculate cone center (based on shifted start position)
-    const center = getConeCenterPosition(coneStartPos, normal, profile);
-    const quaternion = getConeQuaternion(normal);
+        const center = {
+            x: coneStartPos.x + renderNormal.x * (renderLength / 2),
+            y: coneStartPos.y + renderNormal.y * (renderLength / 2),
+            z: coneStartPos.z + renderNormal.z * (renderLength / 2),
+        };
+
+        return {
+            primitiveThickness: renderThickness,
+            length: renderLength,
+            normal: renderNormal,
+            coneStartPos,
+            center,
+            quaternion: getConeQuaternion(renderNormal),
+        };
+    }, [diskLengthOverride, effectiveSurfaceNormal, liveSocketJointPos, normal, pos, profile]);
+
+    const { primitiveThickness, length, normal: renderNormal, coneStartPos, center, quaternion } = renderGeometry;
     const displayEmissive = hoverVisible ? '#efd8c2' : emissive;
     const displayEmissiveIntensity = hoverVisible ? Math.max(emissiveIntensity, 0.16) : emissiveIntensity;
 
@@ -239,10 +284,10 @@ export function ContactConeRenderer({
                     id={contactDiskId}
                     pos={pos}
                     normal={effectiveSurfaceNormal} // Must use Surface Normal!
-                    coneAxis={normal}               // The direction of the cone
+                    coneAxis={renderNormal}         // The direction of the cone
                     profile={profile}
                     contactDiameterMm={profile.contactDiameterMm}
-                    overrideThickness={diskLengthOverride} // Pass the collision override!
+                    overrideThickness={primitiveThickness} // Live drag keeps disk/socket perfectly aligned
                     penetrationMm={penetrationMm}
                     color={finalDiskColor}
                     transparent={transparent}

--- a/src/supports/SupportPrimitives/ContactDisk/contactDiskDragController.ts
+++ b/src/supports/SupportPrimitives/ContactDisk/contactDiskDragController.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { calculateSmoothedNormal } from '../../PlacementLogic/PlacementUtils';
 import type { Vec3 } from '../../types';
+import { getClipBounds } from '@/components/scene/SceneCanvas/clipBoundsStore';
 
 export interface ContactDiskDragHit {
     point: Vec3;
@@ -73,8 +74,29 @@ export function startContactDiskDragSession(options: ContactDiskDragSessionOptio
         if (modelMeshes.length === 0) return;
 
         const hits = raycaster.intersectObjects(modelMeshes, true);
-        const hit = hits[0];
+        let hit = hits[0];
         if (!hit) return;
+
+        // If the hit is in the clipped (invisible) zone, skip past it to
+        // find the visible inner wall so contact disks attach correctly
+        // when editing supports inside a cross-section view.
+        const { clipLower, clipUpper } = getClipBounds();
+        const clipped =
+          (clipUpper != null && hit.point.z > clipUpper) ||
+          (clipLower != null && hit.point.z < clipLower);
+        if (clipped) {
+          // Find first hit within visible bounds
+          let fallback: THREE.Intersection | null = null;
+          for (let i = 1; i < hits.length; i++) {
+            const h = hits[i];
+            if (clipUpper != null && h.point.z > clipUpper) continue;
+            if (clipLower != null && h.point.z < clipLower) continue;
+            fallback = h;
+            break;
+          }
+          if (!fallback) return;
+          hit = fallback;
+        }
 
         onHit({
             point: { x: hit.point.x, y: hit.point.y, z: hit.point.z },

--- a/src/supports/SupportPrimitives/Joint/JointGizmo.tsx
+++ b/src/supports/SupportPrimitives/Joint/JointGizmo.tsx
@@ -1,4 +1,4 @@
-import React, { useSyncExternalStore, useCallback, useRef, useEffect } from 'react';
+import React, { useSyncExternalStore, useCallback, useRef, useEffect, useLayoutEffect } from 'react';
 import { ScreenSpaceGizmo } from '@/components/gizmo/ScreenSpaceGizmo';
 import { subscribe, getSnapshot, updateTrunk, updateBranch, updateTwig, updateStick, getTrunkById, getBranchById, getTwigById, getStickById } from '../../state';
 import * as THREE from 'three';
@@ -553,24 +553,13 @@ export function JointGizmo() {
         applyMoveDelta(delta);
     }, [applyMoveDelta]);
 
-    const scheduleMoveFlush = useCallback(() => {
-        if (typeof window === 'undefined') return;
-        if (moveRafRef.current !== null) return;
-
-        moveRafRef.current = window.requestAnimationFrame(() => {
-            moveRafRef.current = null;
-            flushPendingMove();
-
-            if (pendingDeltaRef.current.lengthSq() > MOVE_DELTA_EPS_SQ) {
-                scheduleMoveFlush();
-            }
-        });
-    }, [flushPendingMove]);
-
     const handleMove = (delta: THREE.Vector3) => {
         if (!joint) return;
+        // Apply immediately so support geometry stays in lockstep with gizmo.
+        // rAF-batching introduces a persistent one-frame lag where the cone
+        // appears pseudo-detached from the dragged socket joint.
         pendingDeltaRef.current.add(delta);
-        scheduleMoveFlush();
+        flushPendingMove();
     };
 
     const handleMoveEnd = () => {
@@ -642,11 +631,22 @@ export function JointGizmo() {
         liveKickstandPreviewRef.current = null;
     };
 
+    // Sync gizmo group position to joint.pos, but only when not dragging.
+    // Do NOT use a declarative R3F `position` prop on the group — on every React re-render
+    // (caused by the deferred useActiveJointDragPreview state update), R3F would re-apply
+    // the committed (old) joint position to the Three.js group, overwriting the imperative
+    // position.set() from applyMoveDelta and creating a persistent 1-frame cone/ball desync.
+    useLayoutEffect(() => {
+        if (!gizmoTargetRef.current || !joint) return;
+        if (dragPosRef.current !== null) return; // skip during active drag
+        gizmoTargetRef.current.position.set(joint.pos.x, joint.pos.y, joint.pos.z);
+    }, [joint?.pos.x, joint?.pos.y, joint?.pos.z]);
+
     if (!joint) return null;
 
     return (
         <>
-            <group ref={gizmoTargetRef as React.MutableRefObject<THREE.Group>} position={[joint.pos.x, joint.pos.y, joint.pos.z]} />
+            <group ref={gizmoTargetRef as React.MutableRefObject<THREE.Group>} />
             <ScreenSpaceGizmo
                 meshRef={gizmoTargetRef as React.RefObject<THREE.Group>}
                 position={[joint.pos.x, joint.pos.y, joint.pos.z]}

--- a/src/supports/SupportRenderer.tsx
+++ b/src/supports/SupportRenderer.tsx
@@ -1197,10 +1197,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
     const groupRef = React.useRef<THREE.Group>(null);
     useImperativeHandle(ref, () => groupRef.current!);
 
-    // Initialize clipping planes once (update in-place to avoid recreation)
-    const clippingPlanesRef = React.useRef<THREE.Plane[]>([]);
-
-    React.useEffect(() => {
+    // Derive clipping planes synchronously so a freshly mounted renderer
+    // (e.g. after support refresh key changes) is clipped correctly on its
+    // very first render, without waiting for a post-commit effect.
+    const clippingPlanes = useMemo(() => {
         const planes: THREE.Plane[] = [];
 
         if (clipLower != null) {
@@ -1211,10 +1211,8 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             planes.push(new THREE.Plane(new THREE.Vector3(0, 0, -1), clipUpper));
         }
 
-        clippingPlanesRef.current = planes;
+        return planes;
     }, [clipLower, clipUpper]);
-
-    const clippingPlanes = clippingPlanesRef.current;
 
     const resolveBaseColor = useMemo(() => {
         const baseHex = '#9a9a9a';
@@ -3638,7 +3636,28 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 applyMaterialGhostOpacity(mesh.material);
             }
         });
-    }, [clippingPlanes, ghostOpacityClamped, ghostTransparent, ghostRenderOrder, selectedId]);
+    }, [
+        clippingPlanes,
+        ghostOpacityClamped,
+        ghostTransparent,
+        ghostRenderOrder,
+        selectedId,
+        // Re-apply clipping when committed support geometry collections change.
+        // Without this, newly added meshes can miss clipping until some other
+        // dependency (like slider movement) forces a re-run.
+        state.roots,
+        state.trunks,
+        state.branches,
+        state.leaves,
+        state.twigs,
+        state.sticks,
+        state.braces,
+        state.anchors,
+        state.knots,
+        kickstandState.roots,
+        kickstandState.kickstands,
+        kickstandState.knots,
+    ]);
 
     return (
         <group ref={groupRef}>

--- a/src/supports/SupportRenderer.tsx
+++ b/src/supports/SupportRenderer.tsx
@@ -3592,18 +3592,49 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             }
         };
 
+        const clearMaterialClipping = (material: THREE.Material) => {
+            const m = material as THREE.Material & { clippingPlanes?: THREE.Plane[] | null };
+            if (m.clippingPlanes !== null) {
+                m.clippingPlanes = null;
+                material.needsUpdate = true;
+            }
+        };
+
+        // Returns true if this object should be exempt from cross-section clipping.
+        // Gizmo handles tag themselves with isGizmoHandle. Selected-support groups
+        // are tagged with noClipping so their entire subtree is preserved.
+        const isClipExempt = (obj: THREE.Object3D): boolean => {
+            if (obj.userData.isGizmoHandle === true) return true;
+            let cur: THREE.Object3D | null = obj;
+            while (cur && cur !== root) {
+                if (cur.userData.noClipping === true) return true;
+                cur = cur.parent;
+            }
+            return false;
+        };
+
         root.traverse((obj) => {
             const mesh = obj as THREE.Mesh;
             if (!mesh.material) return;
             applyMeshRenderOrder(mesh);
 
+            const exempt = isClipExempt(obj);
+
             if (Array.isArray(mesh.material)) {
                 mesh.material.forEach((material) => {
-                    applyMaterialClipping(material);
+                    if (exempt) {
+                        clearMaterialClipping(material);
+                    } else {
+                        applyMaterialClipping(material);
+                    }
                     applyMaterialGhostOpacity(material);
                 });
             } else {
-                applyMaterialClipping(mesh.material);
+                if (exempt) {
+                    clearMaterialClipping(mesh.material);
+                } else {
+                    applyMaterialClipping(mesh.material);
+                }
                 applyMaterialGhostOpacity(mesh.material);
             }
         });
@@ -3878,7 +3909,9 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 const deferTrunkInteractionToSceneBatch = !effectiveSelected;
 
                 return (
-                    <group key={trunk.id}>
+                    // noClipping: this trunk is actively selected/edited — exempt it
+                    // from cross-section clipping so it always renders fully visible.
+                    <group key={trunk.id} userData={{ noClipping: true }}>
                     <TrunkRenderer
                         key={trunk.id}
                         trunk={trunk}
@@ -3931,7 +3964,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 const showKnots = !hideUnselectedKnots || effectiveSelected;
 
                 return (
-                    <group key={branch.id}>
+                    <group key={branch.id} userData={{ noClipping: true }}>
                     <BranchRenderer
                         key={branch.id}
                         branch={branch}
@@ -3963,7 +3996,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 const showKnots = !hideUnselectedKnots || effectiveSelected;
 
                 return (
-                    <group key={leaf.id}>
+                    <group key={leaf.id} userData={{ noClipping: true }}>
                     <LeafRenderer
                         key={leaf.id}
                         leaf={leaf}
@@ -3994,7 +4027,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 const deferTwigInteractionToSceneBatch = !effectiveSelected && isTwigBatchable;
 
                 return (
-                    <group key={twig.id}>
+                    <group key={twig.id} userData={{ noClipping: effectiveSelected }}>
                     <TwigRenderer
                         key={twig.id}
                         twig={twig}
@@ -4040,7 +4073,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 const deferStickInteractionToSceneBatch = !effectiveSelected && isStickBatchable;
 
                 return (
-                    <group key={stick.id}>
+                    <group key={stick.id} userData={{ noClipping: effectiveSelected }}>
                     <StickRenderer
                         key={stick.id}
                         stick={stick}
@@ -4107,7 +4140,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 if (!braceStartKnot || !braceEndKnot) return null;
 
                 return (
-                    <group key={brace.id}>
+                    <group key={brace.id} userData={{ noClipping: effectiveSelected }}>
                         <BraceRenderer
                             key={brace.id}
                             brace={brace}
@@ -4148,7 +4181,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 const showKnot = !hideUnselectedKnots || effectiveSelected;
 
                 return (
-                    <group key={kickstand.id}>
+                    <group key={kickstand.id} userData={{ noClipping: effectiveSelected }}>
                     <KickstandRenderer
                         key={kickstand.id}
                         kickstand={kickstand}

--- a/src/supports/SupportTypes/Branch/BranchPlacementController.tsx
+++ b/src/supports/SupportTypes/Branch/BranchPlacementController.tsx
@@ -20,6 +20,7 @@ import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
 import { matchesConfiguredHotkeyUp } from '@/hotkeys/hotkeyConfig';
 import { subscribe, getSnapshot, addBranch, addKnot, addTwig, addStick } from '../../state';
 import { pushHistory } from '@/history/historyStore';
+import { getClipBounds } from '@/components/scene/SceneCanvas/clipBoundsStore';
 import { SUPPORT_ADD_BRANCH, SUPPORT_ADD_TWIG, SUPPORT_ADD_STICK } from '../../history/actionTypes';
 import { SnapTarget } from '../../interaction/SnappingManager';
 import { Vec3, Knot } from '../../types';
@@ -46,6 +47,40 @@ import { previewNormalKey, previewVecKey, quantizePreviewValue } from '../shared
 interface ShaftHoverDetail {
     segmentId?: string | null;
     point?: Vec3 | null;
+}
+
+// Scratch raycaster reused for clip-zone fallback raycasts (same pattern as StlMesh).
+const _branchClipFallbackRaycaster = new THREE.Raycaster();
+
+/**
+ * When a raycast hit falls in the clipped (invisible) portion of the mesh,
+ * re-raycast starting just past that surface to find the visible inner wall.
+ */
+function findClipAwareHitForBranch(
+  ray: THREE.Ray,
+  meshes: THREE.Object3D[],
+  clipLower: number | null,
+  clipUpper: number | null,
+  primaryDistance: number,
+): THREE.Intersection | null {
+  const rc = _branchClipFallbackRaycaster;
+  rc.ray.copy(ray);
+  rc.near = primaryDistance + 0.05;
+  rc.far = primaryDistance + 500;
+  (rc as any).firstHitOnly = true;
+  const hits = rc.intersectObjects(meshes, false);
+  rc.near = 0;
+  rc.far = Infinity;
+  (rc as any).firstHitOnly = false;
+  if (hits.length === 0) return null;
+  const hit = hits[0];
+  if (
+    (clipUpper != null && hit.point.z > clipUpper) ||
+    (clipLower != null && hit.point.z < clipLower)
+  ) {
+    return null;
+  }
+  return hit;
 }
 
 export function BranchPlacementController() {
@@ -509,6 +544,22 @@ export function BranchPlacementController() {
                     const intersects = raycaster.intersectObjects(modelMeshes, false);
                     if (intersects.length > 0) {
                         meshHit = intersects[0];
+
+                        // If the hit falls within the clipped (invisible) region,
+                        // re-raycast past the clipped surface to find the visible inner wall.
+                        const { clipLower, clipUpper } = getClipBounds();
+                        const clipped =
+                          (clipUpper != null && meshHit.point.z > clipUpper) ||
+                          (clipLower != null && meshHit.point.z < clipLower);
+                        if (clipped) {
+                            meshHit = findClipAwareHitForBranch(
+                              raycaster.ray,
+                              modelMeshes,
+                              clipLower,
+                              clipUpper,
+                              meshHit.distance,
+                            );
+                        }
                     }
                 }
 

--- a/src/supports/SupportTypes/Leaf/LeafPlacementController.tsx
+++ b/src/supports/SupportTypes/Leaf/LeafPlacementController.tsx
@@ -23,6 +23,7 @@ import { useKickstandStoreState } from '../Kickstand/kickstandStore';
 import { projectPointToSnapTargetPath, projectRayToSnapTargetPath, selectNearestPathTarget } from '../../interaction/shared/placement/snapping/pathProjection';
 import { isSupportEditInteractionActive } from '../../interaction/gizmoInteractionLock';
 import { previewVecKey, previewNormalKey, quantizePreviewValue } from '../shared/previewSignature';
+import { getClipBounds } from '@/components/scene/SceneCanvas/clipBoundsStore';
 
 interface ShaftHoverDetail {
     segmentId?: string | null;
@@ -283,8 +284,30 @@ export function LeafPlacementController() {
                 if (modelMeshes.length > 0) {
                     const intersects = raycaster.intersectObjects(modelMeshes, false);
                     if (intersects.length > 0) {
-                        const hit = intersects[0];
-                        knotPos = { x: hit.point.x, y: hit.point.y, z: hit.point.z };
+                        let hit = intersects[0];
+
+                        // Skip hits in the clipped (hidden) zone to find the
+                        // visible inner wall in cross-section view.
+                        const { clipLower: cl, clipUpper: cu } = getClipBounds();
+                        const isClipped =
+                          (cu != null && hit.point.z > cu) ||
+                          (cl != null && hit.point.z < cl);
+                        if (isClipped) {
+                            let fallback: THREE.Intersection | null = null;
+                            for (let i = 1; i < intersects.length; i++) {
+                                const h = intersects[i];
+                                if (cu != null && h.point.z > cu) continue;
+                                if (cl != null && h.point.z < cl) continue;
+                                fallback = h;
+                                break;
+                            }
+                            if (fallback) hit = fallback;
+                            else hit = null as any;
+                        }
+
+                        if (hit) {
+                            knotPos = { x: hit.point.x, y: hit.point.y, z: hit.point.z };
+                        }
                     }
                 }
 

--- a/src/supports/SupportTypes/Trunk/trunkBuilder.ts
+++ b/src/supports/SupportTypes/Trunk/trunkBuilder.ts
@@ -174,8 +174,11 @@ export function buildTrunkData(input: TrunkBuildInput): TrunkBuildResult {
         // V2 grid A* pathfinder (SDF-backed, no raycast bundles).
         // For hover preview, use a reduced A* budget (600 vs 2000) and skip the
         // expensive V1 raycast fallback entirely — hover preview doesn't need
-        // perfect accuracy. Click placement always uses full budget + V1 fallback.
-        const v2Context = isPreview ? { maxExpansions: 600 } : undefined;
+        // perfect accuracy. `isPreview` also enables the preview-exhausted spatial
+        // cache so budget-exhausted positions near steep/internal surfaces are
+        // fast-failed on subsequent hover frames instead of re-running 600 expansions.
+        // Click placement always uses full budget + V1 fallback.
+        const v2Context = isPreview ? { maxExpansions: 600, isPreview: true } : undefined;
         const v2Result = calculateSmartPlacementV2({ ...placementInput, mesh, modelId }, v2Context);
         if (v2Result.error === 'COLLISION_WITH_MODEL') {
             if (isPreview) {

--- a/src/supports/SupportTypes/Trunk/trunkBuilder.ts
+++ b/src/supports/SupportTypes/Trunk/trunkBuilder.ts
@@ -50,6 +50,9 @@ export interface TrunkBuildInput {
     tipNormal: Vec3;
     modelId: string;
     mesh?: THREE.Mesh;
+    /** When true, uses a reduced A* expansion budget and skips V1 fallback
+     *  for faster hover preview. Click placement should always use false/undefined. */
+    isPreview?: boolean;
     overrides?: {
         rootsDiameterMm?: number;
         rootsDiskHeightMm?: number;
@@ -72,6 +75,8 @@ export interface TrunkBuildResult {
     warning?: WarningCode;
     /** True if the pathfinder stagnated (trapped in a cavity). */
     stagnated?: boolean;
+    /** True if V2 exhausted its expansion budget without reaching the goal. */
+    exhaustedBudget?: boolean;
 }
 
 /**
@@ -82,8 +87,64 @@ export interface TrunkBuildResult {
  * - Route-driven shaft segments and joints
  * - ContactCone at the tip
  */
+// ---------------------------------------------------------------------------
+// Placement result cache — covers V2 A* + V1 fallback together.
+// Multi-entry LRU per model (24 slots) avoids cache thrashing when the cursor
+// sweeps through a transition zone at the 0.5mm quantisation boundary.
+// ---------------------------------------------------------------------------
+const PLACEMENT_CACHE_QUANT = 0.5; // mm — matches SDF cell size
+const NORMAL_CACHE_QUANT = 0.05;   // ~2.9° buckets
+const MAX_PLACEMENT_CACHE_ENTRIES = 24;
+
+// Map<modelId, Map<cacheKey, result>> — insertion-ordered for FIFO eviction
+type ModelPlacementCache = Map<string, TrunkPlacementResult>;
+const placementCacheByModel = new Map<string, ModelPlacementCache>();
+
+function placementCacheKey(tipPos: Vec3, tipNormal: Vec3): string {
+    const Q = PLACEMENT_CACHE_QUANT;
+    const NQ = NORMAL_CACHE_QUANT;
+    return `${Math.round(tipPos.x / Q)},${Math.round(tipPos.y / Q)},${Math.round(tipPos.z / Q)},${Math.round(tipNormal.x / NQ)},${Math.round(tipNormal.y / NQ)},${Math.round(tipNormal.z / NQ)}`;
+}
+
+function getPlacementCache(modelId: string, key: string): TrunkPlacementResult | undefined {
+    return placementCacheByModel.get(modelId)?.get(key);
+}
+
+function setPlacementCache(modelId: string, key: string, result: TrunkPlacementResult): void {
+    let cache = placementCacheByModel.get(modelId);
+    if (!cache) {
+        cache = new Map();
+        placementCacheByModel.set(modelId, cache);
+    }
+    if (cache.has(key)) {
+        // Re-insert to promote to newest (for FIFO correctness)
+        cache.delete(key);
+    } else if (cache.size >= MAX_PLACEMENT_CACHE_ENTRIES) {
+        // Evict oldest entry (first inserted)
+        cache.delete(cache.keys().next().value!);
+    }
+    cache.set(key, result);
+}
+
+/** Clear cached placement for a specific model (call when model moves). */
+export function clearPlacementCache(modelId?: string): void {
+    if (modelId) placementCacheByModel.delete(modelId);
+    else placementCacheByModel.clear();
+}
+
 export function buildTrunkData(input: TrunkBuildInput): TrunkBuildResult {
-    const { tipPos, tipNormal, modelId, mesh, overrides } = input;
+    const { tipPos, tipNormal, modelId, mesh, overrides, isPreview } = input;
+
+    // Fast-path: check placement cache before any computation.
+    // The cache covers V2 A* + V1 fallback together, keyed by quantised
+    // (tipPos, tipNormal). Only used for mesh-backed placement (hover preview).
+    if (mesh && !overrides) {
+        const pck = placementCacheKey(tipPos, tipNormal);
+        const cached = getPlacementCache(modelId, pck);
+        if (cached) {
+            return buildTrunkDataFromPlacement(input, cached);
+        }
+    }
 
     // Read current settings
     const settings = getSettings();
@@ -110,55 +171,68 @@ export function buildTrunkData(input: TrunkBuildInput): TrunkBuildResult {
 
     let placement: TrunkPlacementResult;
     if (mesh) {
-        // V2 grid A* pathfinder (SDF-backed, no raycast bundles)
-        const v2Result = calculateSmartPlacementV2({ ...placementInput, mesh, modelId });
+        // V2 grid A* pathfinder (SDF-backed, no raycast bundles).
+        // For hover preview, use a reduced A* budget (600 vs 2000) and skip the
+        // expensive V1 raycast fallback entirely — hover preview doesn't need
+        // perfect accuracy. Click placement always uses full budget + V1 fallback.
+        const v2Context = isPreview ? { maxExpansions: 600 } : undefined;
+        const v2Result = calculateSmartPlacementV2({ ...placementInput, mesh, modelId }, v2Context);
         if (v2Result.error === 'COLLISION_WITH_MODEL') {
-            // If V2's A* stagnated (trapped in a cavity with no Z progress),
-            // V1's raycast-bundle search is equally futile. Skip it entirely
-            // to avoid ~160 expansions × ~1500 raycasts each.
-            if (v2Result.stagnated) {
+            if (isPreview) {
+                // For hover preview: skip V1 entirely to keep the first-frame cost low.
+                // A stick preview will show instead (corrects to trunk on click).
+                placement = v2Result;
+            } else if (v2Result.stagnated || v2Result.exhaustedBudget) {
+                // V2 stagnated (closed cavity) or exhausted full 2000-expansion budget
+                // — V1's raycast-bundle search is equally futile. Skip it.
                 placement = v2Result;
             } else {
-            // Fallback to V1 raycast-based search, then SDF post-validate.
-            // V1 uses 9-ray bundles which have gaps — verify every segment
-            // of V1's result against the SDF before accepting it.
-            const v1Result = calculateSmartPlacement({ ...placementInput, mesh, modelId });
-            if (v1Result.error) {
-                placement = v1Result; // V1 also failed — pass error through
-            } else {
-                const sdf = getOrCreateSDFCache(mesh);
-                sdf.refreshMatrix();
-                const shaftRadius = settings.shaft.diameterMm / 2;
-                const sdfClearance = shaftRadius + 0.25;
-                // Build the chain: rootTopTarget → joints → socketPos
-                const v1RootTop: Vec3 = { x: v1Result.basePos.x, y: v1Result.basePos.y, z: rootsTopZ };
-                const v1Chain: Vec3[] = [
-                    v1RootTop,
-                    ...(v1Result.joints ?? []),
-                    v1Result.socketPos,
-                ];
-                let v1Clips = false;
-                for (let i = 0; i < v1Chain.length - 1; i++) {
-                    const a = v1Chain[i];
-                    const b = v1Chain[i + 1];
-                    if (sdf.segmentBlocked(a.x, a.y, a.z, b.x, b.y, b.z, sdfClearance)) {
-                        v1Clips = true;
-                        break;
+                // Fallback to V1 raycast-based search, then SDF post-validate.
+                // V1 uses 9-ray bundles which have gaps — verify every segment
+                // of V1's result against the SDF before accepting it.
+                const v1Result = calculateSmartPlacement({ ...placementInput, mesh, modelId });
+                if (v1Result.error) {
+                    placement = v1Result; // V1 also failed — pass error through
+                } else {
+                    const sdf = getOrCreateSDFCache(mesh);
+                    sdf.refreshMatrix();
+                    const shaftRadius = settings.shaft.diameterMm / 2;
+                    const sdfClearance = shaftRadius + 0.25;
+                    // Build the chain: rootTopTarget → joints → socketPos
+                    const v1RootTop: Vec3 = { x: v1Result.basePos.x, y: v1Result.basePos.y, z: rootsTopZ };
+                    const v1Chain: Vec3[] = [
+                        v1RootTop,
+                        ...(v1Result.joints ?? []),
+                        v1Result.socketPos,
+                    ];
+                    let v1Clips = false;
+                    for (let i = 0; i < v1Chain.length - 1; i++) {
+                        const a = v1Chain[i];
+                        const b = v1Chain[i + 1];
+                        if (sdf.segmentBlocked(a.x, a.y, a.z, b.x, b.y, b.z, sdfClearance)) {
+                            v1Clips = true;
+                            break;
+                        }
+                    }
+                    if (v1Clips) {
+                        // V1's path clips the model — reject it
+                        placement = { ...v1Result, error: 'COLLISION_WITH_MODEL' };
+                    } else {
+                        placement = v1Result;
                     }
                 }
-                if (v1Clips) {
-                    // V1's path clips the model — reject it
-                    placement = { ...v1Result, error: 'COLLISION_WITH_MODEL' };
-                } else {
-                    placement = v1Result;
-                }
             }
-            } // end if (!stagnated)
         } else {
             placement = v2Result;
         }
     } else {
         placement = calculateStandardPlacement(placementInput);
+    }
+
+    // Cache the placement result for frame-coherent hover reuse.
+    if (mesh && !overrides) {
+        const pck = placementCacheKey(tipPos, tipNormal);
+        setPlacementCache(modelId, pck, placement);
     }
 
     return buildTrunkDataFromPlacement(input, placement);
@@ -361,5 +435,5 @@ export function buildTrunkDataFromPlacement(input: TrunkBuildInput, placement: T
         angle: angle // Required for gradient color
     };
 
-    return { root, trunk, supportData, route, error, warning, stagnated: placement.stagnated };
+    return { root, trunk, supportData, route, error, warning, stagnated: placement.stagnated, exhaustedBudget: placement.exhaustedBudget };
 }

--- a/src/supports/SupportTypes/Trunk/trunkBuilder.ts
+++ b/src/supports/SupportTypes/Trunk/trunkBuilder.ts
@@ -70,6 +70,8 @@ export interface TrunkBuildResult {
     route: TrunkRouteResult | SnappedTrunkRouteResult;
     error?: LimitationCode;
     warning?: WarningCode;
+    /** True if the pathfinder stagnated (trapped in a cavity). */
+    stagnated?: boolean;
 }
 
 /**
@@ -359,5 +361,5 @@ export function buildTrunkDataFromPlacement(input: TrunkBuildInput, placement: T
         angle: angle // Required for gradient color
     };
 
-    return { root, trunk, supportData, route, error, warning };
+    return { root, trunk, supportData, route, error, warning, stagnated: placement.stagnated };
 }

--- a/src/supports/SupportTypes/Trunk/trunkBuilder.ts
+++ b/src/supports/SupportTypes/Trunk/trunkBuilder.ts
@@ -111,6 +111,12 @@ export function buildTrunkData(input: TrunkBuildInput): TrunkBuildResult {
         // V2 grid A* pathfinder (SDF-backed, no raycast bundles)
         const v2Result = calculateSmartPlacementV2({ ...placementInput, mesh, modelId });
         if (v2Result.error === 'COLLISION_WITH_MODEL') {
+            // If V2's A* stagnated (trapped in a cavity with no Z progress),
+            // V1's raycast-bundle search is equally futile. Skip it entirely
+            // to avoid ~160 expansions × ~1500 raycasts each.
+            if (v2Result.stagnated) {
+                placement = v2Result;
+            } else {
             // Fallback to V1 raycast-based search, then SDF post-validate.
             // V1 uses 9-ray bundles which have gaps — verify every segment
             // of V1's result against the SDF before accepting it.
@@ -145,6 +151,7 @@ export function buildTrunkData(input: TrunkBuildInput): TrunkBuildResult {
                     placement = v1Result;
                 }
             }
+            } // end if (!stagnated)
         } else {
             placement = v2Result;
         }

--- a/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
+++ b/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
@@ -1,8 +1,8 @@
 import { useCallback, useState, useEffect, useRef } from 'react';
 import * as THREE from 'three';
-import { addAnchor, addBranch, addKnot, addRoot, addTrunk, getSnapshot, setSnapshot, updateKnot, updateTrunk } from '../../state';
+import { addAnchor, addBranch, addKnot, addRoot, addStick, addTrunk, getSnapshot, setSnapshot, updateKnot, updateTrunk } from '../../state';
 import { pushHistory } from '@/history/historyStore';
-import { SUPPORT_ADD_ANCHOR, SUPPORT_ADD_BRANCH, SUPPORT_ADD_TRUNK } from '../../history/actionTypes';
+import { SUPPORT_ADD_ANCHOR, SUPPORT_ADD_BRANCH, SUPPORT_ADD_STICK, SUPPORT_ADD_TRUNK } from '../../history/actionTypes';
 import { useInteractionStatus } from '../../interaction/useInteractionStatus';
 import { buildTrunkData } from './trunkBuilder';
 import { applyTrunkReplacement, computeAndApplyTrunkDiameterProfile, planTrunkReplacement } from './TrunkReplacement';
@@ -13,6 +13,63 @@ import { getSettings } from '../../Settings';
 import { decideGridPlacement } from '../../PlacementLogic/Grid';
 import { clearSupportSelection } from '../../interaction/shared/selection/selectionController';
 import { isContactDiskHudInteractionActive } from '../../SupportPrimitives/ContactDisk/contactDiskHudInteraction';
+import { buildStick } from '../Stick/stickBuilder';
+
+// ---------------------------------------------------------------------------
+// Cavity stick helpers
+// ---------------------------------------------------------------------------
+
+const _cavityRaycaster = new THREE.Raycaster();
+const _downDir = new THREE.Vector3(0, 0, -1);
+
+/**
+ * When A* stagnates (tip is inside a closed cavity), attempt to find the
+ * cavity floor by raycasting straight down.  Returns a buildStick result +
+ * a SupportData preview object, or null if no lower surface is found.
+ */
+function buildCavityStick(
+    tipPos: { x: number; y: number; z: number },
+    tipNormal: { x: number; y: number; z: number },
+    modelId: string,
+    mesh: THREE.Mesh,
+): { supportData: SupportData; stick: ReturnType<typeof buildStick>['stick'] } | null {
+    _cavityRaycaster.set(
+        new THREE.Vector3(tipPos.x, tipPos.y, tipPos.z),
+        _downDir,
+    );
+    // Offset origin slightly inward along tip normal so we don't self-hit the
+    // surface we just clicked.
+    const OFFSET_MM = 0.5;
+    _cavityRaycaster.ray.origin.addScaledVector(
+        new THREE.Vector3(tipNormal.x, tipNormal.y, tipNormal.z),
+        OFFSET_MM,
+    );
+    _cavityRaycaster.ray.origin.z -= OFFSET_MM * 0.1; // nudge down past origin surface
+
+    const hits = _cavityRaycaster.intersectObject(mesh, false);
+    if (hits.length === 0) return null;
+
+    // Pick the closest downward hit that is strictly below the tip.
+    const floorHit = hits.find((h) => h.point.z < tipPos.z - 0.1);
+    if (!floorHit || !floorHit.face) return null;
+
+    // Compute the floor normal in world space.
+    const normalMatrix = new THREE.Matrix3().getNormalMatrix(mesh.matrixWorld);
+    const floorNormal = floorHit.face.normal.clone().applyNormalMatrix(normalMatrix).normalize();
+
+    const bPos = { x: floorHit.point.x, y: floorHit.point.y, z: floorHit.point.z };
+    const bNormal = { x: floorNormal.x, y: floorNormal.y, z: floorNormal.z };
+
+    const { stick } = buildStick({ modelId, aPos: tipPos, aNormal: tipNormal, bPos, bNormal });
+
+    const supportData: SupportData = {
+        id: stick.id,
+        segments: stick.segments,
+        contactCones: [stick.contactConeA, stick.contactConeB],
+    };
+
+    return { stick, supportData };
+}
 
 export function useTrunkPlacementV2() {
     const HOVER_MIN_INTERVAL_MS = 9;
@@ -135,10 +192,19 @@ export function useTrunkPlacementV2() {
         const mesh = hit.object instanceof THREE.Mesh ? hit.object : undefined;
         const result = buildTrunkData({ tipPos, tipNormal, modelId, mesh });
 
-        // Fast-path for cavity hover: if the pathfinder stagnated, there's
-        // no valid support path. Skip grid placement entirely — it would just
-        // burn cycles re-evaluating an unsolvable position.
+        // Fast-path for cavity hover: if the pathfinder stagnated, the tip is
+        // inside a closed cavity.  Try to find the cavity floor and show a
+        // cavity-stick preview instead of an error.
         if (result.stagnated) {
+            if (mesh) {
+                const cavityStick = buildCavityStick(tipPos, tipNormal, modelId, mesh);
+                if (cavityStick) {
+                    setPreviewData(cavityStick.supportData);
+                    setPreviewError(null);
+                    setPreviewWarning(null);
+                    return;
+                }
+            }
             setPreviewData(result.supportData);
             setPreviewError(result.error || null);
             setPreviewWarning(null);
@@ -224,6 +290,26 @@ export function useTrunkPlacementV2() {
         // Pass mesh for collision detection
         const mesh = hit.object instanceof THREE.Mesh ? hit.object : undefined;
         const result = buildTrunkData({ tipPos, tipNormal, modelId, mesh });
+
+        // When the pathfinder stagnates the tip is inside a closed cavity and
+        // can't reach the build plate.  Fall back to a cavity stick that spans
+        // straight down to the nearest cavity floor surface.
+        if (result.stagnated) {
+            if (mesh) {
+                const cavityStick = buildCavityStick(tipPos, tipNormal, modelId, mesh);
+                if (cavityStick) {
+                    addStick(cavityStick.stick);
+                    pushHistory({
+                        type: SUPPORT_ADD_STICK,
+                        payload: { stick: cavityStick.stick },
+                    });
+                    clearSupportSelection();
+                    return;
+                }
+            }
+            // No cavity floor found — bail silently; hover preview already shows the error.
+            return;
+        }
 
         // In grid mode, decideGridPlacement may override a trunk error into a place_branch decision.
         // Only bail on trunk errors when grid is disabled (direct placement path).

--- a/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
+++ b/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
@@ -49,16 +49,30 @@ function buildCavityStick(
     const hits = _cavityRaycaster.intersectObject(mesh, false);
     if (hits.length === 0) return null;
 
-    // Pick the closest downward hit that is strictly below the tip.
-    const floorHit = hits.find((h) => h.point.z < tipPos.z - 0.1);
-    if (!floorHit || !floorHit.face) return null;
-
-    // Compute the floor normal in world space.
+    // Prefer a true "floor" hit (normal has meaningful +Z) so the bottom
+    // endpoint clings vertically down when possible. Only fall back to any
+    // below-tip hit (e.g. sidewall) if no floor-like surface is found.
+    const BELOW_EPS_MM = 0.1;
+    const FLOOR_Z_MIN = 0.35;
     const normalMatrix = new THREE.Matrix3().getNormalMatrix(mesh.matrixWorld);
-    const floorNormal = floorHit.face.normal.clone().applyNormalMatrix(normalMatrix).normalize();
 
-    const bPos = { x: floorHit.point.x, y: floorHit.point.y, z: floorHit.point.z };
-    const bNormal = { x: floorNormal.x, y: floorNormal.y, z: floorNormal.z };
+    type Candidate = { hit: THREE.Intersection; normal: THREE.Vector3 };
+    const belowCandidates: Candidate[] = [];
+
+    for (const h of hits) {
+        if (h.point.z >= tipPos.z - BELOW_EPS_MM) continue;
+        if (!h.face) continue;
+        const n = h.face.normal.clone().applyNormalMatrix(normalMatrix).normalize();
+        belowCandidates.push({ hit: h, normal: n });
+    }
+
+    if (belowCandidates.length === 0) return null;
+
+    const floorCandidate = belowCandidates.find((c) => c.normal.z >= FLOOR_Z_MIN);
+    const chosen = floorCandidate ?? belowCandidates[0];
+
+    const bPos = { x: chosen.hit.point.x, y: chosen.hit.point.y, z: chosen.hit.point.z };
+    const bNormal = { x: chosen.normal.x, y: chosen.normal.y, z: chosen.normal.z };
 
     const { stick } = buildStick({ modelId, aPos: tipPos, aNormal: tipNormal, bPos, bNormal });
 
@@ -73,8 +87,8 @@ function buildCavityStick(
 
 export function useTrunkPlacementV2() {
     const HOVER_MIN_INTERVAL_MS = 9;
-    const HOVER_POS_EPSILON_MM = 0.06;
-    const HOVER_NORMAL_DOT_MIN = 0.999;
+    const HOVER_POS_EPSILON_MM = 0.1;
+    const HOVER_NORMAL_DOT_MIN = 0.998;
 
     const [previewData, setPreviewData] = useState<SupportData | null>(null);
     const [previewError, setPreviewError] = useState<LimitationCode | null>(null);
@@ -190,12 +204,11 @@ export function useTrunkPlacementV2() {
 
         // Pass mesh for collision detection
         const mesh = hit.object instanceof THREE.Mesh ? hit.object : undefined;
-        const result = buildTrunkData({ tipPos, tipNormal, modelId, mesh });
+        const result = buildTrunkData({ tipPos, tipNormal, modelId, mesh, isPreview: true });
 
-        // Fast-path for cavity hover: if the pathfinder stagnated, the tip is
-        // inside a closed cavity.  Try to find the cavity floor and show a
-        // cavity-stick preview instead of an error.
-        if (result.stagnated) {
+        // Fast-path for cavity hover: if the pathfinder stagnated or exhausted its
+        // reduced preview budget, try to find the cavity floor and show a stick preview.
+        if (result.stagnated || result.exhaustedBudget) {
             if (mesh) {
                 const cavityStick = buildCavityStick(tipPos, tipNormal, modelId, mesh);
                 if (cavityStick) {
@@ -251,10 +264,29 @@ export function useTrunkPlacementV2() {
 
         // reject
         if (decision.trunkBuild) {
+            if (mesh && decision.trunkBuild.error === 'COLLISION_WITH_MODEL') {
+                const cavityStick = buildCavityStick(tipPos, tipNormal, modelId, mesh);
+                if (cavityStick) {
+                    setPreviewData(cavityStick.supportData);
+                    setPreviewError(null);
+                    setPreviewWarning(null);
+                    return;
+                }
+            }
             setPreviewData(decision.trunkBuild.supportData);
             setPreviewError(decision.trunkBuild.error || null);
             setPreviewWarning(decision.trunkBuild.warning || null);
             return;
+        }
+
+        if (decision.reason === 'COLLISION_WITH_MODEL' && mesh) {
+            const cavityStick = buildCavityStick(tipPos, tipNormal, modelId, mesh);
+            if (cavityStick) {
+                setPreviewData(cavityStick.supportData);
+                setPreviewError(null);
+                setPreviewWarning(null);
+                return;
+            }
         }
 
         setPreviewData((prev) => (prev === null ? prev : null));
@@ -291,10 +323,11 @@ export function useTrunkPlacementV2() {
         const mesh = hit.object instanceof THREE.Mesh ? hit.object : undefined;
         const result = buildTrunkData({ tipPos, tipNormal, modelId, mesh });
 
-        // When the pathfinder stagnates the tip is inside a closed cavity and
-        // can't reach the build plate.  Fall back to a cavity stick that spans
-        // straight down to the nearest cavity floor surface.
-        if (result.stagnated) {
+        // When the pathfinder stagnates (or exhausts its preview budget) the tip
+        // is effectively trapped in a cavity and can't route to the build plate.
+        // Fall back to a cavity stick that spans straight down to the nearest
+        // suitable surface.
+        if (result.stagnated || result.exhaustedBudget) {
             if (mesh) {
                 const cavityStick = buildCavityStick(tipPos, tipNormal, modelId, mesh);
                 if (cavityStick) {
@@ -314,7 +347,21 @@ export function useTrunkPlacementV2() {
         // In grid mode, decideGridPlacement may override a trunk error into a place_branch decision.
         // Only bail on trunk errors when grid is disabled (direct placement path).
         const settings = getSettings();
-        if (result.error && !settings.grid?.enabled) return;
+        if (result.error && !settings.grid?.enabled) {
+            if (result.error === 'COLLISION_WITH_MODEL' && mesh) {
+                const cavityStick = buildCavityStick(tipPos, tipNormal, modelId, mesh);
+                if (cavityStick) {
+                    addStick(cavityStick.stick);
+                    pushHistory({
+                        type: SUPPORT_ADD_STICK,
+                        payload: { stick: cavityStick.stick },
+                    });
+                    clearSupportSelection();
+                    return;
+                }
+            }
+            return;
+        }
 
         const decision = decideGridPlacement({
             settings,
@@ -407,6 +454,18 @@ export function useTrunkPlacementV2() {
         }
 
         if (decision.kind === 'reject') {
+            if (decision.reason === 'COLLISION_WITH_MODEL' && mesh) {
+                const cavityStick = buildCavityStick(tipPos, tipNormal, modelId, mesh);
+                if (cavityStick) {
+                    addStick(cavityStick.stick);
+                    pushHistory({
+                        type: SUPPORT_ADD_STICK,
+                        payload: { stick: cavityStick.stick },
+                    });
+                    clearSupportSelection();
+                    return;
+                }
+            }
             return;
         }
 

--- a/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
+++ b/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
@@ -134,6 +134,17 @@ export function useTrunkPlacementV2() {
         // Pass mesh for collision detection
         const mesh = hit.object instanceof THREE.Mesh ? hit.object : undefined;
         const result = buildTrunkData({ tipPos, tipNormal, modelId, mesh });
+
+        // Fast-path for cavity hover: if the pathfinder stagnated, there's
+        // no valid support path. Skip grid placement entirely — it would just
+        // burn cycles re-evaluating an unsolvable position.
+        if (result.stagnated) {
+            setPreviewData(result.supportData);
+            setPreviewError(result.error || null);
+            setPreviewWarning(null);
+            return;
+        }
+
         const decision = decideGridPlacement({
             settings: getSettings(),
             snapshot: getSnapshot(),

--- a/src/supports/interaction/jointDragPreview.ts
+++ b/src/supports/interaction/jointDragPreview.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { flushSync } from 'react-dom';
 import type { Branch, Knot, Roots, Trunk } from '../types';
 import { computeJointDragPreviewKnots, type JointDragPreviewCandidateKnots, type JointDragPreviewContext, type JointDragPreviewKind, type JointDragPreviewPayload, type JointDragPreviewSnapshot } from './jointDragPreviewMath';
 import type { PartDragPreviewPayload } from './partDragPreview';
@@ -214,21 +215,18 @@ export function useActiveJointDragPreview() {
 
   const schedulePreview = React.useCallback((nextPreview: JointDragPreviewSnapshot | null) => {
     const nextPreviewKey = buildPreviewSnapshotKey(nextPreview);
-    const currentKey = frameRef.current !== null
-      ? pendingPreviewKeyRef.current
-      : committedPreviewKeyRef.current;
-
-    if (nextPreviewKey === currentKey) return;
+    if (nextPreviewKey === committedPreviewKeyRef.current) return;
 
     pendingPreviewRef.current = nextPreview;
     pendingPreviewKeyRef.current = nextPreviewKey;
-    if (frameRef.current !== null) return;
+    committedPreviewKeyRef.current = nextPreviewKey;
 
-    frameRef.current = window.requestAnimationFrame(() => {
-      frameRef.current = null;
-      committedPreviewKeyRef.current = pendingPreviewKeyRef.current;
-      setPreview(pendingPreviewRef.current);
-    });
+    // flushSync forces a synchronous React commit so InstancedContactConeGroup's
+    // useLayoutEffect runs and updates instance matrices before R3F renders the
+    // next frame. Without this, React 18 auto-batches the update and flushes it
+    // asynchronously, letting R3F render the gizmo ball (imperative) at the new
+    // position while the cone (React props) is still one frame behind.
+    flushSync(() => setPreview(nextPreview));
   }, []);
 
   React.useEffect(() => {

--- a/src/supports/interaction/partDragPreview.ts
+++ b/src/supports/interaction/partDragPreview.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { flushSync } from 'react-dom';
 
 const EVENT_NAME = 'dragonfruit-part-drag-update';
 
@@ -21,6 +22,7 @@ export function clearPartDragUpdate(kind: PartDragPreviewKind, supportId: string
 
 export function usePartDragUpdate<T>(kind: PartDragPreviewKind, supportId: string): T | null {
   const [preview, setPreview] = React.useState<T | null>(null);
+  const previewRef = React.useRef<T | null>(null);
 
   React.useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -29,7 +31,11 @@ export function usePartDragUpdate<T>(kind: PartDragPreviewKind, supportId: strin
       const detail = (event as CustomEvent<PartDragPreviewPayload<T>>).detail;
       if (!detail) return;
       if (detail.kind !== kind || detail.supportId !== supportId) return;
-      setPreview(detail.support ?? null);
+      const nextPreview = detail.support ?? null;
+      if (Object.is(previewRef.current, nextPreview)) return;
+      previewRef.current = nextPreview;
+      // Keep support geometry in lockstep with gizmo movement.
+      flushSync(() => setPreview(nextPreview));
     };
 
     window.addEventListener(EVENT_NAME, handlePreview);

--- a/src/supports/interaction/pointerOcclusion.ts
+++ b/src/supports/interaction/pointerOcclusion.ts
@@ -1,9 +1,11 @@
 import * as THREE from 'three';
 import { isContactDiskHudInteractionActive } from '../SupportPrimitives/ContactDisk/contactDiskHudInteraction';
 import { isSupportEditInteractionActive } from './gizmoInteractionLock';
+import { getClipBounds } from '@/components/scene/SceneCanvas/clipBoundsStore';
 
 type PointerIntersectionLike = {
     object?: THREE.Object3D | null;
+    point?: THREE.Vector3 | null;
 };
 
 type PointerEventLike = {
@@ -30,13 +32,24 @@ export function getFrontBlockingModelId(event: PointerEventLike | null | undefin
     if (!targetRoot) return null;
 
     const intersections = Array.isArray(event?.intersections) ? event.intersections : [];
+    const { clipLower, clipUpper } = getClipBounds();
     for (const entry of intersections) {
         const object = entry?.object ?? null;
         if (!object) continue;
         if (isWithinTargetSubtree(object, targetRoot)) return null;
 
         const modelId = object.userData?.modelId;
-        if (typeof modelId === 'string' && modelId.length > 0) return modelId;
+        if (typeof modelId === 'string' && modelId.length > 0) {
+            // When cross-section is active, skip model hits whose intersection
+            // point falls in the clipped (invisible) zone — the surface is
+            // visually removed and should not block interactions behind it.
+            const pt = (entry as { point?: THREE.Vector3 | null }).point;
+            if (pt) {
+                if (clipUpper != null && pt.z > clipUpper) continue;
+                if (clipLower != null && pt.z < clipLower) continue;
+            }
+            return modelId;
+        }
     }
 
     return null;


### PR DESCRIPTION
This PR introduces the ability to place supports in internal model cavities, places that may only be reachable by utilizing the cross-section view.

Also includes:
- Updates to the supports pathfinding
- Render fixes to contact cones when editing joints
- Automatic switch to sticks if trunks are unplacable (e.g. internal cavity)

<img width="1422" height="897" alt="image" src="https://github.com/user-attachments/assets/60ff9314-a9f0-4efc-9fc3-cfd735ce0c88" />

As well as:
- Split upper and lower sliders
- Moving window slider
- Double-Click to temporarily disable cross-section view without losing slider positions

<img width="2297" height="1205" alt="image" src="https://github.com/user-attachments/assets/4e04d384-5f8a-4860-b3c1-074f1c8de972" />

