### PR TITLE
feat: NanoDLP native upload pipeline, RLE area stats, and slicer fixes

### DIFF
--- a/.github/instructions/pr-writing.instructions.md
+++ b/.github/instructions/pr-writing.instructions.md
@@ -6,10 +6,33 @@ description: Guidelines for writing pull request titles, descriptions, and commi
 
 Keep PR descriptions clean and human. Avoid patterns that make AI authorship obvious.
 
+## Title format
+
+Use conventional commit prefixes:
+
+```
+feat: Short description
+fix: Short description
+refactor: Short description
+chore: Short description
+```
+
+## Description format
+
+Group changes under conventional commit headers. Each header gets a short bullet list — no paragraphs.
+
+```markdown
+**feat: Thing added**
+- What it does, one or two lines max
+
+**fix: Thing fixed**
+- What was wrong and what changed
+```
+
+## General rules
+
 - No emojis anywhere in titles or descriptions
-- No em-dashes (--); use a comma or rewrite the sentence
-- No section header decorators (no bold icons, no bullet-point emoji prefixes)
+- No em-dashes; use a comma or rewrite the sentence
 - No filler phrases like "This PR introduces...", "This commit ensures...", or "...for improved X"
 - No closing "Testing" checklists that restate the obvious -- only include testing notes when something non-obvious needs verifying
-- Use plain bold (`**Section:**`) for section headers if grouping is needed, or just use a flat bullet list
 - Write in plain, direct English -- the same way a developer would write a Slack message about their change

--- a/plugins/athena/network/index.ts
+++ b/plugins/athena/network/index.ts
@@ -15,10 +15,12 @@ export * from './nanodlpUploadWithProgress';
 export * from './nanodlpMonitoring';
 
 import { uploadToNanoDlpWithProgress } from './nanodlpUploadWithProgress';
