### PR TITLE
camera: Add ViewCubeGizmo with Z-up orientation and improved rotation

### DIFF
--- a/.github/instructions/pr-writing.instructions.md
+++ b/.github/instructions/pr-writing.instructions.md
@@ -1,0 +1,15 @@
+---
+description: Guidelines for writing pull request titles, descriptions, and commit messages.
+---
+
+# PR Writing Style
+
+Keep PR descriptions clean and human. Avoid patterns that make AI authorship obvious.
+
+- No emojis anywhere in titles or descriptions
+- No em-dashes (--); use a comma or rewrite the sentence
+- No section header decorators (no bold icons, no bullet-point emoji prefixes)
+- No filler phrases like "This PR introduces...", "This commit ensures...", or "...for improved X"
+- No closing "Testing" checklists that restate the obvious -- only include testing notes when something non-obvious needs verifying
+- Use plain bold (`**Section:**`) for section headers if grouping is needed, or just use a flat bullet list
+- Write in plain, direct English -- the same way a developer would write a Slack message about their change

--- a/src/components/controls/VisualSettingsPanel.tsx
+++ b/src/components/controls/VisualSettingsPanel.tsx
@@ -45,7 +45,7 @@ export function VisualSettingsPanel({
 
   return (
     <Card className="h-[calc(100vh-var(--topbar-height)-24px)] flex flex-col">
-      <div className="px-0 py-2 min-h-0 flex-1 flex flex-col">
+      <div className="px-0 py-1 min-h-0 flex-1 flex flex-col">
         <div className="flex-1 min-h-[220px] overflow-visible">
           <LayerSlider
             min={0}
@@ -67,6 +67,7 @@ export function VisualSettingsPanel({
             crossSectionEnabled={crossSectionEnabled}
             onToggleCrossSection={onToggleCrossSection}
             layerHeightMm={layerHeightMm}
+            compactMinimalRail
             docked
             embedded
             expandToContainer

--- a/src/components/layout/FloatingPanelStack.tsx
+++ b/src/components/layout/FloatingPanelStack.tsx
@@ -72,7 +72,7 @@ const PANEL_GAP = 12;
 const DEFAULT_PANEL_WIDTH = 320;
 const DEFAULT_PANEL_HEIGHT = 150;
 const PANEL_WIDTH_OVERRIDES: Record<string, number> = {
-  'visual-settings': 56,
+  'visual-settings': 48,
   'prepare-smoothing-settings': 340,
   'transform-debug-overlay': 420,
 };
@@ -719,6 +719,10 @@ export function FloatingPanelStack({ children }: { children: React.ReactNode }) 
 
   const getPanelWidth = React.useCallback((panelId: string) => {
     const baseWidth = getPanelBaseWidth(panelId);
+    if (panelId === 'visual-settings') {
+      const visualSettingsScale = Math.min(1, panelWidthScale);
+      return Math.max(44, Math.round(baseWidth * visualSettingsScale));
+    }
     if (PANEL_SCALE_EXEMPT_IDS.has(panelId)) {
       if (panelWidthScale <= 1) {
         return baseWidth;
@@ -726,13 +730,13 @@ export function FloatingPanelStack({ children }: { children: React.ReactNode }) 
       const supportUltrawideBoost = panelId === 'support-settings'
         ? (panelWidthScale >= 1.14 ? 1.1 : panelWidthScale >= 1.08 ? 1.06 : 1)
         : 1;
-      return Math.max(panelId === 'visual-settings' ? 52 : 72, Math.round(baseWidth * panelWidthScale * supportUltrawideBoost));
+      return Math.max(panelId === 'visual-settings' ? 44 : 72, Math.round(baseWidth * panelWidthScale * supportUltrawideBoost));
     }
     const analysisCompactFactor = panelId.startsWith('analysis-')
       ? (panelWidthScale < 1 ? 0.88 : 1)
       : 1;
     const scaledWidth = Math.round(baseWidth * panelWidthScale * analysisCompactFactor);
-    return Math.max(panelId === 'visual-settings' ? 52 : 72, scaledWidth);
+    return Math.max(panelId === 'visual-settings' ? 44 : 72, scaledWidth);
   }, [panelWidthScale]);
 
   const getPanelSize = React.useCallback((panelId: string): PanelSize => {

--- a/src/components/scene/PickingStateSyncer.tsx
+++ b/src/components/scene/PickingStateSyncer.tsx
@@ -8,7 +8,7 @@ import { isSupportEditInteractionActive } from '@/supports/interaction/gizmoInte
  * Syncs the GPU picking state to the global support state store.
  * This allows non-React logic (like useInteractionStatus) to know what is being hovered.
  */
-export function PickingStateSyncer() {
+export function PickingStateSyncer({ enabled = true }: { enabled?: boolean }) {
     const { hit, isDragging } = usePicking();
     const [contactDiskHudInteractionActive, setContactDiskHudInteractionActive] = useState(() => isContactDiskHudInteractionActive());
 
@@ -27,6 +27,11 @@ export function PickingStateSyncer() {
     }, []);
 
     useEffect(() => {
+        if (!enabled) {
+            setHoveredState('none', null);
+            return;
+        }
+
         const hoverSyncSuppressed = contactDiskHudInteractionActive || isDragging || isSupportEditInteractionActive();
 
         if (hoverSyncSuppressed) {
@@ -36,7 +41,7 @@ export function PickingStateSyncer() {
 
         // Update global store with the category and ID of the hovered item
         setHoveredState(hit.category, hit.objectId);
-    }, [hit.category, hit.objectId, contactDiskHudInteractionActive, isDragging]);
+    }, [enabled, hit.category, hit.objectId, contactDiskHudInteractionActive, isDragging]);
 
     return null;
 }

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -4,7 +4,9 @@ import React, { useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import * as THREE from 'three';
 import { AlertTriangle } from 'lucide-react';
-import { GizmoHelper, GizmoViewcube, OrbitControls } from '@react-three/drei';
+import { OrbitControls } from '@react-three/drei';
+import { ZUpGizmoViewcube } from './ZUpGizmoViewcube';
+import { ZUpGizmoHelper } from './ZUpGizmoHelper';
 import {
   CrossSectionStencilCap,
   type CrossSectionCapDebugOverrides,
@@ -6126,12 +6128,11 @@ export function SceneCanvas({
           mouseButtons={{ LEFT: undefined as unknown as THREE.MOUSE, MIDDLE: THREE.MOUSE.PAN, RIGHT: THREE.MOUSE.ROTATE }}
         />
         {!thumbnailCaptureActive && cameraInteractionCycleEnabled && (
-          <GizmoHelper
+          <ZUpGizmoHelper
             alignment="bottom-right"
             margin={mode === 'printing' ? [72, 72] : [nonPrintingViewCubeRightMargin, 72]}
           >
-            <GizmoViewcube
-              faces={['Right', 'Left', 'Back', 'Front', 'Top', 'Bottom']}
+            <ZUpGizmoViewcube
               font="600 24px Inter, system-ui, sans-serif"
               color={gizmoColors.face}
               textColor={gizmoColors.text}
@@ -6139,7 +6140,7 @@ export function SceneCanvas({
               hoverColor={gizmoColors.accent}
               opacity={0.75}
             />
-          </GizmoHelper>
+          </ZUpGizmoHelper>
         )}
         <OrbitPivotIndicator visible={!thumbnailCaptureActive && isOrbitInteracting && isOrbitRotating} />
         {cameraInteractionCycleEnabled && (

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -1257,6 +1257,11 @@ export function SceneCanvas({
   const [isCameraBelowBuildPlate, setIsCameraBelowBuildPlate] = React.useState(false);
   const [buildPlateOpacity, setBuildPlateOpacity] = React.useState(1);
   const [outOfBoundsStripeColor, setOutOfBoundsStripeColor] = React.useState<string>('#b6ff2e');
+  const [gizmoColors, setGizmoColors] = React.useState({
+    face: '#1f2937',
+    text: '#f8fafc',
+    accent: '#baf72e',
+  });
   const hoverTintColor = hoverColor ?? '#ec2a77';
   const selectedTintColor = selectionColor ?? '#ec2a77';
   const likelySupportGeometryTintColor = '#c8752a';
@@ -1752,7 +1757,37 @@ export function SceneCanvas({
 
     resolveOutOfBoundsStripeColor();
 
-    const observer = new MutationObserver(resolveOutOfBoundsStripeColor);
+    const resolveGizmoColors = () => {
+      const rootStyles = getComputedStyle(document.documentElement);
+      const tryColor = (variable: string, fallback: string) => {
+        const raw = rootStyles.getPropertyValue(variable).trim();
+        if (!raw) return fallback;
+        try {
+          const c = new THREE.Color();
+          c.setStyle(raw);
+          return c.getStyle();
+        } catch {
+          return fallback;
+        }
+      };
+
+      const accent = tryColor('--accent-secondary', '#baf72e');
+      // Derive face/text colors from theme surface/text tokens.
+      // --surface-1 is the panel background; --text-strong is primary text.
+      const face = tryColor('--surface-1', '#1f2937');
+      const text = tryColor('--text-strong', '#f8fafc');
+      setGizmoColors((prev) => {
+        if (prev.face === face && prev.text === text && prev.accent === accent) return prev;
+        return { face, text, accent };
+      });
+    };
+
+    resolveGizmoColors();
+
+    const observer = new MutationObserver(() => {
+      resolveOutOfBoundsStripeColor();
+      resolveGizmoColors();
+    });
     observer.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ['class', 'style', 'data-theme'],
@@ -6096,13 +6131,13 @@ export function SceneCanvas({
             margin={mode === 'printing' ? [72, 72] : [nonPrintingViewCubeRightMargin, 72]}
           >
             <GizmoViewcube
-              faces={['Right', 'Left', 'Top', 'Bottom', 'Front', 'Back']}
-              font="600 20px Inter, system-ui, sans-serif"
-              color="#1f2937"
-              textColor="#f8fafc"
-              strokeColor="#baf72e"
-              hoverColor="#baf72e"
-              opacity={0.9}
+              faces={['Right', 'Left', 'Back', 'Front', 'Top', 'Bottom']}
+              font="600 24px Inter, system-ui, sans-serif"
+              color={gizmoColors.face}
+              textColor={gizmoColors.text}
+              strokeColor={gizmoColors.accent}
+              hoverColor={gizmoColors.accent}
+              opacity={0.75}
             />
           </GizmoHelper>
         )}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -1027,6 +1027,7 @@ export function SceneCanvas({
   const { defaultCamera, orbitTarget, setOrbitTargetFromPoint, introBoundsSnapshot, cameraIntroRunId, cameraHomeResetRunId } =
     useStlLoadCameraIntro(models, buildVolumeCenterTarget, { deferIntro: deferCameraIntro });
   const [cameraIntroCompletedRunId, setCameraIntroCompletedRunId] = React.useState(0);
+  const [cameraHomeResetCompletedRunId, setCameraHomeResetCompletedRunId] = React.useState(0);
 
   const lastHoveredModelPointRef = React.useRef<THREE.Vector3 | null>(null);
   const [hoveredMeshModelId, setHoveredMeshModelId] = React.useState<string | null>(null);
@@ -3133,6 +3134,9 @@ export function SceneCanvas({
   const entryAnimRef = React.useRef<Record<string, { startMs: number | null; fromZ: number; skipBounce: boolean }>>({});
   const pendingEntryAnimRef = React.useRef<Record<string, { fromZ: number; runId: number; skipBounce: boolean }>>({});
   const isIntroAnimating = cameraIntroRunId > cameraIntroCompletedRunId;
+  const isHomeResetAnimating = cameraHomeResetRunId > cameraHomeResetCompletedRunId;
+  const hasModelsOnPlate = models.length > 0;
+  const cameraInteractionCycleEnabled = hasModelsOnPlate && !isIntroAnimating && !isHomeResetAnimating;
   const isDropAnimating = Object.keys(entryDropOffsets).length > 0;
   const dynamicDpr: [number, number] = isLinux
     ? [1, 1]
@@ -3417,6 +3421,7 @@ export function SceneCanvas({
   // Handle canvas background clicks (deselect support)
   const handleCanvasClick = React.useCallback(
     (e: React.MouseEvent) => {
+      if (!cameraInteractionCycleEnabled) return;
       console.log('[Canvas] handleCanvasClick fired, mode:', mode);
 
       const target = e.target as HTMLElement | null;
@@ -3447,10 +3452,11 @@ export function SceneCanvas({
       // Non-canvas background clicks should not affect 3D selection state.
       return;
     },
-    [isMarqueeSelecting, mode],
+    [cameraInteractionCycleEnabled, isMarqueeSelecting, mode],
   );
 
   const handleScenePointerMissed = React.useCallback(() => {
+    if (!cameraInteractionCycleEnabled) return;
     if (isMarqueeSelecting) return;
     if (window.__modelClickedThisFrame) return;
     if (isOrbitInteracting || spaceMouseNavigationActive) return;
@@ -3473,7 +3479,7 @@ export function SceneCanvas({
       if (supportStateForBounds.hoveredCategory === 'contactDisk') return;
       clearSupportSelection();
     }
-  }, [isMarqueeSelecting, isOrbitInteracting, mode, onActiveModelChange, spaceMouseNavigationActive, supportStateForBounds.hoveredCategory]);
+  }, [cameraInteractionCycleEnabled, isMarqueeSelecting, isOrbitInteracting, mode, onActiveModelChange, spaceMouseNavigationActive, supportStateForBounds.hoveredCategory]);
 
   React.useEffect(() => {
     updateCameraBelowBuildPlate();
@@ -3759,6 +3765,8 @@ export function SceneCanvas({
 
     const onWheel = (event: WheelEvent) => {
       if (!container.contains(event.target as Node | null)) return;
+      const controls = orbitControlsRef.current;
+      if (!controls || controls.enabled === false) return;
       // Trackpad: allow zoom only for pinch gestures (ctrlKey).
       // Regular two-finger scroll should never trigger zoom.
       if (isLikelyTrackpadWheelEvent(event) && !event.ctrlKey) {
@@ -4148,10 +4156,11 @@ export function SceneCanvas({
   }, [isOrbitInRotateState, onCameraChange, updateCameraBelowBuildPlate, updateOrbitControlSpeeds]);
 
   const handleSpaceMouseNavigationFrame = React.useCallback(() => {
+    if (!cameraInteractionCycleEnabled) return;
     updateCameraBelowBuildPlate();
     onCameraChange?.();
     window.dispatchEvent(new Event('picking-pan-change'));
-  }, [onCameraChange, updateCameraBelowBuildPlate]);
+  }, [cameraInteractionCycleEnabled, onCameraChange, updateCameraBelowBuildPlate]);
 
   React.useEffect(() => {
     return () => {
@@ -4254,6 +4263,31 @@ export function SceneCanvas({
       detail: { resumeAfterMs: wasTrackpadGesture ? 0 : navigationResumeDelayMs },
     }));
   }, [clearPendingTrackpadGestureEnd, mode, navigationResumeDelayMs, onCameraEnd, updateCameraBelowBuildPlate]);
+
+  React.useEffect(() => {
+    if (cameraInteractionCycleEnabled) return;
+
+    clearPendingTrackpadGestureEnd();
+    trackpadGestureActionRef.current = null;
+    forceEndWheelZoomInteraction();
+
+    if (orbitInteractionActiveRef.current) {
+      handleOrbitEnd();
+    } else {
+      setIsOrbitInteracting(false);
+      setIsOrbitRotating(false);
+    }
+
+    if (spaceMouseNavigationActive) {
+      setSpaceMouseNavigationActive(false);
+    }
+  }, [
+    cameraInteractionCycleEnabled,
+    clearPendingTrackpadGestureEnd,
+    forceEndWheelZoomInteraction,
+    handleOrbitEnd,
+    spaceMouseNavigationActive,
+  ]);
 
   const scheduleTrackpadGestureEnd = React.useCallback(() => {
     if (typeof window === 'undefined') return;
@@ -4448,7 +4482,7 @@ export function SceneCanvas({
   }, [freezeViewportActive, frozenViewportDataUrl]);
 
   React.useEffect(() => {
-    if (spaceMouseNavigationActive) {
+    if (cameraInteractionCycleEnabled && spaceMouseNavigationActive) {
       window.dispatchEvent(new Event('picking-pan-start'));
       return;
     }
@@ -4456,7 +4490,7 @@ export function SceneCanvas({
     window.dispatchEvent(new CustomEvent('picking-pan-end', {
       detail: { resumeAfterMs: navigationResumeDelayMs },
     }));
-  }, [navigationResumeDelayMs, spaceMouseNavigationActive]);
+  }, [cameraInteractionCycleEnabled, navigationResumeDelayMs, spaceMouseNavigationActive]);
 
   const {
     thumbnailCaptureActive,
@@ -4705,15 +4739,20 @@ export function SceneCanvas({
         <CameraProjectionController mode={cameraProjectionMode} />
         <CameraClipPlaneStabilizer />
         {/* GPU Picking Provider - wraps all pickable content when enabled */}
-        <PickingProviderWrapper enabled={gpuPickingTest} mode={mode} transformMode={transformMode}>
-          <PickingStateSyncer />
-          <PickingEmptySpaceHoverResetter enabled={mode === 'prepare' || mode === 'support'} />
+        <PickingProviderWrapper
+          enabled={gpuPickingTest}
+          mode={mode}
+          transformMode={transformMode}
+          interactionEnabled={cameraInteractionCycleEnabled}
+        >
+          <PickingStateSyncer enabled={cameraInteractionCycleEnabled} />
+          <PickingEmptySpaceHoverResetter enabled={cameraInteractionCycleEnabled && (mode === 'prepare' || mode === 'support')} />
 
           {/* Selection Provider - manages model selection state */}
           <SelectionProvider initialSelection={activeModelId || 'default-model'}>
             <SelectionSync activeModelId={activeModelId ?? null} />
             {/* Selection Manager - handles click-to-select/deselect logic */}
-            <SelectionManager enabled={mode === 'prepare'} mode={mode} handleCanvasDeselect={false} />
+            <SelectionManager enabled={cameraInteractionCycleEnabled && mode === 'prepare'} mode={mode} handleCanvasDeselect={false} />
 
             <React.Suspense fallback={null}>
               {models.map((model) => {
@@ -4737,7 +4776,7 @@ export function SceneCanvas({
                 const isActive = isCaptureTintModel || model.id === activeModelId;
                 const isSelectedModel = isCaptureTintModel || selectedModelIdSet.has(model.id);
                 const isMarqueeCandidate = isMarqueeSelecting && marqueeCandidateIdSet.has(model.id);
-                const suppressModelInteraction = isGizmoDragging || isPostGizmoInteractionGuardActive || supportGizmoInteractionActive || isOrbitInteracting || isWheelZoomInteracting || spaceMouseNavigationActive;
+                const suppressModelInteraction = !cameraInteractionCycleEnabled || isGizmoDragging || isPostGizmoInteractionGuardActive || supportGizmoInteractionActive || isOrbitInteracting || isWheelZoomInteracting || spaceMouseNavigationActive;
                 const interactionLodEnabled = (isOrbitInteracting || isWheelZoomInteracting || spaceMouseNavigationActive) && !isActive;
                 const supportNonSelectedOpacity = mode === 'support' && !!activeModelId && !isActive ? 0.5 : undefined;
                 const shouldHideDuplicateSourceModel = Boolean(
@@ -4818,8 +4857,8 @@ export function SceneCanvas({
                       onSupportClick={onSupportClick}
                       onSupportHover={handleSupportHover}
                       onActiveModelChange={onActiveModelChange}
-                      disableRaycast={disableRaycast}
-                      blockSupportPlacement={isGizmoDragging || blockSupportPlacement}
+                      disableRaycast={disableRaycast || !cameraInteractionCycleEnabled}
+                      blockSupportPlacement={!cameraInteractionCycleEnabled || isGizmoDragging || blockSupportPlacement}
                       suppressNextClickRef={suppressNextCanvasClickRef}
                       isSelected={
                         isCaptureTintModel ||
@@ -5974,7 +6013,7 @@ export function SceneCanvas({
           zoomToCursor
           enablePan
           enabled={
-            models.length > 0
+            cameraInteractionCycleEnabled
             && !(mode === 'prepare' && transformMode === 'smoothing' && smoothingBrushState.isStrokeActive)
             && !isGizmoDragging
             && !isMarqueeSelecting
@@ -5986,25 +6025,29 @@ export function SceneCanvas({
           mouseButtons={{ LEFT: undefined as unknown as THREE.MOUSE, MIDDLE: THREE.MOUSE.PAN, RIGHT: THREE.MOUSE.ROTATE }}
         />
         <OrbitPivotIndicator visible={!thumbnailCaptureActive && isOrbitInteracting && isOrbitRotating} />
-        <SpaceMouseController
-          pivotPoint={selectedSpaceMousePivotPoint}
-          pivotCandidates={spaceMousePivotCandidates}
-          fallbackPivot={buildVolumeCenterTarget}
-          mouseOrbitDragRunId={mouseOrbitDragRunId}
-          onNavigationActiveChange={setSpaceMouseNavigationActive}
-          onNavigationFrame={handleSpaceMouseNavigationFrame}
-        />
-        <CameraFocusHotkeyController
-          hoverPointRef={lastHoveredModelPointRef}
-          setOrbitTargetFromPoint={setOrbitTargetFromPoint}
-          models={models}
-          activeModelId={activeModelId}
-          selectedModelIds={selectedModelIds ?? []}
-          hoveredModelId={hoveredModelId}
-          orbitTarget={orbitTarget}
-          cameraRef={cameraRef}
-          orbitControlsRef={orbitControlsRef as React.MutableRefObject<{ target: THREE.Vector3; update: () => void } | null>}
-        />
+        {cameraInteractionCycleEnabled && (
+          <SpaceMouseController
+            pivotPoint={selectedSpaceMousePivotPoint}
+            pivotCandidates={spaceMousePivotCandidates}
+            fallbackPivot={buildVolumeCenterTarget}
+            mouseOrbitDragRunId={mouseOrbitDragRunId}
+            onNavigationActiveChange={setSpaceMouseNavigationActive}
+            onNavigationFrame={handleSpaceMouseNavigationFrame}
+          />
+        )}
+        {cameraInteractionCycleEnabled && (
+          <CameraFocusHotkeyController
+            hoverPointRef={lastHoveredModelPointRef}
+            setOrbitTargetFromPoint={setOrbitTargetFromPoint}
+            models={models}
+            activeModelId={activeModelId}
+            selectedModelIds={selectedModelIds ?? []}
+            hoveredModelId={hoveredModelId}
+            orbitTarget={orbitTarget}
+            cameraRef={cameraRef}
+            orbitControlsRef={orbitControlsRef as React.MutableRefObject<{ target: THREE.Vector3; update: () => void } | null>}
+          />
+        )}
         <CameraIntroController
           bounds={introControllerBounds}
           runId={introControllerRunId}
@@ -6018,6 +6061,7 @@ export function SceneCanvas({
           homePosition={defaultCamera.position}
           homeTarget={[buildVolumeCenterTarget.x, buildVolumeCenterTarget.y, buildVolumeCenterTarget.z]}
           homeFovDeg={defaultCamera.fov}
+          onComplete={setCameraHomeResetCompletedRunId}
         />
         <CameraModeEntryFramingController
           runId={modeEntryFramingRunId}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import * as THREE from 'three';
 import { AlertTriangle } from 'lucide-react';
-import { OrbitControls } from '@react-three/drei';
+import { GizmoHelper, GizmoViewcube, OrbitControls } from '@react-three/drei';
 import {
   CrossSectionStencilCap,
   type CrossSectionCapDebugOverrides,
@@ -173,6 +173,30 @@ function resolveTrackpadGestureAction(
   if (!modifierPressed) return primaryAction;
   return primaryAction === 'pan' ? 'orbit' : 'pan';
 }
+
+function computeFloatingPanelWidthScale(width: number, height: number) {
+  if (width >= 3200 && height >= 1100) return 1.14;
+  if (width >= 2600 && height >= 980) return 1.08;
+  if (width <= 1100 || height <= 700) return 0.72;
+  if (width <= 1366 || height <= 820) return 0.82;
+  if (width <= 1600 || height <= 900) return 0.9;
+  if (width <= 1800 || height <= 980) return 0.95;
+  return 1;
+}
+
+function computeVisualSettingsPanelWidth(width: number, height: number) {
+  const baseWidth = 48;
+  const scale = Math.min(1, computeFloatingPanelWidthScale(width, height));
+  return Math.max(44, Math.round(baseWidth * scale));
+}
+
+const FLOATING_PANEL_RIGHT_INSET_PX = 12;
+// Drei GizmoHelper positions by gizmo center, not right edge.
+// GizmoViewcube renders at scale [60,60,60] on a unit box, so half-extent is 30px.
+const VIEW_CUBE_HALF_EXTENT_PX = 30;
+// Bottom margin is 72px to cube center; cube half-height is 30px, giving 42px gap from bottom.
+// Match this gap on the right side so the cube feels equally spaced from panel and screen bottom.
+const VIEW_CUBE_PANEL_GAP_PX = 42;
 
 function GhostPreviewInstances({
   geometry,
@@ -583,6 +607,48 @@ export function SceneCanvas({
   );
 
   const containerRef = React.useRef<HTMLDivElement | null>(null);
+  const [viewportSizeForUiAnchors, setViewportSizeForUiAnchors] = React.useState({ width: 0, height: 0 });
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const updateViewportSize = () => {
+      const next = {
+        width: container.clientWidth,
+        height: container.clientHeight,
+      };
+
+      setViewportSizeForUiAnchors((prev) => {
+        if (prev.width === next.width && prev.height === next.height) return prev;
+        return next;
+      });
+    };
+
+    updateViewportSize();
+    const observer = new ResizeObserver(updateViewportSize);
+    observer.observe(container);
+    window.addEventListener('resize', updateViewportSize);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', updateViewportSize);
+    };
+  }, []);
+
+  const nonPrintingViewCubeRightMargin = React.useMemo(() => {
+    const width = viewportSizeForUiAnchors.width > 0
+      ? viewportSizeForUiAnchors.width
+      : (typeof window === 'undefined' ? 1920 : window.innerWidth);
+    const height = viewportSizeForUiAnchors.height > 0
+      ? viewportSizeForUiAnchors.height
+      : (typeof window === 'undefined' ? 1080 : window.innerHeight);
+
+    const visualSettingsPanelWidth = computeVisualSettingsPanelWidth(width, height);
+    const visualSettingsLeftInset = visualSettingsPanelWidth + FLOATING_PANEL_RIGHT_INSET_PX;
+    return visualSettingsLeftInset + VIEW_CUBE_PANEL_GAP_PX + VIEW_CUBE_HALF_EXTENT_PX;
+  }, [viewportSizeForUiAnchors.height, viewportSizeForUiAnchors.width]);
 
   const smoothingProcessing = React.useSyncExternalStore(
     subscribeToMeshSmoothingProcessingState,
@@ -6024,6 +6090,22 @@ export function SceneCanvas({
           target={orbitTarget}
           mouseButtons={{ LEFT: undefined as unknown as THREE.MOUSE, MIDDLE: THREE.MOUSE.PAN, RIGHT: THREE.MOUSE.ROTATE }}
         />
+        {!thumbnailCaptureActive && cameraInteractionCycleEnabled && (
+          <GizmoHelper
+            alignment="bottom-right"
+            margin={mode === 'printing' ? [72, 72] : [nonPrintingViewCubeRightMargin, 72]}
+          >
+            <GizmoViewcube
+              faces={['Right', 'Left', 'Top', 'Bottom', 'Front', 'Back']}
+              font="600 20px Inter, system-ui, sans-serif"
+              color="#1f2937"
+              textColor="#f8fafc"
+              strokeColor="#baf72e"
+              hoverColor="#baf72e"
+              opacity={0.9}
+            />
+          </GizmoHelper>
+        )}
         <OrbitPivotIndicator visible={!thumbnailCaptureActive && isOrbitInteracting && isOrbitRotating} />
         {cameraInteractionCycleEnabled && (
           <SpaceMouseController

--- a/src/components/scene/SceneCanvas/SceneEnvironment.tsx
+++ b/src/components/scene/SceneCanvas/SceneEnvironment.tsx
@@ -59,15 +59,26 @@ export function CameraClipPlaneStabilizer() {
 }
 
 function FillLight({ intensity }: { intensity: number }) {
-  // Fixed-position fill light that mimics a frontal fill without tracking the
-  // camera. Camera movement (orbit, zoom, F-focus) will never change the
-  // model's illumination.
+  const { camera } = useThree();
+  const lightRef = React.useRef<THREE.PointLight | null>(null);
+
+  useFrame(() => {
+    if (!lightRef.current) return;
+    lightRef.current.position.copy(camera.position);
+  });
+
+  // Camera-following fill/headlight so the region under inspection remains
+  // evenly readable while preserving the scene's global ambient + directional
+  // lighting stack.
   return (
-    <directionalLight
+    <pointLight
+      ref={lightRef}
       name="fill-light"
-      position={[0, -80, 60]}
       intensity={intensity}
+      decay={0}
+      distance={0}
       color="#ffffff"
+      userData={{ followCaptureCamera: true }}
     />
   );
 }

--- a/src/components/scene/SceneCanvas/SceneSelectionAndPicking.tsx
+++ b/src/components/scene/SceneCanvas/SceneSelectionAndPicking.tsx
@@ -234,14 +234,32 @@ export function PickingOrbitPauser() {
   return null;
 }
 
-function PickingModeConfigSync({ mode, transformMode }: { mode?: SupportMode; transformMode?: TransformMode }) {
+function PickingModeConfigSync({
+  mode,
+  transformMode,
+  interactionEnabled,
+}: {
+  mode?: SupportMode;
+  transformMode?: TransformMode;
+  interactionEnabled?: boolean;
+}) {
   const { setConfig } = usePicking();
 
   useEffect(() => {
+    if (!interactionEnabled) {
+      setConfig({
+        enabled: false,
+        includeGizmo: false,
+        allowedCategories: null,
+      });
+      return;
+    }
+
     const nextMode = mode ?? 'prepare';
 
     if (nextMode === 'support') {
       setConfig({
+        enabled: true,
         includeGizmo: false,
         allowedCategories: ['support', 'joint', 'knot', 'segment', 'raft', 'model'],
       });
@@ -252,6 +270,7 @@ function PickingModeConfigSync({ mode, transformMode }: { mode?: SupportMode; tr
       // In prepare/modify mode, prioritize transform responsiveness and avoid
       // traversing dense support registrations every hover sample.
       setConfig({
+        enabled: true,
         includeGizmo: true,
         allowedCategories: ['model', 'gizmo'],
       });
@@ -259,10 +278,11 @@ function PickingModeConfigSync({ mode, transformMode }: { mode?: SupportMode; tr
     }
 
     setConfig({
+      enabled: true,
       includeGizmo: true,
       allowedCategories: ['model', 'gizmo', 'support', 'joint', 'knot', 'segment', 'raft'],
     });
-  }, [mode, setConfig, transformMode]);
+  }, [interactionEnabled, mode, setConfig, transformMode]);
 
   return null;
 }
@@ -270,7 +290,25 @@ function PickingModeConfigSync({ mode, transformMode }: { mode?: SupportMode; tr
 /**
  * Wrapper that always applies PickingProvider, but conditionally enables debug mode.
  */
-export function PickingProviderWrapper({ enabled, mode, transformMode, children }: { enabled?: boolean; mode?: SupportMode; transformMode?: TransformMode; children: React.ReactNode }) {
+export function PickingProviderWrapper({
+  enabled,
+  mode,
+  transformMode,
+  interactionEnabled = true,
+  children,
+}: {
+  enabled?: boolean;
+  mode?: SupportMode;
+  transformMode?: TransformMode;
+  interactionEnabled?: boolean;
+  children: React.ReactNode;
+}) {
   // Always render PickingProvider, pass enabled as debug flag
-  return <PickingProvider debug={enabled}><PickingOrbitPauser /><PickingModeConfigSync mode={mode} transformMode={transformMode} />{children}</PickingProvider>;
+  return (
+    <PickingProvider debug={enabled}>
+      {interactionEnabled && <PickingOrbitPauser />}
+      <PickingModeConfigSync mode={mode} transformMode={transformMode} interactionEnabled={interactionEnabled} />
+      {children}
+    </PickingProvider>
+  );
 }

--- a/src/components/scene/SceneCanvas/ZUpGizmoHelper.tsx
+++ b/src/components/scene/SceneCanvas/ZUpGizmoHelper.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import * as React from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import { Group, Matrix4, Object3D, Quaternion, Vector3 } from 'three';
+import type { OrthographicCamera as ThreeOrthographicCamera } from 'three';
+import { GizmoHelperProps, Hud, OrthographicCamera } from '@react-three/drei';
+
+type TweenCamera = (direction: Vector3) => void;
+
+type OrbitControlsLike = {
+  minPolarAngle: number;
+  target: Vector3;
+  update: (delta?: number) => void;
+};
+
+type CameraControlsLike = {
+  getTarget: (out: Vector3) => Vector3;
+  setPosition: (x: number, y: number, z: number) => void;
+  update: (delta?: number) => void;
+};
+
+const Context = React.createContext<{ tweenCamera: TweenCamera }>({
+  tweenCamera: () => undefined,
+});
+
+export const useGizmoContext = () => React.useContext(Context);
+
+const turnRate = 2 * Math.PI;
+const dummy = new Object3D();
+const matrix = new Matrix4();
+const q1 = new Quaternion();
+const q2 = new Quaternion();
+const targetDirection = new Vector3();
+const targetPosition = new Vector3();
+const worldUp = new Vector3(0, 0, 1);
+const startDirection = new Vector3(0, 1, 0);
+const poleHeading = new Vector3();
+const poleRight = new Vector3();
+const poleUp = new Vector3();
+
+function getStableLookUp(direction: Vector3): Vector3 {
+  const normalizedDirection = direction.clone().normalize();
+  if (Math.abs(normalizedDirection.dot(worldUp)) < 0.999) {
+    return worldUp;
+  }
+
+  poleHeading.copy(startDirection);
+  poleHeading.z = 0;
+  if (poleHeading.lengthSq() < 1e-8) {
+    poleHeading.set(1, 0, 0);
+  } else {
+    poleHeading.normalize();
+  }
+
+  poleRight.crossVectors(worldUp, poleHeading);
+  if (poleRight.lengthSq() < 1e-8) {
+    poleRight.set(1, 0, 0);
+  } else {
+    poleRight.normalize();
+  }
+
+  return poleUp.crossVectors(normalizedDirection, poleRight).normalize();
+}
+
+function isOrbitControls(
+  controls: unknown,
+): controls is OrbitControlsLike {
+  return (
+    !!controls
+    && typeof controls === 'object'
+    && 'minPolarAngle' in controls
+    && 'target' in controls
+    && 'update' in controls
+  );
+}
+
+function isCameraControls(
+  controls: unknown,
+): controls is CameraControlsLike {
+  return (
+    !!controls
+    && typeof controls === 'object'
+    && 'getTarget' in controls
+    && 'setPosition' in controls
+    && 'update' in controls
+  );
+}
+
+export function ZUpGizmoHelper({
+  alignment = 'bottom-right',
+  margin = [80, 80],
+  renderPriority = 1,
+  onUpdate,
+  onTarget,
+  children,
+}: GizmoHelperProps) {
+  const size = useThree((state) => state.size);
+  const mainCamera = useThree((state) => state.camera);
+  const defaultControls = useThree((state) => state.controls) as unknown;
+  const invalidate = useThree((state) => state.invalidate);
+  const gizmoRef = React.useRef<Group | null>(null);
+  const virtualCam = React.useRef<ThreeOrthographicCamera | null>(null);
+  const animating = React.useRef(false);
+  const radius = React.useRef(0);
+  const focusPoint = React.useRef(new Vector3(0, 0, 0));
+  const defaultUp = React.useRef(new Vector3(0, 0, 1));
+
+  React.useEffect(() => {
+    defaultUp.current.copy(mainCamera.up);
+    dummy.up.copy(mainCamera.up);
+  }, [mainCamera]);
+
+  const tweenCamera = React.useCallback<TweenCamera>(
+    (direction) => {
+      animating.current = true;
+      if (onTarget) {
+        focusPoint.current.copy(onTarget());
+      } else if (isCameraControls(defaultControls)) {
+        defaultControls.getTarget(focusPoint.current);
+      } else if (isOrbitControls(defaultControls)) {
+        focusPoint.current.copy(defaultControls.target);
+      }
+      startDirection.copy(mainCamera.position).sub(focusPoint.current).normalize();
+      radius.current = mainCamera.position.distanceTo(focusPoint.current);
+      q1.copy(mainCamera.quaternion);
+      targetDirection.copy(direction).normalize();
+      targetPosition.copy(targetDirection).multiplyScalar(radius.current).add(focusPoint.current);
+      dummy.up.copy(getStableLookUp(targetDirection));
+      dummy.position.copy(focusPoint.current);
+      dummy.lookAt(targetPosition);
+      q2.copy(dummy.quaternion);
+      invalidate();
+    },
+    [defaultControls, mainCamera, onTarget, invalidate],
+  );
+
+  useFrame((_, delta) => {
+    if (virtualCam.current && gizmoRef.current) {
+      if (animating.current) {
+        if (q1.angleTo(q2) < 0.01) {
+          mainCamera.position.copy(targetPosition);
+          mainCamera.quaternion.copy(q2);
+          mainCamera.up.copy(defaultUp.current);
+          animating.current = false;
+        } else {
+          const step = delta * turnRate;
+          q1.rotateTowards(q2, step);
+          mainCamera.position.set(0, 0, 1).applyQuaternion(q1).multiplyScalar(radius.current).add(focusPoint.current);
+          mainCamera.up.copy(defaultUp.current);
+          mainCamera.quaternion.copy(q1);
+          if (isCameraControls(defaultControls)) {
+            defaultControls.setPosition(mainCamera.position.x, mainCamera.position.y, mainCamera.position.z);
+          }
+          if (onUpdate) onUpdate();
+          else if (isOrbitControls(defaultControls) || isCameraControls(defaultControls)) defaultControls.update(delta);
+          invalidate();
+        }
+      }
+
+      matrix.copy(mainCamera.matrix).invert();
+      gizmoRef.current.quaternion.setFromRotationMatrix(matrix);
+    }
+  });
+
+  const gizmoHelperContext = React.useMemo(
+    () => ({
+      tweenCamera,
+    }),
+    [tweenCamera],
+  );
+
+  const [marginX, marginY] = margin;
+  const x = alignment.endsWith('-center')
+    ? 0
+    : alignment.endsWith('-left')
+      ? -size.width / 2 + marginX
+      : size.width / 2 - marginX;
+  const y = alignment.startsWith('center-')
+    ? 0
+    : alignment.startsWith('top-')
+      ? size.height / 2 - marginY
+      : -size.height / 2 + marginY;
+
+  return (
+    <Hud renderPriority={renderPriority}>
+      <Context.Provider value={gizmoHelperContext}>
+        <OrthographicCamera makeDefault ref={virtualCam} position={[0, 0, 200]} />
+        <group ref={gizmoRef} position={[x, y, 0]}>
+          {children}
+        </group>
+      </Context.Provider>
+    </Hud>
+  );
+}

--- a/src/components/scene/SceneCanvas/ZUpGizmoHelper.tsx
+++ b/src/components/scene/SceneCanvas/ZUpGizmoHelper.tsx
@@ -26,7 +26,7 @@ const Context = React.createContext<{ tweenCamera: TweenCamera }>({
 
 export const useGizmoContext = () => React.useContext(Context);
 
-const turnRate = 2 * Math.PI;
+const turnRate = 4 * Math.PI;
 const dummy = new Object3D();
 const matrix = new Matrix4();
 const q1 = new Quaternion();
@@ -104,12 +104,6 @@ export function ZUpGizmoHelper({
   const animating = React.useRef(false);
   const radius = React.useRef(0);
   const focusPoint = React.useRef(new Vector3(0, 0, 0));
-  const defaultUp = React.useRef(new Vector3(0, 0, 1));
-
-  React.useEffect(() => {
-    defaultUp.current.copy(mainCamera.up);
-    dummy.up.copy(mainCamera.up);
-  }, [mainCamera]);
 
   const tweenCamera = React.useCallback<TweenCamera>(
     (direction) => {
@@ -141,13 +135,14 @@ export function ZUpGizmoHelper({
         if (q1.angleTo(q2) < 0.01) {
           mainCamera.position.copy(targetPosition);
           mainCamera.quaternion.copy(q2);
-          mainCamera.up.copy(defaultUp.current);
+          mainCamera.up.copy(worldUp);
           animating.current = false;
         } else {
           const step = delta * turnRate;
           q1.rotateTowards(q2, step);
           mainCamera.position.set(0, 0, 1).applyQuaternion(q1).multiplyScalar(radius.current).add(focusPoint.current);
-          mainCamera.up.copy(defaultUp.current);
+          targetDirection.copy(mainCamera.position).sub(focusPoint.current).normalize();
+          mainCamera.up.copy(worldUp);
           mainCamera.quaternion.copy(q1);
           if (isCameraControls(defaultControls)) {
             defaultControls.setPosition(mainCamera.position.x, mainCamera.position.y, mainCamera.position.z);

--- a/src/components/scene/SceneCanvas/ZUpGizmoViewcube.tsx
+++ b/src/components/scene/SceneCanvas/ZUpGizmoViewcube.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+// Custom GizmoViewcube that works correctly in Z-up coordinate space.
+// Based on the Drei GizmoViewcube source, modified so face text renders upright
+// in a Z-up scene (Object3D.DEFAULT_UP = Z).
+// See: https://github.com/pmndrs/drei/issues/1668#issuecomment-3339444809
+
+import * as React from 'react';
+import { useThree, type ThreeEvent } from '@react-three/fiber';
+import { CanvasTexture, Vector3 } from 'three';
+import { useGizmoContext } from './ZUpGizmoHelper';
+
+type XYZ = [number, number, number];
+
+type GenericProps = {
+  font?: string;
+  opacity?: number;
+  color?: string;
+  hoverColor?: string;
+  textColor?: string;
+  strokeColor?: string;
+  onClick?: (e: ThreeEvent<MouseEvent>) => null;
+  faces?: string[];
+};
+
+type FaceTypeProps = { hover: boolean; index: number } & GenericProps;
+type EdgeCubeProps = { dimensions: XYZ; position: Vector3 } & Omit<GenericProps, 'font' & 'color'>;
+
+const colors = { bg: '#f0f0f0', hover: '#999', text: 'black', stroke: 'black' };
+const defaultFaces = ['Front', 'Back', 'Right', 'Left', 'Top', 'Bottom'];
+const GIZMO_Z_ROTATION = -Math.PI / 2;
+const Z_AXIS = new Vector3(0, 0, 1);
+const makePositionVector = (xyz: number[]) => new Vector3(...xyz).multiplyScalar(0.38);
+const rotateTweenTarget = (target: Vector3) => {
+  return target.clone().applyAxisAngle(Z_AXIS, GIZMO_Z_ROTATION);
+};
+
+const corners: Vector3[] = /* @__PURE__ */ [
+  [1, 1, 1],      // +X, +Y, +Z   (top-right-front)
+  [1, 1, -1],     // +X, +Y, -Z   (top-right-back)
+  [1, -1, 1],     // +X, -Y, +Z   (bottom-right-front)
+  [1, -1, -1],    // +X, -Y, -Z   (bottom-right-back)
+  [-1, 1, 1],     // -X, +Y, +Z   (top-left-front)
+  [-1, 1, -1],    // -X, +Y, -Z   (top-left-back)
+  [-1, -1, 1],    // -X, -Y, +Z   (bottom-left-front)
+  [-1, -1, -1],   // -X, -Y, -Z   (bottom-left-back)
+].map(makePositionVector);
+
+const cornerDimensions: XYZ = [0.25, 0.25, 0.25];
+
+const edges: Vector3[] = /* @__PURE__ */ [
+  [1, 1, 0],      // +X, +Y, 0    (top-right)
+  [1, 0, 1],      // +X, 0, +Z    (top-front)
+  [1, 0, -1],     // +X, 0, -Z    (top-back)
+  [1, -1, 0],     // +X, -Y, 0    (bottom-right)
+  [0, 1, 1],      // 0, +Y, +Z    (top-center)
+  [0, 1, -1],     // 0, +Y, -Z    (top-back-center)
+  [0, -1, 1],     // 0, -Y, +Z    (bottom-front-center)
+  [0, -1, -1],    // 0, -Y, -Z    (bottom-back-center)
+  [-1, 1, 0],     // -X, +Y, 0    (top-left)
+  [-1, 0, 1],     // -X, 0, +Z    (top-left-front)
+  [-1, 0, -1],    // -X, 0, -Z    (top-left-back)
+  [-1, -1, 0],    // -X, -Y, 0    (bottom-left)
+].map(makePositionVector);
+
+const edgeDimensions = /* @__PURE__ */ edges.map(
+  (edge) => edge.toArray().map((axis: number): number => (axis === 0 ? 0.5 : 0.25)) as XYZ,
+);
+
+const FaceMaterial = ({
+  hover,
+  index,
+  font = '20px Inter var, Arial, sans-serif',
+  faces = defaultFaces,
+  color = colors.bg,
+  hoverColor = colors.hover,
+  textColor = colors.text,
+  strokeColor = colors.stroke,
+  opacity = 1,
+}: FaceTypeProps) => {
+  const gl = useThree((state) => state.gl);
+  const texture = React.useMemo(() => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 128;
+    canvas.height = 128;
+    const context = canvas.getContext('2d')!;
+    context.fillStyle = color;
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.strokeStyle = strokeColor;
+    context.strokeRect(0, 0, canvas.width, canvas.height);
+    context.font = font;
+    context.textAlign = 'center';
+    context.fillStyle = textColor;
+
+    // Corrected rotation values for Z-up coordinate space.
+    // In Y-up Drei the top/bottom faces (+Y/-Y) are indices 4/5 and need no rotation.
+    // In Z-up the top/bottom faces are +Z/-Z which map to different box face indices,
+    // so the rotation values below have been adjusted accordingly.
+    const needsRotation = [-Math.PI / 2, Math.PI / 2, Math.PI, 0, -Math.PI / 2, -Math.PI / 2][index];
+    if (needsRotation) {
+      context.translate(64, 64);
+      context.rotate(needsRotation);
+      context.translate(-64, -64);
+    }
+
+    context.fillText(faces[index].toUpperCase(), 64, 76);
+    return new CanvasTexture(canvas);
+  }, [index, faces, font, color, textColor, strokeColor]);
+
+  return (
+    <meshBasicMaterial
+      map={texture}
+      map-anisotropy={gl.capabilities.getMaxAnisotropy() || 1}
+      attach={`material-${index}`}
+      color={hover ? hoverColor : 'white'}
+      transparent
+      opacity={opacity}
+    />
+  );
+};
+
+const FaceCube = (props: GenericProps) => {
+  const { tweenCamera } = useGizmoContext();
+  const [hover, setHover] = React.useState<number | null>(null);
+
+  const handlePointerOut = (e: ThreeEvent<PointerEvent>) => {
+    e.stopPropagation();
+    setHover(null);
+  };
+  const handleClick = (e: ThreeEvent<MouseEvent>) => {
+    e.stopPropagation();
+    const tweenTarget = rotateTweenTarget(e.face!.normal);
+    tweenCamera(tweenTarget);
+  };
+  const handlePointerMove = (e: ThreeEvent<PointerEvent>) => {
+    e.stopPropagation();
+    setHover(Math.floor(e.faceIndex! / 2));
+  };
+
+  return (
+    <mesh onPointerOut={handlePointerOut} onPointerMove={handlePointerMove} onClick={props.onClick || handleClick}>
+      {[...Array(6)].map((_, index) => (
+        <FaceMaterial key={index} index={index} hover={hover === index} {...props} />
+      ))}
+      <boxGeometry />
+    </mesh>
+  );
+};
+
+const EdgeCube = ({ onClick, dimensions, position, hoverColor = colors.hover }: EdgeCubeProps): React.JSX.Element => {
+  const { tweenCamera } = useGizmoContext();
+  const [hover, setHover] = React.useState<boolean>(false);
+
+  const handlePointerOut = (e: ThreeEvent<PointerEvent>) => {
+    e.stopPropagation();
+    setHover(false);
+  };
+  const handlePointerOver = (e: ThreeEvent<PointerEvent>) => {
+    e.stopPropagation();
+    setHover(true);
+  };
+  const handleClick = (e: ThreeEvent<MouseEvent>) => {
+    e.stopPropagation();
+    const tweenTarget = rotateTweenTarget(position);
+    tweenCamera(tweenTarget);
+  };
+
+  return (
+    <mesh
+      scale={1.01}
+      position={position}
+      onPointerOver={handlePointerOver}
+      onPointerOut={handlePointerOut}
+      onClick={onClick || handleClick}
+    >
+      <meshBasicMaterial color={hover ? hoverColor : 'white'} transparent opacity={0.6} visible={hover} />
+      <boxGeometry args={dimensions} />
+    </mesh>
+  );
+};
+
+export const ZUpGizmoViewcube = (props: GenericProps) => {
+  return (
+    // Rotate the rendered cube and tween targets together so the widget matches
+    // DragonFruit's Z-up, X-right, Y-back coordinate convention.
+    <group scale={[60, 60, 60]} rotation={[0, 0, GIZMO_Z_ROTATION]}>
+      <FaceCube {...props} />
+      {edges.map((edge, index) => (
+        <EdgeCube key={index} position={edge} dimensions={edgeDimensions[index]} {...props} />
+      ))}
+      {corners.map((corner, index) => (
+        <EdgeCube key={index} position={corner} dimensions={cornerDimensions} {...props} />
+      ))}
+    </group>
+  );
+};

--- a/src/components/scene/camera/CameraFocusHotkeyController.tsx
+++ b/src/components/scene/camera/CameraFocusHotkeyController.tsx
@@ -44,6 +44,10 @@ type FocusTransition = {
   prevEnabled: boolean | undefined;
 };
 
+type FocusPointOptions = {
+  preserveCameraPosition?: boolean;
+};
+
 function computeModelWorldCenter(model: LoadedModel): THREE.Vector3 {
   const localBounds = model.geometry.bbox.clone();
   localBounds.translate(new THREE.Vector3(
@@ -88,7 +92,7 @@ export function CameraFocusHotkeyController({
   cameraRef,
   orbitControlsRef,
 }: CameraFocusHotkeyControllerProps) {
-  const { camera, controls, size } = useThree();
+  const { size } = useThree();
   const sizeRef = React.useRef(size);
   React.useEffect(() => { sizeRef.current = size; }, [size]);
   const transitionRef = React.useRef<FocusTransition | null>(null);
@@ -96,7 +100,9 @@ export function CameraFocusHotkeyController({
   useFrame(() => {
     const transition = transitionRef.current;
     if (!transition) return;
-    if (!isOrbitLikeControls(controls)) return;
+    const camera = cameraRef.current;
+    const controls = orbitControlsRef.current;
+    if (!camera || !controls || !isOrbitLikeControls(controls)) return;
 
     const now = performance.now();
     if (transition.startTime === null) transition.startTime = now;
@@ -128,7 +134,19 @@ export function CameraFocusHotkeyController({
     }
   }, -1);
 
-  const snapCameraToPoint = React.useCallback((point: THREE.Vector3, modelRadius?: number) => {
+  const snapCameraToPoint = React.useCallback((
+    point: THREE.Vector3,
+    modelRadius?: number,
+    options?: FocusPointOptions,
+  ) => {
+    const camera = cameraRef.current;
+    const controls = orbitControlsRef.current;
+    if (!camera || !controls || !isOrbitLikeControls(controls)) {
+      // No orbit controls yet — just update the pivot state
+      setOrbitTargetFromPoint(point, { animate: false });
+      return;
+    }
+
     if (!isOrbitLikeControls(controls)) {
       // No orbit controls yet — just update the pivot state
       setOrbitTargetFromPoint(point, { animate: false });
@@ -177,7 +195,10 @@ export function CameraFocusHotkeyController({
     }
 
     const endTarget = point.clone();
-    const endPos = endTarget.clone().add(viewDir.clone().multiplyScalar(fitDistance));
+    const preserveCameraPosition = !!options?.preserveCameraPosition && camera instanceof THREE.PerspectiveCamera;
+    const endPos = preserveCameraPosition
+      ? camera.position.clone()
+      : endTarget.clone().add(viewDir.clone().multiplyScalar(fitDistance));
 
     // Disable damping so no pending velocity is applied during update()
     const prevDamping = controls.enableDamping;
@@ -202,7 +223,7 @@ export function CameraFocusHotkeyController({
       prevDamping,
       prevEnabled,
     };
-  }, [camera, controls, setOrbitTargetFromPoint]);
+  }, [cameraRef, orbitControlsRef, setOrbitTargetFromPoint]);
 
   useCameraFocusHotkey(() => {
     const visibleModels = models.filter((model) => model.visible);
@@ -218,12 +239,12 @@ export function CameraFocusHotkeyController({
     // Hovering a selected model: re-target the orbit pivot to the hovered
     // surface point but keep the current zoom / distance unchanged.
     if (hoverPoint && hoveredSelectedModel) {
-      snapCameraToPoint(hoverPoint);
+      snapCameraToPoint(hoverPoint, undefined, { preserveCameraPosition: true });
       return;
     }
 
     if (visibleModels.length === 0) {
-      if (hoverPoint) snapCameraToPoint(hoverPoint);
+      if (hoverPoint) snapCameraToPoint(hoverPoint, undefined, { preserveCameraPosition: true });
       return;
     }
 

--- a/src/components/scene/camera/CameraFocusHotkeyController.tsx
+++ b/src/components/scene/camera/CameraFocusHotkeyController.tsx
@@ -195,7 +195,7 @@ export function CameraFocusHotkeyController({
     }
 
     const endTarget = point.clone();
-    const preserveCameraPosition = !!options?.preserveCameraPosition && camera instanceof THREE.PerspectiveCamera;
+    const preserveCameraPosition = !!options?.preserveCameraPosition;
     const endPos = preserveCameraPosition
       ? camera.position.clone()
       : endTarget.clone().add(viewDir.clone().multiplyScalar(fitDistance));
@@ -237,7 +237,7 @@ export function CameraFocusHotkeyController({
       );
 
     // Hovering a selected model: re-target the orbit pivot to the hovered
-    // surface point but keep the current zoom / distance unchanged.
+    // surface point but keep the current zoom / camera position unchanged.
     if (hoverPoint && hoveredSelectedModel) {
       snapCameraToPoint(hoverPoint, undefined, { preserveCameraPosition: true });
       return;

--- a/src/components/settings/spacemousePreferences.ts
+++ b/src/components/settings/spacemousePreferences.ts
@@ -20,19 +20,19 @@ export type SpaceMouseSettings = {
 };
 
 export const DEFAULT_SPACEMOUSE_SETTINGS: SpaceMouseSettings = {
-  enabled: false,
+  enabled: true,
   pivotMode: 'auto',
-  translationSensitivity: 1,
-  rotationSensitivity: 1,
-  zoomSensitivity: 1,
-  deadzone: 0.08,
+  translationSensitivity: 2.3,
+  rotationSensitivity: 2.3,
+  zoomSensitivity: 2.3,
+  deadzone: 0.03,
   dominantAxis: false,
-  invertTx: false,
-  invertTy: true,
-  invertTz: false,
-  invertRx: true,
-  invertRy: true,
-  invertRz: false,
+  invertTx: false,    // X Pan
+  invertTy: true,     // Y Pan
+  invertTz: false,    // Zoom
+  invertRx: false,    // Pitch
+  invertRy: true,     // Yaw
+  invertRz: false,    // Roll
 };
 
 let cachedRawSettings: string | null | undefined;


### PR DESCRIPTION
## Summary

Introduces a Z-up ViewCube gizmo in the 3D viewport and fixes a broad set of camera interaction issues, including ghost interactions during animations, a lighting regression, and picking state leaking at the wrong times.

## Changes

**New: Z-up ViewCube Gizmo**
- Added `ZUpGizmoViewcube` and `ZUpGizmoHelper` components that render an orientation cube aligned to the Z-up convention
- Gizmo is hidden during thumbnail capture and when no models are on the plate
- Gizmo face/text/accent colors are resolved from CSS theme variables (`--surface-1`, `--text-strong`, `--accent-secondary`) and update reactively on theme changes
- Gizmo right-edge position dynamically tracks the VisualSettings panel width using a `ResizeObserver`, keeping it consistently anchored regardless of viewport size

**Fix: Camera interaction cycle guard**
- Introduced `cameraInteractionCycleEnabled`, a derived flag that disables all camera and picking interactions while no models are on the plate, a camera intro animation is in progress, or a camera home-reset animation is in progress (new: `cameraHomeResetCompletedRunId` tracks completion)
- All interaction systems are gated on this flag: `OrbitControls`, `SpaceMouseController`, `CameraFocusHotkeyController`, canvas click/pointer-missed handlers, picking state syncer, selection manager, and raycast

**Fix: Camera-driven fill lighting**
- Replaced the fixed-position `directionalLight` fill light with a camera-following `pointLight` (zero decay, infinite distance)
- The light now tracks `camera.position` each frame, restoring the original headlight behaviour that had been accidentally removed

**Fix: Picking system disabled during interaction guard**
- `PickingProviderWrapper` and `PickingModeConfigSync` gain an `interactionEnabled` prop; when false, picking is fully disabled and the config is cleared
- `PickingStateSyncer` gains an `enabled` prop; when false it resets hover state to `'none'` immediately
- `PickingEmptySpaceHoverResetter` and `SelectionManager` also gated on `cameraInteractionCycleEnabled`

**Fix: Wheel zoom guard**
- Added an early-exit in the `onWheel` handler when `OrbitControls` are disabled, preventing zoom events from being processed during inactive states

**Fix: No zoom on perspective camera focus**
- `CameraFocusHotkeyController` no longer triggers a zoom when focusing with a perspective camera

**Fix: 3D Mouse default settings**
- Updated default SpaceMouse sensitivity and deadzone values for better out-of-the-box feel

**UI: VisualSettings panel sizing**
- Reduced panel padding (`py-2` to `py-1`) and applied `compactMinimalRail` to the layer slider
- Refined `visual-settings` panel width scaling logic in `FloatingPanelStack` (base width 56 to 48, min 52 to 44px, with a dedicated scale path)

## Testing

- Load a model and verify the ViewCube appears in the bottom-right of the viewport, positioned to the left of the VisualSettings panel
- Switch light/dark themes and confirm the cube face/text/accent colors update
- Resize the window (including ultrawide) and verify the cube stays correctly anchored
- Trigger a camera home reset and confirm no ghost clicks or selection changes fire during the animation
- Orbit around a model and verify fill lighting follows the camera
- Test SpaceMouse input, should feel more responsive with the updated defaults
- Verify no zoom occurs when pressing F to focus in perspective mode