### PR TITLE
feat: Initial implementation of an Anycubic printer plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,9 @@
 [submodule "plugins/sdcp-v3"]
 	path = plugins/sdcp-v3
 	url = ../df-plugin-sdcp-v3.git
+[submodule "plugins/anycubic"]
+	path = plugins/anycubic
+	url = ../df-plugin-anycubic.git
 [submodule "plugins/elegoo"]
 	path = plugins/elegoo
 	url = ../df-plugin-elegoo

--- a/src/config/complex-plugin-allowlist.json
+++ b/src/config/complex-plugin-allowlist.json
@@ -5,6 +5,9 @@
       "id": "athena"
     },
     {
+      "id": "anycubic"
+    },
+    {
       "id": "ctb"
     },
     {

--- a/src/features/slicing/sliceExportOrchestrator.ts
+++ b/src/features/slicing/sliceExportOrchestrator.ts
@@ -347,6 +347,7 @@ function mergeMetadataOverridesIntoMetadata(
   outputFormat: string,
   materialProfile: MaterialProfile,
   settingsMode?: string,
+  printerOutputFormat?: string,
 ): string {
   try {
     const parsed = JSON.parse(metadataJson) as Record<string, unknown>;
@@ -368,10 +369,13 @@ function mergeMetadataOverridesIntoMetadata(
       parsed.export = exportNode;
     }
 
-    const adapter = getProfileLocalMaterialSettingsAdapter(outputFormat, settingsMode);
+    const adapter = getProfileLocalMaterialSettingsAdapter(printerOutputFormat ?? outputFormat, settingsMode)
+      ?? getProfileLocalMaterialSettingsAdapter(outputFormat, settingsMode);
     const fieldSchema = adapter?.fields ?? [];
     if (fieldSchema.length > 0) {
-      const localForOutput = materialProfile.localSettingsByOutput?.[outputFormat] ?? {};
+      const localForOutput = materialProfile.localSettingsByOutput?.[printerOutputFormat ?? outputFormat]
+        ?? materialProfile.localSettingsByOutput?.[outputFormat]
+        ?? {};
 
       fieldSchema.forEach((field) => {
         const fieldValue = Object.prototype.hasOwnProperty.call(localForOutput, field.key)
@@ -672,6 +676,7 @@ export async function runSliceExportOrchestrator(options: SliceExportOrchestrato
       format.outputFormat,
       options.materialProfile,
       resolveOutputSettingsMode(format.outputFormat, options.printerProfile.display.settingsMode),
+      options.printerProfile.display.outputFormat,
     ),
   };
 
@@ -707,8 +712,8 @@ export async function runSliceExportOrchestrator(options: SliceExportOrchestrato
   throwIfAborted(options.abortSignal);
   options.onProgress?.(Math.max(progressDone, progressTotal), progressTotal, 'Finalizing');
 
-  const outputExt = format.outputFormat.replace(/^\./, '') || 'slice';
-  const outputName = `${safeFilenameBase(options.filenameBase)}.${outputExt}`;
+  const printerExt = options.printerProfile.display.outputFormat.replace(/^\./, '') || format.outputFormat.replace(/^\./, '') || 'slice';
+  const outputName = `${safeFilenameBase(options.filenameBase)}.${printerExt}`;
 
   const totalElapsedMs = performance.now() - orchestratorStartMs;
   options.onProgress?.(progressTotal, progressTotal, 'Handoff');


### PR DESCRIPTION
## Wire in Anycubic plugin + multi-printer output extension support

This PR wires the Anycubic printer plugin into DragonFruit and adds the orchestrator support needed for a single slicing format to fan out to multiple printer-specific file extensions.

### What this PR changes in DragonFruit

- **Plugin wiring** — `plugins/anycubic` registered as a submodule (`.gitmodules`) and added to the complex plugin allowlist (`src/config/complex-plugin-allowlist.json`).
- **Output-format-aware material settings lookup** — `mergeMetadataOverridesIntoMetadata` (in `sliceExportOrchestrator.ts`) now accepts a `printerOutputFormat` parameter and prefers the printer-specific adapter (e.g. `.pm7m`) over the format-generic one (e.g. `.azf`), falling back to the latter if no printer-specific adapter exists. This is what lets a single AZF format definition correctly resolve per-printer settings for `.pm4u`, `.pm7`, `.pm7m`, and `.pwsz`.
- **Printer-specific output filenames** — the orchestrator now names the exported slice file with the printer's declared extension (e.g. `model.pm7m`) rather than the format's canonical extension (`.azf`). Anycubic firmware will not load a file named `.azf`; it expects the printer-specific extension that maps to that format.

---

### What enabling the Anycubic plugin gets you

> The features below ship inside the plugin submodule and are not part of this PR's diff — they're listed here as context for what installing/enabling this plugin provides.

#### Supported printers

| Printer | Extension | Resolution | Physically tested |
|---|---|---|---|
| **Photon Mono M7 Max** | `.pm7m` | 6480 × 3600 | ✅ Yes |
| Photon Mono M7 Pro | `.pwsz` | 13312 × 5120 | No |
| Photon Mono M7 | `.pm7` | 13312 × 5120 | No |
| Photon Mono 4 Ultra | `.pm4u` | 9024 × 5120 | No |

> ⚠️ Only the **Photon Mono M7 Max** has been verified on physical hardware. The other three are wired up per Anycubic's published profiles but should be considered experimental until users with those machines report success.

#### Plugin features

- **AZF container encoding** — ZIP-based output matching Photon Workshop's structure (`anycubic_photon_resins.pwsp`, `layers_controller.conf`, `print_info.json`, `scene.slice`, previews, and PW0-encoded layer images).
- **PW0 RLE layer encoding** with a streaming + parallel fast path for multi-layer prints.
- **Layer preview PNG decoding** — slice files can be re-opened and individual layers rendered back as previews.
- **Material settings** — both Simple and Advanced (two-stage motion) editors, with per-printer adapter mappings. Temperature control is automatically omitted for printers that don't support it (`.pm4u`, `.pwsz`).
- **Per-printer profiles** — max acceleration, intelligent release, transition layer exposure interpolation, and `print_info.json` cost/time/volume estimates driven from the printer's build model.

#### Not included

The Anycubic File Format (AFF) — the legacy container used by older Photon and Photon Mono series — is scaffolded in the plugin but **gated off** behind `TODO(AFF)` markers. It is not advertised to DragonFruit and will not appear as a printer option. Re-enabling is a single block of uncomments in `pluginDefinition.ts` once the AFF encoder is implemented.