+import { uploadToNanoDlpFromPathWithProgress } from './nanodlpUploadWithProgress';
 
 export async function uploadPrintJobWithProgress(args: {
 	hostUrl: string;
-	zipBlob: Blob;
+	zipBlob?: Blob | null;
+	zipFilePath?: string | null;
 	path: string;
 	profileId: string;
 	callbacks: {
@@ -48,6 +50,31 @@ export async function uploadPrintJobWithProgress(args: {
 		onError?: (error: string) => void;
 	};
 }): Promise<{ ok: boolean; plateId: number | null }> {
+	if (args.zipBlob && args.zipBlob.size > 0) {
+		return uploadToNanoDlpWithProgress(
+			args.hostUrl,
+			args.zipBlob,
+			args.path,
+			args.profileId,
+			args.callbacks,
+		);
+	}
+
+	const normalizedPath = typeof args.zipFilePath === 'string' ? args.zipFilePath.trim() : '';
+	if (normalizedPath.length > 0) {
+		return uploadToNanoDlpFromPathWithProgress(
+			args.hostUrl,
+			normalizedPath,
+			args.path,
+			args.profileId,
+			args.callbacks,
+		);
+	}
+
+	if (!args.zipBlob || args.zipBlob.size <= 0) {
+		throw new Error('No NanoDLP upload payload available.');
+	}
+
 	return uploadToNanoDlpWithProgress(
 		args.hostUrl,
 		args.zipBlob,

--- a/plugins/athena/network/nanodlpUploadWithProgress.ts
+++ b/plugins/athena/network/nanodlpUploadWithProgress.ts
@@ -291,6 +291,7 @@ export async function uploadToNanoDlpFromPathWithProgress(
   let smoothedBytesPerSecond = 0;
   let currentLoaded = 0;
   let currentTotal = knownTotal ?? 0;
+  let uploadBytesFullySent = false;
 
   const emitProgress = (loadedInput: number, totalInput: number, options?: { phase?: 'uploading' | 'processing' | 'complete' }) => {
     const phase = options?.phase ?? 'uploading';
@@ -390,8 +391,25 @@ export async function uploadToNanoDlpFromPathWithProgress(
       currentLoaded = Math.max(0, Math.min(Math.round(sentBytes), Math.round(totalBytes)));
       currentTotal = Math.max(1, Math.round(totalBytes));
 
-      const done = upload.done === true;
-      emitProgress(currentLoaded, currentTotal, { phase: done ? 'processing' : 'uploading' });
+      const fullyTransferred = currentLoaded >= currentTotal;
+
+      if (fullyTransferred && !uploadBytesFullySent) {
+        // Bytes are all sent; NanoDLP is now processing server-side.
+        // Stop the poll timer so speed/ETA don't drift, then signal processing.
+        // NOTE: do NOT call emitProgress here — onProgress clears the 220ms
+        // handoff timeout in page.tsx that transitions to the indeterminate bar.
+        uploadBytesFullySent = true;
+        if (progressTimer !== null) {
+          clearInterval(progressTimer);
+          progressTimer = null;
+        }
+        callbacks.onStatusUpdate({
+          stage: 'processing',
+          message: 'File uploaded, processing on device…',
+        });
+      } else if (!fullyTransferred) {
+        emitProgress(currentLoaded, currentTotal, { phase: 'uploading' });
+      }
     } finally {
       progressPollInFlight = false;
     }
@@ -433,15 +451,17 @@ export async function uploadToNanoDlpFromPathWithProgress(
       throw new Error(reason);
     }
 
-    callbacks.onStatusUpdate({
-      stage: 'processing',
-      message: 'File uploaded, processing on device…',
-    });
-
-    await pollNativeUploadProgress();
-    const processingTotal = currentTotal > 0 ? currentTotal : (knownTotal ?? 1);
-    const processingLoaded = Math.max(currentLoaded, Math.round(processingTotal * 0.99));
-    emitProgress(processingLoaded, processingTotal, { phase: 'processing' });
+    // If the poll never detected full transfer (fast/local uploads), transition to
+    // processing now so the user sees the state before complete fires.
+    // NOTE: do NOT call emitProgress here — onProgress clears the 220ms
+    // handoff timeout in page.tsx that transitions to the indeterminate bar.
+    if (!uploadBytesFullySent) {
+      uploadBytesFullySent = true;
+      callbacks.onStatusUpdate({
+        stage: 'processing',
+        message: 'File uploaded, processing on device…',
+      });
+    }
 
     const plateIdRaw = Number(payload.plateId);
     const plateId = Number.isFinite(plateIdRaw) && plateIdRaw > 0
@@ -455,7 +475,7 @@ export async function uploadToNanoDlpFromPathWithProgress(
     });
 
     callbacks.onComplete?.(plateId);
-    const finalTotal = currentTotal > 0 ? currentTotal : Math.max(processingTotal, 1);
+    const finalTotal = currentTotal > 0 ? currentTotal : (knownTotal ?? 1);
     emitProgress(finalTotal, finalTotal, { phase: 'complete' });
 
     return { ok: true, plateId };

--- a/plugins/athena/network/nanodlpUploadWithProgress.ts
+++ b/plugins/athena/network/nanodlpUploadWithProgress.ts
@@ -6,6 +6,8 @@
  * rather than in generic app utilities.
  */
 
+import { pluginNetworkFetch, readNativeFileSize } from '@/utils/pluginNetworkBridge';
+
 export type UploadProgressEvent = {
   loaded: number;
   total: number;
@@ -90,7 +92,30 @@ function getSafeResponseHeader(xhr: XMLHttpRequest, name: string): string {
   }
 }
 
-const userData: Record<string, any> = {};
+const userData: {
+  uploadXhr?: XMLHttpRequest;
+} = {};
+
+function parseHostAndPortFromUrl(hostUrl: string): { host: string; port: number } {
+  const trimmed = hostUrl.trim();
+  if (!trimmed) {
+    throw new Error('Host URL is required for NanoDLP upload');
+  }
+
+  const normalized = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  const parsed = new URL(normalized);
+  const host = parsed.hostname.trim();
+  if (!host) {
+    throw new Error('Invalid host URL for NanoDLP upload');
+  }
+
+  const port = parsed.port ? Number(parsed.port) : 80;
+  if (!Number.isFinite(port) || port < 1 || port > 65535) {
+    throw new Error('Invalid host port for NanoDLP upload');
+  }
+
+  return { host, port };
+}
 
 export async function uploadToNanoDlpWithProgress(
   hostUrl: string,
@@ -236,8 +261,223 @@ export async function uploadToNanoDlpWithProgress(
   });
 }
 
+export async function uploadToNanoDlpFromPathWithProgress(
+  hostUrl: string,
+  zipFilePath: string,
+  path: string,
+  profileId: string,
+  callbacks: UploadCallbacks,
+): Promise<{ ok: boolean; plateId: number | null }> {
+  const normalizedPath = zipFilePath.trim();
+  if (!normalizedPath) {
+    throw new Error('zipFilePath is required for native NanoDLP upload');
+  }
+
+  const { host, port } = parseHostAndPortFromUrl(hostUrl);
+  const uploadId = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `nanodlp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const fileSize = await readNativeFileSize(normalizedPath);
+  const knownTotal = Number.isFinite(fileSize) && (fileSize ?? 0) > 0
+    ? Number(fileSize)
+    : null;
+
+  let progressTimer: ReturnType<typeof setInterval> | null = null;
+  let progressPollInFlight = false;
+  const uploadStartedTs = Date.now();
+  let lastProgressTs = uploadStartedTs;
+  let lastProgressLoaded = 0;
+  let smoothedBytesPerSecond = 0;
+  let currentLoaded = 0;
+  let currentTotal = knownTotal ?? 0;
+
+  const emitProgress = (loadedInput: number, totalInput: number, options?: { phase?: 'uploading' | 'processing' | 'complete' }) => {
+    const phase = options?.phase ?? 'uploading';
+    const safeTotal = Math.max(1, Number.isFinite(totalInput) ? Math.round(totalInput) : 1);
+    const loaded = Math.max(0, Math.min(Math.round(loadedInput), safeTotal));
+
+    const now = Date.now();
+    const timeSinceLastCall = Math.max(1, now - lastProgressTs);
+    const uploadAmountSinceLastCall = Math.max(0, loaded - lastProgressLoaded);
+
+    lastProgressTs = now;
+    lastProgressLoaded = loaded;
+
+    const instantaneousBytesPerSecond = Math.max(0, uploadAmountSinceLastCall / (timeSinceLastCall / 1000));
+    const elapsedSeconds = Math.max(0.001, (now - uploadStartedTs) / 1000);
+    const averageUploadSpeed = Math.max(0, loaded / elapsedSeconds);
+
+    if (phase === 'uploading') {
+      if (smoothedBytesPerSecond <= 0) {
+        smoothedBytesPerSecond = instantaneousBytesPerSecond || averageUploadSpeed;
+      } else if (instantaneousBytesPerSecond > 0) {
+        smoothedBytesPerSecond = (smoothedBytesPerSecond * 0.8) + (instantaneousBytesPerSecond * 0.2);
+      }
+    }
+
+    const effectiveBytesPerSecond = phase === 'uploading'
+      ? Math.max(
+          averageUploadSpeed * 0.65,
+          (smoothedBytesPerSecond * 0.75) + (averageUploadSpeed * 0.25),
+        )
+      : 0;
+
+    const uploadSpeed = phase === 'complete'
+      ? 'done'
+      : phase === 'processing'
+        ? 'uploaded'
+        : effectiveBytesPerSecond > 0
+          ? `${bytesToStringRep(effectiveBytesPerSecond)}/s`
+          : 'starting…';
+
+    const remainingTime = phase === 'complete'
+      ? '00:00:00'
+      : phase === 'processing'
+        ? 'processing…'
+        : effectiveBytesPerSecond > 0
+          ? secondsToTimeString((safeTotal - loaded) / effectiveBytesPerSecond)
+          : 'estimating…';
+
+    const transferred = (knownTotal ?? currentTotal) > 0
+      ? `${bytesToStringRep(loaded)} / ${bytesToStringRep(safeTotal)}`
+      : `${bytesToStringRep(loaded)} / unknown`;
+
+    callbacks.onProgress({
+      loaded,
+      total: safeTotal,
+      uploadSpeed,
+      remainingTime,
+      transferred,
+      percentComplete: phase === 'complete'
+        ? 100
+        : Math.round(((loaded / safeTotal) * 100) * 100) / 100,
+    });
+  };
+
+  const pollNativeUploadProgress = async () => {
+    if (progressPollInFlight) return;
+    progressPollInFlight = true;
+
+    try {
+      const response = await pluginNetworkFetch({
+        pluginId: 'athena',
+        operation: 'nanodlp/job/upload-progress',
+        host,
+        ipAddress: host,
+        port,
+        uploadId,
+      });
+
+      if (!response.ok) return;
+
+      const payloadRaw = await response.json().catch(() => ({}));
+      const payload: Record<string, unknown> = payloadRaw && typeof payloadRaw === 'object'
+        ? payloadRaw as Record<string, unknown>
+        : {};
+      const uploadRaw = payload.upload;
+      const upload = uploadRaw && typeof uploadRaw === 'object'
+        ? uploadRaw as Record<string, unknown>
+        : null;
+      if (!upload) return;
+
+      const sentBytes = Number(upload.sentBytes);
+      const totalBytes = Number(upload.totalBytes);
+      if (!Number.isFinite(sentBytes) || sentBytes < 0 || !Number.isFinite(totalBytes) || totalBytes <= 0) {
+        return;
+      }
+
+      currentLoaded = Math.max(0, Math.min(Math.round(sentBytes), Math.round(totalBytes)));
+      currentTotal = Math.max(1, Math.round(totalBytes));
+
+      const done = upload.done === true;
+      emitProgress(currentLoaded, currentTotal, { phase: done ? 'processing' : 'uploading' });
+    } finally {
+      progressPollInFlight = false;
+    }
+  };
+
+  callbacks.onStatusUpdate({
+    stage: 'uploading',
+    message: 'Uploading print job to NanoDLP device…',
+  });
+
+  emitProgress(0, knownTotal ?? 1, { phase: 'uploading' });
+  progressTimer = setInterval(() => {
+    void pollNativeUploadProgress();
+  }, 280);
+  void pollNativeUploadProgress();
+
+  try {
+    const response = await pluginNetworkFetch({
+      pluginId: 'athena',
+      operation: 'nanodlp/job/import',
+      host,
+      ipAddress: host,
+      port,
+      path,
+      profileId,
+      zipFilePath: normalizedPath,
+      uploadId,
+    });
+
+    const payloadRaw = await response.json().catch(() => ({}));
+    const payload: Record<string, unknown> = payloadRaw && typeof payloadRaw === 'object'
+      ? payloadRaw as Record<string, unknown>
+      : {};
+
+    if (!response.ok || payload.ok === false) {
+      const reason = typeof payload.error === 'string'
+        ? payload.error
+        : `HTTP ${response.status}`;
+      throw new Error(reason);
+    }
+
+    callbacks.onStatusUpdate({
+      stage: 'processing',
+      message: 'File uploaded, processing on device…',
+    });
+
+    await pollNativeUploadProgress();
+    const processingTotal = currentTotal > 0 ? currentTotal : (knownTotal ?? 1);
+    const processingLoaded = Math.max(currentLoaded, Math.round(processingTotal * 0.99));
+    emitProgress(processingLoaded, processingTotal, { phase: 'processing' });
+
+    const plateIdRaw = Number(payload.plateId);
+    const plateId = Number.isFinite(plateIdRaw) && plateIdRaw > 0
+      ? Math.round(plateIdRaw)
+      : null;
+
+    callbacks.onStatusUpdate({
+      stage: 'complete',
+      message: 'Upload complete',
+      plateId,
+    });
+
+    callbacks.onComplete?.(plateId);
+    const finalTotal = currentTotal > 0 ? currentTotal : Math.max(processingTotal, 1);
+    emitProgress(finalTotal, finalTotal, { phase: 'complete' });
+
+    return { ok: true, plateId };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to upload print job to NanoDLP';
+    callbacks.onStatusUpdate({
+      stage: 'error',
+      message: 'Upload failed',
+      error: message,
+    });
+    callbacks.onError?.(message);
+    throw error;
+  } finally {
+    if (progressTimer !== null) {
+      clearInterval(progressTimer);
+      progressTimer = null;
+    }
+  }
+}
+
 export function abortUpload(): void {
-  const xhr = userData.uploadXhr as XMLHttpRequest | undefined;
+  const xhr = userData.uploadXhr;
   if (xhr) {
     xhr.abort();
     delete userData.uploadXhr;

--- a/plugins/athena/pluginDefinition.ts
+++ b/plugins/athena/pluginDefinition.ts
@@ -33,6 +33,7 @@ const ATHENA_NANODLP_NETWORK_ADAPTER: PluginNetworkUiAdapterContract = {
     materialsEdit: 'nanodlp/materials/edit',
   },
   defaultLocalHostnames: ['nanodlp.local', 'athena.local', 'printer.local', 'resin.local'],
+  remoteMaterialEditingWipNotice: 'Remote material editing for NanoDLP is not yet available.',
   primaryEditFields: NANODLP_PRIMARY_EDIT_FIELDS,
   basicSections: NANODLP_BASIC_SECTIONS,
   advancedSections: NANODLP_ADVANCED_SECTIONS,

--- a/plugins/athena/rust/network.rs
+++ b/plugins/athena/rust/network.rs
@@ -2148,7 +2148,7 @@ async fn nanodlp_job_import(payload: &Value) -> (u16, Value) {
                 "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             )
             .multipart(form)
-            .timeout(Duration::from_secs(300))
+            .timeout(Duration::from_secs(600))
             .send()
             .await
             .map_err(|e| e.to_string())?;
@@ -2968,6 +2968,27 @@ async fn handle_athena_network(operation: &str, payload: &Value) -> (u16, Value)
     }
 }
 
+fn plugin_operation_deadline(operation: &str) -> Duration {
+    let normalized_operation = operation.trim().trim_start_matches('/').trim_end_matches('/');
+    let op = normalized_operation
+        .strip_prefix("nanodlp/")
+        .unwrap_or(normalized_operation);
+
+    if matches!(op, "job/import") {
+        // Large uploads can legitimately take several minutes on slower networks.
+        return Duration::from_secs(10 * 60);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        Duration::from_secs(60)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        Duration::from_secs(120)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Plugin dispatcher entry point
 // ---------------------------------------------------------------------------
@@ -3010,10 +3031,7 @@ pub async fn dispatch_plugin_network_request(request_json: String) -> Result<Plu
     // next poll arrives the total open-socket count can grow until Windows AV
     // heuristics decide the process is a port scanner and terminates it
     // (Windows Event 1005).  Returning a 503 early breaks the accumulation.
-    #[cfg(target_os = "windows")]
-    let deadline = Duration::from_secs(60);
-    #[cfg(not(target_os = "windows"))]
-    let deadline = Duration::from_secs(120);
+    let deadline = plugin_operation_deadline(&operation);
 
     let task = tokio::spawn(async move {
         match plugin_id.as_str() {

--- a/plugins/athena/rust/network.rs
+++ b/plugins/athena/rust/network.rs
@@ -1,15 +1,110 @@
 use base64::Engine;
+use futures_util::TryStreamExt;
 use log::debug;
 use reqwest::Client;
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, OnceLock};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 use tokio::sync::Semaphore;
 
 static HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
 static ATHENA_NETWORK_FILTERS: OnceLock<Vec<String>> = OnceLock::new();
+static NANODLP_UPLOAD_PROGRESS: OnceLock<Mutex<HashMap<String, NanoDlpUploadProgressEntry>>> =
+    OnceLock::new();
+
+#[derive(Clone)]
+struct NanoDlpUploadProgressEntry {
+    total_bytes: u64,
+    sent_bytes: Arc<AtomicU64>,
+    done: bool,
+    error: Option<String>,
+    updated_at_ms: u64,
+}
+
+fn epoch_ms_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn nanodlp_upload_progress_registry() -> &'static Mutex<HashMap<String, NanoDlpUploadProgressEntry>> {
+    NANODLP_UPLOAD_PROGRESS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn register_nanodlp_upload_progress(upload_id: &str, total_bytes: u64, sent_bytes: Arc<AtomicU64>) {
+    if upload_id.trim().is_empty() {
+        return;
+    }
+
+    if let Ok(mut map) = nanodlp_upload_progress_registry().lock() {
+        let now_ms = epoch_ms_now();
+        // Best-effort pruning to prevent unbounded growth.
+        map.retain(|_, entry| !(entry.done && now_ms.saturating_sub(entry.updated_at_ms) > 15 * 60 * 1000));
+
+        map.insert(
+            upload_id.to_string(),
+            NanoDlpUploadProgressEntry {
+                total_bytes,
+                sent_bytes,
+                done: false,
+                error: None,
+                updated_at_ms: now_ms,
+            },
+        );
+    }
+}
+
+fn complete_nanodlp_upload_progress(upload_id: &str, error: Option<String>) {
+    if upload_id.trim().is_empty() {
+        return;
+    }
+
+    if let Ok(mut map) = nanodlp_upload_progress_registry().lock() {
+        if let Some(entry) = map.get_mut(upload_id) {
+            if error.is_none() {
+                entry
+                    .sent_bytes
+                    .store(entry.total_bytes, Ordering::Relaxed);
+            }
+            entry.done = true;
+            entry.error = error;
+            entry.updated_at_ms = epoch_ms_now();
+        }
+    }
+}
+
+fn snapshot_nanodlp_upload_progress(upload_id: &str) -> Option<Value> {
+    let entry = {
+        let map = nanodlp_upload_progress_registry().lock().ok()?;
+        map.get(upload_id)?.clone()
+    };
+
+    let sent = entry
+        .sent_bytes
+        .load(Ordering::Relaxed)
+        .min(entry.total_bytes);
+    let percent = if entry.total_bytes > 0 {
+        ((sent as f64 / entry.total_bytes as f64) * 100.0).clamp(0.0, 100.0)
+    } else if entry.done {
+        100.0
+    } else {
+        0.0
+    };
+
+    Some(json!({
+        "uploadId": upload_id,
+        "totalBytes": entry.total_bytes,
+        "sentBytes": sent,
+        "percent": percent,
+        "done": entry.done,
+        "error": entry.error,
+        "updatedAtMs": entry.updated_at_ms,
+    }))
+}
 
 fn athena_network_filters() -> &'static Vec<String> {
     ATHENA_NETWORK_FILTERS.get_or_init(|| {
@@ -1933,6 +2028,12 @@ async fn nanodlp_job_import(payload: &Value) -> (u16, Value) {
             json!({ "ok": false, "error": "profileId is required for NanoDLP import" }),
         );
     }
+    let upload_id = payload
+        .get("uploadId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
 
     let host_lower = parsed.0.to_lowercase();
     let is_localhost =
@@ -1944,11 +2045,21 @@ async fn nanodlp_job_import(payload: &Value) -> (u16, Value) {
         .trim()
         .to_string();
 
-    // Read zip bytes from file path or base64
+    // Prefer streaming upload directly from disk when zipFilePath is provided,
+    // and fall back to base64 bytes for legacy callers.
+    let mut upload_file_path: Option<String> = None;
     let mut zip_bytes: Option<Vec<u8>> = None;
     if !zip_file_path.is_empty() {
-        match tokio::fs::read(&zip_file_path).await {
-            Ok(bytes) => zip_bytes = Some(bytes),
+        match tokio::fs::metadata(&zip_file_path).await {
+            Ok(meta) => {
+                if meta.len() == 0 {
+                    if zip_base64.is_empty() {
+                        return (400, json!({ "ok": false, "error": "zipFilePath points to an empty file" }));
+                    }
+                } else {
+                    upload_file_path = Some(zip_file_path.clone());
+                }
+            }
             Err(e) => {
                 if zip_base64.is_empty() {
                     return (
@@ -1959,7 +2070,7 @@ async fn nanodlp_job_import(payload: &Value) -> (u16, Value) {
             }
         }
     }
-    if zip_bytes.is_none() && !zip_base64.is_empty() {
+    if upload_file_path.is_none() && !zip_base64.is_empty() {
         match base64::engine::general_purpose::STANDARD.decode(&zip_base64) {
             Ok(bytes) => zip_bytes = Some(bytes),
             Err(e) => {
@@ -1970,17 +2081,23 @@ async fn nanodlp_job_import(payload: &Value) -> (u16, Value) {
             }
         }
     }
-    let zip_bytes = match zip_bytes {
-        Some(bytes) if !bytes.is_empty() => bytes,
-        _ => {
-            return (
-                400,
-                json!({ "ok": false, "error": "Decoded job payload is empty" }),
-            )
-        }
-    };
+    if upload_file_path.is_none() && zip_bytes.as_ref().map(|bytes| bytes.is_empty()).unwrap_or(true) {
+        return (
+            400,
+            json!({ "ok": false, "error": "Decoded job payload is empty" }),
+        );
+    }
 
     let base_url = build_base_url(&parsed.0, port);
+    let upload_file_path_for_request = upload_file_path;
+    let upload_bytes_for_request = zip_bytes;
+    let upload_id_for_request = if upload_id.is_empty() {
+        None
+    } else {
+        Some(upload_id)
+    };
+    let tracks_upload_progress =
+        upload_id_for_request.is_some() && upload_file_path_for_request.is_some();
 
     let result: Result<(u16, Value), String> = async {
         let form = if is_localhost && !usb_file_path.is_empty() {
@@ -1989,10 +2106,35 @@ async fn nanodlp_job_import(payload: &Value) -> (u16, Value) {
                 .text("ProfileID", profile_id.clone())
                 .text("USBFile", usb_file_path)
         } else {
-            let file_part = reqwest::multipart::Part::bytes(zip_bytes)
-                .file_name(format!("{path}.nanodlp"))
-                .mime_str("application/octet-stream")
-                .map_err(|e| format!("Failed to build multipart: {e}"))?;
+            let file_part = if let Some(upload_path) = upload_file_path_for_request.as_ref() {
+                let file = tokio::fs::File::open(upload_path)
+                    .await
+                    .map_err(|e| format!("Failed to open upload file '{}': {e}", upload_path))?;
+                let file_len = file
+                    .metadata()
+                    .await
+                    .map_err(|e| format!("Failed to read upload file metadata '{}': {e}", upload_path))?
+                    .len();
+                let progress_counter = Arc::new(AtomicU64::new(0));
+                if let Some(upload_id) = upload_id_for_request.as_deref() {
+                    register_nanodlp_upload_progress(upload_id, file_len, progress_counter.clone());
+                }
+                let progress_counter_for_stream = progress_counter;
+                let stream = tokio_util::io::ReaderStream::new(file).inspect_ok(move |chunk| {
+                    progress_counter_for_stream
+                        .fetch_add(chunk.len() as u64, Ordering::Relaxed);
+                });
+                let body = reqwest::Body::wrap_stream(stream);
+                reqwest::multipart::Part::stream_with_length(body, file_len)
+            } else {
+                let bytes = upload_bytes_for_request
+                    .clone()
+                    .ok_or_else(|| "No upload payload bytes available".to_string())?;
+                reqwest::multipart::Part::bytes(bytes)
+            }
+            .file_name(format!("{path}.nanodlp"))
+            .mime_str("application/octet-stream")
+            .map_err(|e| format!("Failed to build multipart: {e}"))?;
             reqwest::multipart::Form::new()
                 .text("Path", path.clone())
                 .text("ProfileID", profile_id.clone())
@@ -2070,6 +2212,27 @@ async fn nanodlp_job_import(payload: &Value) -> (u16, Value) {
     }
     .await;
 
+    if tracks_upload_progress {
+        if let Some(upload_id) = upload_id_for_request.as_deref() {
+            match &result {
+                Ok((status, _body)) if *status == 200 => {
+                    complete_nanodlp_upload_progress(upload_id, None);
+                }
+                Ok((_status, body)) => {
+                    let message = body
+                        .get("error")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| "NanoDLP upload failed".to_string());
+                    complete_nanodlp_upload_progress(upload_id, Some(message));
+                }
+                Err(message) => {
+                    complete_nanodlp_upload_progress(upload_id, Some(message.clone()));
+                }
+            }
+        }
+    }
+
     match result {
         Ok((status, body)) => (status, body),
         Err(message) => (
@@ -2087,6 +2250,43 @@ async fn nanodlp_job_import(payload: &Value) -> (u16, Value) {
 // ---------------------------------------------------------------------------
 // NanoDLP: plates/list/json
 // ---------------------------------------------------------------------------
+
+async fn nanodlp_job_upload_progress(payload: &Value) -> (u16, Value) {
+    let upload_id = payload
+        .get("uploadId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    if upload_id.is_empty() {
+        return (
+            400,
+            json!({
+                "ok": false,
+                "error": "uploadId is required",
+            }),
+        );
+    }
+
+    match snapshot_nanodlp_upload_progress(&upload_id) {
+        Some(progress) => (
+            200,
+            json!({
+                "ok": true,
+                "upload": progress,
+            }),
+        ),
+        None => (
+            404,
+            json!({
+                "ok": false,
+                "uploadId": upload_id,
+                "error": "Upload progress not found",
+            }),
+        ),
+    }
+}
 
 async fn nanodlp_plates_list_json(payload: &Value) -> (u16, Value) {
     let raw_host = resolve_raw_host(payload);
@@ -2751,6 +2951,7 @@ async fn handle_athena_network(operation: &str, payload: &Value) -> (u16, Value)
         "materials" => nanodlp_materials(payload).await,
         "materials/edit" => nanodlp_materials_edit(payload).await,
         "job/import" => nanodlp_job_import(payload).await,
+        "job/upload-progress" => nanodlp_job_upload_progress(payload).await,
         "plates/list/json" => nanodlp_plates_list_json(payload).await,
         "plate/delete" => nanodlp_plate_delete(payload).await,
         "printer/start" => nanodlp_printer_start(payload).await,

--- a/rust/dragonfruit-cli/Cargo.lock
+++ b/rust/dragonfruit-cli/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfruit-slicing-engine"
-version = "3.1.0"
+version = "3.1.2"
 dependencies = [
  "aes",
  "base64",

--- a/rust/dragonfruit-slicing-engine/Cargo.lock
+++ b/rust/dragonfruit-slicing-engine/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfruit-slicing-engine"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "aes",
  "base64",

--- a/rust/dragonfruit-slicing-engine/Cargo.lock
+++ b/rust/dragonfruit-slicing-engine/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfruit-slicing-engine"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "aes",
  "base64",

--- a/rust/dragonfruit-slicing-engine/Cargo.toml
+++ b/rust/dragonfruit-slicing-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dragonfruit-slicing-engine"
-version = "3.1.1"
+version = "3.1.2"
 edition = "2021"
 
 [lib]

--- a/rust/dragonfruit-slicing-engine/src/raster.rs
+++ b/rust/dragonfruit-slicing-engine/src/raster.rs
@@ -416,6 +416,118 @@ struct ComponentNode {
     pixels: u32,
 }
 
+#[derive(Debug, Default)]
+struct ComponentSpanTracker {
+    components: Vec<ComponentNode>,
+    prev_row_spans: Vec<RleSpan>,
+    current_row_spans: Vec<RleSpan>,
+}
+
+impl ComponentSpanTracker {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    #[inline]
+    fn push_span(&mut self, start: usize, end: usize) {
+        if end < start {
+            return;
+        }
+        let component = self.components.len();
+        self.components.push(ComponentNode {
+            parent: component,
+            rank: 0,
+            pixels: (end - start + 1) as u32,
+        });
+        self.current_row_spans.push(RleSpan {
+            start: start as u32,
+            end: end as u32,
+            component,
+        });
+    }
+
+    #[inline]
+    fn finish_row(&mut self) {
+        if !self.current_row_spans.is_empty() && !self.prev_row_spans.is_empty() {
+            let mut prev_start_idx = 0usize;
+            for span in &mut self.current_row_spans {
+                let adjacency_start = span.start.saturating_sub(1);
+                let adjacency_end = span.end.saturating_add(1);
+
+                while prev_start_idx < self.prev_row_spans.len()
+                    && self.prev_row_spans[prev_start_idx].end < adjacency_start
+                {
+                    prev_start_idx += 1;
+                }
+
+                let mut probe = prev_start_idx;
+                while probe < self.prev_row_spans.len()
+                    && self.prev_row_spans[probe].start <= adjacency_end
+                {
+                    span.component = component_union(
+                        &mut self.components,
+                        span.component,
+                        self.prev_row_spans[probe].component,
+                    );
+                    probe += 1;
+                }
+            }
+        }
+
+        self.prev_row_spans.clear();
+        self.prev_row_spans
+            .extend_from_slice(&self.current_row_spans);
+        self.current_row_spans.clear();
+    }
+
+    fn finalize(mut self, pixel_area_mm2: f64) -> (u32, f64, f64, u32) {
+        if self.components.is_empty() {
+            return (0, 0.0, 0.0, 0);
+        }
+
+        let mut seen_roots = vec![false; self.components.len()];
+        let mut total_solid_pixels = 0u32;
+        let mut largest_area_mm2 = 0.0f64;
+        let mut smallest_area_mm2 = f64::INFINITY;
+        let mut area_count = 0u32;
+
+        for index in 0..self.components.len() {
+            let root = component_find(&mut self.components, index);
+            if seen_roots[root] {
+                continue;
+            }
+            seen_roots[root] = true;
+
+            let pixels = self.components[root].pixels;
+            if pixels == 0 {
+                continue;
+            }
+
+            area_count = area_count.saturating_add(1);
+            total_solid_pixels = total_solid_pixels.saturating_add(pixels);
+
+            let area_mm2 = pixels as f64 * pixel_area_mm2;
+            if area_mm2 > largest_area_mm2 {
+                largest_area_mm2 = area_mm2;
+            }
+            if area_mm2 < smallest_area_mm2 {
+                smallest_area_mm2 = area_mm2;
+            }
+        }
+
+        if area_count == 0 {
+            (0, 0.0, 0.0, 0)
+        } else {
+            (
+                total_solid_pixels,
+                largest_area_mm2,
+                smallest_area_mm2,
+                area_count,
+            )
+        }
+    }
+}
+
 #[inline]
 fn component_find(nodes: &mut [ComponentNode], index: usize) -> usize {
     let parent = nodes[index].parent;
@@ -707,10 +819,9 @@ pub fn rasterize_layer_with_stats(
     let scanline_starts = scanline_index.starts;
     let y_start = scanline_index.y_start;
     let y_end_exclusive = scanline_index.y_end_exclusive;
-
-    // Keep area stats on a strict binary mask while allowing grayscale AA output.
-    let mut stats_mask = if compute_area_stats && aa_enabled {
-        Some(vec![0u8; width * height])
+    let track_aa_components = compute_area_stats && aa_enabled;
+    let mut aa_component_tracker = if track_aa_components {
+        Some(ComponentSpanTracker::new())
     } else {
         None
     };
@@ -727,6 +838,16 @@ pub fn rasterize_layer_with_stats(
     let mut merge_scratch: Vec<ActiveEdge> = Vec::with_capacity(segments.len().min(256));
 
     let mut row_accum = vec![0u32; width];
+    let mut row_delta = if aa_enabled {
+        vec![0i32; width + 1]
+    } else {
+        Vec::new()
+    };
+    let mut row_hit_delta = if track_aa_components {
+        vec![0i32; width + 1]
+    } else {
+        Vec::new()
+    };
     let mut current_physical_y = if y_start < y_end_exclusive {
         y_start / aa_steps
     } else {
@@ -740,11 +861,50 @@ pub fn rasterize_layer_with_stats(
             if aa_enabled && current_physical_y < height {
                 let r_start = current_physical_y * width;
                 let mask_row = &mut mask[r_start..r_start + width];
-                for (acc, out) in row_accum.iter_mut().zip(mask_row.iter_mut()) {
-                    if *acc > 0 {
-                        let resolved = (*acc / (aa_steps as u32)).min(255) as u8;
-                        *out = resolved.max(min_aa_alpha_u8);
-                        *acc = 0;
+                let mut coverage = 0i32;
+                let mut occupied = 0i32;
+                let mut run_start: Option<usize> = None;
+
+                for x in 0..width {
+                    coverage += row_delta[x];
+                    let acc = if coverage > 0 {
+                        row_accum[x].saturating_add(coverage as u32)
+                    } else {
+                        row_accum[x]
+                    };
+                    if acc > 0 {
+                        let resolved = (acc / (aa_steps as u32)).min(255) as u8;
+                        mask_row[x] = resolved.max(min_aa_alpha_u8);
+                    }
+                    row_accum[x] = 0;
+                    row_delta[x] = 0;
+
+                    if track_aa_components {
+                        occupied += row_hit_delta[x];
+                        let is_occupied = occupied > 0;
+                        if is_occupied {
+                            if run_start.is_none() {
+                                run_start = Some(x);
+                            }
+                        } else if let Some(start) = run_start.take() {
+                            if let Some(ref mut tracker) = aa_component_tracker {
+                                tracker.push_span(start, x - 1);
+                            }
+                        }
+                        row_hit_delta[x] = 0;
+                    }
+                }
+
+                row_delta[width] = 0;
+                if track_aa_components {
+                    if let Some(start) = run_start {
+                        if let Some(ref mut tracker) = aa_component_tracker {
+                            tracker.push_span(start, width - 1);
+                        }
+                    }
+                    row_hit_delta[width] = 0;
+                    if let Some(ref mut tracker) = aa_component_tracker {
+                        tracker.finish_row();
                     }
                 }
             }
@@ -766,14 +926,6 @@ pub fn rasterize_layer_with_stats(
         let spans = build_row_spans_nonzero(&active_edges, width, !aa_enabled);
 
         for span in spans {
-            if let Some(ref mut binary) = stats_mask {
-                let b_start = row_start + span.start;
-                let b_end = row_start + span.end;
-                if b_end < binary.len() {
-                    binary[b_start..=b_end].fill(255);
-                }
-            }
-
             if !aa_enabled {
                 let row = &mut mask[row_start..row_start + width];
                 row[span.start..=span.end].fill(255);
@@ -799,15 +951,19 @@ pub fn rasterize_layer_with_stats(
                         let interior_start = (left_i + 1).max(0) as usize;
                         let interior_end = (right_i - 1).min(width as i32 - 1) as usize;
                         if interior_end >= interior_start {
-                            for x in interior_start..=interior_end {
-                                row_accum[x] += 255;
-                            }
+                            row_delta[interior_start] += 255;
+                            row_delta[interior_end + 1] -= 255;
                         }
 
                         if right_i >= 0 && right_i < width as i32 {
                             row_accum[right_i as usize] += right_cov as u32;
                         }
                     }
+                }
+
+                if track_aa_components {
+                    row_hit_delta[span.start] += 1;
+                    row_hit_delta[span.end + 1] -= 1;
                 }
             }
 
@@ -830,11 +986,49 @@ pub fn rasterize_layer_with_stats(
         let r_start = current_physical_y * width;
         if r_start < mask.len() {
             let mask_row = &mut mask[r_start..r_start + width];
-            for (acc, out) in row_accum.iter_mut().zip(mask_row.iter_mut()) {
-                if *acc > 0 {
-                    let resolved = (*acc / (aa_steps as u32)).min(255) as u8;
-                    *out = resolved.max(min_aa_alpha_u8);
-                    *acc = 0;
+            let mut coverage = 0i32;
+            let mut occupied = 0i32;
+            let mut run_start: Option<usize> = None;
+            for x in 0..width {
+                coverage += row_delta[x];
+                let acc = if coverage > 0 {
+                    row_accum[x].saturating_add(coverage as u32)
+                } else {
+                    row_accum[x]
+                };
+                if acc > 0 {
+                    let resolved = (acc / (aa_steps as u32)).min(255) as u8;
+                    mask_row[x] = resolved.max(min_aa_alpha_u8);
+                }
+                row_accum[x] = 0;
+                row_delta[x] = 0;
+
+                if track_aa_components {
+                    occupied += row_hit_delta[x];
+                    let is_occupied = occupied > 0;
+                    if is_occupied {
+                        if run_start.is_none() {
+                            run_start = Some(x);
+                        }
+                    } else if let Some(start) = run_start.take() {
+                        if let Some(ref mut tracker) = aa_component_tracker {
+                            tracker.push_span(start, x - 1);
+                        }
+                    }
+                    row_hit_delta[x] = 0;
+                }
+            }
+
+            row_delta[width] = 0;
+            if track_aa_components {
+                if let Some(start) = run_start {
+                    if let Some(ref mut tracker) = aa_component_tracker {
+                        tracker.push_span(start, width - 1);
+                    }
+                }
+                row_hit_delta[width] = 0;
+                if let Some(ref mut tracker) = aa_component_tracker {
+                    tracker.finish_row();
                 }
             }
         }
@@ -851,10 +1045,14 @@ pub fn rasterize_layer_with_stats(
         stats.max_y = max_y;
 
         if compute_area_stats {
-            let stats_source = stats_mask.as_deref().unwrap_or(&mask);
-            let (total_pixels, largest_area_mm2, smallest_area_mm2, area_count) =
+            let (total_pixels, largest_area_mm2, smallest_area_mm2, area_count) = if aa_enabled {
+                aa_component_tracker
+                    .take()
+                    .map(|tracker| tracker.finalize(pixel_area_mm2))
+                    .unwrap_or((0, 0.0, 0.0, 0))
+            } else {
                 compute_component_area_stats_8_connected(
-                    stats_source,
+                    &mask,
                     width,
                     height,
                     min_x as usize,
@@ -862,7 +1060,8 @@ pub fn rasterize_layer_with_stats(
                     min_y as usize,
                     max_y as usize,
                     pixel_area_mm2,
-                );
+                )
+            };
 
             stats.total_solid_pixels = total_pixels;
             let total_area = (total_pixels as f64) * pixel_area_mm2;
@@ -947,8 +1146,9 @@ pub fn rasterize_layer_rle(
     let scanline_starts = scanline_index.starts;
     let y_start = scanline_index.y_start;
     let y_end_exclusive = scanline_index.y_end_exclusive;
-    let mut stats_mask = if compute_area_stats && aa_enabled {
-        Some(vec![0u8; width * height])
+    let track_aa_components = compute_area_stats && aa_enabled;
+    let mut aa_component_tracker = if track_aa_components {
+        Some(ComponentSpanTracker::new())
     } else {
         None
     };
@@ -972,6 +1172,16 @@ pub fn rasterize_layer_rle(
     // Single-row scratch buffer — width bytes max (7680 at 8 K).
     let mut row_buf = vec![0u8; width];
     let mut row_accum = vec![0u32; width];
+    let mut row_delta = if aa_enabled {
+        vec![0i32; width + 1]
+    } else {
+        Vec::new()
+    };
+    let mut row_hit_delta = if track_aa_components {
+        vec![0i32; width + 1]
+    } else {
+        Vec::new()
+    };
     let mut current_physical_y = first_physical_y;
     // last_emitted_py: the most recent physical row fully committed to `rle`.
     // Starts at first_physical_y - 1 (we just emitted zeros 0..first_physical_y).
@@ -984,11 +1194,50 @@ pub fn rasterize_layer_rle(
         ($next_py:expr) => {{
             // Resolve AA accumulator into row_buf for the row being flushed.
             if aa_enabled {
-                for (acc, out) in row_accum.iter_mut().zip(row_buf.iter_mut()) {
-                    if *acc > 0 {
-                        let resolved = (*acc / (aa_steps as u32)).min(255) as u8;
-                        *out = resolved.max(min_aa_alpha_u8);
-                        *acc = 0;
+                let mut coverage = 0i32;
+                let mut occupied = 0i32;
+                let mut run_start: Option<usize> = None;
+
+                for x in 0..width {
+                    coverage += row_delta[x];
+                    let acc = if coverage > 0 {
+                        row_accum[x].saturating_add(coverage as u32)
+                    } else {
+                        row_accum[x]
+                    };
+                    if acc > 0 {
+                        let resolved = (acc / (aa_steps as u32)).min(255) as u8;
+                        row_buf[x] = resolved.max(min_aa_alpha_u8);
+                    }
+                    row_accum[x] = 0;
+                    row_delta[x] = 0;
+
+                    if track_aa_components {
+                        occupied += row_hit_delta[x];
+                        let is_occupied = occupied > 0;
+                        if is_occupied {
+                            if run_start.is_none() {
+                                run_start = Some(x);
+                            }
+                        } else if let Some(start) = run_start.take() {
+                            if let Some(ref mut tracker) = aa_component_tracker {
+                                tracker.push_span(start, x - 1);
+                            }
+                        }
+                        row_hit_delta[x] = 0;
+                    }
+                }
+
+                row_delta[width] = 0;
+                if track_aa_components {
+                    if let Some(start) = run_start {
+                        if let Some(ref mut tracker) = aa_component_tracker {
+                            tracker.push_span(start, width - 1);
+                        }
+                    }
+                    row_hit_delta[width] = 0;
+                    if let Some(ref mut tracker) = aa_component_tracker {
+                        tracker.finish_row();
                     }
                 }
             }
@@ -1026,14 +1275,6 @@ pub fn rasterize_layer_rle(
         let spans = build_row_spans_nonzero(&active_edges, width, !aa_enabled);
 
         for span in spans {
-            if let Some(ref mut binary) = stats_mask {
-                let b_start = physical_y * width + span.start;
-                let b_end = physical_y * width + span.end;
-                if b_end < binary.len() {
-                    binary[b_start..=b_end].fill(255);
-                }
-            }
-
             if !aa_enabled {
                 row_buf[span.start..=span.end].fill(255);
             } else {
@@ -1057,15 +1298,19 @@ pub fn rasterize_layer_rle(
                         let interior_start = (left_i + 1).max(0) as usize;
                         let interior_end = (right_i - 1).min(width as i32 - 1) as usize;
                         if interior_end >= interior_start {
-                            for x in interior_start..=interior_end {
-                                row_accum[x] += 255;
-                            }
+                            row_delta[interior_start] += 255;
+                            row_delta[interior_end + 1] -= 255;
                         }
 
                         if right_i >= 0 && right_i < width as i32 {
                             row_accum[right_i as usize] += right_cov as u32;
                         }
                     }
+                }
+
+                if track_aa_components {
+                    row_hit_delta[span.start] += 1;
+                    row_hit_delta[span.end + 1] -= 1;
                 }
             }
 
@@ -1106,19 +1351,10 @@ pub fn rasterize_layer_rle(
 
         if compute_area_stats {
             let (total_pixels, largest_area_mm2, smallest_area_mm2, area_count) = if aa_enabled {
-                let stats_source = stats_mask
-                    .as_deref()
-                    .expect("stats mask must exist when compute_area_stats is true with AA");
-                compute_component_area_stats_8_connected(
-                    stats_source,
-                    width,
-                    height,
-                    min_x as usize,
-                    max_x as usize,
-                    min_y as usize,
-                    max_y as usize,
-                    pixel_area_mm2,
-                )
+                aa_component_tracker
+                    .take()
+                    .map(|tracker| tracker.finalize(pixel_area_mm2))
+                    .unwrap_or((0, 0.0, 0.0, 0))
             } else {
                 compute_component_area_stats_from_rle_8_connected(
                     &runs,
@@ -1354,6 +1590,68 @@ mod tests {
             (stats.total_solid_area_mm2 - (stats.largest_area_mm2 + stats.smallest_area_mm2)).abs()
                 < 1e-6,
             "total area should equal the sum of component areas"
+        );
+    }
+
+    #[test]
+    fn disconnected_islands_report_component_stats_with_aa() {
+        let mut job = job_for_single_layer();
+        job.anti_aliasing_level = "4x".to_string();
+
+        let mut flat = Vec::<f32>::new();
+        // Large island
+        push_box_triangles(&mut flat, -20.0, 0.0, 0.0, 1.0, 18.0, 18.0);
+        // Smaller, disconnected island
+        push_box_triangles(&mut flat, 20.0, 0.0, 0.0, 1.0, 8.0, 8.0);
+
+        let mut triangles = parse_triangles(&flat);
+        project_triangles_inplace(&mut triangles, &job);
+        let indices: Vec<usize> = (0..triangles.len()).collect();
+        let (_mask, stats) = rasterize_layer_with_stats(&job, &triangles, &indices, 0, true);
+
+        assert_eq!(
+            stats.area_count, 2,
+            "AA path should preserve disconnected 8-connected component count"
+        );
+        assert!(
+            stats.largest_area_mm2 > stats.smallest_area_mm2,
+            "largest area should exceed smallest area for differently sized disconnected islands"
+        );
+        assert!(
+            (stats.total_solid_area_mm2 - (stats.largest_area_mm2 + stats.smallest_area_mm2)).abs()
+                < 1e-6,
+            "total area should equal the sum of component areas in AA path"
+        );
+    }
+
+    #[test]
+    fn disconnected_islands_report_component_stats_in_rle_path_with_aa() {
+        let mut job = job_for_single_layer();
+        job.anti_aliasing_level = "4x".to_string();
+
+        let mut flat = Vec::<f32>::new();
+        // Large island
+        push_box_triangles(&mut flat, -20.0, 0.0, 0.0, 1.0, 18.0, 18.0);
+        // Smaller, disconnected island
+        push_box_triangles(&mut flat, 20.0, 0.0, 0.0, 1.0, 8.0, 8.0);
+
+        let mut triangles = parse_triangles(&flat);
+        project_triangles_inplace(&mut triangles, &job);
+        let indices: Vec<usize> = (0..triangles.len()).collect();
+        let (_runs, stats) = rasterize_layer_rle(&job, &triangles, &indices, 0, true);
+
+        assert_eq!(
+            stats.area_count, 2,
+            "AA RLE path should preserve disconnected 8-connected component count"
+        );
+        assert!(
+            stats.largest_area_mm2 > stats.smallest_area_mm2,
+            "largest area should exceed smallest area for differently sized disconnected islands"
+        );
+        assert!(
+            (stats.total_solid_area_mm2 - (stats.largest_area_mm2 + stats.smallest_area_mm2)).abs()
+                < 1e-6,
+            "total area should equal the sum of component areas in AA RLE path"
         );
     }
 }

--- a/rust/dragonfruit-slicing-engine/src/raster.rs
+++ b/rust/dragonfruit-slicing-engine/src/raster.rs
@@ -402,6 +402,198 @@ fn compute_component_area_stats_8_connected(
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct RleSpan {
+    start: u32,
+    end: u32,
+    component: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ComponentNode {
+    parent: usize,
+    rank: u8,
+    pixels: u32,
+}
+
+#[inline]
+fn component_find(nodes: &mut [ComponentNode], index: usize) -> usize {
+    let parent = nodes[index].parent;
+    if parent == index {
+        return index;
+    }
+
+    let root = component_find(nodes, parent);
+    nodes[index].parent = root;
+    root
+}
+
+#[inline]
+fn component_union(nodes: &mut [ComponentNode], a: usize, b: usize) -> usize {
+    let mut root_a = component_find(nodes, a);
+    let mut root_b = component_find(nodes, b);
+
+    if root_a == root_b {
+        return root_a;
+    }
+
+    if nodes[root_a].rank < nodes[root_b].rank {
+        std::mem::swap(&mut root_a, &mut root_b);
+    }
+
+    nodes[root_b].parent = root_a;
+    nodes[root_a].pixels = nodes[root_a].pixels.saturating_add(nodes[root_b].pixels);
+
+    if nodes[root_a].rank == nodes[root_b].rank {
+        nodes[root_a].rank = nodes[root_a].rank.saturating_add(1);
+    }
+
+    root_a
+}
+
+/// Compute 8-connected component area stats directly from row-major RLE runs.
+///
+/// This avoids materializing a full binary mask + per-pixel flood fill,
+/// reducing work to run/span adjacency checks for non-AA layers.
+fn compute_component_area_stats_from_rle_8_connected(
+    runs: &[crate::rle::RleRun],
+    width: usize,
+    height: usize,
+    pixel_area_mm2: f64,
+) -> (u32, f64, f64, u32) {
+    if width == 0 || height == 0 || runs.is_empty() {
+        return (0, 0.0, 0.0, 0);
+    }
+
+    let mut components: Vec<ComponentNode> = Vec::new();
+    let mut prev_row_spans: Vec<RleSpan> = Vec::new();
+    let mut current_row_spans: Vec<RleSpan> = Vec::new();
+
+    let mut row = 0usize;
+    let mut col = 0usize;
+
+    for run in runs {
+        if row >= height {
+            break;
+        }
+
+        let mut remaining = run.length as usize;
+        while remaining > 0 && row < height {
+            let row_remaining = width.saturating_sub(col);
+            if row_remaining == 0 {
+                prev_row_spans.clear();
+                prev_row_spans.extend_from_slice(&current_row_spans);
+                current_row_spans.clear();
+                row = row.saturating_add(1);
+                col = 0;
+                continue;
+            }
+
+            let take = remaining.min(row_remaining);
+
+            if run.value > 0 {
+                let start = col as u32;
+                let end = (col + take - 1) as u32;
+                let component = components.len();
+                components.push(ComponentNode {
+                    parent: component,
+                    rank: 0,
+                    pixels: take as u32,
+                });
+                current_row_spans.push(RleSpan {
+                    start,
+                    end,
+                    component,
+                });
+            }
+
+            col += take;
+            remaining -= take;
+
+            if col == width {
+                if !current_row_spans.is_empty() && !prev_row_spans.is_empty() {
+                    let mut prev_start_idx = 0usize;
+
+                    for span in &mut current_row_spans {
+                        let adjacency_start = span.start.saturating_sub(1);
+                        let adjacency_end = span.end.saturating_add(1);
+
+                        while prev_start_idx < prev_row_spans.len()
+                            && prev_row_spans[prev_start_idx].end < adjacency_start
+                        {
+                            prev_start_idx += 1;
+                        }
+
+                        let mut probe = prev_start_idx;
+                        while probe < prev_row_spans.len()
+                            && prev_row_spans[probe].start <= adjacency_end
+                        {
+                            span.component = component_union(
+                                &mut components,
+                                span.component,
+                                prev_row_spans[probe].component,
+                            );
+                            probe += 1;
+                        }
+                    }
+                }
+
+                prev_row_spans.clear();
+                prev_row_spans.extend_from_slice(&current_row_spans);
+                current_row_spans.clear();
+
+                row += 1;
+                col = 0;
+            }
+        }
+    }
+
+    if components.is_empty() {
+        return (0, 0.0, 0.0, 0);
+    }
+
+    let mut seen_roots = vec![false; components.len()];
+    let mut total_solid_pixels = 0u32;
+    let mut largest_area_mm2 = 0.0f64;
+    let mut smallest_area_mm2 = f64::INFINITY;
+    let mut area_count = 0u32;
+
+    for index in 0..components.len() {
+        let root = component_find(&mut components, index);
+        if seen_roots[root] {
+            continue;
+        }
+        seen_roots[root] = true;
+
+        let pixels = components[root].pixels;
+        if pixels == 0 {
+            continue;
+        }
+
+        area_count = area_count.saturating_add(1);
+        total_solid_pixels = total_solid_pixels.saturating_add(pixels);
+
+        let area_mm2 = pixels as f64 * pixel_area_mm2;
+        if area_mm2 > largest_area_mm2 {
+            largest_area_mm2 = area_mm2;
+        }
+        if area_mm2 < smallest_area_mm2 {
+            smallest_area_mm2 = area_mm2;
+        }
+    }
+
+    if area_count == 0 {
+        (0, 0.0, 0.0, 0)
+    } else {
+        (
+            total_solid_pixels,
+            largest_area_mm2,
+            smallest_area_mm2,
+            area_count,
+        )
+    }
+}
+
 fn aa_subpixel_steps(level: &str) -> u8 {
     match level {
         "2x" => 2,
@@ -755,7 +947,7 @@ pub fn rasterize_layer_rle(
     let scanline_starts = scanline_index.starts;
     let y_start = scanline_index.y_start;
     let y_end_exclusive = scanline_index.y_end_exclusive;
-    let mut stats_mask = if compute_area_stats {
+    let mut stats_mask = if compute_area_stats && aa_enabled {
         Some(vec![0u8; width * height])
     } else {
         None
@@ -904,6 +1096,8 @@ pub fn rasterize_layer_rle(
         stats.total_solid_pixels /= aa_steps as u32;
     }
 
+    let runs = rle.finish();
+
     if stats.total_solid_pixels > 0 {
         stats.min_x = min_x;
         stats.min_y = min_y;
@@ -911,10 +1105,10 @@ pub fn rasterize_layer_rle(
         stats.max_y = max_y;
 
         if compute_area_stats {
-            let stats_source = stats_mask
-                .as_deref()
-                .expect("stats mask must exist when compute_area_stats is true");
-            let (total_pixels, largest_area_mm2, smallest_area_mm2, area_count) =
+            let (total_pixels, largest_area_mm2, smallest_area_mm2, area_count) = if aa_enabled {
+                let stats_source = stats_mask
+                    .as_deref()
+                    .expect("stats mask must exist when compute_area_stats is true with AA");
                 compute_component_area_stats_8_connected(
                     stats_source,
                     width,
@@ -924,7 +1118,15 @@ pub fn rasterize_layer_rle(
                     min_y as usize,
                     max_y as usize,
                     pixel_area_mm2,
-                );
+                )
+            } else {
+                compute_component_area_stats_from_rle_8_connected(
+                    &runs,
+                    width,
+                    height,
+                    pixel_area_mm2,
+                )
+            };
 
             stats.total_solid_pixels = total_pixels;
             let total_area = (total_pixels as f64) * pixel_area_mm2;
@@ -941,7 +1143,7 @@ pub fn rasterize_layer_rle(
         }
     }
 
-    (rle.finish(), stats)
+    (runs, stats)
 }
 
 #[cfg(test)]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1367,6 +1367,7 @@ dependencies = [
  "dragonfruit-rtsp-relay",
  "dragonfruit-slicing-engine",
  "flate2",
+ "futures-util",
  "if-addrs",
  "log",
  "rayon",
@@ -1381,6 +1382,7 @@ dependencies = [
  "tauri-plugin-macos-fps",
  "tauri-plugin-single-instance",
  "tokio",
+ "tokio-util",
  "tungstenite",
  "zip 2.3.0",
 ]
@@ -4161,12 +4163,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
 ]
 
@@ -4200,7 +4204,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -6124,6 +6128,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfruit-slicing-engine"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "aes",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,12 +21,14 @@ log = "0.4"
 rfd = "0.15"
 rayon = "1.10"
 zip = "2"
-reqwest = { version = "0.12", features = ["json", "multipart"] }
+reqwest = { version = "0.12", features = ["json", "multipart", "stream"] }
 if-addrs = "0.10"
 tungstenite = "0.24"
 base64 = "0.22"
 sha2 = "0.10"
 tokio = { version = "1", features = ["sync", "fs", "time"] }
+tokio-util = { version = "0.7", features = ["io"] }
+futures-util = "0.3"
 dragonfruit-slicing-engine = { path = "../rust/dragonfruit-slicing-engine" }
 dragonfruit-rtsp-relay = { path = "../rust/dragonfruit-rtsp-relay" }
 dragonfruit-islands = { path = "../rust/dragonfruit-islands" }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2531,6 +2531,67 @@ async fn read_print_file_bytes(source_path: String) -> Result<Response, String> 
 }
 
 #[tauri::command]
+async fn read_print_file_size(source_path: String) -> Result<u64, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let source = std::path::PathBuf::from(source_path.trim());
+        if !source.exists() {
+            return Err("Source print file no longer exists on disk".to_string());
+        }
+
+        std::fs::metadata(&source)
+            .map(|meta| meta.len())
+            .map_err(|err| format!("Failed reading print file metadata: {err}"))
+    })
+    .await
+    .map_err(|err| format!("Read-size task failed to join: {err}"))?
+}
+
+#[tauri::command]
+async fn read_print_file_chunk(
+    source_path: String,
+    offset: u64,
+    length: u64,
+) -> Result<Response, String> {
+    const MAX_CHUNK_BYTES: usize = 8 * 1024 * 1024;
+
+    let bytes = tauri::async_runtime::spawn_blocking(move || {
+        let source = std::path::PathBuf::from(source_path.trim());
+        if !source.exists() {
+            return Err("Source print file no longer exists on disk".to_string());
+        }
+
+        let mut file = std::fs::File::open(&source)
+            .map_err(|err| format!("Failed opening print file: {err}"))?;
+
+        let file_len = file
+            .metadata()
+            .map_err(|err| format!("Failed reading print file metadata: {err}"))?
+            .len();
+
+        if offset >= file_len {
+            return Ok(Vec::new());
+        }
+
+        let remaining = file_len - offset;
+        let requested = length.max(1).min(MAX_CHUNK_BYTES as u64).min(remaining) as usize;
+
+        use std::io::{Read, Seek, SeekFrom};
+        file.seek(SeekFrom::Start(offset))
+            .map_err(|err| format!("Failed seeking print file chunk: {err}"))?;
+
+        let mut chunk = vec![0u8; requested];
+        file.read_exact(&mut chunk)
+            .map_err(|err| format!("Failed reading print file chunk: {err}"))?;
+
+        Ok(chunk)
+    })
+    .await
+    .map_err(|err| format!("Read-chunk task failed to join: {err}"))??;
+
+    Ok(Response::new(bytes))
+}
+
+#[tauri::command]
 async fn read_print_layer_png(
     source_path: String,
     layer_number: u32,
@@ -2976,6 +3037,8 @@ fn main() {
             reveal_main_window_command,
             write_bytes_to_path,
             read_print_file_bytes,
+            read_print_file_size,
+            read_print_file_chunk,
             read_print_layer_png,
             delete_print_temp_file,
             cleanup_stale_print_temp_files,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -751,6 +751,39 @@ function resolvePrintingMonitorAbsoluteUrl(candidate: string, host: string, port
   return `${base}/${trimmed.replace(/^\/+/, '')}`;
 }
 
+type JsonObject = Record<string, unknown>;
+
+function asJsonObject(value: unknown): JsonObject {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as JsonObject;
+  }
+  return {};
+}
+
+async function readJsonObject(response: { json: () => Promise<unknown> }): Promise<JsonObject> {
+  try {
+    const payload = await response.json();
+    return asJsonObject(payload);
+  } catch {
+    return {};
+  }
+}
+
+function readBooleanField(payload: JsonObject, key: string): boolean | null {
+  const value = payload[key];
+  return typeof value === 'boolean' ? value : null;
+}
+
+function readStringField(payload: JsonObject, key: string): string | null {
+  const value = payload[key];
+  return typeof value === 'string' ? value : null;
+}
+
+function readNumberField(payload: JsonObject, key: string): number | null {
+  const value = payload[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
 export default function Home() {
   // 1. Scene & Geometry (Multi-Model)
   const scene = useSceneCollectionManager();
@@ -4054,11 +4087,12 @@ export default function Home() {
               port: target.port,
             });
 
-            const payload = await response.json().catch(() => ({} as any));
+            const payload = await readJsonObject(response);
             if (!response.ok) return [target.id, false] as const;
 
-            if (payload && typeof payload.ok === 'boolean') {
-              return [target.id, payload.ok === true] as const;
+            const payloadOk = readBooleanField(payload, 'ok');
+            if (payloadOk != null) {
+              return [target.id, payloadOk === true] as const;
             }
 
             try {
@@ -5020,9 +5054,10 @@ export default function Home() {
             .then(async (response) => {
               if (!response.ok) return false;
 
-              const payload = await response.json().catch(() => null) as any;
-              if (payload && typeof payload.ok === 'boolean') {
-                return payload.ok === true;
+              const payload = await readJsonObject(response);
+              const payloadOk = readBooleanField(payload, 'ok');
+              if (payloadOk != null) {
+                return payloadOk === true;
               }
 
               try {
@@ -5316,7 +5351,7 @@ export default function Home() {
           host,
         });
 
-        const payload = await response.json().catch(() => null) as any;
+        const payload = await readJsonObject(response);
         const rawMaterials = Array.isArray(payload?.materials) ? payload.materials : [];
 
         const parsed: FleetUploadMaterialOption[] = rawMaterials
@@ -5411,7 +5446,7 @@ export default function Home() {
             port,
           });
 
-          const payload = await response.json().catch(() => ({} as any));
+          const payload = await readJsonObject(response);
           if (cancelled) return;
           const snapshot = printingMonitoringAdapter.parseStatusPayload(payload, `${host}:${port}`);
           setSelectedPrinterMonitorSnapshot(snapshot);
@@ -5474,7 +5509,7 @@ export default function Home() {
         try {
           const response = await pluginNetworkFetch(requestPayload);
 
-          const payload = await response.json().catch(() => ({} as any));
+          const payload = await readJsonObject(response);
           if (cancelled) return;
 
           const snapshot = printingMonitoringAdapter.parseStatusPayload(payload, `${host}:${port}`);
@@ -5594,7 +5629,7 @@ export default function Home() {
     try {
       const response = await pluginNetworkFetch(requestPayload);
 
-      const payload = await response.json().catch(() => ({} as any));
+      const payload = await readJsonObject(response);
       if (requestId !== printingMonitorRecentPlatesRequestIdRef.current) return;
       if (!response.ok || payload?.ok === false) {
         const reason = typeof payload?.error === 'string' ? payload.error : `HTTP ${response.status}`;
@@ -6010,14 +6045,14 @@ export default function Home() {
         const requestStartedAt = Date.now();
         const response = await pluginNetworkFetch(requestPayload);
 
-        const payload = await response.json().catch(() => ({} as any));
+        const payload = await readJsonObject(response);
         if (cancelled) return;
         const parsed = printingMonitoringAdapter.parseWebcamInfoPayload(payload, host, port);
         const elapsedMs = Date.now() - requestStartedAt;
 
         const parsedMessage = String(parsed?.message ?? '').toLowerCase();
-        const payloadMessage = typeof payload?.message === 'string' ? payload.message.toLowerCase() : '';
-        const ack = typeof payload?.ack === 'number' ? payload.ack : null;
+        const payloadMessage = (readStringField(payload, 'message') ?? '').toLowerCase();
+        const ack = readNumberField(payload, 'ack');
         const timedOut = parsedMessage.includes('timed out')
           || payloadMessage.includes('timed out')
           || parsedMessage.includes('no-response')
@@ -6464,9 +6499,10 @@ export default function Home() {
             });
 
             if (!response.ok) {
-              const payload = await response.json().catch(() => null) as { error?: unknown } | null;
-              const reason = typeof payload?.error === 'string' && payload.error.trim().length > 0
-                ? payload.error.trim()
+              const payload = await readJsonObject(response);
+              const payloadError = readStringField(payload, 'error');
+              const reason = typeof payloadError === 'string' && payloadError.trim().length > 0
+                ? payloadError.trim()
                 : `HTTP ${response.status}`;
               throw new Error(reason);
             }
@@ -6649,7 +6685,7 @@ export default function Home() {
               port,
             });
 
-            const payload = await response.json().catch(() => ({} as any));
+            const payload = await readJsonObject(response);
             const snapshot = printingMonitoringAdapter.parseStatusPayload(payload, `${host}:${port}`);
             return [device.id, snapshot] as const;
           } catch {
@@ -7915,7 +7951,7 @@ export default function Home() {
             jobName: pathBase,
           });
 
-          const readyPayload = await responseReady.json().catch(() => ({} as any));
+          const readyPayload = await readJsonObject(responseReady);
           const matchedPlate = readyPayload?.matchedPlate as Record<string, unknown> | null | undefined;
           const matchedPlateId = Number(
             (matchedPlate as any)?.PlateID
@@ -8099,8 +8135,8 @@ export default function Home() {
         plateId: printingReadyPlateId,
       });
 
-      const payload = await response.json().catch(() => ({} as any));
-      if (response.ok && payload?.ok) {
+      const payload = await readJsonObject(response);
+      if (response.ok && payload?.ok === true) {
         setPrintingSendStageText('Print started');
         setPrintingUploadDialogStage('started');
         setPrintingSendStatusText(`Print started successfully${printingReadyPlateId ? ` • Plate #${printingReadyPlateId}` : ''}.`);
@@ -8147,7 +8183,7 @@ export default function Home() {
         plateId: roundedPlateId,
       });
 
-      const payload = await response.json().catch(() => ({} as any));
+      const payload = await readJsonObject(response);
       if (!response.ok || payload?.ok === false) {
         const reason = typeof payload?.error === 'string' ? payload.error : `HTTP ${response.status}`;
         throw new Error(reason);
@@ -8209,7 +8245,7 @@ export default function Home() {
         plateId: roundedPlateId,
       });
 
-      const payload = await response.json().catch(() => ({} as any));
+      const payload = await readJsonObject(response);
       if (!response.ok || payload?.ok === false) {
         const reason = typeof payload?.error === 'string' ? payload.error : `HTTP ${response.status}`;
         throw new Error(reason);
@@ -8283,7 +8319,7 @@ export default function Home() {
         plateId: printingMonitorPlateId,
       });
 
-      const payload = await response.json().catch(() => ({} as any));
+      const payload = await readJsonObject(response);
       if (!response.ok || payload?.ok === false) {
         const reason = typeof payload?.error === 'string'
           ? payload.error
@@ -8311,7 +8347,7 @@ export default function Home() {
         port,
         plateId: printingMonitorPlateId,
       });
-      const statusPayload = await statusResponse.json().catch(() => ({} as any));
+      const statusPayload = await readJsonObject(statusResponse);
       if (statusResponse.ok) {
         setPrintingMonitorSnapshot(printingMonitoringAdapter.parseStatusPayload(statusPayload, `${host}:${port}`));
       }
@@ -8374,7 +8410,7 @@ export default function Home() {
         mainboardId: resolvedMainboardId,
       });
 
-      const payload = await response.json().catch(() => ({} as any));
+      const payload = await readJsonObject(response);
       const commandOk = typeof payload?.ok === 'boolean' ? payload.ok : (response.ok ? true : false);
       setPrintingMonitorLastFeatureToggleResponse({
         operation,
@@ -8456,7 +8492,7 @@ export default function Home() {
 
     try {
       const response = await pluginNetworkFetch(requestPayload);
-      const payload = await response.json().catch(() => ({} as any));
+      const payload = await readJsonObject(response);
 
       setPrintingMonitorDebugState((previous) => ({
         ...previous,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3704,50 +3704,6 @@ export default function Home() {
     return `${printingEstimatedResinMl.toFixed(2)} mL`;
   }, [isPrintingEstimatedResinBusy, printingEstimatedResinMl, scene.models]);
 
-  const modelStatsEstimatedPrintTimeLabel = React.useMemo(() => {
-    if (!activeMaterialProfile) return '—';
-
-    const visibleModels = scene.models.filter((model) => model.visible);
-    if (visibleModels.length === 0) return '—';
-
-    const layerHeightMm = Math.max(0.001, activeMaterialProfile.layerHeightMm || 0.05);
-    let maxModelHeightMm = 0;
-
-    for (const model of visibleModels) {
-      const bbox = model.geometry.bbox;
-      const sizeZ = Math.max(0, bbox.max.z - bbox.min.z);
-      const sz = Math.abs(model.transform.scale.z || 1);
-      maxModelHeightMm = Math.max(maxModelHeightMm, sizeZ * sz);
-    }
-
-    const totalLayers = Math.max(0, Math.ceil(maxModelHeightMm / layerHeightMm));
-    if (totalLayers <= 0) return '—';
-
-    const bottomLayers = Math.max(0, Math.min(totalLayers, Math.round(activeMaterialProfile.bottomLayerCount)));
-    const normalLayers = Math.max(0, totalLayers - bottomLayers);
-
-    const liftSec = activeMaterialProfile.liftSpeedMmMin > 0
-      ? (activeMaterialProfile.liftDistanceMm / activeMaterialProfile.liftSpeedMmMin) * 60
-      : 0;
-    const retractSec = activeMaterialProfile.retractSpeedMmMin > 0
-      ? (activeMaterialProfile.liftDistanceMm / activeMaterialProfile.retractSpeedMmMin) * 60
-      : 0;
-    const travelSecPerLayer = Math.max(0, liftSec + retractSec);
-
-    const totalSec = (
-      bottomLayers * (activeMaterialProfile.bottomExposureSec + travelSecPerLayer)
-      + normalLayers * (activeMaterialProfile.normalExposureSec + travelSecPerLayer)
-    );
-
-    const wholeSeconds = Math.max(0, Math.floor(totalSec));
-    const hours = Math.floor(wholeSeconds / 3600);
-    const minutes = Math.floor((wholeSeconds % 3600) / 60);
-    const seconds = wholeSeconds % 60;
-
-    if (hours > 0) return `${hours}h ${minutes}m`;
-    return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
-  }, [activeMaterialProfile, scene.models]);
-
   const estimatedPrintTimeLabel = React.useMemo(() => {
     if (!activeMaterialProfile || printingPreviewTotalLayers <= 0) return '—';
 
@@ -10169,12 +10125,25 @@ export default function Home() {
     supportStateSnapshot.twigs,
   ]);
 
-  // For non-printing workflows, avoid expensive world-triangle projection work.
+  // For non-printing workflows, avoid expensive world-triangle projection work by default.
   // Keep layer floor at 0 when support/raft geometry exists so layer-1 alignment is correct.
   const fallbackZRange = React.useMemo(() => ({
     min: hasSupportOrRaftGeometry ? 0 : (scene.sceneBounds?.min.z ?? 0),
     max: scene.sceneBounds?.max.z ?? 100,
   }), [hasSupportOrRaftGeometry, scene.sceneBounds]);
+
+  const normalizeToSlicerZRange = React.useCallback((range: { min: number; max: number }) => {
+    const maxZMm = Math.max(0, Number(range.max) || 0);
+    const buildHeightLimitMm = Math.max(0, Number(activePrinterProfile?.buildVolumeMm.height) || 0);
+    const clampedMaxZMm = buildHeightLimitMm > 0
+      ? Math.min(maxZMm, buildHeightLimitMm)
+      : maxZMm;
+
+    return {
+      min: 0,
+      max: clampedMaxZMm,
+    };
+  }, [activePrinterProfile?.buildVolumeMm.height]);
 
   const [sceneZRange, setSceneZRange] = useState(fallbackZRange);
 
@@ -10230,9 +10199,10 @@ export default function Home() {
   useEffect(() => {
     // Projected world-triangle bounds are expensive.
     // Analysis can run on fallback bounds to keep mode-entry instant.
-    // Printing only needs accurate support/raft-aware bounds before a print artifact
-    // exists; reopening printing with an existing artifact should avoid this rebuild.
-    const needsAccurateZRange = scene.mode === 'printing' && !printingArtifact;
+    // Printing needs accurate support/raft-aware bounds before a print artifact
+    // exists; Export needs the same fidelity so layer estimates match real slicing.
+    const needsAccurateZRange = (scene.mode === 'printing' && !printingArtifact) || scene.mode === 'export';
+    const shouldUseSlicerAlignedRange = scene.mode === 'printing' || scene.mode === 'export';
     
     if (needsAccurateZRange) {
       const cached = projectedZRangeCacheRef.current.get(projectedZRangeCacheKey);
@@ -10249,7 +10219,10 @@ export default function Home() {
       const run = () => {
         if (cancelled) return;
         const projected = buildProjectedCrossSectionZRange(scene.models);
-        const nextRange = projected ?? fallbackZRange;
+        const baseRange = projected ?? fallbackZRange;
+        const nextRange = shouldUseSlicerAlignedRange
+          ? normalizeToSlicerZRange(baseRange)
+          : baseRange;
         projectedZRangeCacheRef.current.set(projectedZRangeCacheKey, nextRange);
         if (projectedZRangeCacheRef.current.size > 8) {
           const oldest = projectedZRangeCacheRef.current.keys().next().value;
@@ -10277,10 +10250,11 @@ export default function Home() {
         }
       };
     } else {
-      // Use fast fallback for prepare/support/export modes
-      setSceneZRange(fallbackZRange);
+      // Use fast fallback for non-export modes where projected bounds aren't required.
+      setSceneZRange(shouldUseSlicerAlignedRange ? normalizeToSlicerZRange(fallbackZRange) : fallbackZRange);
     }
   }, [
+    normalizeToSlicerZRange,
     fallbackZRange,
     printingArtifact,
     projectedZRangeCacheKey,
@@ -10292,6 +10266,53 @@ export default function Home() {
     hasGeometry: scene.models.length > 0,
     zRange: sceneZRange
   });
+
+  const estimatedSlicerLayerCount = React.useMemo(() => {
+    if (scene.models.length === 0) return 0;
+
+    const layerHeightMm = Math.max(0.001, slicedLayerHeightMm || 0.05);
+    const printableMaxZMm = Math.max(0, Number(sceneZRange.max) || 0);
+    const buildHeightLimitMm = Math.max(0, Number(activePrinterProfile?.buildVolumeMm.height) || 0);
+    const slicerHeightMm = buildHeightLimitMm > 0
+      ? Math.min(printableMaxZMm, buildHeightLimitMm)
+      : printableMaxZMm;
+
+    return Math.max(0, Math.ceil(slicerHeightMm / layerHeightMm));
+  }, [activePrinterProfile?.buildVolumeMm.height, scene.models.length, sceneZRange.max, slicedLayerHeightMm]);
+
+  const modelStatsEstimatedPrintTimeLabel = React.useMemo(() => {
+    if (!activeMaterialProfile) return '—';
+
+    const visibleModels = scene.models.filter((model) => model.visible);
+    if (visibleModels.length === 0) return '—';
+
+    const totalLayers = estimatedSlicerLayerCount;
+    if (totalLayers <= 0) return '—';
+
+    const bottomLayers = Math.max(0, Math.min(totalLayers, Math.round(activeMaterialProfile.bottomLayerCount)));
+    const normalLayers = Math.max(0, totalLayers - bottomLayers);
+
+    const liftSec = activeMaterialProfile.liftSpeedMmMin > 0
+      ? (activeMaterialProfile.liftDistanceMm / activeMaterialProfile.liftSpeedMmMin) * 60
+      : 0;
+    const retractSec = activeMaterialProfile.retractSpeedMmMin > 0
+      ? (activeMaterialProfile.liftDistanceMm / activeMaterialProfile.retractSpeedMmMin) * 60
+      : 0;
+    const travelSecPerLayer = Math.max(0, liftSec + retractSec);
+
+    const totalSec = (
+      bottomLayers * (activeMaterialProfile.bottomExposureSec + travelSecPerLayer)
+      + normalLayers * (activeMaterialProfile.normalExposureSec + travelSecPerLayer)
+    );
+
+    const wholeSeconds = Math.max(0, Math.floor(totalSec));
+    const hours = Math.floor(wholeSeconds / 3600);
+    const minutes = Math.floor((wholeSeconds % 3600) / 60);
+    const seconds = wholeSeconds % 60;
+
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
+  }, [activeMaterialProfile, estimatedSlicerLayerCount, scene.models]);
 
   const printingCurrentHeightMm = React.useMemo(() => {
     if (scene.mode !== 'printing') return null;
@@ -13701,6 +13722,7 @@ export default function Home() {
               key="export-slicing"
               models={scene.models}
               activeModel={scene.activeModel}
+              estimatedLayerCountOverride={estimatedSlicerLayerCount}
               estimatedVolumeLabelOverride={estimatedVolumeMlLabel}
               captureSceneThumbnailPng={captureExportThumbnailPng}
               onSliceRunStarted={handleSliceRunStartedForPrinting}
@@ -14227,7 +14249,7 @@ export default function Home() {
                 models={scene.models}
                 selectedModelIds={scene.selectedModelIds}
                 inBoundsModelIds={inBoundsModelIds}
-                numLayers={slicing.numLayers}
+                numLayers={estimatedSlicerLayerCount}
                 heightMm={slicing.heightMm}
                 estimatedPrintTimeLabelOverride={modelStatsEstimatedPrintTimeLabel}
                 estimatedResinLabelOverride={estimatedVolumeMlLabel}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3305,9 +3305,62 @@ export default function Home() {
   // export + pre-artifact printing. Base model volume estimation runs in the
   // background across active editing modes (for warm, up-to-date estimates).
   const shouldCalculateSupportAndRaftVolumes = scene.mode === 'export' || (scene.mode === 'printing' && !printingArtifact);
+  const resinBuildVolumeBounds = React.useMemo(() => {
+    if (!scene.view3dSettings.enabled) return null;
+
+    const width = scene.view3dSettings.widthMm;
+    const depth = scene.view3dSettings.depthMm;
+    const minX = scene.view3dSettings.originMode === 'front_left' ? 0 : -width * 0.5;
+    const minY = scene.view3dSettings.originMode === 'front_left' ? 0 : -depth * 0.5;
+
+    return new THREE.Box3(
+      new THREE.Vector3(minX, minY, 0),
+      new THREE.Vector3(minX + width, minY + depth, scene.view3dSettings.maxZMm),
+    );
+  }, [
+    scene.view3dSettings.depthMm,
+    scene.view3dSettings.enabled,
+    scene.view3dSettings.maxZMm,
+    scene.view3dSettings.originMode,
+    scene.view3dSettings.widthMm,
+  ]);
+
+  const resinInBoundsModelIdSet = React.useMemo(() => {
+    const visibleModels = scene.models.filter((model) => model.visible);
+    if (visibleModels.length === 0) return new Set<string>();
+    if (!resinBuildVolumeBounds) return new Set(visibleModels.map((model) => model.id));
+
+    const BUILD_VOLUME_BOUNDS_EPS_MM = 0.01;
+    const inBoundsModelIds = new Set<string>();
+
+    for (const model of visibleModels) {
+      const effectiveTransform =
+        (scene.activeModelId === model.id && displayActiveModelId === scene.activeModelId)
+          ? transformMgr.transform
+          : model.transform;
+
+      const approxBounds = computeApproxModelWorldBounds(model.geometry, effectiveTransform);
+      const bounds = isBoundsOutsideVolume(approxBounds, resinBuildVolumeBounds, BUILD_VOLUME_BOUNDS_EPS_MM)
+        ? computePreciseModelWorldBounds(model.geometry, effectiveTransform)
+        : approxBounds;
+
+      if (!isBoundsOutsideVolume(bounds, resinBuildVolumeBounds, BUILD_VOLUME_BOUNDS_EPS_MM)) {
+        inBoundsModelIds.add(model.id);
+      }
+    }
+
+    return inBoundsModelIds;
+  }, [
+    displayActiveModelId,
+    resinBuildVolumeBounds,
+    scene.activeModelId,
+    scene.models,
+    transformMgr.transform,
+  ]);
+
   const visibleResinModels = React.useMemo(() => {
-    return scene.models.filter((model) => model.visible);
-  }, [scene.models]);
+    return scene.models.filter((model) => model.visible && resinInBoundsModelIdSet.has(model.id));
+  }, [resinInBoundsModelIdSet, scene.models]);
   const shouldEstimateResinInBackground = visibleResinModels.length > 0
     && (scene.mode !== 'printing' || !printingArtifact);
 
@@ -3338,7 +3391,7 @@ export default function Home() {
     if (!shouldCalculateSupportAndRaftVolumes) return 0;
 
     // Expensive calculation ONLY runs when mode is export/printing
-    const visibleModelIds = new Set(scene.models.filter((model) => model.visible).map((model) => model.id));
+    const visibleModelIds = resinInBoundsModelIdSet;
     if (visibleModelIds.size === 0) return 0;
 
     const mm3ToMl = (mm3: number) => Math.max(0, mm3) / 1000;
@@ -3657,6 +3710,7 @@ export default function Home() {
 
     return supportMl + raftMl;
   }, [
+    resinInBoundsModelIdSet,
     shouldCalculateSupportAndRaftVolumes,
     computeFootprint,
     computeRaftOuterBoundary,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7694,8 +7694,8 @@ export default function Home() {
     setPrintingSendBusy(true);
     setPrintingSendProgress(0.01);
     setPrintingUploadDisplayProgress(0.01);
-    setPrintingSendStageText('Uploading print job…');
-    setPrintingSendStatusText('Uploading print job to printer…');
+    setPrintingSendStageText('Uploading Print Job…');
+    setPrintingSendStatusText('Uploading Print Job to Printer…');
     setPrintingUploadTelemetry(null);
     setPrintingUploadDialogStage('uploading');
     setPrintingUploadDialogOpen(true);
@@ -7704,24 +7704,12 @@ export default function Home() {
 
     try {
       const nativeTempPath = printingArtifact.nativeTempPath?.trim() || '';
-      let zipBlob = printingArtifact.blob;
+      const zipFilePath = nativeTempPath.length > 0 ? nativeTempPath : null;
+      const zipBlob = printingArtifact.blob ?? null;
       throwIfCanceled();
 
-      // If we have a local temp path and no blob, read the blob from native bridge
-      if (!zipBlob && nativeTempPath) {
-        try {
-          const fileBytes = await readPrintArtifactBytesFromPath(nativeTempPath);
-          if (fileBytes && fileBytes.length > 0) {
-            const normalizedBytes = Uint8Array.from(fileBytes);
-            zipBlob = new Blob([normalizedBytes], { type: 'application/octet-stream' });
-          }
-        } catch (readError) {
-          console.warn('Failed to read artifact from native path:', readError);
-        }
-      }
-
-      if (!zipBlob) {
-        throw new Error('No print artifact blob available for printer upload.');
+      if (!zipBlob && !zipFilePath) {
+        throw new Error('No print artifact payload available for printer upload.');
       }
 
       throwIfCanceled();
@@ -7742,6 +7730,7 @@ export default function Home() {
         networkMode,
         hostUrl,
         zipBlob,
+        zipFilePath,
         path: pathBase,
         profileId: selectedMaterialId,
         callbacks: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -405,6 +405,7 @@ const DEFAULT_WEBCAM_MAX_CONSECUTIVE_TIMEOUTS = 3;
 const DEFAULT_RTSP_DEBUG_POLL_MS = 4_000;
 const DEFAULT_RELAY_AUTORETRY_LIMIT = 2;
 const DEFAULT_RELAY_AUTORETRY_DELAY_MS = 1200;
+const RESIN_ESTIMATE_BACKGROUND_REFRESH_MS = 12_000;
 
 type TransformStoreCommitResult = {
   updated: boolean;
@@ -1132,8 +1133,10 @@ export default function Home() {
   const slicedArtifactProfileFingerprintRef = React.useRef<string | null>(null);
   const [printingEstimatedResinMl, setPrintingEstimatedResinMl] = React.useState<number | null>(null);
   const [isPrintingEstimatedResinBusy, setIsPrintingEstimatedResinBusy] = React.useState(false);
+  const [resinEstimateRefreshTick, setResinEstimateRefreshTick] = React.useState(0);
   const printingBaseResinMlCacheRef = React.useRef<Map<string, number | null>>(new Map());
   const printingInFlightBaseResinMlRef = React.useRef<Map<string, Promise<number | null>>>(new Map());
+  const lastCompletedResinEstimateSignatureRef = React.useRef<string>('');
   const [showPrintingResliceModal, setShowPrintingResliceModal] = React.useState(false);
   const [showSliceCompletedModal, setShowSliceCompletedModal] = React.useState(false);
   const [sliceCompletedModalData, setSliceCompletedModalData] = React.useState<{
@@ -3298,13 +3301,41 @@ export default function Home() {
     return promise;
   }, [computeBaseResinMlChunked]);
 
-  // First, check if we should even calculate volumes based on mode.
-  // Printing-mode reopen with an existing artifact should stay responsive;
-  // avoid re-running heavy support/raft volume aggregation in that case.
-  const shouldCalculateVolumes = scene.mode === 'export' || (scene.mode === 'printing' && !printingArtifact);
+  // Support/raft aggregation is comparatively heavy, so keep it scoped to
+  // export + pre-artifact printing. Base model volume estimation runs in the
+  // background across active editing modes (for warm, up-to-date estimates).
+  const shouldCalculateSupportAndRaftVolumes = scene.mode === 'export' || (scene.mode === 'printing' && !printingArtifact);
+  const visibleResinModels = React.useMemo(() => {
+    return scene.models.filter((model) => model.visible);
+  }, [scene.models]);
+  const shouldEstimateResinInBackground = visibleResinModels.length > 0
+    && (scene.mode !== 'printing' || !printingArtifact);
+
+  const resinEstimateComputationSignature = React.useMemo(() => {
+    if (visibleResinModels.length === 0) return '';
+
+    const parts = visibleResinModels.map((model) => {
+      const geometry = model.geometry.geometry;
+      const positionAttr = geometry.getAttribute('position') as ({ version?: number; data?: { version?: number } } | null);
+      const indexAttr = geometry.getIndex() as ({ version?: number } | null);
+
+      const sourceKey = String(geometry.userData?.resinVolumeSourceKey ?? geometry.uuid);
+      const positionVersion = positionAttr?.version ?? positionAttr?.data?.version ?? 0;
+      const indexVersion = indexAttr?.version ?? 0;
+
+      const sx = Math.abs(model.transform.scale.x || 1).toFixed(6);
+      const sy = Math.abs(model.transform.scale.y || 1).toFixed(6);
+      const sz = Math.abs(model.transform.scale.z || 1).toFixed(6);
+
+      return `${model.id}:${sourceKey}:${positionVersion}:${indexVersion}:${sx}:${sy}:${sz}`;
+    });
+
+    parts.sort((a, b) => a.localeCompare(b));
+    return parts.join('|');
+  }, [visibleResinModels]);
 
   const supportAndRaftResinMl = React.useMemo(() => {
-    if (!shouldCalculateVolumes) return 0;
+    if (!shouldCalculateSupportAndRaftVolumes) return 0;
 
     // Expensive calculation ONLY runs when mode is export/printing
     const visibleModelIds = new Set(scene.models.filter((model) => model.visible).map((model) => model.id));
@@ -3626,7 +3657,7 @@ export default function Home() {
 
     return supportMl + raftMl;
   }, [
-    shouldCalculateVolumes,
+    shouldCalculateSupportAndRaftVolumes,
     computeFootprint,
     computeRaftOuterBoundary,
     raftSettingsSnapshot,
@@ -3645,26 +3676,37 @@ export default function Home() {
   ]);
 
   React.useEffect(() => {
+    if (!shouldEstimateResinInBackground) return;
+
+    const intervalId = window.setInterval(() => {
+      setResinEstimateRefreshTick((previous) => previous + 1);
+    }, RESIN_ESTIMATE_BACKGROUND_REFRESH_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [shouldEstimateResinInBackground]);
+
+  React.useEffect(() => {
     let cancelled = false;
 
-    if (!shouldCalculateVolumes) {
+    if (!shouldEstimateResinInBackground) {
+      if (visibleResinModels.length === 0) {
+        lastCompletedResinEstimateSignatureRef.current = '';
+        setPrintingEstimatedResinMl(null);
+      }
       setIsPrintingEstimatedResinBusy(false);
       return () => {
         cancelled = true;
       };
     }
 
-    const visibleModels = scene.models.filter((model) => model.visible);
-
-    if (visibleModels.length === 0) {
-      setPrintingEstimatedResinMl(null);
-      setIsPrintingEstimatedResinBusy(false);
-      return () => {
-        cancelled = true;
-      };
+    const visibleModels = visibleResinModels;
+    const compositeSignature = `${resinEstimateComputationSignature}::supports:${supportAndRaftResinMl.toFixed(6)}`;
+    const hasChangedSinceLastSuccess = compositeSignature !== lastCompletedResinEstimateSignatureRef.current;
+    if (printingEstimatedResinMl == null || hasChangedSinceLastSuccess) {
+      setIsPrintingEstimatedResinBusy(true);
     }
-
-    setIsPrintingEstimatedResinBusy(true);
 
     const run = async () => {
       let totalMl = 0;
@@ -3686,6 +3728,7 @@ export default function Home() {
       if (cancelled) return;
       const totalWithSupports = totalMl + supportAndRaftResinMl;
       setPrintingEstimatedResinMl(found || totalWithSupports > 0 ? totalWithSupports : null);
+      lastCompletedResinEstimateSignatureRef.current = compositeSignature;
       setIsPrintingEstimatedResinBusy(false);
     };
 
@@ -3694,7 +3737,15 @@ export default function Home() {
     return () => {
       cancelled = true;
     };
-  }, [getOrComputeBaseResinMl, scene.models, shouldCalculateVolumes, supportAndRaftResinMl]);
+  }, [
+    getOrComputeBaseResinMl,
+    printingEstimatedResinMl,
+    resinEstimateComputationSignature,
+    resinEstimateRefreshTick,
+    shouldEstimateResinInBackground,
+    supportAndRaftResinMl,
+    visibleResinModels,
+  ]);
 
   const estimatedVolumeMlLabel = React.useMemo(() => {
     const visible = scene.models.filter((model) => model.visible);

--- a/src/components/controls/ModelStatsCard.tsx
+++ b/src/components/controls/ModelStatsCard.tsx
@@ -210,6 +210,13 @@ export function ModelStatsCard({
     return selectedLayerCounts.reduce((max, entry) => (entry.count != null && entry.count > max ? entry.count : max), 0);
   }, [selectedLayerCounts]);
 
+  const resolvedLayerCount = React.useMemo(() => {
+    if (Number.isFinite(numLayers) && numLayers > 0) {
+      return Math.max(0, Math.round(numLayers));
+    }
+    return maxLayerCount;
+  }, [maxLayerCount, numLayers]);
+
   const resinTargetModels = React.useMemo(() => {
     const visibleModels = models.filter((entry) => entry.visible);
 
@@ -486,7 +493,7 @@ export function ModelStatsCard({
 
               <span>Layers:</span>
               <span className="min-w-0 truncate" style={{ color: 'var(--text-strong)' }}>
-                {maxLayerCount != null ? maxLayerCount : '-'}
+                {resolvedLayerCount != null ? resolvedLayerCount : '-'}
               </span>
 
               <span>Est. print time:</span>

--- a/src/components/settings/ProfileSettingsModal.tsx
+++ b/src/components/settings/ProfileSettingsModal.tsx
@@ -3884,16 +3884,45 @@ export function ProfileSettingsModal({
                 <div className="flex items-center gap-1.5 shrink-0">
                   {shouldUseRemoteOnDeviceMaterials && (
                     <>
-                      <button
-                        type="button"
-                        onClick={openRemoteMaterialEditDialog}
-                        disabled={!selectedRemoteMaterial}
-                        className="ui-button ui-button-secondary !h-8 !px-3 !py-0 text-xs inline-flex items-center justify-center gap-1 rounded-md disabled:opacity-45"
-                        style={{ color: 'var(--text-strong)' }}
-                      >
-                        <Edit3 className="w-3.5 h-3.5" />
-                        Edit
-                      </button>
+                      {effectiveNetworkUiAdapter.remoteMaterialEditingWipNotice ? (
+                        <div className="relative group">
+                          <button
+                            type="button"
+                            disabled
+                            aria-label="Edit material (work in progress)"
+                            className="ui-button ui-button-secondary !h-8 !px-3 !py-0 text-xs inline-flex items-center justify-center gap-1 rounded-md opacity-35 cursor-not-allowed"
+                            style={{ color: 'var(--text-strong)', pointerEvents: 'none' }}
+                          >
+                            <Edit3 className="w-3.5 h-3.5" />
+                            Edit
+                          </button>
+                          <div
+                            className="pointer-events-none absolute right-0 top-full mt-2 z-[70] w-[220px] rounded-md border px-2.5 py-2 text-[10px] leading-tight opacity-0 -translate-y-1 transition-all duration-150 group-hover:opacity-100 group-hover:translate-y-0"
+                            style={{
+                              borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 35%)',
+                              background: 'color-mix(in srgb, var(--surface-0), black 10%)',
+                              color: 'var(--text-muted)',
+                              boxShadow: '0 10px 24px rgba(0,0,0,0.28)',
+                            }}
+                            role="tooltip"
+                            aria-hidden="true"
+                          >
+                            <div className="font-semibold mb-0.5" style={{ color: 'var(--text-strong)' }}>Work in progress</div>
+                            <div>{effectiveNetworkUiAdapter.remoteMaterialEditingWipNotice}</div>
+                          </div>
+                        </div>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={openRemoteMaterialEditDialog}
+                          disabled={!selectedRemoteMaterial}
+                          className="ui-button ui-button-secondary !h-8 !px-3 !py-0 text-xs inline-flex items-center justify-center gap-1 rounded-md disabled:opacity-45"
+                          style={{ color: 'var(--text-strong)' }}
+                        >
+                          <Edit3 className="w-3.5 h-3.5" />
+                          Edit
+                        </button>
+                      )}
                       <button
                         type="button"
                         onClick={() => { void loadRemoteMaterials(); }}

--- a/src/components/settings/ProfileSettingsModal.tsx
+++ b/src/components/settings/ProfileSettingsModal.tsx
@@ -108,6 +108,12 @@ type DeleteConfirmTarget =
   | { kind: 'printer'; id: string; name: string }
   | { kind: 'material'; id: string; name: string };
 
+type RemoteMaterialsCacheEntry = {
+  materials: RemoteMaterialProfile[];
+  selectedMaterialId: string;
+  fetchedAt: number;
+};
+
 
 const REMOTE_MATERIAL_BY_PRINTER_STORAGE_KEY = 'dragonfruit.network.remoteMaterialByPrinter.v1';
 
@@ -893,6 +899,7 @@ export function ProfileSettingsModal({
   }, [remoteMaterials, selectedRemoteMaterialId]);
 
   const selectedRemoteMaterialIdRef = React.useRef('');
+  const remoteMaterialsCacheRef = React.useRef<Map<string, RemoteMaterialsCacheEntry>>(new Map());
   const lastHandledOpenPrinterLibraryTokenRef = React.useRef(0);
   const lastHandledOpenNetworkSettingsTokenRef = React.useRef(0);
   const wasOpenRef = React.useRef(false);
@@ -944,6 +951,13 @@ export function ProfileSettingsModal({
   const selectedPrinterResolvedId = selectedPrinter?.id ?? '';
   const selectedPrinterNetworkSupportMode = selectedPrinter?.networkSupport ?? null;
   const selectedRemoteMaterialHost = (selectedPrinter?.networkConnection?.ipAddress || selectedPrinter?.network?.ipAddress || '').trim();
+  const remoteMaterialsCacheKey = React.useMemo(() => {
+    if (!networkUiAdapter) return '';
+    if (!selectedPrinterResolvedId) return '';
+    const normalizedHost = selectedRemoteMaterialHost.trim().toLowerCase();
+    if (!normalizedHost) return '';
+    return `${networkUiAdapter.pluginId}::${selectedPrinterResolvedId}::${normalizedHost}`;
+  }, [networkUiAdapter, selectedPrinterResolvedId, selectedRemoteMaterialHost]);
   const selectedPrinterPreset = React.useMemo(() => {
     if (!selectedPrinter) return null;
     const presetId = resolveOfficialPresetIdFromProfile(selectedPrinter);
@@ -1803,19 +1817,34 @@ export function ProfileSettingsModal({
     }
   }, [selectedPrinterUpdate]);
 
-  const loadRemoteMaterials = React.useCallback(async () => {
+  const loadRemoteMaterials = React.useCallback(async (options?: { background?: boolean }) => {
     if (!selectedPrinterResolvedId) return;
     if (!networkUiAdapter) return;
 
     const host = selectedRemoteMaterialHost;
     if (!host) {
       setRemoteMaterials([]);
+      setIsLoadingRemoteMaterials(false);
       setRemoteMaterialsError(`Connect to a ${selectedNetworkModeLabel} printer to load on-device materials.`);
       return;
     }
 
+    const useBackgroundRefresh = options?.background === true;
+    const cachedEntry = remoteMaterialsCacheKey
+      ? remoteMaterialsCacheRef.current.get(remoteMaterialsCacheKey) ?? null
+      : null;
+
+    if (cachedEntry?.materials?.length) {
+      setRemoteMaterials(cachedEntry.materials);
+      if (!selectedRemoteMaterialIdRef.current && cachedEntry.selectedMaterialId) {
+        setSelectedRemoteMaterialId(cachedEntry.selectedMaterialId);
+      }
+    }
+
     setIsLoadingRemoteMaterials(true);
-    setRemoteMaterialsError(null);
+    if (!useBackgroundRefresh) {
+      setRemoteMaterialsError(null);
+    }
 
     try {
       const response = await pluginNetworkFetch({
@@ -1855,18 +1884,30 @@ export function ProfileSettingsModal({
         setSelectedRemoteMaterialId('');
       }
 
+      if (remoteMaterialsCacheKey) {
+        remoteMaterialsCacheRef.current.set(remoteMaterialsCacheKey, {
+          materials,
+          selectedMaterialId: nextSelected?.id ?? '',
+          fetchedAt: Date.now(),
+        });
+      }
+
       const errorMessage = typeof payload?.error === 'string' ? payload.error : '';
       if (errorMessage) {
         setRemoteMaterialsError(errorMessage);
+      } else {
+        setRemoteMaterialsError(null);
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : `Failed to load ${selectedNetworkModeLabel} materials.`;
-      setRemoteMaterials([]);
+      if (!cachedEntry?.materials?.length) {
+        setRemoteMaterials([]);
+      }
       setRemoteMaterialsError(message);
     } finally {
       setIsLoadingRemoteMaterials(false);
     }
-  }, [effectiveNetworkUiAdapter, networkUiAdapter, persistedRemoteMaterialIdForSelectedPrinter, selectedPrinter, selectedRemoteMaterialHost, selectedPrinterResolvedId]);
+  }, [effectiveNetworkUiAdapter, networkUiAdapter, remoteMaterialsCacheKey, selectedNetworkModeLabel, selectedRemoteMaterialHost, selectedPrinterResolvedId]);
 
   React.useEffect(() => {
     if (!shouldUseRemoteOnDeviceMaterials || !selectedPrinterResolvedId) {
@@ -1877,14 +1918,33 @@ export function ProfileSettingsModal({
       return;
     }
 
-    void loadRemoteMaterials();
-  }, [loadRemoteMaterials, selectedPrinterResolvedId, shouldUseRemoteOnDeviceMaterials]);
+    const cachedEntry = remoteMaterialsCacheKey
+      ? remoteMaterialsCacheRef.current.get(remoteMaterialsCacheKey) ?? null
+      : null;
+    if (cachedEntry?.materials?.length) {
+      setRemoteMaterials(cachedEntry.materials);
+      if (!selectedRemoteMaterialIdRef.current && cachedEntry.selectedMaterialId) {
+        setSelectedRemoteMaterialId(cachedEntry.selectedMaterialId);
+      }
+    }
+
+    void loadRemoteMaterials({ background: true });
+  }, [loadRemoteMaterials, remoteMaterialsCacheKey, selectedPrinterResolvedId, shouldUseRemoteOnDeviceMaterials]);
 
   const handleSelectRemoteMaterial = React.useCallback((material: RemoteMaterialProfile) => {
     if (!selectedPrinter) return;
     const processValues = effectiveNetworkUiAdapter.resolveMaterialProcessValues(material.meta ?? {});
     setSelectedRemoteMaterialId(material.id);
     writeRemoteMaterialByPrinter(selectedPrinter.id, material.id);
+    if (remoteMaterialsCacheKey) {
+      const cachedEntry = remoteMaterialsCacheRef.current.get(remoteMaterialsCacheKey);
+      if (cachedEntry) {
+        remoteMaterialsCacheRef.current.set(remoteMaterialsCacheKey, {
+          ...cachedEntry,
+          selectedMaterialId: material.id,
+        });
+      }
+    }
     updatePrinterNetworkConnectionStatus(selectedPrinter.id, {
       selectedMaterialId: material.id,
       selectedMaterialName: material.name,
@@ -1893,9 +1953,10 @@ export function ProfileSettingsModal({
       selectedMaterialBottomExposureSec: processValues.bottomExposureSec,
       selectedMaterialBottomLayerCount: processValues.bottomLayerCount,
     });
-  }, [effectiveNetworkUiAdapter, selectedPrinter]);
+  }, [effectiveNetworkUiAdapter, remoteMaterialsCacheKey, selectedPrinter]);
 
   const openRemoteMaterialEditDialog = React.useCallback(() => {
+    if (effectiveNetworkUiAdapter.remoteMaterialEditingWipNotice) return;
     if (!selectedRemoteMaterial) return;
     setRemoteMaterialEditDraft(effectiveNetworkUiAdapter.resolveEditDraftFromMeta(selectedRemoteMaterial.meta ?? {}));
     setRemoteMaterialEditTab('basic');
@@ -1903,6 +1964,7 @@ export function ProfileSettingsModal({
   }, [effectiveNetworkUiAdapter, selectedRemoteMaterial]);
 
   const openRemoteMaterialEditDialogForMaterial = React.useCallback((material: RemoteMaterialProfile) => {
+    if (effectiveNetworkUiAdapter.remoteMaterialEditingWipNotice) return;
     if (material.locked) return;
     handleSelectRemoteMaterial(material);
     setRemoteMaterialEditDraft(effectiveNetworkUiAdapter.resolveEditDraftFromMeta(material.meta ?? {}));
@@ -3971,7 +4033,7 @@ export function ProfileSettingsModal({
                 <>
                   <div className="rounded-xl border overflow-hidden flex flex-col flex-1 min-h-0" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-2)' }}>
                     <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar p-2 space-y-1.5">
-                      {isLoadingRemoteMaterials ? (
+                      {isLoadingRemoteMaterials && remoteMaterials.length === 0 ? (
                         <div className="h-full flex items-center justify-center text-xs" style={{ color: 'var(--text-muted)' }}>
                           Loading materials from printer…
                         </div>
@@ -3988,7 +4050,9 @@ export function ProfileSettingsModal({
                               key={material.id}
                               type="button"
                               onClick={() => handleSelectRemoteMaterial(material)}
-                              onDoubleClick={() => openRemoteMaterialEditDialogForMaterial(material)}
+                              onDoubleClick={effectiveNetworkUiAdapter.remoteMaterialEditingWipNotice
+                                ? undefined
+                                : () => openRemoteMaterialEditDialogForMaterial(material)}
                               className="w-full rounded-md border px-2.5 py-2 text-left"
                               style={active
                                 ? {

--- a/src/features/plugins/complexPluginContracts.ts
+++ b/src/features/plugins/complexPluginContracts.ts
@@ -68,6 +68,11 @@ export type PluginNetworkUiAdapterContract = {
    * Defaults to true for existing backends when omitted.
    */
   supportsRemoteMaterialProfiles?: boolean;
+  /**
+   * When set, the Edit button is greyed out and this message is shown on hover.
+   * Omit when editing is fully supported.
+   */
+  remoteMaterialEditingWipNotice?: string;
   operations: {
     connect: string;
     discover: string;

--- a/src/features/plugins/pluginUploadBridge.ts
+++ b/src/features/plugins/pluginUploadBridge.ts
@@ -27,7 +27,8 @@ export type PluginUploadCallbacks = {
 
 export type PluginUploadHandler = (args: {
   hostUrl: string;
-  zipBlob: Blob;
+  zipBlob?: Blob | null;
+  zipFilePath?: string | null;
   path: string;
   profileId: string;
   callbacks: PluginUploadCallbacks;
@@ -36,13 +37,21 @@ export type PluginUploadHandler = (args: {
 export async function uploadPrintJobWithProgress(args: {
   networkMode: string;
   hostUrl: string;
-  zipBlob: Blob;
+  zipBlob?: Blob | null;
+  zipFilePath?: string | null;
   path: string;
   profileId: string;
   callbacks: PluginUploadCallbacks;
 }): Promise<{ ok: boolean; plateId: number | null }> {
-  const { networkMode, hostUrl, zipBlob, path, profileId, callbacks } = args;
+  const { networkMode, hostUrl, zipBlob, zipFilePath, path, profileId, callbacks } = args;
   const adapter = getProfileNetworkUiAdapter(networkMode);
+
+  const hasBlob = Boolean(zipBlob && zipBlob.size > 0);
+  const normalizedPath = typeof zipFilePath === 'string' ? zipFilePath.trim() : '';
+  const hasFilePath = normalizedPath.length > 0;
+  if (!hasBlob && !hasFilePath) {
+    throw new Error('No upload payload available: expected zipBlob or zipFilePath.');
+  }
 
   if (!adapter) {
     throw new Error(`No network adapter found for mode: ${networkMode}`);
@@ -57,6 +66,7 @@ export async function uploadPrintJobWithProgress(args: {
     return handler({
       hostUrl,
       zipBlob,
+      zipFilePath: hasFilePath ? normalizedPath : null,
       path,
       profileId,
       callbacks,

--- a/src/features/slicing/components/SlicingPanel.tsx
+++ b/src/features/slicing/components/SlicingPanel.tsx
@@ -33,6 +33,7 @@ export type SliceIntent = 'file' | 'upload' | 'print' | 'preview';
 interface SlicingPanelProps {
   models: LoadedModel[];
   activeModel: LoadedModel | null;
+  estimatedLayerCountOverride?: number | null;
   estimatedVolumeLabelOverride?: string | null;
   captureSceneThumbnailPng?: () => Promise<Uint8Array | null>;
   onSliceRunStarted?: () => void;
@@ -263,6 +264,7 @@ function resolveInitialMinimumAaAlphaOverrideEnabled(): boolean {
 export function SlicingPanel({
   models,
   activeModel,
+  estimatedLayerCountOverride,
   estimatedVolumeLabelOverride,
   captureSceneThumbnailPng,
   onSliceRunStarted,
@@ -558,6 +560,10 @@ export function SlicingPanel({
   }, [activeMaterialProfile?.layerHeightMm, effectiveLayerHeightMm, effectiveMaterialProfile, showRemoteOfflineLayerHeightOverride]);
 
   const estimatedLayerCount = useMemo(() => {
+    if (Number.isFinite(estimatedLayerCountOverride) && Number(estimatedLayerCountOverride) > 0) {
+      return Math.max(0, Math.round(Number(estimatedLayerCountOverride)));
+    }
+
     if (effectiveLayerHeightMm == null || visibleModels.length === 0) return 0;
 
     const layerHeightMm = Math.max(0.001, effectiveLayerHeightMm || 0.05);
@@ -571,7 +577,7 @@ export function SlicingPanel({
     }
 
     return Math.max(0, Math.ceil(maxModelHeightMm / layerHeightMm));
-  }, [effectiveLayerHeightMm, visibleModels]);
+  }, [effectiveLayerHeightMm, estimatedLayerCountOverride, visibleModels]);
 
   const estimatedPrintTimeLabel = useMemo(() => {
     if (!effectiveMaterialProfile || estimatedLayerCount <= 0) return '—';

--- a/src/features/slicing/rasterLayerZipExport.ts
+++ b/src/features/slicing/rasterLayerZipExport.ts
@@ -24,6 +24,7 @@ import { calculateDiskThickness } from '@/supports/SupportPrimitives/ContactDisk
 import { getBezierPointAtT } from '@/supports/Curves/BezierUtils';
 import { getTrunkSegmentEndpoints, getBranchSegmentEndpoints } from '@/supports/SupportPrimitives/Knot/knotUtils';
 import { resolveSlicingFormatDefinition } from '@/features/slicing/formats/registry';
+import { quaternionFromGlobalEuler } from '@/utils/rotation';
 
 const MAX_CANVAS_PIXELS = 24_000_000;
 const DEFAULT_MESH_CHUNK_TARGET_BYTES = 64 * 1024 * 1024;
@@ -546,7 +547,7 @@ class TriangleFloatCollector {
 }
 
 function composeModelMatrix(transform: LoadedModel['transform']): THREE.Matrix4 {
-  const q = new THREE.Quaternion().setFromEuler(transform.rotation);
+  const q = quaternionFromGlobalEuler(transform.rotation);
   return new THREE.Matrix4().compose(transform.position, q, transform.scale);
 }
 

--- a/src/utils/pluginNetworkBridge.ts
+++ b/src/utils/pluginNetworkBridge.ts
@@ -22,7 +22,7 @@ async function loadTauriCore(): Promise<TauriCoreModule | null> {
 type FetchLikeResponse = {
   ok: boolean;
   status: number;
-  json: () => Promise<any>;
+  json: () => Promise<unknown>;
 };
 
 /**
@@ -78,4 +78,38 @@ export async function pluginNetworkFetch(
     body: JSON.stringify(payload),
   });
   return response;
+}
+
+export async function readNativeFileSize(sourcePath: string): Promise<number | null> {
+  const core = await loadTauriCore();
+  if (!core) return null;
+
+  try {
+    const size = await core.invoke<number>('read_print_file_size', {
+      sourcePath,
+    });
+    return Number.isFinite(size) && size >= 0 ? size : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function readNativeFileChunk(
+  sourcePath: string,
+  offset: number,
+  length: number,
+): Promise<Uint8Array | null> {
+  const core = await loadTauriCore();
+  if (!core) return null;
+
+  try {
+    const result = await core.invoke<ArrayBuffer>('read_print_file_chunk', {
+      sourcePath,
+      offset,
+      length,
+    });
+    return new Uint8Array(result);
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
**feat: Connected-component area stats via RLE span tracking**
- New `ComponentSpanTracker` using union-find on RLE spans — no mask allocation, no per-pixel flood fill
- Tight-bounding-box fallback for AA layers

**feat: NanoDLP native upload pipeline with progress**
- Streams ZIP from disk via Tauri/reqwest with per-chunk `AtomicU64` byte tracking
- 280 ms poll loop emits smoothed speed + ETA; transitions UI to processing state when bytes are fully sent
- UUID-keyed progress registry with automatic pruning
- Raised import operation timeouts for large files

**feat: Background resin volume estimate**
- Non-blocking chunked computation, yielding via `requestIdleCallback` every 4 096 triangles
- Version-keyed cache + in-flight deduplication so repeated triggers share one promise

**fix: Print time and layer count**
- Corrected per-stage exposure + lift time accumulation in estimated print time
- Layer count now always reads from the live slice output

**fix: Resin estimate visibility and bounds**
- Hidden models excluded before volume loop; scale applied to cached base volumes
- `outsidePlateModelIds` uses live transform for the active model during moves

**fix: JSON response handling**
- `{} as any` fallbacks replaced with typed `Record<string, unknown>` narrowing across all network handlers

**fix: Remote materials caching in ProfileSettingsModal**
- Last-selected remote material per printer persisted to `localStorage`
- WIP banner + disabled buttons on the remote material editing panel