### PR TITLE
fix(cli): catch up dragonfruit-cli to dragonfruit-slicing-engine rename + expose x_packing_mode flag

### DIFF
--- a/1_Documentation/V3_AA_and_Advanced_Grayscale_Notes.md
+++ b/1_Documentation/V3_AA_and_Advanced_Grayscale_Notes.md
@@ -37,7 +37,7 @@ Quick implementation-grounded notes for direction planning.
 
 ## 2) Current **2D AA** implementation (today)
 
-Implemented in `rust/dragonfruit-slicer-v3/src/raster.rs`:
+Implemented in `rust/dragonfruit-slicing-engine/src/raster.rs`:
 
 - AA levels are parsed via `aa_subpixel_steps`: `Off`, `2x`, `4x`, `8x`, `16x`.
 - Rasterization is winding-based scanline fill.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ High-level layout of key project areas:
 
 - `src/` — Next.js app, React components, scene controls, support systems, hooks, and utilities.
 - `src-tauri/` — Tauri desktop host and native integration points.
-- `rust/dragonfruit-slicer-v3/` — Rust slicer backend workspace.
+- `rust/dragonfruit-slicing-engine/` — Rust slicer backend workspace.
 - `plugins/` — Plugin architecture and ecosystem integrations.
 - `profiles/` — Printer and material profile definitions.
 - `docs/` and `1_Documentation/` — Architecture notes, implementation guides, and domain documentation.

--- a/rust/dragonfruit-cli/Cargo.lock
+++ b/rust/dragonfruit-cli/Cargo.lock
@@ -148,6 +148,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,7 +306,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "dragonfruit-islands",
- "dragonfruit-slicer-v3",
+ "dragonfruit-slicing-engine",
  "proptest",
  "serde",
  "serde_json",
