### PR TITLE
feat: rotation gizmo snap tick marks (#103)

### DIFF
--- a/src/components/gizmo/rotate/GizmoRotation.tsx
+++ b/src/components/gizmo/rotate/GizmoRotation.tsx
@@ -6,6 +6,7 @@ import { ThreeEvent, useThree, useFrame } from '@react-three/fiber';
 import { Line } from '@react-three/drei';
 import { GIZMO_COLORS, GIZMO_SIZES, GIZMO_LIGHTING } from '../constants';
 import { snapAngle, SNAP_COARSE, SNAP_FINE, SNAP_STORAGE_KEY } from './snapRotation';
+import { SnapTickMarks } from './SnapTickMarks';
 import type { GizmoAxis } from '../types';
 import { usePicking } from '@/components/picking';
 import type { GizmoHandleType } from '@/components/picking/types';
@@ -489,7 +490,18 @@ export function GizmoRotation({
         opacity={Math.max(0, opacity * 0.26)}
         depthTest={false}
       />
-      
+
+      {/* Static snap tick marks at fixed angular positions (not in the rotating
+          arc group). Axis-colored, fade in on hover, strongest during drag. */}
+      {!isHidden && (
+        <SnapTickMarks
+          color={ringColors.ring}
+          hovered={!!effectiveHovered}
+          active={ringIsActive}
+          opacityScale={opacityScale}
+        />
+      )}
+
       {/* Rotating group to keep colored arc facing camera - uses same angle as handle */}
       <group ref={rotatingArcRef}>
         {/* Front arc with gradient - pure color at center, lighter at ends */}

--- a/src/components/gizmo/rotate/SnapTickMarks.tsx
+++ b/src/components/gizmo/rotate/SnapTickMarks.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import React, { useMemo } from 'react';
+import { Line } from '@react-three/drei';
+import { GIZMO_SIZES } from '../constants';
+import {
+  getSnapTicks,
+  buildTierSegmentPoints,
+  DEFAULT_SNAP_TICK_CONFIG,
+  type SnapTickConfig,
+  type TickTier,
+} from './snapRotation';
+
+interface SnapTickMarksProps {
+  /** Axis ring color (red/green/blue). Stays axis-colored regardless of drag state. */
+  color: string;
+  /** True when the ring is hovered — ticks fade in. */
+  hovered: boolean;
+  /** True during an active drag — ticks are strongest. */
+  active: boolean;
+  /** Multiplies the computed opacity (mirrors the ring's opacityScale). */
+  opacityScale?: number;
+  /** Tier intervals. Defaults to 45/15/5; #104 supplies persisted config. */
+  config?: SnapTickConfig;
+}
+
+/** Full (major) tick length as a fraction of the ring radius; tiers scale via lengthMult. */
+const TICK_BASE_LENGTH = GIZMO_SIZES.ringMajorRadius * 0.12;
+
+/** Stroke width per tier — higher tiers are thicker. */
+const TIER_LINE_WIDTH: Record<TickTier, number> = {
+  major: 2.0,
+  medium: 1.3,
+  minor: 0.7,
+};
+
+const TIERS: TickTier[] = ['major', 'medium', 'minor'];
+
+/**
+ * SnapTickMarks — static radial tick marks around the rotation ring marking the
+ * snap positions on the rotation ring. Rendered in the ring's
+ * fixed local frame (NOT the camera-following arc group) so the marks stay at
+ * fixed angular positions. Hidden when idle, fades in on hover, strongest during
+ * an active drag. One <Line segments> per tier so length and stroke width can
+ * differ per tier.
+ */
+export function SnapTickMarks({
+  color,
+  hovered,
+  active,
+  opacityScale = 1,
+  config = DEFAULT_SNAP_TICK_CONFIG,
+}: SnapTickMarksProps) {
+  const segmentsByTier = useMemo(() => {
+    const ticks = getSnapTicks(config);
+    const radius = GIZMO_SIZES.ringMajorRadius;
+    return TIERS.map((tier) => ({
+      tier,
+      points: buildTierSegmentPoints(ticks, radius, TICK_BASE_LENGTH, tier),
+    }));
+  }, [config]);
+
+  const opacity = (active ? 0.85 : hovered ? 0.45 : 0) * opacityScale;
+  if (opacity <= 0) return null;
+
+  return (
+    <group>
+      {segmentsByTier.map(({ tier, points }) =>
+        points.length > 0 ? (
+          <Line
+            key={tier}
+            points={points}
+            segments
+            color={color}
+            lineWidth={TIER_LINE_WIDTH[tier]}
+            transparent
+            opacity={opacity}
+            depthTest={false}
+            toneMapped={false}
+          />
+        ) : null,
+      )}
+    </group>
+  );
+}

--- a/src/components/gizmo/rotate/__tests__/snapRotation.test.ts
+++ b/src/components/gizmo/rotate/__tests__/snapRotation.test.ts
@@ -1,6 +1,16 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { snapAngle, SNAP_COARSE, SNAP_FINE } from "../snapRotation";
+import {
+  snapAngle,
+  SNAP_COARSE,
+  SNAP_FINE,
+  TICK_MINOR,
+  getSnapTicks,
+  DEFAULT_SNAP_TICK_CONFIG,
+  buildTierSegmentPoints,
+} from "../snapRotation";
+
+const toDeg = (rad: number) => Math.round((rad * 180) / Math.PI);
 
 describe("snapAngle", () => {
   it("snaps 0 to 0", () => {
@@ -84,5 +94,107 @@ describe("transition tolerance", () => {
       error <= halfFine + 1e-10,
       `Quantization error ${error} exceeds half-increment ${halfFine}`,
     );
+  });
+});
+
+describe("getSnapTicks (default 45/15/5 config)", () => {
+  const ticks = getSnapTicks();
+
+  it("produces 72 ticks (360 / 5deg)", () => {
+    assert.equal(ticks.length, 72);
+  });
+
+  it("classifies into 8 major / 16 medium / 48 minor", () => {
+    const counts = ticks.reduce(
+      (acc, t) => {
+        acc[t.tier] += 1;
+        return acc;
+      },
+      { major: 0, medium: 0, minor: 0 } as Record<string, number>,
+    );
+    assert.deepEqual(counts, { major: 8, medium: 16, minor: 48 });
+  });
+
+  it("assigns each angular position to exactly one tier (no duplicate angles)", () => {
+    const seen = new Set(ticks.map((t) => toDeg(t.angleRad)));
+    assert.equal(seen.size, ticks.length);
+  });
+
+  it("major angles are multiples of 45deg", () => {
+    for (const t of ticks.filter((t) => t.tier === "major")) {
+      assert.equal(toDeg(t.angleRad) % 45, 0, `major at ${toDeg(t.angleRad)} not multiple of 45`);
+    }
+  });
+
+  it("medium angles are multiples of 15 but not 45", () => {
+    for (const t of ticks.filter((t) => t.tier === "medium")) {
+      const deg = toDeg(t.angleRad);
+      assert.equal(deg % 15, 0, `medium ${deg} not multiple of 15`);
+      assert.notEqual(deg % 45, 0, `medium ${deg} should not also be major`);
+    }
+  });
+
+  it("minor angles are multiples of 5 but not 15", () => {
+    for (const t of ticks.filter((t) => t.tier === "minor")) {
+      const deg = toDeg(t.angleRad);
+      assert.equal(deg % 5, 0, `minor ${deg} not multiple of 5`);
+      assert.notEqual(deg % 15, 0, `minor ${deg} should not also be medium/major`);
+    }
+  });
+
+  it("length multipliers are 1.0 / 0.6 / 0.3 by tier", () => {
+    for (const t of ticks) {
+      const expected = t.tier === "major" ? 1.0 : t.tier === "medium" ? 0.6 : 0.3;
+      assert.equal(t.lengthMult, expected, `tier ${t.tier} lengthMult ${t.lengthMult}`);
+    }
+  });
+
+  it("all angles fall in [0, 2PI)", () => {
+    for (const t of ticks) {
+      assert.ok(
+        t.angleRad >= 0 && t.angleRad < 2 * Math.PI,
+        `angle ${t.angleRad} out of [0, 2PI)`,
+      );
+    }
+  });
+
+  it("TICK_MINOR equals 5 degrees in radians", () => {
+    assert.ok(Math.abs(TICK_MINOR - Math.PI / 36) < 1e-12, `Expected PI/36, got ${TICK_MINOR}`);
+  });
+
+  it("passing the explicit default config equals the no-arg call", () => {
+    assert.deepEqual(getSnapTicks(DEFAULT_SNAP_TICK_CONFIG), ticks);
+  });
+});
+
+describe("buildTierSegmentPoints", () => {
+  const ticks = getSnapTicks();
+  const R = 4.8;
+  const baseLength = 0.6;
+
+  it("emits two points (outer, inner) per tick of the requested tier", () => {
+    assert.equal(buildTierSegmentPoints(ticks, R, baseLength, "major").length, 8 * 2);
+    assert.equal(buildTierSegmentPoints(ticks, R, baseLength, "medium").length, 16 * 2);
+    assert.equal(buildTierSegmentPoints(ticks, R, baseLength, "minor").length, 48 * 2);
+  });
+
+  it("outer point lies on the ring radius; inner is shortened by baseLength*lengthMult", () => {
+    const major = buildTierSegmentPoints(ticks, R, baseLength, "major");
+    const outer = major[0];
+    const inner = major[1];
+    assert.ok(Math.abs(Math.hypot(outer[0], outer[1]) - R) < 1e-9, `outer radius ${Math.hypot(outer[0], outer[1])}`);
+    // major lengthMult is 1.0 → inner radius = R - baseLength
+    assert.ok(
+      Math.abs(Math.hypot(inner[0], inner[1]) - (R - baseLength)) < 1e-9,
+      `inner radius ${Math.hypot(inner[0], inner[1])}`,
+    );
+  });
+
+  it("minor ticks are shorter than major ticks (lengthMult 0.3 vs 1.0)", () => {
+    const major = buildTierSegmentPoints(ticks, R, baseLength, "major");
+    const minor = buildTierSegmentPoints(ticks, R, baseLength, "minor");
+    const majorLen = R - Math.hypot(major[1][0], major[1][1]);
+    const minorLen = R - Math.hypot(minor[1][0], minor[1][1]);
+    assert.ok(minorLen < majorLen, `minor ${minorLen} should be < major ${majorLen}`);
   });
 });

--- a/src/components/gizmo/rotate/snapRotation.ts
+++ b/src/components/gizmo/rotate/snapRotation.ts
@@ -11,3 +11,95 @@ export const SNAP_FINE = Math.PI / 12;
 
 /** localStorage key for persistent snap toggle */
 export const SNAP_STORAGE_KEY = 'dragonfruit:rotation-snap-enabled';
+
+/** Minor (visual-only) tick increment: 5 degrees. Major/medium reuse SNAP_COARSE/SNAP_FINE. */
+export const TICK_MINOR = Math.PI / 36;
+
+/** Visual size class of a tick mark. */
+export type TickTier = 'major' | 'medium' | 'minor';
+
+/** A single tick mark around the rotation ring. */
+export interface SnapTick {
+  /** Angle around the ring in radians, normalized to [0, 2*PI). */
+  angleRad: number;
+  /** Which tier this position belongs to (its highest applicable tier). */
+  tier: TickTier;
+  /** Tick length as a fraction of the full (major) tick length. */
+  lengthMult: number;
+}
+
+/** Tick interval per tier, in whole degrees. */
+export interface SnapTickConfig {
+  /** Major (coarse-snap) interval, e.g. 45. */
+  majorDeg: number;
+  /** Medium (fine-snap) interval, e.g. 15. */
+  mediumDeg: number;
+  /** Minor (visual-only) interval, e.g. 5. */
+  minorDeg: number;
+}
+
+/** Tick length as a fraction of the major tick length, by tier. */
+export const TICK_LENGTH_MULT: Record<TickTier, number> = {
+  major: 1.0,
+  medium: 0.6,
+  minor: 0.3,
+};
+
+/** Default tiers: 45 / 15 / 5 degrees (the common slicer default). */
+export const DEFAULT_SNAP_TICK_CONFIG: SnapTickConfig = {
+  majorDeg: 45,
+  mediumDeg: 15,
+  minorDeg: 5,
+};
+
+const DEG_TO_RAD = Math.PI / 180;
+
+/**
+ * Build the de-duplicated set of tick marks around the full 360-degree ring for
+ * the given tier config. Every angular position (a multiple of `minorDeg`) is
+ * classified to its highest applicable tier: a multiple of `majorDeg` is
+ * `major` and is never also emitted as `medium`/`minor`. Classification is done
+ * in integer degrees so overlapping tiers (e.g. 45 is a multiple of both 45 and
+ * 15) can never be misclassified by floating-point modulo.
+ *
+ * Tiers do not have to nest (e.g. a Custom 45/10/5 config is accepted); when
+ * they do not, ticks of different tiers simply will not coincide.
+ */
+export function getSnapTicks(config: SnapTickConfig = DEFAULT_SNAP_TICK_CONFIG): SnapTick[] {
+  const { majorDeg, mediumDeg, minorDeg } = config;
+  const steps = Math.round(360 / minorDeg);
+  const ticks: SnapTick[] = [];
+  for (let i = 0; i < steps; i++) {
+    const deg = i * minorDeg;
+    const tier: TickTier =
+      deg % majorDeg === 0 ? 'major' : deg % mediumDeg === 0 ? 'medium' : 'minor';
+    ticks.push({ angleRad: deg * DEG_TO_RAD, tier, lengthMult: TICK_LENGTH_MULT[tier] });
+  }
+  return ticks;
+}
+
+/**
+ * Build flat line-segment endpoints for all ticks of one tier, as [x, y, z]
+ * triples in the ring's local XY plane (z = 0). Each tick yields two points:
+ * an outer point on the ring radius and an inner point shortened toward centre
+ * by `baseLength * lengthMult`. Points come in outer/inner pairs so the result
+ * can be fed to a drei <Line segments> as disconnected radial ticks. Pure and
+ * deterministic — unit-tested independently of the R3F render.
+ */
+export function buildTierSegmentPoints(
+  ticks: SnapTick[],
+  radius: number,
+  baseLength: number,
+  tier: TickTier,
+): [number, number, number][] {
+  const points: [number, number, number][] = [];
+  for (const tick of ticks) {
+    if (tick.tier !== tier) continue;
+    const innerRadius = radius - baseLength * tick.lengthMult;
+    const cos = Math.cos(tick.angleRad);
+    const sin = Math.sin(tick.angleRad);
+    points.push([cos * radius, sin * radius, 0]);
+    points.push([cos * innerRadius, sin * innerRadius, 0]);
+  }
+  return points;
+}


### PR DESCRIPTION
## Summary
Adds static visual tick marks around each rotation gizmo ring at three tiers — full-length every 45°, medium every 15°, short every 5° — fading in on hover and strongest during an active drag. Marks stay at fixed angular positions as the camera orbits.

## Implementation
- **`snapRotation.ts`**: `getSnapTicks(config?)` builds the de-duplicated 72-tick set (classified in integer degrees so 45/15 overlaps can't misclassify) + `buildTierSegmentPoints()` pure geometry helper + tier types/consts. `getSnapTicks` takes an optional tier config so #104 plugs in.
- **`SnapTickMarks.tsx`**: new R3F component — one `<Line segments>` per tier (length via `lengthMult`, width per tier); mounted in the **static** ring frame (not the camera-following arc group); non-interactive (no pointer handlers, returns `null` when idle) so it never blocks the diamond-handle drag.
- **`GizmoRotation.tsx`**: mounts `SnapTickMarks`, axis-coloured, driven by hover/active state.

## Tests
13 new `getSnapTicks` / `buildTierSegmentPoints` unit tests (`node:test`). Type-check + eslint clean. Built and ran in `tauri dev`.

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
