### PR TITLE
fix: Prevent Focus Lighting

### DIFF
--- a/src/components/scene/SceneCanvas/SceneCanvasCameraControllers.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvasCameraControllers.tsx
@@ -212,6 +212,7 @@ export function CameraModeEntryFramingController({
   plateDepthMm: number;
 }) {
   const { camera, controls, size } = useThree();
+  const sizeRef = React.useRef(size);
 
   const activeRunIdRef = React.useRef<number | null>(null);
   const completedFrameRunIdRef = React.useRef(0);
@@ -228,6 +229,10 @@ export function CameraModeEntryFramingController({
     target: THREE.Vector3;
     zoom: number | null;
   } | null>(null);
+
+  React.useEffect(() => {
+    sizeRef.current = size;
+  }, [size]);
 
   const cancelAnimation = React.useCallback(() => {
     animatingRef.current = false;
@@ -371,7 +376,8 @@ export function CameraModeEntryFramingController({
     const fov = camera instanceof THREE.PerspectiveCamera
       ? THREE.MathUtils.degToRad(camera.fov)
       : THREE.MathUtils.degToRad(50);
-    const aspect = size.width / Math.max(1, size.height);
+    const viewport = sizeRef.current;
+    const aspect = viewport.width / Math.max(1, viewport.height);
     const hFov = 2 * Math.atan(Math.tan(fov * 0.5) * aspect);
     const minFov = Math.max(0.0001, Math.min(fov, hFov));
 
@@ -412,7 +418,7 @@ export function CameraModeEntryFramingController({
         activeRunIdRef.current = null;
       }
     };
-  }, [animateTo, camera, controls, plateDepthMm, plateWidthMm, runId, size.height, size.width, target]);
+  }, [animateTo, camera, controls, plateDepthMm, plateWidthMm, runId, target]);
 
   React.useLayoutEffect(() => {
     if (!restoreRunId) return;

--- a/src/components/scene/SceneCanvas/SceneEnvironment.tsx
+++ b/src/components/scene/SceneCanvas/SceneEnvironment.tsx
@@ -58,23 +58,15 @@ export function CameraClipPlaneStabilizer() {
   return null;
 }
 
-function CameraHeadlight({ intensity }: { intensity: number }) {
-  const { camera } = useThree();
-  const lightRef = React.useRef<THREE.PointLight | null>(null);
-
-  useFrame(() => {
-    if (!lightRef.current) return;
-    lightRef.current.position.copy(camera.position);
-  });
-
+function FillLight({ intensity }: { intensity: number }) {
+  // Fixed-position fill light that mimics a frontal fill without tracking the
+  // camera. Camera movement (orbit, zoom, F-focus) will never change the
+  // model's illumination.
   return (
-    <pointLight
-      ref={lightRef}
-      name="camera-headlight"
-      userData={{ followCaptureCamera: true }}
+    <directionalLight
+      name="fill-light"
+      position={[0, -80, 60]}
       intensity={intensity}
-      decay={0}
-      distance={0}
       color="#ffffff"
     />
   );
@@ -97,7 +89,7 @@ export function Lights({
       <directionalLight position={[0, 0, 12]} intensity={directionalIntensity} color="#ffffff" />
       <directionalLight position={[0, 0, -12]} intensity={directionalIntensity * 0.15} color="#90a7ff" />
       <hemisphereLight args={['#f6e8ff', '#3e415c', ambientIntensity * 0.6]} />
-      <CameraHeadlight intensity={clampedHeadlightIntensity} />
+      <FillLight intensity={clampedHeadlightIntensity} />
     </>
   );
 }

--- a/src/components/scene/camera/CameraIntroController.tsx
+++ b/src/components/scene/camera/CameraIntroController.tsx
@@ -49,10 +49,15 @@ export function CameraIntroController({
   plateDepthMm,
 }: CameraIntroControllerProps) {
   const { camera, controls, size } = useThree();
+  const sizeRef = React.useRef(size);
   const animatingRef = React.useRef(false);
   const rafRef = React.useRef<number | null>(null);
   const activeRunIdRef = React.useRef<number>(0);
   const completedRunIdRef = React.useRef<number>(0);
+
+  React.useEffect(() => {
+    sizeRef.current = size;
+  }, [size]);
 
   React.useLayoutEffect(() => {
     if (!runId) return;
@@ -74,7 +79,8 @@ export function CameraIntroController({
     const vFov = isPerspective
       ? THREE.MathUtils.degToRad((camera as THREE.PerspectiveCamera).fov)
       : THREE.MathUtils.degToRad(50);
-    const aspect = size.width / Math.max(1, size.height);
+    const viewport = sizeRef.current;
+    const aspect = viewport.width / Math.max(1, viewport.height);
 
     const hFov = 2 * Math.atan(Math.tan(vFov * 0.5) * aspect);
     const minFov = Math.max(0.0001, Math.min(vFov, hFov));
@@ -253,7 +259,7 @@ export function CameraIntroController({
         activeRunIdRef.current = 0;
       }
     };
-  }, [bounds, camera, controls, mode, onComplete, plateDepthMm, plateWidthMm, preserveCurrentViewDirection, runId, size.height, size.width]);
+  }, [bounds, camera, controls, mode, onComplete, plateDepthMm, plateWidthMm, preserveCurrentViewDirection, runId]);
 
   return null;
 }

--- a/src/components/selection/SelectionSpotlight.tsx
+++ b/src/components/selection/SelectionSpotlight.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import * as THREE from 'three';
-import { useThree, useFrame } from '@react-three/fiber';
+import { useFrame } from '@react-three/fiber';
 
 interface SelectionSpotlightProps {
   /** Ref to the mesh to illuminate */
@@ -28,7 +28,7 @@ interface SelectionSpotlightProps {
 /**
  * SelectionSpotlight
  *
- * Illuminates the selected model with a camera-tracking spotlight.
+ * Illuminates the selected model with a camera-following spotlight.
  *
  * WebGLRenderer does NOT filter lights per-object via layers, so we bound
  * spotlight distance to cover only the selected model and taper out before
@@ -51,7 +51,6 @@ export function SelectionSpotlight({
   const helperRef = React.useRef<THREE.SpotLightHelper | null>(null);
   const hasValidPlacementRef = React.useRef(false);
   const lastMeshIdRef = React.useRef<string | null>(null);
-  const { camera } = useThree();
 
   React.useEffect(() => {
     hasValidPlacementRef.current = false;
@@ -92,37 +91,22 @@ export function SelectionSpotlight({
     const worldSize = worldBox.getSize(new THREE.Vector3());
     const fitRadius = 0.5 * Math.max(worldSize.x, worldSize.y, worldSize.z);
 
-    // Camera-mounted spotlight: source follows camera position,
-    // direction follows camera forward vector.
-    const camForward = new THREE.Vector3();
-    camera.getWorldDirection(camForward);
-    const targetDistance = Math.max(120, Math.min(420, worldCenter.distanceTo(camera.position) + fitRadius));
-    const targetPoint = camera.position.clone().addScaledVector(camForward.normalize(), targetDistance);
+    // Place the light at a fixed world-space offset above the model center.
+    // Position is derived entirely from the model bounding box -- camera movement
+    // (orbit, zoom, F-focus) has zero effect on illumination.
+    const lightZ = worldCenter.z + Math.max(elevation, fitRadius * 1.2);
+    // Slight -Y bias gives a natural top-front key-light look.
+    const horizontalOffset = radius > 0 ? radius : fitRadius * 0.3;
+    light.position.set(worldCenter.x, worldCenter.y - horizontalOffset, lightZ);
+    target.position.copy(worldCenter);
+    light.target = target;
 
-    light.position.copy(camera.position);
-    target.position.copy(targetPoint);
-    light.target = target as any;
-
-    // Keep cone wide enough for selected model, but stable.
-    const distToModel = Math.max(1e-3, worldCenter.distanceTo(camera.position));
+    // Auto-fit cone angle to the model from the fixed light position.
+    const distToModel = Math.max(1e-3, light.position.distanceTo(worldCenter));
     const halfAngle = Math.atan((fitRadius * 1.2) / distToModel);
     light.angle = THREE.MathUtils.clamp(halfAngle, THREE.MathUtils.degToRad(10), THREE.MathUtils.degToRad(55));
     light.penumbra = THREE.MathUtils.clamp(penumbra, 0.2, 0.6);
-
-    // ---- bounded distance: keep model lit, limit floor spill ----
-    // Floor plane at z = 0.  Compute distance from light to the point on the
-    // floor directly beneath the model centre.
-    const floorBeneath = new THREE.Vector3(worldCenter.x, worldCenter.y, 0);
-    const distToFloor = camera.position.distanceTo(floorBeneath);
-
-    // Ensure we always light model center + silhouette, but keep reach tight.
-    const minReach = distToModel + Math.min(fitRadius * 0.25, 5);
-    const desiredCoverage = distToModel + fitRadius * 0.95;
-
-    // Keep distance short so floor illumination is strongly suppressed.
-    const floorSafe = Math.max(distToModel * 1.015, distToFloor * 0.78);
-
-    light.distance = Math.max(minReach, Math.min(desiredCoverage, floorSafe));
+    light.distance = distToModel + fitRadius * 1.5;
     light.decay = 0;
 
     if (!hasValidPlacementRef.current) {
@@ -153,7 +137,7 @@ export function SelectionSpotlight({
         intensity={0}
         angle={angle}
         distance={0}
-        position={[camera.position.x, camera.position.y, camera.position.z]}
+        position={[0, 0, 0]}
         penumbra={penumbra}
         decay={0}
         visible={false}


### PR DESCRIPTION
Improve camera aspect ratio calculations by utilizing refs for size. Replace the camera-tracking spotlight with a fixed-position fill light in the SelectionSpotlight component to enhance lighting consistency.