### PR TITLE
fix: guard navigator access in platform hooks for Node 20 SSR

### DIFF
--- a/src/hooks/usePlatform.ts
+++ b/src/hooks/usePlatform.ts
@@ -1,7 +1,7 @@
-import { useMemo } from 'react';
+import { useEffect, useState } from 'react';
 
-/** Detect the host OS from the browser's navigator API. */
-function detectPlatform(): 'mac' | 'windows' | 'linux' | 'unknown' {
+export function detectPlatform(): 'mac' | 'windows' | 'linux' | 'unknown' {
+  if (typeof navigator === 'undefined') return 'unknown';
   const ua = (navigator as { userAgentData?: { platform?: string } }).userAgentData?.platform ?? navigator.platform ?? '';
   if (ua.startsWith('Mac') || ua === 'macOS') return 'mac';
   if (ua.startsWith('Win')) return 'windows';
@@ -9,7 +9,10 @@ function detectPlatform(): 'mac' | 'windows' | 'linux' | 'unknown' {
   return 'unknown';
 }
 
-/** Returns true when the app is running on Linux (WebKitGTK or CEF). */
 export function useIsLinux(): boolean {
-  return useMemo(() => detectPlatform() === 'linux', []);
+  const [isLinux, setIsLinux] = useState(false);
+  useEffect(() => {
+    setIsLinux(detectPlatform() === 'linux');
+  }, []);
+  return isLinux;
 }

--- a/src/hooks/usePlatformModifier.ts
+++ b/src/hooks/usePlatformModifier.ts
@@ -1,9 +1,10 @@
-import { useMemo } from 'react';
+import { useEffect, useState } from 'react';
+import { detectPlatform } from './usePlatform';
 
-/** Returns "Cmd" on macOS, "Ctrl" on other platforms. */
 export function usePlatformModifier(): string {
-  return useMemo(() => {
-    const platform = (navigator as any).userAgentData?.platform ?? navigator.platform ?? '';
-    return platform.startsWith('Mac') ? 'Cmd' : 'Ctrl';
+  const [mod, setMod] = useState('Ctrl');
+  useEffect(() => {
+    setMod(detectPlatform() === 'mac' ? 'Cmd' : 'Ctrl');
   }, []);
+  return mod;
 }


### PR DESCRIPTION
## Summary
- Next.js production build fails on Node 20 (pinned in `.nvmrc`) with `ReferenceError: navigator is not defined` during SSR prerendering of page `/`
- Root cause: Node 20 lacks the `navigator` global (added in Node 21). Two hooks (`usePlatformModifier`, `usePlatform`) accessed it via `useMemo` during the SSR render pass
- Replace `useMemo` with `useState` + `useEffect` and add `typeof navigator` guards. DRY platform detection into shared `detectPlatform()` helper

## Test plan
- [x] Reproduced failure in Node 20.18.0 container (`df-node20-repro`)
- [x] Verified fix: `next build` passes on Node 20.18.0
- [x] Verified fix: `npm run build:tauri` passes on Mac (Node 22)
- [x] Verified no API signature changes in consuming components (TransformToolbar, RotationHintTooltip, SceneCanvas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)