### PR TITLE
feat: Add Export support reconstruction

### DIFF
--- a/src/features/export/logic/ExportManager.ts
+++ b/src/features/export/logic/ExportManager.ts
@@ -3,6 +3,7 @@ import { STLExporter } from 'three-stdlib';
 import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import { KNOWN_SOURCE_EXTENSION_STRIP_RE } from '@/features/plugins/pluginFileTypeExtensions';
 import { buildSupportExportFromStores, serializeVoxlDocumentV2 } from '@/features/scene/voxl';
+import { buildScopedSupportExportDocument, buildScopedSupportGeometryGroup } from '@/features/export/logic/supportExportReconstruction';
 import { allocateMeshStagePath, exportMeshFile, pickSavePathWithNativeDialog, writeChunkedToNativePath } from '@/features/slicing/tauri/nativeSlicerBridge';
 import { getKickstandSnapshot } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 import { getSnapshot } from '@/supports/state';
@@ -901,13 +902,15 @@ export class ExportManager {
 
     // Supports: use the live R3F ref directly — its matrixWorld is already current.
     // Hitbox meshes are filtered per-node inside the serializers via isMaterialHitbox().
-    if (options.includeSupports && supportsGroup) {
+    if (options.includeSupports) {
       if (hasScopedModelFilter) {
-        const scopedSupports = this.buildScopedSupportsGroup(supportsGroup, scopedModelIds);
-        if (scopedSupports) {
+        const supportSnapshot = getSnapshot();
+        const kickstandSnapshot = getKickstandSnapshot();
+        const scopedSupports = buildScopedSupportGeometryGroup(supportSnapshot, kickstandSnapshot, scopedModelIds);
+        if (scopedSupports.children.length > 0) {
           exportObjects.push(scopedSupports);
         }
-      } else {
+      } else if (supportsGroup) {
         supportsGroup.updateMatrixWorld(true);
         exportObjects.push(supportsGroup);
       }
@@ -1068,21 +1071,22 @@ export class ExportManager {
 
     const supportSnapshot = getSnapshot();
     const kickstandSnapshot = getKickstandSnapshot();
-    const supports = buildSupportExportFromStores(
-      supportSnapshot,
-      kickstandSnapshot,
-      'dragonfruit-voxl-export',
-    );
 
     const scopedModelIds = new Set((sceneContext?.models ?? []).map((model) => model.id));
     const hasScopedModelFilter = scopedModelIds.size > 0;
 
-    const belongsToScopedModel = (candidate: unknown): boolean => {
-      if (!hasScopedModelFilter) return true;
-      if (!candidate || typeof candidate !== 'object') return false;
-      const modelId = (candidate as { modelId?: unknown }).modelId;
-      return typeof modelId === 'string' && scopedModelIds.has(modelId);
-    };
+    const supports = hasScopedModelFilter
+      ? buildScopedSupportExportDocument(
+          supportSnapshot,
+          kickstandSnapshot,
+          scopedModelIds,
+          'dragonfruit-voxl-export',
+        )
+      : buildSupportExportFromStores(
+          supportSnapshot,
+          kickstandSnapshot,
+          'dragonfruit-voxl-export',
+        );
 
     if (!options.includeSupports) {
       supports.roots = [];
@@ -1094,16 +1098,6 @@ export class ExportManager {
       supports.braces = [];
       supports.knots = [];
       supports.kickstands = [];
-    } else if (hasScopedModelFilter) {
-      supports.roots = (supports.roots ?? []).filter((item) => belongsToScopedModel(item));
-      supports.trunks = (supports.trunks ?? []).filter((item) => belongsToScopedModel(item));
-      supports.branches = (supports.branches ?? []).filter((item) => belongsToScopedModel(item));
-      supports.leaves = (supports.leaves ?? []).filter((item) => belongsToScopedModel(item));
-      supports.twigs = (supports.twigs ?? []).filter((item) => belongsToScopedModel(item));
-      supports.sticks = (supports.sticks ?? []).filter((item) => belongsToScopedModel(item));
-      supports.braces = (supports.braces ?? []).filter((item) => belongsToScopedModel(item));
-      supports.knots = (supports.knots ?? []).filter((item) => belongsToScopedModel(item));
-      supports.kickstands = (supports.kickstands ?? []).filter((item) => belongsToScopedModel(item));
     }
 
     const meshBytesMap = new Map<number, Uint8Array>();

--- a/src/features/export/logic/SupportGeometryGenerator.ts
+++ b/src/features/export/logic/SupportGeometryGenerator.ts
@@ -1,9 +1,11 @@
 import * as THREE from 'three';
 import { Roots, Segment, Joint, Vec3 } from '@/supports/types';
 import { SupportData } from '@/supports/rendering/SupportBuilder';
-import { getSocketPosition } from '@/supports/SupportPrimitives/ContactCone';
+import { getFinalSocketPosition } from '@/supports/SupportPrimitives/ContactCone';
+import { getConeQuaternion } from '@/supports/SupportPrimitives/ContactCone/contactConeUtils';
 import { calculateDiskThickness, getDiskCenter, getDiskRotation } from '@/supports/SupportPrimitives/ContactDisk/contactDiskUtils';
 import { RaftSettings } from '@/supports/Rafts/Crenelated/RaftTypes';
+import { JOINT_DIAMETER_OFFSET_MM } from '@/supports/constants';
 
 /**
  * SupportGeometryGenerator
@@ -20,6 +22,22 @@ import { RaftSettings } from '@/supports/Rafts/Crenelated/RaftTypes';
  * - ContactConeRenderer
  */
 export class SupportGeometryGenerator {
+  private static readonly NON_SELECTED_JOINT_BLEND_MM = JOINT_DIAMETER_OFFSET_MM * 0.75;
+
+  private static buildSphereMesh(pos: { x: number; y: number; z: number }, diameter: number, widthSegments = 16, heightSegments = 16): THREE.Mesh {
+    const geometry = new THREE.SphereGeometry(Math.max(0.001, diameter) / 2, widthSegments, heightSegments);
+    const mesh = new THREE.Mesh(geometry);
+    mesh.position.set(pos.x, pos.y, pos.z);
+    return mesh;
+  }
+
+  public static getExportJointDiameter(diameter: number): number {
+    return Math.max(0.001, diameter - this.NON_SELECTED_JOINT_BLEND_MM);
+  }
+
+  public static getExportKnotDiameter(diameter: number): number {
+    return Math.max(0.001, diameter - JOINT_DIAMETER_OFFSET_MM);
+  }
   
   /**
    * Generates a single group containing all meshes for a support structure
@@ -50,12 +68,7 @@ export class SupportGeometryGenerator {
       if (seg.topJoint) {
         endPoint = new THREE.Vector3(seg.topJoint.pos.x, seg.topJoint.pos.y, seg.topJoint.pos.z);
       } else if (data.contactCone) {
-        // Calculate socket position
-        const socketPos = getSocketPosition(
-          data.contactCone.pos,
-          data.contactCone.normal,
-          data.contactCone.profile
-        );
+        const socketPos = getFinalSocketPosition(data.contactCone);
         endPoint = new THREE.Vector3(socketPos.x, socketPos.y, socketPos.z);
       } else {
         // Fallback
@@ -179,10 +192,11 @@ export class SupportGeometryGenerator {
   }
 
   public static generateJointMesh(joint: Joint): THREE.Mesh {
-    const geometry = new THREE.SphereGeometry(joint.diameter / 2, 16, 16);
-    const mesh = new THREE.Mesh(geometry);
-    mesh.position.set(joint.pos.x, joint.pos.y, joint.pos.z);
-    return mesh;
+    return this.buildSphereMesh(joint.pos, this.getExportJointDiameter(joint.diameter), 16, 16);
+  }
+
+  public static generateKnotMesh(knot: { pos: Vec3; diameter?: number }): THREE.Mesh {
+    return this.buildSphereMesh(knot.pos, this.getExportKnotDiameter(knot.diameter ?? 1.2), 8, 8);
   }
 
   public static generateConeMesh(coneData: any): THREE.Group {
@@ -204,89 +218,35 @@ export class SupportGeometryGenerator {
     const contactRadius = profile.contactDiameterMm / 2;
     const bodyRadius = profile.bodyDiameterMm / 2;
     const length = profile.lengthMm;
+    const effectiveSurfaceNormal = coneData.surfaceNormal || coneData.normal;
+    const primitiveThickness = profile.type === 'disk'
+      ? (coneData.diskLengthOverride ?? calculateDiskThickness(effectiveSurfaceNormal, coneData.normal, profile))
+      : 0;
+    const coneStartPos = {
+      x: coneData.pos.x + effectiveSurfaceNormal.x * primitiveThickness,
+      y: coneData.pos.y + effectiveSurfaceNormal.y * primitiveThickness,
+      z: coneData.pos.z + effectiveSurfaceNormal.z * primitiveThickness,
+    };
+    const center = {
+      x: coneStartPos.x + coneData.normal.x * (length / 2),
+      y: coneStartPos.y + coneData.normal.y * (length / 2),
+      z: coneStartPos.z + coneData.normal.z * (length / 2),
+    };
+    const quaternion = getConeQuaternion(coneData.normal);
 
     // 2. Cone Body
     // Standard Cylinder: Top radius = contact, Bottom radius = body
     const geometry = new THREE.CylinderGeometry(contactRadius, bodyRadius, length, 16);
-    
-    // ContactConeRenderer logic:
-    // const center = getConeCenterPosition(pos, normal, profile);
-    // const quaternion = getConeQuaternion(normal);
-    // group position = center, quaternion = quaternion
-    
-    // Let's replicate the math inline or import helpers if possible.
-    // The helpers are in `contactConeUtils.ts`. Can we import them?
-    // Yes, they are just math.
-    
-    // However, `ContactConeRenderer` does:
-    // <group position={center} quaternion={quaternion}> <mesh> ... </mesh> </group>
-    
-    // We can't import `getConeCenterPosition` easily if it's not exported from index.
-    // Let's recreate the math. Y-up cylinder.
-    // Center of cylinder is at local (0,0,0).
-    // We want Top (contact) to touch the model at `pos`.
-    // "Top" is at local Y = +length/2.
-    // So we need to position the mesh such that +Y end is at `pos`.
-    // Wait, ContactConeRenderer uses `getConeCenterPosition`.
-    // If we don't match it exactly, we drift.
-    
-    // Let's look at `getSocketPosition` usage earlier in this file.
-    // It is imported from `@/supports/SupportPrimitives/ContactCone`.
-    // Let's check if we can import `getConeCenterPosition` and `getConeQuaternion`.
-    // If not, let's approximate.
-    
-    // Math:
-    // Normal points INTO model? Or AWAY?
-    // `ContactConeRenderer`: "normal: Cone axis (points into model)"?
-    // Actually, usually normal points OUT of model surface.
-    // If normal points OUT (e.g. 0,0,1), and cone attaches to bottom face...
-    // We want the small tip at `pos`.
-    // The large base (socket) at `pos + normal * length`?
-    // `getSocketPosition`: `pos + normal * length`.
-    // So `normal` points AWAY from the model surface towards the floor.
-    
-    // Cylinder Y-up. Top (+Y) = contact (small). Bottom (-Y) = socket (large).
-    // We want Top (+Y) at `pos`.
-    // We want Bottom (-Y) at `pos + normal * length`.
-    // So the vector (Bottom - Top) = (pos + N*L) - pos = N*L.
-    // Local vector (Bottom - Top) = (0, -L/2, 0) - (0, L/2, 0) = (0, -L, 0).
-    // So we want (0, -1, 0) to align with Normal.
-    // Or (0, 1, 0) to align with -Normal.
-    
-    // Rotation:
-    const up = new THREE.Vector3(0, 1, 0);
-    const normalVec = new THREE.Vector3(coneData.normal.x, coneData.normal.y, coneData.normal.z);
-    // If we align UP (small end) with -Normal (pointing into model):
-    const quaternion = new THREE.Quaternion().setFromUnitVectors(up, normalVec.clone().negate());
-    
-    // Position:
-    // Midpoint of cone is at `pos + normal * (length / 2)`.
-    const midpoint = new THREE.Vector3(coneData.pos.x, coneData.pos.y, coneData.pos.z)
-      .add(normalVec.clone().multiplyScalar(length / 2));
-      
+
     const coneMesh = new THREE.Mesh(geometry);
-    coneMesh.position.copy(midpoint);
+    coneMesh.position.set(center.x, center.y, center.z);
     coneMesh.setRotationFromQuaternion(quaternion);
     group.add(coneMesh);
 
-    // 3. Socket Sphere
-    // At `socketPos` (large end).
-    // `getSocketPosition` already calculated this for the shaft end.
-    const socketPos = new THREE.Vector3(coneData.pos.x, coneData.pos.y, coneData.pos.z)
-      .add(normalVec.clone().multiplyScalar(length));
-      
-    // Joint radius logic from renderer: `getJointRadius(bodyDiameter)`
-    // We can approximate or import.
-    // Default joint radius is usually slightly larger than shaft.
-    // Let's use bodyRadius * 1.2 or similar if we can't find the constant.
-    // In `ContactConeRenderer`: `const jointRadius = getJointRadius(profile.bodyDiameterMm);`
-    // `getJointRadius` usually returns `diameter * 0.5 * 1.2` (from constants).
-    // Let's assume 1.0mm radius for standard 1.5mm shaft.
-    const jointRadius = bodyRadius * 1.2; 
-    
-    const sphereGeom = new THREE.SphereGeometry(jointRadius, 16, 12);
+    // 3. Cone-start sphere (matches the live ContactConeRenderer)
+    const sphereGeom = new THREE.SphereGeometry(contactRadius, 16, 12);
     const sphereMesh = new THREE.Mesh(sphereGeom);
-    sphereMesh.position.copy(socketPos);
+    sphereMesh.position.set(coneStartPos.x, coneStartPos.y, coneStartPos.z);
     group.add(sphereMesh);
 
     return group;

--- a/src/features/export/logic/supportExportReconstruction.test.ts
+++ b/src/features/export/logic/supportExportReconstruction.test.ts
@@ -1,0 +1,274 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from 'three';
+import type { KickstandState } from '@/supports/SupportTypes/Kickstand/types';
+import type { SupportState } from '@/supports/types';
+import { JOINT_DIAMETER_OFFSET_MM } from '@/supports/constants';
+import { SupportGeometryGenerator } from './SupportGeometryGenerator';
+import { buildScopedSupportExportDocument, buildScopedSupportGeometryGroup } from './supportExportReconstruction';
+
+function makeSupportState(): SupportState {
+  return {
+    roots: {
+      'root-a': {
+        id: 'root-a',
+        modelId: 'model-a',
+        transform: { pos: { x: 0, y: 0, z: 0 }, rot: { x: 0, y: 0, z: 0, w: 1 } },
+        diameter: 3,
+        diskHeight: 0.8,
+        coneHeight: 1.2,
+      },
+      'root-b': {
+        id: 'root-b',
+        modelId: 'model-b',
+        transform: { pos: { x: 20, y: 0, z: 0 }, rot: { x: 0, y: 0, z: 0, w: 1 } },
+        diameter: 3,
+        diskHeight: 0.8,
+        coneHeight: 1.2,
+      },
+    },
+    trunks: {
+      'trunk-a': {
+        id: 'trunk-a',
+        modelId: 'model-a',
+        rootId: 'root-a',
+        segments: [{ id: 'trunk-a-seg', diameter: 1, topJoint: { id: 'trunk-a-joint', pos: { x: 0, y: 0, z: 8 }, diameter: 1.2 } }],
+      },
+      'trunk-b': {
+        id: 'trunk-b',
+        modelId: 'model-b',
+        rootId: 'root-b',
+        segments: [{ id: 'trunk-b-seg', diameter: 1, topJoint: { id: 'trunk-b-joint', pos: { x: 20, y: 0, z: 8 }, diameter: 1.2 } }],
+      },
+    },
+    branches: {
+      'branch-a': {
+        id: 'branch-a',
+        modelId: 'model-a',
+        parentKnotId: 'knot-a',
+        segments: [{ id: 'branch-a-seg', diameter: 0.8 }],
+      },
+      'branch-b': {
+        id: 'branch-b',
+        modelId: 'model-b',
+        parentKnotId: 'knot-b',
+        segments: [{ id: 'branch-b-seg', diameter: 0.8 }],
+      },
+    },
+    leaves: {
+      'leaf-a': {
+        id: 'leaf-a',
+        modelId: 'model-a',
+        parentKnotId: 'knot-a',
+        contactCone: {
+          id: 'leaf-a-cone',
+          pos: { x: 1, y: 0, z: 9 },
+          normal: { x: 0, y: 0, z: -1 },
+          profile: { type: 'disk', contactDiameterMm: 0.4, bodyDiameterMm: 1.2, lengthMm: 2, penetrationMm: 0.05, diskThicknessMm: 0.1, maxStandoffMm: 0.2, standoffAngleThreshold: Math.PI / 4 },
+        },
+      },
+      'leaf-b': {
+        id: 'leaf-b',
+        modelId: 'model-b',
+        parentKnotId: 'knot-b',
+        contactCone: {
+          id: 'leaf-b-cone',
+          pos: { x: 21, y: 0, z: 9 },
+          normal: { x: 0, y: 0, z: -1 },
+          profile: { type: 'disk', contactDiameterMm: 0.4, bodyDiameterMm: 1.2, lengthMm: 2, penetrationMm: 0.05, diskThicknessMm: 0.1, maxStandoffMm: 0.2, standoffAngleThreshold: Math.PI / 4 },
+        },
+      },
+    },
+    twigs: {},
+    sticks: {},
+    braces: {
+      'brace-a': {
+        id: 'brace-a',
+        modelId: 'model-a',
+        startKnotId: 'knot-a',
+        endKnotId: 'brace-knot-a',
+        profile: { diameter: 0.6 },
+      },
+      'brace-b': {
+        id: 'brace-b',
+        modelId: 'model-b',
+        startKnotId: 'knot-b',
+        endKnotId: 'brace-knot-b',
+        profile: { diameter: 0.6 },
+      },
+    },
+    anchors: {
+      'anchor-a': {
+        id: 'anchor-a',
+        modelId: 'model-a',
+        rootPos: { x: -2, y: 0, z: 0 },
+        rootBaseDiameter: 2,
+        rootTopDiameter: 1.2,
+        rootHeight: 1,
+        joint: { id: 'anchor-a-joint', pos: { x: -2, y: 0, z: 1 }, diameter: 1.2 },
+        segments: [{ id: 'anchor-a-seg', diameter: 1 }],
+        contactCone: {
+          id: 'anchor-a-cone',
+          pos: { x: -2, y: 0, z: 3 },
+          normal: { x: 0, y: 0, z: -1 },
+          profile: { type: 'disk', contactDiameterMm: 0.4, bodyDiameterMm: 1.2, lengthMm: 2, penetrationMm: 0.05, diskThicknessMm: 0.1, maxStandoffMm: 0.2, standoffAngleThreshold: Math.PI / 4 },
+        },
+      },
+    },
+    knots: {
+      'knot-a': { id: 'knot-a', parentShaftId: 'trunk-a-seg', pos: { x: 0, y: 0, z: 4 }, diameter: 1.1 },
+      'knot-b': { id: 'knot-b', parentShaftId: 'trunk-b-seg', pos: { x: 20, y: 0, z: 4 }, diameter: 1.1 },
+      'brace-knot-a': { id: 'brace-knot-a', parentShaftId: 'braceSegment:brace-a', pos: { x: 0.5, y: 0, z: 5 }, diameter: 0.8 },
+      'brace-knot-b': { id: 'brace-knot-b', parentShaftId: 'braceSegment:brace-b', pos: { x: 20.5, y: 0, z: 5 }, diameter: 0.8 },
+    },
+    selectedId: null,
+    selectedCategory: null,
+    hoveredId: null,
+    hoveredCategory: 'none',
+    interactionWarning: null,
+  };
+}
+
+function makeKickstandState(): KickstandState {
+  return {
+    kickstands: {
+      'kickstand-a': {
+        id: 'kickstand-a',
+        modelId: 'model-a',
+        rootId: 'kick-root-a',
+        hostKnotId: 'kick-knot-a',
+        hostSegmentId: 'trunk-a-seg',
+        hostMinT: 0,
+        segments: [{ id: 'kick-seg-a', diameter: 0.7 }],
+        profile: { bodyDiameterMm: 0.7, terminalStartDiameterMm: 0.7, terminalEndDiameterMm: 0.9 },
+      },
+      'kickstand-b': {
+        id: 'kickstand-b',
+        modelId: 'model-b',
+        rootId: 'kick-root-b',
+        hostKnotId: 'kick-knot-b',
+        hostSegmentId: 'trunk-b-seg',
+        hostMinT: 0,
+        segments: [{ id: 'kick-seg-b', diameter: 0.7 }],
+        profile: { bodyDiameterMm: 0.7, terminalStartDiameterMm: 0.7, terminalEndDiameterMm: 0.9 },
+      },
+    },
+    roots: {
+      'kick-root-a': {
+        id: 'kick-root-a',
+        modelId: 'model-a',
+        transform: { pos: { x: -1, y: 0, z: 0 }, rot: { x: 0, y: 0, z: 0, w: 1 } },
+        diameter: 2,
+        diskHeight: 0.5,
+        coneHeight: 0.8,
+      },
+      'kick-root-b': {
+        id: 'kick-root-b',
+        modelId: 'model-b',
+        transform: { pos: { x: 19, y: 0, z: 0 }, rot: { x: 0, y: 0, z: 0, w: 1 } },
+        diameter: 2,
+        diskHeight: 0.5,
+        coneHeight: 0.8,
+      },
+    },
+    knots: {
+      'kick-knot-a': { id: 'kick-knot-a', parentShaftId: 'trunk-a-seg', pos: { x: 0, y: 0, z: 6 }, diameter: 0.8 },
+      'kick-knot-b': { id: 'kick-knot-b', parentShaftId: 'trunk-b-seg', pos: { x: 20, y: 0, z: 6 }, diameter: 0.8 },
+    },
+    selectedId: null,
+  };
+}
+
+test('scoped support export document keeps only requested model supports', () => {
+  const supportState = makeSupportState();
+  const kickstandState = makeKickstandState();
+
+  const scoped = buildScopedSupportExportDocument(supportState, kickstandState, ['model-a'], 'test-export');
+
+  assert.equal(scoped.roots.length, 1);
+  assert.equal(scoped.trunks.length, 1);
+  assert.equal(scoped.branches.length, 1);
+  assert.equal(scoped.leaves.length, 1);
+  assert.equal(scoped.braces.length, 1);
+  assert.equal(scoped.anchors?.length ?? 0, 1);
+  assert.equal(scoped.kickstands?.length ?? 0, 1);
+
+  for (const collection of [scoped.roots, scoped.trunks, scoped.branches, scoped.leaves, scoped.braces, scoped.anchors ?? []]) {
+    for (const item of collection) {
+      assert.equal(item.modelId, 'model-a');
+    }
+  }
+
+  assert.ok(scoped.knots.every((knot) => !knot.id.endsWith('-b')));
+  assert.equal(scoped.kickstands?.[0]?.kickstand.modelId, 'model-a');
+});
+
+test('scoped support geometry group only contains requested model metadata', () => {
+  const supportState = makeSupportState();
+  const kickstandState = makeKickstandState();
+
+  const group = buildScopedSupportGeometryGroup(supportState, kickstandState, ['model-a']);
+
+  assert.ok(group.children.length > 0);
+
+  group.traverse((node) => {
+    if (node === group) return;
+    const modelId = (node.userData as { modelId?: string | null }).modelId;
+    if (modelId == null) return;
+    assert.equal(modelId, 'model-a');
+  });
+});
+
+test('export joint and knot diameters use non-edit display sizing', () => {
+  const jointDisplayDiameter = SupportGeometryGenerator.getExportJointDiameter(1.2);
+  const knotDisplayDiameter = SupportGeometryGenerator.getExportKnotDiameter(1.2);
+
+  assert.equal(jointDisplayDiameter, 1.2 - (JOINT_DIAMETER_OFFSET_MM * 0.75));
+  assert.equal(knotDisplayDiameter, 1.2 - JOINT_DIAMETER_OFFSET_MM);
+});
+
+test('export cone mesh uses the visible contact-side sphere instead of a socket sphere', () => {
+  const coneGroup = SupportGeometryGenerator.generateConeMesh({
+    pos: { x: 0, y: 0, z: 10 },
+    normal: { x: 0, y: 0, z: -1 },
+    surfaceNormal: { x: 0, y: 0, z: -1 },
+    diskLengthOverride: 0.5,
+    profile: {
+      type: 'disk',
+      contactDiameterMm: 0.4,
+      bodyDiameterMm: 1.2,
+      lengthMm: 2,
+      penetrationMm: 0.05,
+      diskThicknessMm: 0.1,
+      maxStandoffMm: 0.2,
+      standoffAngleThreshold: Math.PI / 4,
+    },
+  });
+
+  const sphereMeshes = coneGroup.children.filter((child) => (child as THREE.Mesh).geometry?.type === 'SphereGeometry');
+  assert.equal(sphereMeshes.length, 1);
+  assert.equal(sphereMeshes[0]?.position.z, 9.5);
+});
+
+test('kickstand export does not add a host-knot sphere affordance', () => {
+  const supportState = makeSupportState();
+  const kickstandState = makeKickstandState();
+  const group = buildScopedSupportGeometryGroup(supportState, kickstandState, ['model-a']);
+
+  const kickstandGroup = group.children.find((child) => child.name === 'Kickstand_kickstand-a');
+  assert.ok(kickstandGroup);
+
+  kickstandGroup!.updateMatrixWorld(true);
+
+  const hostSphereMeshes: THREE.Object3D[] = [];
+  kickstandGroup!.traverse((node) => {
+    if ((node as THREE.Mesh).geometry?.type !== 'SphereGeometry') return;
+    const worldPos = new THREE.Vector3();
+    node.getWorldPosition(worldPos);
+    if (Math.abs(worldPos.x - 0) < 1e-6 && Math.abs(worldPos.y - 0) < 1e-6 && Math.abs(worldPos.z - 6) < 1e-6) {
+      hostSphereMeshes.push(node);
+    }
+  });
+
+  assert.equal(hostSphereMeshes.length, 0);
+});

--- a/src/features/export/logic/supportExportReconstruction.ts
+++ b/src/features/export/logic/supportExportReconstruction.ts
@@ -1,0 +1,570 @@
+import * as THREE from 'three';
+import { bezierToLineSegments } from '@/supports/Curves/BezierUtils';
+import { getModelIdForSupportEntityId } from '@/supports/state';
+import { getFinalSocketPosition } from '@/supports/SupportPrimitives/ContactCone';
+import { calculateDiskThickness } from '@/supports/SupportPrimitives/ContactDisk/contactDiskUtils';
+import { getRaftSettingsForModel } from '@/supports/Rafts/Crenelated/RaftState';
+import type { Kickstand, KickstandBuildResult, KickstandState } from '@/supports/SupportTypes/Kickstand/types';
+import type {
+  Anchor,
+  Brace,
+  Branch,
+  DragonfruitImportFormat,
+  Knot,
+  Leaf,
+  Roots,
+  Segment,
+  Stick,
+  SupportState,
+  Twig,
+  Vec3,
+} from '@/supports/types';
+import { SupportGeometryGenerator } from './SupportGeometryGenerator';
+
+export interface ScopedSupportPayload {
+  roots: Roots[];
+  trunks: SupportState['trunks'][string][];
+  branches: Branch[];
+  leaves: Leaf[];
+  twigs: Twig[];
+  sticks: Stick[];
+  braces: Brace[];
+  anchors: Anchor[];
+  knots: Knot[];
+  kickstandRoots: Roots[];
+  kickstandKnots: Knot[];
+  kickstands: Kickstand[];
+}
+
+function hasAllowedModelId(allowedModelIds: ReadonlySet<string>, modelId: string | null | undefined): boolean {
+  return typeof modelId === 'string' && allowedModelIds.has(modelId);
+}
+
+function firstAllowedModelId(
+  allowedModelIds: ReadonlySet<string>,
+  ...candidateIds: Array<string | null | undefined>
+): string | null {
+  for (const candidateId of candidateIds) {
+    if (hasAllowedModelId(allowedModelIds, candidateId)) {
+      return candidateId!;
+    }
+  }
+
+  return null;
+}
+
+function resolveBranchModelId(branch: Branch, allowedModelIds: ReadonlySet<string>): string | null {
+  return firstAllowedModelId(
+    allowedModelIds,
+    branch.modelId,
+    getModelIdForSupportEntityId(branch.parentKnotId),
+  );
+}
+
+function resolveLeafModelId(leaf: Leaf, allowedModelIds: ReadonlySet<string>): string | null {
+  return firstAllowedModelId(
+    allowedModelIds,
+    leaf.modelId,
+    getModelIdForSupportEntityId(leaf.parentKnotId),
+  );
+}
+
+function resolveBraceModelId(brace: Brace, allowedModelIds: ReadonlySet<string>): string | null {
+  return firstAllowedModelId(
+    allowedModelIds,
+    brace.modelId,
+    getModelIdForSupportEntityId(brace.startKnotId),
+    getModelIdForSupportEntityId(brace.endKnotId),
+  );
+}
+
+function resolveKickstandModelId(kickstand: Kickstand, allowedModelIds: ReadonlySet<string>): string | null {
+  return firstAllowedModelId(
+    allowedModelIds,
+    kickstand.modelId,
+    getModelIdForSupportEntityId(kickstand.rootId),
+    getModelIdForSupportEntityId(kickstand.hostKnotId),
+    getModelIdForSupportEntityId(kickstand.hostSegmentId),
+  );
+}
+
+function buildTwigDiskTipCenter(disk: Twig['contactDiskA']): Vec3 {
+  const thickness = disk.diskLengthOverride ?? calculateDiskThickness(disk.surfaceNormal, disk.coneAxis, disk.profile);
+  return {
+    x: disk.pos.x + (disk.surfaceNormal.x * thickness),
+    y: disk.pos.y + (disk.surfaceNormal.y * thickness),
+    z: disk.pos.z + (disk.surfaceNormal.z * thickness),
+  };
+}
+
+function addModelMetadata(object: THREE.Object3D, modelId: string | null | undefined) {
+  object.userData = {
+    ...object.userData,
+    modelId: modelId ?? null,
+  };
+}
+
+function appendConeGeometry(group: THREE.Group, cone: Leaf['contactCone']) {
+  const coneGroup = SupportGeometryGenerator.generateConeMesh(cone);
+  group.add(coneGroup);
+
+  const diskGroup = SupportGeometryGenerator.generateContactDiskMesh(cone);
+  if (diskGroup.children.length > 0) {
+    group.add(diskGroup);
+  }
+}
+
+function appendStraightOrBezierShafts(
+  group: THREE.Group,
+  segment: Segment,
+  start: Vec3,
+  end: Vec3,
+) {
+  if (segment.type === 'bezier') {
+    const points = bezierToLineSegments(
+      start,
+      segment.controlPoint1,
+      segment.controlPoint2,
+      end,
+      segment.resolution,
+    );
+    for (let i = 0; i < points.length - 1; i += 1) {
+      const shaft = SupportGeometryGenerator.generateShaftMesh(
+        new THREE.Vector3(points[i].x, points[i].y, points[i].z),
+        new THREE.Vector3(points[i + 1].x, points[i + 1].y, points[i + 1].z),
+        segment.diameter,
+      );
+      if (shaft) group.add(shaft);
+    }
+    return;
+  }
+
+  const shaft = SupportGeometryGenerator.generateShaftMesh(
+    new THREE.Vector3(start.x, start.y, start.z),
+    new THREE.Vector3(end.x, end.y, end.z),
+    segment.diameter,
+  );
+  if (shaft) group.add(shaft);
+}
+
+function buildAnchorGroup(anchor: Anchor, modelId: string | null | undefined): THREE.Group {
+  const group = new THREE.Group();
+  group.name = `Anchor_${anchor.id}`;
+  addModelMetadata(group, modelId);
+
+  const rootHeight = Math.max(0.001, anchor.rootHeight);
+  const rootMesh = new THREE.Mesh(
+    new THREE.CylinderGeometry(
+      Math.max(0.001, anchor.rootTopDiameter / 2),
+      Math.max(0.001, anchor.rootBaseDiameter / 2),
+      rootHeight,
+      20,
+    ),
+  );
+  rootMesh.position.set(anchor.rootPos.x, anchor.rootPos.y, anchor.rootPos.z + (rootHeight / 2));
+  rootMesh.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), new THREE.Vector3(0, 0, 1));
+  group.add(rootMesh);
+
+  group.add(SupportGeometryGenerator.generateJointMesh(anchor.joint));
+
+  let currentStart: Vec3 = anchor.joint.pos;
+  anchor.segments.forEach((segment) => {
+    const end = segment.topJoint
+      ? segment.topJoint.pos
+      : anchor.contactCone
+        ? getFinalSocketPosition(anchor.contactCone)
+        : currentStart;
+
+    appendStraightOrBezierShafts(group, segment, currentStart, end);
+
+    if (segment.topJoint) {
+      group.add(SupportGeometryGenerator.generateJointMesh(segment.topJoint));
+    }
+
+    currentStart = end;
+  });
+
+  appendConeGeometry(group, anchor.contactCone);
+  return group;
+}
+
+function buildBraceGroup(
+  brace: Brace,
+  startKnot: Knot,
+  endKnot: Knot,
+  modelId: string | null | undefined,
+): THREE.Group {
+  const group = new THREE.Group();
+  group.name = `Brace_${brace.id}`;
+  addModelMetadata(group, modelId);
+
+  const diameter = Math.max(
+    0.001,
+    brace.profile?.diameter
+      ?? Math.max(
+        0.001,
+        ((startKnot.diameter ?? 1.2) + (endKnot.diameter ?? 1.2)) * 0.5,
+      ),
+  );
+
+  if (brace.curve?.type === 'bezier') {
+    const points = bezierToLineSegments(
+      startKnot.pos,
+      brace.curve.controlPoint1,
+      brace.curve.controlPoint2,
+      endKnot.pos,
+      brace.curve.resolution,
+    );
+    for (let i = 0; i < points.length - 1; i += 1) {
+      const shaft = SupportGeometryGenerator.generateShaftMesh(
+        new THREE.Vector3(points[i].x, points[i].y, points[i].z),
+        new THREE.Vector3(points[i + 1].x, points[i + 1].y, points[i + 1].z),
+        diameter,
+      );
+      if (shaft) group.add(shaft);
+    }
+    return group;
+  }
+
+  const shaft = SupportGeometryGenerator.generateShaftMesh(
+    new THREE.Vector3(startKnot.pos.x, startKnot.pos.y, startKnot.pos.z),
+    new THREE.Vector3(endKnot.pos.x, endKnot.pos.y, endKnot.pos.z),
+    diameter,
+  );
+  if (shaft) group.add(shaft);
+
+  return group;
+}
+
+function buildLeafGroup(leaf: Leaf, modelId: string | null | undefined): THREE.Group {
+  const group = new THREE.Group();
+  group.name = `Leaf_${leaf.id}`;
+  addModelMetadata(group, modelId);
+  appendConeGeometry(group, leaf.contactCone);
+  return group;
+}
+
+function buildStickGroup(stick: Stick, modelId: string | null | undefined): THREE.Group {
+  const startPos = getFinalSocketPosition(stick.contactConeA);
+  const group = SupportGeometryGenerator.generateSupportGroup(
+    {
+      id: stick.id,
+      startPos,
+      segments: stick.segments,
+      contactCone: stick.contactConeB,
+    },
+  );
+  group.name = `Stick_${stick.id}`;
+  addModelMetadata(group, modelId);
+  appendConeGeometry(group, stick.contactConeA);
+  return group;
+}
+
+function buildTwigGroup(twig: Twig, modelId: string | null | undefined): THREE.Group {
+  const startPos = buildTwigDiskTipCenter(twig.contactDiskA);
+  const endPos = buildTwigDiskTipCenter(twig.contactDiskB);
+  const group = new THREE.Group();
+  group.name = `Twig_${twig.id}`;
+  addModelMetadata(group, modelId);
+
+  const seenJointIds = new Set<string>();
+  let currentStart = startPos;
+
+  twig.segments.forEach((segment, index) => {
+    if (segment.bottomJoint && !seenJointIds.has(segment.bottomJoint.id)) {
+      seenJointIds.add(segment.bottomJoint.id);
+      group.add(SupportGeometryGenerator.generateJointMesh(segment.bottomJoint));
+    }
+
+    const isLast = index === twig.segments.length - 1;
+    const end = segment.topJoint
+      ? segment.topJoint.pos
+      : isLast
+        ? endPos
+        : currentStart;
+
+    appendStraightOrBezierShafts(group, segment, segment.bottomJoint?.pos ?? currentStart, end);
+
+    if (segment.topJoint && !seenJointIds.has(segment.topJoint.id)) {
+      seenJointIds.add(segment.topJoint.id);
+      group.add(SupportGeometryGenerator.generateJointMesh(segment.topJoint));
+    }
+
+    currentStart = end;
+  });
+
+  const diskA = SupportGeometryGenerator.generateContactDiskMesh({
+    pos: twig.contactDiskA.pos,
+    normal: twig.contactDiskA.coneAxis,
+    surfaceNormal: twig.contactDiskA.surfaceNormal,
+    diskLengthOverride: twig.contactDiskA.diskLengthOverride,
+    profile: twig.contactDiskA.profile,
+  });
+  const diskB = SupportGeometryGenerator.generateContactDiskMesh({
+    pos: twig.contactDiskB.pos,
+    normal: twig.contactDiskB.coneAxis,
+    surfaceNormal: twig.contactDiskB.surfaceNormal,
+    diskLengthOverride: twig.contactDiskB.diskLengthOverride,
+    profile: twig.contactDiskB.profile,
+  });
+  if (diskA.children.length > 0) group.add(diskA);
+  if (diskB.children.length > 0) group.add(diskB);
+  return group;
+}
+
+function buildKickstandGroup(
+  kickstand: Kickstand,
+  root: Roots,
+  hostKnot: Knot,
+  modelId: string | null | undefined,
+): THREE.Group {
+  const group = new THREE.Group();
+  group.name = `Kickstand_${kickstand.id}`;
+  addModelMetadata(group, modelId);
+
+  const raftSettings = modelId ? getRaftSettingsForModel(modelId) : undefined;
+  const rootGroup = SupportGeometryGenerator.generateRootsMesh(
+    root,
+    kickstand.segments[0]?.diameter ?? kickstand.profile.bodyDiameterMm,
+    raftSettings,
+  );
+  group.add(rootGroup);
+
+  const hasSolidBottom = raftSettings?.bottomMode === 'solid';
+  const raftThickness = raftSettings?.thickness ?? 0;
+  const effectiveDiskHeight = hasSolidBottom ? 0.05 : Math.max(0.001, root.diskHeight);
+  const verticalOffset = hasSolidBottom ? Math.max(raftThickness - effectiveDiskHeight, 0) : 0;
+  let currentStart: Vec3 = {
+    x: root.transform.pos.x,
+    y: root.transform.pos.y,
+    z: root.transform.pos.z + verticalOffset + effectiveDiskHeight + Math.max(0, root.coneHeight),
+  };
+
+  kickstand.segments.forEach((segment, index) => {
+    const isLast = index === kickstand.segments.length - 1;
+    const end = segment.topJoint
+      ? segment.topJoint.pos
+      : isLast
+        ? hostKnot.pos
+        : currentStart;
+
+    appendStraightOrBezierShafts(group, segment, currentStart, end);
+
+    if (segment.topJoint) {
+      group.add(SupportGeometryGenerator.generateJointMesh(segment.topJoint));
+    }
+
+    currentStart = end;
+  });
+
+  return group;
+}
+
+export function extractScopedSupportPayload(
+  supportState: SupportState,
+  kickstandState: KickstandState,
+  modelIds: Iterable<string>,
+): ScopedSupportPayload {
+  const allowedModelIds = new Set(Array.from(modelIds).filter((modelId) => modelId.trim().length > 0));
+
+  const roots = Object.values(supportState.roots)
+    .filter((item) => hasAllowedModelId(allowedModelIds, item.modelId));
+  const trunks = Object.values(supportState.trunks)
+    .filter((item) => hasAllowedModelId(allowedModelIds, item.modelId));
+  const branches = Object.values(supportState.branches)
+    .filter((item) => resolveBranchModelId(item, allowedModelIds) !== null);
+  const leaves = Object.values(supportState.leaves)
+    .filter((item) => resolveLeafModelId(item, allowedModelIds) !== null);
+  const twigs = Object.values(supportState.twigs)
+    .filter((item) => hasAllowedModelId(allowedModelIds, item.modelId));
+  const sticks = Object.values(supportState.sticks)
+    .filter((item) => hasAllowedModelId(allowedModelIds, item.modelId));
+  const braces = Object.values(supportState.braces)
+    .filter((item) => resolveBraceModelId(item, allowedModelIds) !== null);
+  const anchors = Object.values(supportState.anchors)
+    .filter((item) => hasAllowedModelId(allowedModelIds, item.modelId));
+  const kickstands = Object.values(kickstandState.kickstands)
+    .filter((item) => resolveKickstandModelId(item, allowedModelIds) !== null);
+
+  const kickstandRootIds = new Set(kickstands.map((item) => item.rootId));
+  const kickstandKnotIds = new Set(kickstands.map((item) => item.hostKnotId));
+  const kickstandRoots = Object.values(kickstandState.roots)
+    .filter((item) => kickstandRootIds.has(item.id));
+  const kickstandKnots = Object.values(kickstandState.knots)
+    .filter((item) => kickstandKnotIds.has(item.id));
+
+  const includedSegmentIds = new Set<string>();
+  trunks.forEach((item) => item.segments.forEach((segment) => includedSegmentIds.add(segment.id)));
+  branches.forEach((item) => item.segments.forEach((segment) => includedSegmentIds.add(segment.id)));
+  twigs.forEach((item) => item.segments.forEach((segment) => includedSegmentIds.add(segment.id)));
+  sticks.forEach((item) => item.segments.forEach((segment) => includedSegmentIds.add(segment.id)));
+  braces.forEach((item) => includedSegmentIds.add(`braceSegment:${item.id}`));
+  kickstands.forEach((item) => item.segments.forEach((segment) => includedSegmentIds.add(segment.id)));
+
+  const referencedKnotIds = new Set<string>();
+  branches.forEach((item) => referencedKnotIds.add(item.parentKnotId));
+  leaves.forEach((item) => referencedKnotIds.add(item.parentKnotId));
+  braces.forEach((item) => {
+    referencedKnotIds.add(item.startKnotId);
+    referencedKnotIds.add(item.endKnotId);
+  });
+
+  const leafIds = new Set(leaves.map((item) => item.id));
+  const braceIds = new Set(braces.map((item) => item.id));
+
+  const knots = Object.values(supportState.knots)
+    .filter((item) => {
+      if (referencedKnotIds.has(item.id)) return true;
+      if (includedSegmentIds.has(item.parentShaftId)) return true;
+      if (item.parentShaftId.startsWith('leafCone:')) {
+        return leafIds.has(item.parentShaftId.slice('leafCone:'.length));
+      }
+      if (item.parentShaftId.startsWith('braceSegment:')) {
+        return braceIds.has(item.parentShaftId.slice('braceSegment:'.length));
+      }
+      return hasAllowedModelId(allowedModelIds, getModelIdForSupportEntityId(item.id));
+    });
+
+  return {
+    roots,
+    trunks,
+    branches,
+    leaves,
+    twigs,
+    sticks,
+    braces,
+    anchors,
+    knots,
+    kickstandRoots,
+    kickstandKnots,
+    kickstands,
+  };
+}
+
+export function buildScopedSupportExportDocument(
+  supportState: SupportState,
+  kickstandState: KickstandState,
+  modelIds: Iterable<string>,
+  source = 'dragonfruit-voxl',
+): DragonfruitImportFormat {
+  const payload = extractScopedSupportPayload(supportState, kickstandState, modelIds);
+  const kickstandRootsById = new Map(payload.kickstandRoots.map((item) => [item.id, item]));
+  const kickstandKnotsById = new Map(payload.kickstandKnots.map((item) => [item.id, item]));
+
+  const kickstandBuilds: KickstandBuildResult[] = payload.kickstands
+    .map((kickstand) => {
+      const root = kickstandRootsById.get(kickstand.rootId);
+      const hostKnot = kickstandKnotsById.get(kickstand.hostKnotId);
+      if (!root || !hostKnot) return null;
+      return { root, hostKnot, kickstand };
+    })
+    .filter((item): item is KickstandBuildResult => item !== null);
+
+  return {
+    version: 1,
+    meta: {
+      source,
+      objectCenter: { x: 0, y: 0, z: 0 },
+      updatedAt: Date.now(),
+    },
+    roots: payload.roots,
+    trunks: payload.trunks,
+    branches: payload.branches,
+    leaves: payload.leaves,
+    twigs: payload.twigs,
+    sticks: payload.sticks,
+    braces: payload.braces,
+    anchors: payload.anchors,
+    knots: payload.knots,
+    kickstands: kickstandBuilds,
+  };
+}
+
+export function buildScopedSupportGeometryGroup(
+  supportState: SupportState,
+  kickstandState: KickstandState,
+  modelIds: Iterable<string>,
+): THREE.Group {
+  const payload = extractScopedSupportPayload(supportState, kickstandState, modelIds);
+  const group = new THREE.Group();
+  group.name = 'ScopedSupportExport';
+
+  const rootsById = supportState.roots;
+  const knotsById = supportState.knots;
+  const kickstandRootsById = kickstandState.roots;
+  const kickstandKnotsById = kickstandState.knots;
+
+  payload.trunks.forEach((trunk) => {
+    const root = rootsById[trunk.rootId];
+    if (!root) return;
+    const modelId = trunk.modelId ?? root.modelId ?? null;
+    const trunkGroup = SupportGeometryGenerator.generateSupportGroup(
+      {
+        id: trunk.id,
+        roots: root,
+        segments: trunk.segments,
+        contactCone: trunk.contactCone,
+      },
+      modelId ? getRaftSettingsForModel(modelId) : undefined,
+    );
+    trunkGroup.name = `Trunk_${trunk.id}`;
+    addModelMetadata(trunkGroup, modelId);
+    group.add(trunkGroup);
+  });
+
+  payload.branches.forEach((branch) => {
+    const parentKnot = knotsById[branch.parentKnotId];
+    if (!parentKnot) return;
+    const modelId = branch.modelId ?? getModelIdForSupportEntityId(branch.parentKnotId);
+    const branchGroup = SupportGeometryGenerator.generateSupportGroup({
+      id: branch.id,
+      startPos: parentKnot.pos,
+      segments: branch.segments,
+      contactCone: branch.contactCone,
+    });
+    branchGroup.name = `Branch_${branch.id}`;
+    addModelMetadata(branchGroup, modelId);
+    group.add(branchGroup);
+  });
+
+  payload.leaves.forEach((leaf) => {
+    const modelId = leaf.modelId ?? getModelIdForSupportEntityId(leaf.parentKnotId);
+    group.add(buildLeafGroup(leaf, modelId));
+  });
+
+  payload.twigs.forEach((twig) => {
+    group.add(buildTwigGroup(twig, twig.modelId));
+  });
+
+  payload.sticks.forEach((stick) => {
+    group.add(buildStickGroup(stick, stick.modelId));
+  });
+
+  payload.braces.forEach((brace) => {
+    const startKnot = knotsById[brace.startKnotId];
+    const endKnot = knotsById[brace.endKnotId];
+    if (!startKnot || !endKnot) return;
+    const modelId = brace.modelId
+      ?? getModelIdForSupportEntityId(brace.startKnotId)
+      ?? getModelIdForSupportEntityId(brace.endKnotId);
+    group.add(buildBraceGroup(brace, startKnot, endKnot, modelId));
+  });
+
+  payload.kickstands.forEach((kickstand) => {
+    const root = kickstandRootsById[kickstand.rootId];
+    const hostKnot = kickstandKnotsById[kickstand.hostKnotId];
+    if (!root || !hostKnot) return;
+    const modelId = kickstand.modelId
+      ?? root.modelId
+      ?? getModelIdForSupportEntityId(kickstand.hostKnotId)
+      ?? getModelIdForSupportEntityId(kickstand.hostSegmentId);
+    group.add(buildKickstandGroup(kickstand, root, hostKnot, modelId));
+  });
+
+  payload.anchors.forEach((anchor) => {
+    group.add(buildAnchorGroup(anchor, anchor.modelId));
+  });
+
+  group.updateMatrixWorld(true);
+  return group;
+}


### PR DESCRIPTION
**feat: support export reconstruction**
- Reworks `ExportManager` and `SupportGeometryGenerator` to export reconstructed support geometry.
- Adds `supportExportReconstruction` logic and targeted coverage.
- Keeps the export path aligned with the new support reconstruction flow.

**notes**
- `npm run build` currently stops on a TypeScript mismatch in `plugins/anycubic/pluginDefinition.ts`.
- `npm test` still has 3 failing support tests unrelated to this branch.