### PR TITLE
feat: Flatpak packaging for Linux

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,108 @@
+name: Build Flatpak Bundle
+
+# Produces a single-file `.flatpak` bundle alongside the existing .deb/.rpm/
+# .AppImage bundles. Consumes the pre-built Tauri/CEF binary produced by
+# scripts/tauri-build.mjs; the Flatpak itself is a thin package around those
+# artefacts plus the manifest/launcher at flatpak/.
+#
+# For the Flathub-style hermetic build (offline cargo + node sources,
+# flatpak-builder-lint --strict, submodules-as-archives) see flatpak/FLATHUB.md.
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-flatpak:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Add SSH private keys for submodule repositories
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: |
+            ${{ secrets.CTB_DEPLOY }}
+            ${{ secrets.ELEGOO_DEPLOY }}
+            ${{ secrets.SDCP_V3_DEPLOY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: false
+
+      - name: Checkout submodules
+        run: |
+          git submodule sync
+          git submodule update --init --recursive
+
+      - name: Install Linux system dependencies for Tauri/CEF
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.18.0"
+          cache: npm
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      # Validate before building — catches .desktop/.metainfo regressions
+      # before wasting 20 min on a Tauri rebuild.
+      - name: Install AppStream + desktop-file validators
+        run: sudo apt-get install -y appstream desktop-file-utils
+
+      - name: Validate metainfo.xml
+        run: appstreamcli validate --no-net flatpak/org.openresinalliance.dragonfruit.metainfo.xml
+
+      - name: Validate .desktop
+        run: desktop-file-validate flatpak/org.openresinalliance.dragonfruit.desktop
+
+      - name: Build Tauri app (CEF variant on Linux)
+        run: node scripts/tauri-build.mjs --bundles none
+
+      - name: Stage CEF libraries next to binary
+        run: bash scripts/bundle-cef-libs.sh
+
+      # bilelmoussaoui's action handles flatpak + flatpak-builder install,
+      # runtime caching, bundle export, and upload.
+      - name: Build Flatpak bundle
+        uses: flathub-infra/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: dragonfruit.flatpak
+          manifest-path: flatpak/org.openresinalliance.dragonfruit.yml
+          cache-key: flatpak-builder-${{ github.sha }}
+          run-tests: false
+
+      # The action already uploads the bundle, but we re-upload into a
+      # consistently-named artifact so tag releases can grab it via
+      # actions/download-artifact. For tag pushes, attach to the release.
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dragonfruit-linux-flatpak-x64
+          path: dragonfruit.flatpak
+          if-no-files-found: error
+
+      - name: Attach to GitHub release (tag pushes only)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dragonfruit.flatpak
+          draft: true
+          prerelease: false

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /.next/
 /build
 /coverage
+/dist/
 /out/
 **/target/
 src-tauri/frontend-dist/**

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ For release-style builds and bundles:
    - `npm run tauri:bundle:linux`
    - `npm run tauri:bundle:macos`
    - `npm run tauri:bundle:macos:arm64`
+4. **Flatpak (Linux):** After a Linux Tauri build, run `bash flatpak/build.sh` to produce a `.flatpak` bundle in `dist/`. See [`flatpak/README.md`](flatpak/README.md) for details.
 
 ## Project Structure
 

--- a/flatpak/.gitignore
+++ b/flatpak/.gitignore
@@ -1,0 +1,5 @@
+# flatpak-builder outputs
+build-dir/
+repo/
+staging/
+.flatpak-builder/

--- a/flatpak/FLATHUB.md
+++ b/flatpak/FLATHUB.md
@@ -1,0 +1,104 @@
+# Flathub submission checklist
+
+Path to listing DragonFruit on [Flathub](https://flathub.org). The v0.1.3
+`.flatpak` in `dist/` is **self-hosted** only — it consumes pre-built binaries
+and does not meet Flathub's reproducibility / offline-source requirements.
+
+## Blockers (must be resolved before opening the submission PR)
+
+- [ ] **GPL-3.0 `LICENCE` file published at repo root.** Flathub rejects
+      submissions without a valid OSS licence file.
+- [ ] **Private submodules public or vendored.** `plugins/ctb`, `plugins/elegoo`,
+      `plugins/sdcp-v3` are currently private (`CTB_DEPLOY` / `ELEGOO_DEPLOY` /
+      `SDCP_V3_DEPLOY` SSH keys in CI). Flathub builders have no SSH access.
+      Either:
+      - Make the three submodule repos public, OR
+      - Vendor their pre-built `.rs`/`.ts` outputs into the main repo as
+        `archive`-type sources in the manifest, OR
+      - Ship a `dragonfruit-core` Flatpak variant without those plugins.
+- [ ] **Public repo**. The main DragonFruit repo must be public.
+
+## Manifest work needed
+
+Replace the fast-path manifest with a hermetic one:
+
+- [ ] **Offline cargo sources** — generate with
+      `flatpak-cargo-generator.py src-tauri/Cargo.lock -o flatpak/generated-cargo-sources.json`.
+      Script lives at <https://github.com/flatpak/flatpak-builder-tools/tree/master/cargo>.
+- [ ] **Offline npm sources** — generate with
+      `flatpak-node-generator.py npm package-lock.json -o flatpak/generated-npm-sources.json`.
+      Script lives at <https://github.com/flatpak/flatpak-builder-tools/tree/master/node>.
+- [ ] **CEF tarball as `type: archive`** — pin the exact
+      `cef_binary_*_linux64_minimal.tar.bz2` URL + SHA256 that `cef-dll-sys`
+      downloads during its build. Spotify's CDN is generally reliable, but
+      Flathub prefers a verified checksum over a runtime download.
+- [ ] **Build from source** — manifest module invokes the Tauri build
+      (`node scripts/tauri-build.mjs`) with `--offline` for cargo and
+      `--prefer-offline` for npm, fed by the generated sources JSON files.
+- [ ] **SDK extensions** enabled:
+      - `org.freedesktop.Sdk.Extension.rust-stable//24.08`
+      - `org.freedesktop.Sdk.Extension.node20//24.08`
+      - `org.freedesktop.Sdk.Extension.llvm18//24.08`
+      - Wire them via `build-options.append-path` +
+        `build-options.prepend-ld-library-path`.
+- [ ] **Remove `--share=network` from `finish-args` while building** — the
+      build itself must be offline. The deployed app retains network access
+      for printer communication.
+
+## Metadata polish
+
+- [ ] **Screenshots (≥3, ≥1280×720)** — commit to `docs/screenshots/flathub-*.png`
+      and reference from `flatpak/org.openresinalliance.dragonfruit.metainfo.xml`
+      `<screenshots>` via `raw.githubusercontent.com` URLs.
+- [ ] **Translated summary / description** — optional but welcomed.
+- [ ] **Release history** — fill `<releases>` with prior versions as the
+      project tags them.
+- [ ] **Content rating** — currently `oars-1.1` with no ratings. Review
+      against the [OARS spec](https://hughsie.github.io/oars/generate.html);
+      a slicer should be clean across the board.
+- [ ] **Branding colours** — already set. Validate they render well in
+      GNOME Software / KDE Discover previews.
+
+## Validation
+
+- [ ] **`appstreamcli validate --strict`** — currently passes with `--no-net`;
+      needs to pass in strict mode (warnings → errors).
+- [ ] **`desktop-file-validate`** — currently passes.
+- [ ] **`flatpak-builder-lint manifest …`** — Flathub's own linter. Install
+      via `flatpak install flathub org.flatpak.Builder//24.08`, run as
+      `flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest flatpak/…yml`.
+      Must report zero errors. Lints `finish-args` completeness, `app-id`
+      conventions, forbidden patterns (`--filesystem=host`, SUID binaries).
+- [ ] **Reproducible rebuild** — run the hermetic build twice, diff the
+      resulting OSTree trees. Any non-determinism is a Flathub auto-reject.
+
+## Submission
+
+- [ ] Fork `flathub/flathub`
+- [ ] Open PR adding a new submission under `com.<id>` — for us,
+      `org.openresinalliance.dragonfruit/` containing the manifest + any
+      patches
+- [ ] Flathub reviewer-bot runs automated checks; human review follows
+      (expect 1–4 weeks)
+- [ ] Respond to review feedback
+- [ ] On merge, Flathub's CI builds and publishes to the stable repo;
+      listing appears on flathub.org usually within a few hours
+
+## Things NOT to do
+
+- ❌ Do not claim `org.openresinalliance.*` as a Flathub app-id prefix
+  without owning the `openresinalliance.org` domain and proving so via
+  reverse-DNS rules. If the domain isn't controlled, use
+  `io.github.open-resin-alliance.dragonfruit` instead (GitHub org mapping
+  is an accepted Flathub convention).
+- ❌ Do not ship `--filesystem=host` or `--share=home` — instant reject.
+  The current manifest does not, and should not.
+- ❌ Do not use `--talk-name=*` as a wildcard. Enumerate each portal name.
+- ❌ Do not add `--device=all` — only `--device=dri` is needed.
+
+## References
+
+- Flathub submission guide: <https://docs.flathub.org/docs/for-app-authors/submission>
+- AppStream spec: <https://www.freedesktop.org/software/appstream/docs/>
+- Flatpak manifest reference: <https://docs.flatpak.org/en/latest/manifests.html>
+- flatpak-builder-tools: <https://github.com/flatpak/flatpak-builder-tools>

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -1,0 +1,134 @@
+# DragonFruit Flatpak
+
+Flatpak packaging for DragonFruit. Adds a sandboxed, auto-updating Linux
+install path alongside the existing `.deb`, `.rpm`, and `.AppImage` bundles.
+
+## Design summary
+
+- **Runtime**: `org.freedesktop.Platform//24.08`
+- **Bundled CEF**: matches the `.deb`/`.rpm`/`.AppImage` Linux build path
+  (Tauri `feat/cef` fork — fixes issue #83 Wayland+Nvidia crash). CEF runs
+  with `--no-sandbox` because Flatpak's own bwrap sandbox already provides
+  namespace isolation.
+- **No thumbnailer**: the file-manager thumbnailer is intentionally not
+  included — host file managers cannot execute binaries inside a Flatpak
+  sandbox. See `THUMBNAILER.md` for the investigation. Users wanting file
+  manager thumbnails should install the `.deb`/`.rpm`.
+
+## Files in this directory
+
+| File | Purpose |
+|------|---------|
+| `org.openresinalliance.dragonfruit.yml` | flatpak-builder manifest (fast path — consumes pre-built binary) |
+| `org.openresinalliance.dragonfruit.metainfo.xml` | AppStream metadata |
+| `org.openresinalliance.dragonfruit.desktop` | Desktop entry |
+| `dragonfruit-voxl-mime.xml` | MIME type registration for `.voxl` files |
+| `launcher.sh` | `/app/bin/dragonfruit` wrapper — sets CEF flags and `LD_LIBRARY_PATH` |
+| `build.sh` | Orchestrator: validates metadata, runs flatpak-builder, exports bundle |
+| `FLATHUB.md` | Flathub submission checklist (blocked on GPL-3.0 LICENCE publication) |
+| `THUMBNAILER.md` | Thumbnailer-in-Flatpak investigation notes |
+
+## Building the bundle
+
+### Host prerequisites
+
+Install flatpak + flatpak-builder + runtimes:
+
+```bash
+# Fedora
+sudo dnf install -y flatpak flatpak-builder appstream desktop-file-utils
+# Ubuntu
+sudo apt-get install -y flatpak flatpak-builder appstreamcli desktop-file-utils
+
+flatpak remote-add --if-not-exists --user flathub \
+    https://flathub.org/repo/flathub.flatpakrepo
+
+flatpak install --user -y flathub \
+    org.freedesktop.Platform//24.08 \
+    org.freedesktop.Sdk//24.08
+```
+
+### Build steps
+
+From the DragonFruit repo root:
+
+```bash
+# 1. Build the Tauri app with CEF
+node scripts/tauri-build.mjs
+bash scripts/bundle-cef-libs.sh
+
+# 2. Build the Flatpak bundle
+bash flatpak/build.sh
+```
+
+Output: `dist/dragonfruit-<version>-x86_64.flatpak`
+
+### Install and run
+
+```bash
+flatpak install --user -y dist/dragonfruit-*.flatpak
+flatpak run org.openresinalliance.dragonfruit
+```
+
+## Building inside the `cef-linux-build` Docker container
+
+The swamp-managed `cef-linux-build` Fedora 43 container has the repo mounted
+at `/build` and already contains the compiled Tauri artifacts from previous
+builds. Full sequence:
+
+```bash
+# Ensure container is running
+swamp model method run cef-linux-build apply
+
+# Enter container
+docker exec -it df-cef-build bash
+
+# Inside container:
+dnf install -y flatpak flatpak-builder appstream desktop-file-utils
+flatpak remote-add --if-not-exists --user flathub \
+    https://flathub.org/repo/flathub.flatpakrepo
+flatpak install --user -y flathub \
+    org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08
+
+cd /build
+# (re)build the Tauri app if needed
+node scripts/tauri-build.mjs
+bash scripts/bundle-cef-libs.sh
+# produce the Flatpak
+bash flatpak/build.sh
+```
+
+## Runtime permissions
+
+The Flatpak is granted:
+
+| Permission | Why |
+|------------|-----|
+| `--share=ipc` | CEF zygote ↔ renderer shared memory |
+| `--share=network` | Printer discovery + uploads (HTTP) |
+| `--socket=wayland` `--socket=fallback-x11` | Display |
+| `--socket=pulseaudio` | (benign; no audio currently used) |
+| `--device=dri` | GPU acceleration for Three.js preview |
+| `--filesystem=xdg-documents` `--filesystem=xdg-download` | Initial read/write for common save locations |
+| `--talk-name=org.freedesktop.portal.*` | File picker + notifications + open-uri via `rfd` crate |
+
+**Not granted** (deliberate): `--filesystem=host`, `--share=home`, USB/serial
+devices. File I/O outside `~/Documents` and `~/Downloads` goes via the
+xdg-desktop-portal file chooser; the `rfd` crate detects Flatpak automatically.
+
+## Known limitations
+
+- **No file-manager thumbnails**: dropping the `dragonfruit-voxl-thumbnailer`
+  binary; see `THUMBNAILER.md`.
+- **No USB/serial printer support**: DragonFruit talks to printers over
+  HTTP/LAN only, so this is not a regression — but worth knowing if that
+  changes upstream.
+- **Single-architecture**: x86_64 only in v0.1.3 (mirrors current CI).
+  aarch64 is future work.
+
+## Related docs
+
+- `FLATHUB.md` — submission checklist and blockers
+- `THUMBNAILER.md` — thumbnailer investigation
+- Root `scripts/tauri-build.mjs` — Linux build path invoking `--features tauri-cef`
+- Root `scripts/bundle-cef-libs.sh` — CEF library staging

--- a/flatpak/THUMBNAILER.md
+++ b/flatpak/THUMBNAILER.md
@@ -1,0 +1,71 @@
+# Thumbnailer support in the Flatpak build — decision record
+
+## Question
+
+DragonFruit ships `dragonfruit-voxl-thumbnailer` (a small Rust binary at
+`rust/dragonfruit-voxl-thumbnail/`) that host file managers (Nautilus, Dolphin,
+Nemo, Thunar) invoke to render thumbnails of `.voxl` files. On `.deb`/`.rpm`
+installs the binary goes to `/usr/bin/` and a `.thumbnailer` file at
+`/usr/share/thumbnailers/` registers it. Should the Flatpak ship this too?
+
+## TL;DR — **No**
+
+Dropped from the Flatpak build in v0.1.3. Users who want file-manager
+thumbnails install the `.deb`/`.rpm` bundle instead. Rationale below.
+
+## Why host file managers cannot call into a Flatpak
+
+File managers invoke thumbnailers by spawning the binary named in
+`Exec=` of the `.thumbnailer` file. The file manager runs **outside** the
+Flatpak sandbox, so:
+
+1. It cannot see `/app/bin/dragonfruit-voxl-thumbnailer` — that path exists
+   only inside the app's mount namespace.
+2. Flatpak *does* export approved binaries to
+   `/var/lib/flatpak/exports/bin/<app-id>.<name>` via `finish-args`, but:
+   - The export is a wrapper that calls `flatpak run --command=<name> <app-id>`.
+   - Each `flatpak run` spins up a fresh sandbox instance: namespace setup,
+     CEF zygote init, D-Bus session. Easily 1–3 s overhead per call.
+   - File managers thumbnail in parallel batches; this would thrash the
+     system and produce terrible UX.
+3. Even with the export, registering the `.thumbnailer` on the host requires
+   writing to `/usr/share/thumbnailers/` — host paths the sandbox cannot reach.
+
+There is no Flatpak portal for thumbnailer registration. This is a known,
+long-standing limitation (flatpak/flatpak#2238, xdg-desktop-portal#1025).
+
+## Options considered
+
+| # | Approach | Verdict |
+|---|----------|---------|
+| 1 | Drop thumbnailer, document limitation | ✅ **Chosen**. Smallest bundle, clearest UX. |
+| 2 | Ship binary + `.thumbnailer` in `/app/share/thumbnailers/` | ❌ Host file managers only look at `/usr/share/thumbnailers/` and `~/.local/share/thumbnailers/` — not `/var/lib/flatpak/exports/share/thumbnailers/`. |
+| 3 | Exported `flatpak run` wrapper in `/var/lib/flatpak/exports/bin/` + `.thumbnailer` pointing at it | ❌ Works in principle but 1–3 s per-thumbnail overhead from sandbox startup makes it unusable at file-manager scale. Also: wrapper is `org.openresinalliance.dragonfruit.dragonfruit-voxl-thumbnailer`, which most file managers silently reject because it contains dots and they treat it as a MIME type. |
+| 4 | Ship as a separate tiny Flatpak just for the thumbnailer | ❌ Same sandbox-startup problem as option 3, plus discoverability is terrible. |
+
+## Recommendation
+
+Document in `flatpak/README.md` (done):
+
+> The Flatpak does not install a file-manager thumbnailer for `.voxl` files.
+> This is a Flatpak sandbox limitation — host file managers cannot cross the
+> sandbox boundary to call a thumbnailer binary. If you want thumbnails in
+> Nautilus/Dolphin/Nemo, install the `.deb` or `.rpm` instead.
+
+Re-evaluate when either:
+- xdg-desktop-portal gains a thumbnailer portal (likely years away), or
+- DragonFruit offers thumbnails via alternative means (e.g., GVfs-visible
+  sidecar `.thumb` files written on export).
+
+## Test artifacts
+
+None — dropped before testing. The analysis above is based on documentation
+and prior Flatpak community experience (e.g. OBS Studio, Inkscape, GIMP all
+face the same constraint and all ship without host thumbnailer integration
+in their Flatpaks).
+
+## Related files
+
+- `rust/dragonfruit-voxl-thumbnail/` — source (kept; used for `.deb`/`.rpm`)
+- `src-tauri/tauri.linux.conf.json` — `.deb` bundle config that ships the
+  thumbnailer on non-Flatpak Linux installs

--- a/flatpak/build.sh
+++ b/flatpak/build.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# flatpak/build.sh — Build a .flatpak bundle from pre-built artifacts.
+#
+# Prerequisites (run manually on the Linux host before this script):
+#   node scripts/tauri-build.mjs           # Linux path => --features tauri-cef
+#   bash scripts/bundle-cef-libs.sh        # stages .so/.pak/.dat/.bin/locales
+#
+# Then from the repo root:
+#   bash flatpak/build.sh
+#
+# Output:
+#   flatpak/repo/                                          local ostree repo
+#   flatpak/build-dir/                                     staged /app tree
+#   dist/dragonfruit-<version>-<arch>.flatpak              single-file bundle
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+APP_ID="org.openresinalliance.dragonfruit"
+MANIFEST="flatpak/org.openresinalliance.dragonfruit.yml"
+# Version — read from package.json without needing node (flatpak build hosts
+# may not have the frontend toolchain installed).
+VERSION="$(sed -nE 's/.*"version": *"([^"]+)".*/\1/p' package.json | head -1)"
+ARCH="$(uname -m)"
+OUT="dist/dragonfruit-${VERSION}-${ARCH}.flatpak"
+
+# Pre-flight: validate metadata before kicking off the real build. These are
+# the validations Flathub runs; catching locally saves a full build cycle.
+echo "[1/6] Validating metainfo.xml"
+# --no-net: URL reachability is not a local-build concern; Flathub runs its own
+# checks with network access. Avoids flaky CI from transient GitHub 5xx.
+appstreamcli validate --no-net flatpak/org.openresinalliance.dragonfruit.metainfo.xml
+
+echo "[2/6] Validating .desktop"
+desktop-file-validate flatpak/org.openresinalliance.dragonfruit.desktop
+
+# Pre-flight: locate the Linux CEF binary. Expectation is that
+# `node scripts/tauri-build.mjs` produces a CEF-linked binary (tauri-build.mjs
+# appends --features tauri-cef on Linux). Candidates, in order of preference:
+#
+#   1. src-tauri/target/release/dragonfruit-desktop                        (native build, current)
+#   2. src-tauri/target/x86_64-unknown-linux-gnu/release/dragonfruit-desktop
+#   3. src-tauri/target/release/bundle/appimage/DragonFruit.AppDir/usr/bin/dragonfruit-desktop
+#                                                                         (from prior AppImage)
+#
+# Requirement: the binary must be Linux x86_64 ELF *and* NEEDED libcef.so.
+# On a shared volume with a macOS host, target/release/ may be overwritten
+# by macOS Mach-O builds, and earlier builds may have been wry/WebKitGTK
+# before the CEF switch. Fail fast with a clear message if the first
+# CEF-linked candidate can't be found.
+REL=src-tauri/target/release
+TRIPLE_REL=src-tauri/target/x86_64-unknown-linux-gnu/release
+APPIMG_REL=src-tauri/target/release/bundle/appimage/DragonFruit.AppDir/usr/bin
+
+find_cef_binary() {
+    for candidate in "$REL/dragonfruit-desktop" \
+                     "$TRIPLE_REL/dragonfruit-desktop" \
+                     "$APPIMG_REL/dragonfruit-desktop"; do
+        [ -f "$candidate" ] || continue
+        if command -v file >/dev/null 2>&1; then
+            file "$candidate" | grep -q 'ELF 64-bit LSB.*x86-64' || continue
+        fi
+        if command -v readelf >/dev/null 2>&1; then
+            readelf -d "$candidate" 2>/dev/null | grep -q 'NEEDED.*libcef' || continue
+        fi
+        echo "$candidate"
+        return 0
+    done
+    return 1
+}
+
+BIN="$(find_cef_binary)" || {
+    echo "ERROR: No Linux x86_64 CEF-linked dragonfruit-desktop binary found." >&2
+    echo "       Looked in: $REL, $TRIPLE_REL, $APPIMG_REL" >&2
+    echo "       Run 'node scripts/tauri-build.mjs' on Linux to produce one." >&2
+    exit 1
+}
+
+for f in libcef.so locales; do
+    if [ ! -e "$REL/$f" ]; then
+        echo "ERROR: $REL/$f missing — run 'bash scripts/bundle-cef-libs.sh' first." >&2
+        exit 1
+    fi
+done
+echo "       Using binary: $BIN"
+
+# Stage only the files flatpak-builder needs. If we point a `type: dir` source
+# at the repo root (or src-tauri/), flatpak-builder copies gigabytes of cargo
+# build artefacts, node_modules, and submodules into its build context — even
+# though we only install a handful of specific files. Staging ~250 MB of
+# relevant files instead keeps the build to tens of seconds.
+echo "[3/6] Staging build inputs"
+STAGING=flatpak/staging
+rm -rf "$STAGING"
+mkdir -p "$STAGING/bin" "$STAGING/cef" "$STAGING/icons"
+
+cp "$BIN"                                  "$STAGING/bin/dragonfruit-desktop"
+cp "$REL"/*.so                             "$STAGING/cef/"
+for f in "$REL"/*.pak "$REL"/*.dat "$REL"/*.bin "$REL"/vk_swiftshader_icd.json; do
+    [ -f "$f" ] && cp "$f" "$STAGING/cef/"
+done
+# chrome-sandbox — harmless if present; CEF is run with --no-sandbox at runtime
+[ -f "$REL/chrome-sandbox" ] && cp "$REL/chrome-sandbox" "$STAGING/cef/"
+cp -r "$REL/locales"                       "$STAGING/cef/"
+
+cp flatpak/launcher.sh                                    "$STAGING/"
+cp flatpak/org.openresinalliance.dragonfruit.desktop      "$STAGING/"
+cp flatpak/org.openresinalliance.dragonfruit.metainfo.xml "$STAGING/"
+cp flatpak/dragonfruit-voxl-mime.xml                      "$STAGING/"
+
+cp src-tauri/icons/32x32.png       "$STAGING/icons/32x32.png"
+cp src-tauri/icons/64x64.png       "$STAGING/icons/64x64.png"
+cp src-tauri/icons/128x128.png     "$STAGING/icons/128x128.png"
+cp src-tauri/icons/128x128@2x.png  "$STAGING/icons/256x256.png"
+cp src-tauri/icons/icon.png        "$STAGING/icons/512x512.png"
+
+echo "       Staging size: $(du -sh "$STAGING" | cut -f1)"
+
+echo "[4/6] Running flatpak-builder"
+rm -rf flatpak/build-dir
+# --disable-rofiles-fuse: FUSE is unavailable inside most Docker containers
+# without CAP_SYS_ADMIN + /dev/fuse. Flatpak-builder falls back to copying,
+# which is slightly slower but works anywhere. Harmless on bare-metal too.
+FLATPAK_BUILDER_FLAGS="${FLATPAK_BUILDER_FLAGS:---disable-rofiles-fuse}"
+flatpak-builder --user --force-clean $FLATPAK_BUILDER_FLAGS \
+    --repo=flatpak/repo \
+    flatpak/build-dir \
+    "$MANIFEST"
+
+echo "[5/6] Exporting single-file bundle to $OUT"
+mkdir -p dist
+flatpak build-bundle flatpak/repo "$OUT" "$APP_ID"
+
+echo "[6/6] Bundle produced:"
+ls -lh "$OUT"
+echo ""
+echo "Install with:"
+echo "    flatpak install --user -y $OUT"
+echo "Run with:"
+echo "    flatpak run $APP_ID"

--- a/flatpak/dragonfruit-voxl-mime.xml
+++ b/flatpak/dragonfruit-voxl-mime.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/vnd.dragonfruit.voxl+json">
+    <comment>DragonFruit VOXL Scene</comment>
+    <icon name="org.openresinalliance.dragonfruit"/>
+    <glob pattern="*.voxl"/>
+    <alias type="application/x-voxl"/>
+    <magic priority="50">
+      <match type="string" offset="0" value="VOXL"/>
+    </magic>
+  </mime-type>
+</mime-info>

--- a/flatpak/launcher.sh
+++ b/flatpak/launcher.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# /app/bin/dragonfruit — Flatpak launcher wrapper for DragonFruit.
+#
+# CEF inside Flatpak notes:
+#   --no-sandbox            CEF SUID-sandbox needs setuid root on chrome-sandbox;
+#                           Flatpak cannot grant it. bwrap already sandboxes, so
+#                           stacking is infeasible and unnecessary.
+#   --disable-dev-shm-usage Flatpak's per-app /dev/shm can be tight; falls back
+#                           to /tmp which is backed by the app's writable layer.
+#   --ozone-platform-hint=auto  Picks Wayland when $WAYLAND_DISPLAY is set,
+#                               falls back to X11 via --socket=fallback-x11.
+#
+# CEF runtime data lives under /app/lib/dragonfruit/cef/. The bundled libcef.so
+# and friends are resolved via LD_LIBRARY_PATH, not rpath, to avoid relinking.
+
+set -e
+
+DF_LIB=/app/lib/dragonfruit
+export LD_LIBRARY_PATH="$DF_LIB/cef:${LD_LIBRARY_PATH:-}"
+
+# Suppress the "chrome-sandbox not SUID" warning spam even though --no-sandbox
+# means it isn't consulted. Harmless; improves log signal.
+export CHROME_DEVEL_SANDBOX="$DF_LIB/cef/chrome-sandbox"
+
+exec "$DF_LIB/dragonfruit-desktop" \
+    --no-sandbox \
+    --disable-dev-shm-usage \
+    --ozone-platform-hint=auto \
+    --enable-features=UseOzonePlatform,WaylandWindowDecorations \
+    "$@"

--- a/flatpak/org.openresinalliance.dragonfruit.desktop
+++ b/flatpak/org.openresinalliance.dragonfruit.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Name=DragonFruit
+GenericName=Resin Slicer
+Comment=Slice STL/3MF models for resin 3D printers
+Exec=dragonfruit %U
+Icon=org.openresinalliance.dragonfruit
+Terminal=false
+Categories=Graphics;3DGraphics;
+MimeType=application/vnd.dragonfruit.voxl+json;application/x-voxl;model/stl;model/3mf;
+StartupWMClass=dragonfruit-desktop
+StartupNotify=true
+Keywords=3D;Print;Printing;Slicer;Resin;MSLA;SLA;CAD;

--- a/flatpak/org.openresinalliance.dragonfruit.metainfo.xml
+++ b/flatpak/org.openresinalliance.dragonfruit.metainfo.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.openresinalliance.dragonfruit</id>
+  <name>DragonFruit</name>
+  <summary>Open-source resin 3D printer slicer</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+
+  <developer id="org.openresinalliance">
+    <name>Open Resin Alliance</name>
+  </developer>
+
+  <launchable type="desktop-id">org.openresinalliance.dragonfruit.desktop</launchable>
+
+  <description>
+    <p>
+      DragonFruit is an open-source resin slicer for SLA and MSLA 3D printers.
+      Prepare STL and 3MF models for printing with multi-printer fleet
+      management, advanced support generation, and integrated preview.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Support for CTB v3/v4, SDCP 3.0.0, Anycubic and Elegoo printer families</li>
+      <li>GPU-accelerated preview with island detection and supports analysis</li>
+      <li>Fleet management for multi-printer workshops</li>
+      <li>Native VOXL scene format for lossless round-trip editing</li>
+      <li>Plugin architecture for extensible printer and format support</li>
+    </ul>
+  </description>
+
+  <categories>
+    <category>Graphics</category>
+    <category>3DGraphics</category>
+  </categories>
+
+  <url type="homepage">https://github.com/open-resin-alliance/DragonFruit</url>
+  <url type="bugtracker">https://github.com/open-resin-alliance/DragonFruit/issues</url>
+  <url type="vcs-browser">https://github.com/open-resin-alliance/DragonFruit</url>
+
+  <provides>
+    <binary>dragonfruit</binary>
+    <mediatype>application/vnd.dragonfruit.voxl+json</mediatype>
+    <mediatype>application/x-voxl</mediatype>
+  </provides>
+
+  <recommends>
+    <display_length compare="ge">768</display_length>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </recommends>
+
+  <requires>
+    <internet>always</internet>
+  </requires>
+
+  <content_rating type="oars-1.1" />
+
+  <releases>
+    <release version="0.1.3" date="2026-04-16">
+      <description>
+        <p>Flatpak packaging introduced (Linux). Ships CEF-based runtime for stability on Wayland+Nvidia.</p>
+      </description>
+    </release>
+  </releases>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#ff6b9d</color>
+    <color type="primary" scheme_preference="dark">#8b3a5c</color>
+  </branding>
+</component>

--- a/flatpak/org.openresinalliance.dragonfruit.yml
+++ b/flatpak/org.openresinalliance.dragonfruit.yml
@@ -1,0 +1,89 @@
+# flatpak-builder manifest — fast-path packaging.
+#
+# This manifest consumes pre-built artifacts from src-tauri/target/release/
+# rather than rebuilding from source inside the flatpak sandbox. Run the
+# Linux Tauri build beforehand:
+#
+#     node scripts/tauri-build.mjs   # Linux path appends --features tauri-cef
+#     bash scripts/bundle-cef-libs.sh
+#
+# Those two commands leave dragonfruit-desktop, libcef.so, *.pak, icudtl.dat,
+# v8_context_snapshot.bin, chrome-sandbox, and locales/ all in
+# src-tauri/target/release/. This manifest picks them up from there.
+#
+# Rationale: the full workspace + CEF rebuild inside flatpak-builder is
+# multi-GB of crates + ~20 minutes of linker time; for iteration and for
+# self-hosted distribution this is wasted work. The hermetic-build variant
+# (required for Flathub) is tracked separately in flatpak/FLATHUB.md.
+
+app-id: org.openresinalliance.dragonfruit
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: dragonfruit
+
+finish-args:
+  # CEF zygote ↔ renderer shared memory
+  - --share=ipc
+
+  # Printer HTTP discovery + uploads (SDCP 3.0.0, Anycubic, Elegoo, Athena)
+  - --share=network
+
+  # Display
+  - --socket=wayland
+  - --socket=fallback-x11
+
+  # Audio (optional, tauri-plugin-log writes to journal; harmless)
+  - --socket=pulseaudio
+
+  # GPU acceleration for Three.js / react-three-fiber preview
+  - --device=dri
+
+  # File open/save via xdg-desktop-portal (rfd crate uses portal automatically
+  # when /.flatpak-info is present; no --filesystem=host needed)
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+
+  # Portal access for file chooser, notifications, open-uri
+  - --talk-name=org.freedesktop.portal.Desktop
+  - --talk-name=org.freedesktop.portal.FileChooser
+  - --talk-name=org.freedesktop.portal.OpenURI
+
+  # Writable app data dir (default; XDG_DATA_HOME-aware code in src-tauri
+  # writes to ~/.var/app/org.openresinalliance.dragonfruit/data/…)
+
+modules:
+  - name: dragonfruit
+    buildsystem: simple
+    build-commands:
+      # Binary + CEF runtime under /app/lib/
+      - install -Dm755 staging/bin/dragonfruit-desktop /app/lib/dragonfruit/dragonfruit-desktop
+      - install -d /app/lib/dragonfruit/cef
+      - 'cp -a staging/cef/. /app/lib/dragonfruit/cef/'
+
+      # Launcher at /app/bin/dragonfruit
+      - install -Dm755 staging/launcher.sh /app/bin/dragonfruit
+
+      # Desktop entry
+      - install -Dm644 staging/org.openresinalliance.dragonfruit.desktop /app/share/applications/org.openresinalliance.dragonfruit.desktop
+
+      # AppStream metainfo
+      - install -Dm644 staging/org.openresinalliance.dragonfruit.metainfo.xml /app/share/metainfo/org.openresinalliance.dragonfruit.metainfo.xml
+
+      # MIME type for .voxl files
+      - install -Dm644 staging/dragonfruit-voxl-mime.xml /app/share/mime/packages/org.openresinalliance.dragonfruit.xml
+
+      # Icons — hicolor theme
+      - install -Dm644 staging/icons/32x32.png   /app/share/icons/hicolor/32x32/apps/org.openresinalliance.dragonfruit.png
+      - install -Dm644 staging/icons/64x64.png   /app/share/icons/hicolor/64x64/apps/org.openresinalliance.dragonfruit.png
+      - install -Dm644 staging/icons/128x128.png /app/share/icons/hicolor/128x128/apps/org.openresinalliance.dragonfruit.png
+      - install -Dm644 staging/icons/256x256.png /app/share/icons/hicolor/256x256/apps/org.openresinalliance.dragonfruit.png
+      - install -Dm644 staging/icons/512x512.png /app/share/icons/hicolor/512x512/apps/org.openresinalliance.dragonfruit.png
+    sources:
+      - type: dir
+        # Staged by flatpak/build.sh prior to invocation. Keeps the flatpak-builder
+        # copy scope small (pre-built binary + CEF blobs only) — the alternative
+        # would pull node_modules + src-tauri/target/{deps,build} into the builder
+        # context (many GB, slow copy even with --disable-rofiles-fuse).
+        path: staging
+        dest: staging


### PR DESCRIPTION
## Summary

Adds `.flatpak` distribution alongside the existing `.deb`, `.rpm`, and `.AppImage` bundles. The bundle ships the same CEF-based Linux runtime used by the other Linux bundles (matching the `tauri-build.mjs` `--features tauri-cef` path for issue #83 stability on Wayland+Nvidia).

## What's in here

- **`flatpak/org.openresinalliance.dragonfruit.yml`** — manifest, fast-path variant that consumes pre-built artefacts from `src-tauri/target/release/`. Runtime: `org.freedesktop.Platform//24.08`.
- **`flatpak/launcher.sh`** — `/app/bin/dragonfruit` wrapper. Sets `LD_LIBRARY_PATH` to the bundled CEF, passes `--no-sandbox --disable-dev-shm-usage --ozone-platform-hint=auto`. `--no-sandbox` is required because CEF's SUID sandbox needs a setuid `chrome-sandbox` that Flatpak cannot grant; bwrap already provides namespace isolation.
- **`flatpak/org.openresinalliance.dragonfruit.metainfo.xml`** + **`.desktop`** + **`dragonfruit-voxl-mime.xml`** — hand-authored AppStream metadata, desktop entry, and `.voxl` MIME registration (Tauri's auto-generated `.desktop` doesn't validate under `appstreamcli` strict mode — empty `Categories=`).
- **`flatpak/build.sh`** — orchestrator. Validates `metainfo.xml` + `.desktop`, locates a Linux ELF CEF-linked binary (rejects Mach-O from macOS builds on the same shared volume), stages ~250 MB of inputs, runs `flatpak-builder`, exports a single-file bundle to `dist/`.
- **`.github/workflows/flatpak.yml`** — CI job using `flathub-infra/flatpak-github-actions/flatpak-builder@v6`. Triggers on `workflow_dispatch` + tag pushes. Re-uses submodule SSH keys from `tauri-bundle.yml`.
- **`flatpak/THUMBNAILER.md`** — decision record on why the `dragonfruit-voxl-thumbnailer` is dropped from the Flatpak (host file managers can't cross the sandbox boundary — same constraint GIMP/Inkscape/OBS hit).
- **`flatpak/FLATHUB.md`** — submission checklist: blocked on LICENCE publication + submodule visibility. Not actionable yet.
- **`flatpak/README.md`** — user-facing build docs.

## Finish-args (sandbox permissions)

Minimal set:
- `--share=ipc` (CEF zygote ↔ renderer shm)
- `--share=network` (printer HTTP discovery + uploads)
- `--socket=wayland` `--socket=fallback-x11` `--socket=pulseaudio`
- `--device=dri` (WebGL / Three.js preview)
- `--filesystem=xdg-documents` `--filesystem=xdg-download`
- `--talk-name=org.freedesktop.portal.{Desktop,FileChooser,OpenURI}` (file picker via `rfd` crate which auto-uses portal inside Flatpak)

**Not granted** (deliberate): `--filesystem=host`, `--share=home`, USB/serial.

## Verification

Built the 113 MB bundle inside a privileged Fedora 43 Docker container and smoke-tested on both Fedora 43 and Ubuntu 24.04:

- ✅ `flatpak install --user -y dist/dragonfruit-0.1.3-x86_64.flatpak` succeeds on both distros
- ✅ `timeout 15 xvfb-run -a flatpak run org.openresinalliance.dragonfruit` runs without segfault, CEF init messages appear, no `bwrap:` errors
- ✅ `appstreamcli validate --no-net` passes
- ✅ `desktop-file-validate` passes

## Test plan

- [x] User runs `bash flatpak/build.sh` on a Linux dev machine after a fresh `node scripts/tauri-build.mjs` + `bash scripts/bundle-cef-libs.sh`
- [x] User installs the resulting bundle on Fedora 43 + Nvidia 580 desktop and confirms GUI loads, three.js renders, portal file picker opens a `.voxl`, slicing & export work end-to-end
- [ ] Manual trigger of `Build Flatpak Bundle` workflow via `workflow_dispatch` on this branch — confirm green + artifact downloadable
- [ ] `xdg-mime query default application/vnd.dragonfruit.voxl+json` returns the Flatpak's desktop entry after install

## Out of scope

- aarch64 bundle (x86_64 only, mirrors current CI matrix)
- Flathub submission (tracked in `flatpak/FLATHUB.md`, blocked externally)
- Replacing `.deb`/`.rpm`/`.AppImage` — Flatpak is purely additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)