@@ -308,7 +318,7 @@ name = "dragonfruit-islands"
 version = "0.1.0"
 dependencies = [
  "clap",
- "dragonfruit-slicer-v3",
+ "dragonfruit-slicing-engine",
  "indexmap",
  "rayon",
  "serde",
@@ -316,13 +326,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "dragonfruit-slicer-v3"
-version = "0.1.1"
+name = "dragonfruit-slicing-engine"
+version = "3.1.0"
 dependencies = [
  "aes",
  "base64",
  "cbc",
+ "crc32fast",
  "crossbeam-channel",
+ "libdeflater",
  "png",
  "rayon",
  "serde",
@@ -370,6 +382,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -500,6 +518,24 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libdeflate-sys"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libdeflater"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
+dependencies = [
+ "libdeflate-sys",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -797,6 +833,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"

--- a/rust/dragonfruit-cli/Cargo.toml
+++ b/rust/dragonfruit-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "dragonfruit_cli"
 path = "src/lib.rs"
 
 [dependencies]
-dragonfruit-slicer-v3 = { path = "../dragonfruit-slicer-v3" }
+dragonfruit-slicing-engine = { path = "../dragonfruit-slicing-engine" }
 dragonfruit-islands = { path = "../dragonfruit-islands" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/dragonfruit-cli/docs/CLI.md
+++ b/rust/dragonfruit-cli/docs/CLI.md
@@ -38,9 +38,9 @@ Every command produces JSON output (`--json`) and reports timing metrics.
 
 ## Rust CLI — `dragonfruit-cli`
 
-Binary: `rust/dragonfruit-slicer-v3/target/release/dragonfruit-cli`
+Binary: `rust/dragonfruit-cli/target/release/dragonfruit-cli`
 
-Build: `cargo build --release` (from `rust/dragonfruit-slicer-v3/`)
+Build: `cargo build --release` (from `rust/dragonfruit-cli/`)
 
 Every command prints `[command] Xms` timing to stderr.
 
@@ -353,7 +353,7 @@ Comprehensive audit of every data-producing operation across Rust, Tauri IPC, an
 
 **Summary:** 12/19 covered, 5 N/A (GUI-only), 1 implicit, 1 gap (plugin dispatch).
 
-### Rust Public API (dragonfruit-slicer-v3)
+### Rust Public API (dragonfruit-slicing-engine)
 
 | Module | Public Functions | Used in CLI | Not in CLI |
 |--------|-----------------|-------------|------------|

--- a/rust/dragonfruit-cli/src/io.rs
+++ b/rust/dragonfruit-cli/src/io.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use serde::{de::DeserializeOwned, Serialize};
 
-use dragonfruit_slicer_v3::geometry::{parse_triangles, Triangle};
+use dragonfruit_slicing_engine::geometry::{parse_triangles, Triangle};
 use dragonfruit_islands::model::{ComponentInfo, RleLabels, RleMask};
 
 // ---------------------------------------------------------------------------
@@ -852,7 +852,7 @@ mod tests {
     #[test]
     fn slice_job_format_version_field() {
         // Verify SliceJobV3 accepts format_version
-        use dragonfruit_slicer_v3::types::SliceJobV3;
+        use dragonfruit_slicing_engine::types::SliceJobV3;
 
         let job_json = r#"{
             "output_format": ".ctb",
@@ -873,7 +873,7 @@ mod tests {
 
     #[test]
     fn slice_job_format_version_defaults_to_none() {
-        use dragonfruit_slicer_v3::types::SliceJobV3;
+        use dragonfruit_slicing_engine::types::SliceJobV3;
 
         let job_json = r#"{
             "output_format": ".nanodlp",

--- a/rust/dragonfruit-cli/src/main.rs
+++ b/rust/dragonfruit-cli/src/main.rs
@@ -316,6 +316,13 @@ enum SliceCommands {
         /// Anti-aliasing level (Off, 2x, 4x, 8x)
         #[arg(long, default_value = "Off")]
         anti_aliasing: String,
+        /// X-axis sub-pixel packing mode.
+        ///
+        /// - `none` (default): raw grayscale at source resolution; width_px = source_width_px.
+        /// - `rgb8_div3`: 3 sub-pixels packed into 1 RGB pixel; width_px = source_width_px / 3.
+        /// - `gray3_div2`: 2 sub-pixels packed into 1 grayscale pixel; width_px = source_width_px / 2.
+        #[arg(long, default_value = "none")]
+        x_packing_mode: String,
         /// Mirror X
         #[arg(long)]
         mirror_x: bool,
@@ -1012,6 +1019,7 @@ fn cmd_slice_run(
     source_height_px: u32,
     png_compression: &str,
     anti_aliasing: &str,
+    x_packing_mode: &str,
     mirror_x: bool,
     mirror_y: bool,
     format_version: &Option<String>,
@@ -1019,6 +1027,30 @@ fn cmd_slice_run(
     metadata_json: &str,
     json_output: bool,
 ) -> Result<(), String> {
+    let width_px = match x_packing_mode {
+        "none" => source_width_px,
+        "rgb8_div3" => {
+            if source_width_px % 3 != 0 {
+                return Err(format!(
+                    "source_width_px ({source_width_px}) must be divisible by 3 for x_packing_mode=rgb8_div3"
+                ));
+            }
+            source_width_px / 3
+        }
+        "gray3_div2" => {
+            if source_width_px % 2 != 0 {
+                return Err(format!(
+                    "source_width_px ({source_width_px}) must be divisible by 2 for x_packing_mode=gray3_div2"
+                ));
+            }
+            source_width_px / 2
+        }
+        other => {
+            return Err(format!(
+                "Invalid x_packing_mode '{other}': expected one of none, rgb8_div3, gray3_div2"
+            ));
+        }
+    };
     use dragonfruit_slicing_engine::engine::slice_with_progress_v3_to_path;
     use dragonfruit_slicing_engine::types::SliceJobV3;
 
@@ -1057,9 +1089,9 @@ fn cmd_slice_run(
         output_format: ext.clone(),
         source_width_px,
         source_height_px,
-        width_px: source_width_px,
+        width_px,
         height_px: source_height_px,
-        x_packing_mode: "none".to_string(),
+        x_packing_mode: x_packing_mode.to_string(),
         build_width_mm,
         build_depth_mm,
         layer_height_mm: layer_height,
@@ -1633,10 +1665,10 @@ fn main() {
         Commands::Slice { command } => match command {
             SliceCommands::Run { input, output, layer_height, build_width_mm, build_depth_mm,
                 source_width_px, source_height_px, png_compression, anti_aliasing,
-                mirror_x, mirror_y, format_version, min_aa_alpha, metadata_json, json } =>
+                x_packing_mode, mirror_x, mirror_y, format_version, min_aa_alpha, metadata_json, json } =>
                 cmd_slice_run(&input, &output, layer_height, build_width_mm, build_depth_mm,
                     source_width_px, source_height_px, &png_compression, &anti_aliasing,
-                    mirror_x, mirror_y, &format_version, min_aa_alpha, &metadata_json, json),
+                    &x_packing_mode, mirror_x, mirror_y, &format_version, min_aa_alpha, &metadata_json, json),
             SliceCommands::Formats => { cmd_slice_formats(); Ok(()) },
             SliceCommands::PreviewLayer { input, layer, output } =>
                 extract_layer_png(&input, layer, &output),

--- a/rust/dragonfruit-cli/src/main.rs
+++ b/rust/dragonfruit-cli/src/main.rs
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 use dragonfruit_cli::io::*;
-use dragonfruit_slicer_v3::geometry::parse_triangles;
+use dragonfruit_slicing_engine::geometry::parse_triangles;
 use dragonfruit_islands::model::*;
 use dragonfruit_islands::rasterize::rasterize_for_island_scan;
 use dragonfruit_islands::rle;
@@ -1019,8 +1019,8 @@ fn cmd_slice_run(
     metadata_json: &str,
     json_output: bool,
 ) -> Result<(), String> {
-    use dragonfruit_slicer_v3::engine::slice_with_progress_v3_to_path;
-    use dragonfruit_slicer_v3::types::SliceJobV3;
+    use dragonfruit_slicing_engine::engine::slice_with_progress_v3_to_path;
+    use dragonfruit_slicing_engine::types::SliceJobV3;
 
     // Same flow as Tauri's slice_solid_native_to_temp_path:
     // load STL or positions.bin → build SliceJobV3 → dispatch to engine
@@ -1059,6 +1059,7 @@ fn cmd_slice_run(
         source_height_px,
         width_px: source_width_px,
         height_px: source_height_px,
+        x_packing_mode: "none".to_string(),
         build_width_mm,
         build_depth_mm,
         layer_height_mm: layer_height,
@@ -1147,7 +1148,7 @@ fn extract_layer_png(archive_path: &PathBuf, layer: u32, output: &PathBuf) -> Re
 }
 
 fn cmd_slice_formats() {
-    use dragonfruit_slicer_v3::encoders::registry::{find_encoder, supported_output_formats};
+    use dragonfruit_slicing_engine::encoders::registry::{find_encoder, supported_output_formats};
 
     let format_names = supported_output_formats();
     let mut formats = Vec::new();
@@ -1324,7 +1325,7 @@ fn cmd_island_batch(
 }
 
 fn cmd_slice_info() {
-    use dragonfruit_slicer_v3::encoders::registry::supported_output_formats;
+    use dragonfruit_slicing_engine::encoders::registry::supported_output_formats;
     let formats = supported_output_formats();
 
     let info = serde_json::json!({
@@ -1470,7 +1471,7 @@ fn cmd_benchmark(
     build_width_mm: f32, build_depth_mm: f32, layer_height: f32,
     cube_count: u32, json_output: bool,
 ) -> Result<(), String> {
-    use dragonfruit_slicer_v3::benchmark::{run_benchmark_v3, BenchmarkConfigV3};
+    use dragonfruit_slicing_engine::benchmark::{run_benchmark_v3, BenchmarkConfigV3};
 
     let cfg = BenchmarkConfigV3 {
         layers,
@@ -1518,7 +1519,7 @@ fn cmd_benchmark(
 }
 
 fn cmd_info() {
-    use dragonfruit_slicer_v3::encoders::registry::supported_output_formats;
+    use dragonfruit_slicing_engine::encoders::registry::supported_output_formats;
     let formats = supported_output_formats();
 
     let info = serde_json::json!({

--- a/rust/dragonfruit-islands/docs/ISLANDS.md
+++ b/rust/dragonfruit-islands/docs/ISLANDS.md
@@ -14,7 +14,7 @@ rust/dragonfruit-islands/
 ├── docs/ISLANDS.md           (this file)
 ├── src/
 │   ├── lib.rs                — Crate root (module declarations)
-│   ├── geometry.rs           — Re-exports from dragonfruit-slicer-v3
+│   ├── geometry.rs           — Re-exports from dragonfruit-slicing-engine
 │   ├── model.rs              — Core domain types (Value Objects, Entities)
 │   ├── rle.rs                — RLE Domain Service (stateless mask algebra)
 │   ├── scan.rs               — Per-layer scan Domain Service
@@ -33,7 +33,7 @@ rust/dragonfruit-islands/
 ### Dependencies
 
 ```
-dragonfruit-slicer-v3  ← geometry types (Vec3, Triangle, parse_triangles)
+dragonfruit-slicing-engine  ← geometry types (Vec3, Triangle, parse_triangles)
        ↑
 dragonfruit-islands    ← this crate (island detection library + tooling)
        ↑
@@ -244,7 +244,7 @@ The rasterizer uses `IndexMap` (not `HashMap`) for polygon loop stitching. This 
 
 | Crate | Purpose |
 |-------|---------|
-| `dragonfruit-slicer-v3` | Geometry types (`Vec3`, `Triangle`, `parse_triangles`) |
+| `dragonfruit-slicing-engine` | Geometry types (`Vec3`, `Triangle`, `parse_triangles`) |
 | `serde` | Serialization for island types |
 | `rayon` | Parallel rasterization |
 | `indexmap` | Insertion-order map for deterministic loop stitching |


### PR DESCRIPTION
## Summary

- **Fix build regression**: commit 9705a0b renamed the Rust crate `dragonfruit-slicer-v3` → `dragonfruit-slicing-engine` but missed `dragonfruit-cli` and several workspace docs, breaking `cargo metadata` for the CLI.
- **Catch up the missed references**: `Cargo.toml` path dep, 10 imports in `src/{io,main}.rs`, `docs/CLI.md` (3 refs + heading), plus workspace docs (`README.md`, `dragonfruit-islands/docs/ISLANDS.md`, `1_Documentation/V3_AA_and_Advanced_Grayscale_Notes.md`).
- **Fix latent struct drift**: `SliceJobV3` gained an `x_packing_mode: String` field that went undetected while the build was blocked. Added to the `cmd_slice_run` initializer.
- **Expose `--x-packing-mode` CLI flag** on `slice run` (default `none`, valid: `none` / `rgb8_div3` / `gray3_div2`) with fail-fast validation and derived `width_px`. Brings CLI to parity with the Tauri rendering path.

### Out of scope (deferred)

- `plugins/**`, `scripts/generate-plugin-registry.mjs` — still reference the old crate name; plugin build tooling has its own cleanup cycle.
- Orphan `rust/Cargo.lock` and `rust/dragonfruit-islands/Cargo.lock` — cargo auto-regenerates on next build.
- Pre-existing lint warnings (`parse_triangles` unused outside tests in `io.rs`, etc.) — unrelated; follow-up lint-cleanup PR.

## Test plan

- [x] `cd rust/dragonfruit-cli && cargo nextest run` — 22/22 pass
- [x] `cargo build --release --bin dragonfruit-cli` — clean build (pre-existing lint warnings only)
- [x] `dragonfruit-cli slice run --help` shows `--x-packing-mode` with default `none`
- [x] Invalid mode → `Error: Invalid x_packing_mode 'invalid': expected one of none, rgb8_div3, gray3_div2`
- [x] `--x-packing-mode rgb8_div3 --source-width-px 11401` → `Error: source_width_px (11401) must be divisible by 3 for x_packing_mode=rgb8_div3`
- [x] Reviewer to verify `slice run --x-packing-mode rgb8_div3` end-to-end on a real STL (smoke only here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)