### PR TITLE
feat: configurable rotation snap tick intervals in settings (#104)

### DIFF
--- a/src/components/gizmo/rotate/GizmoRotation.tsx
+++ b/src/components/gizmo/rotate/GizmoRotation.tsx
@@ -5,8 +5,15 @@ import * as THREE from 'three';
 import { ThreeEvent, useThree, useFrame } from '@react-three/fiber';
 import { Line } from '@react-three/drei';
 import { GIZMO_COLORS, GIZMO_SIZES, GIZMO_LIGHTING } from '../constants';
-import { snapAngle, SNAP_COARSE, SNAP_FINE, SNAP_STORAGE_KEY } from './snapRotation';
+import { snapAngle, SNAP_STORAGE_KEY } from './snapRotation';
 import { SnapTickMarks } from './SnapTickMarks';
+import {
+  getSavedRotationSnapSettings,
+  subscribeToRotationSnapSettings,
+  getRotationSnapIncrements,
+  toSnapTickConfig,
+  type RotationSnapSettings,
+} from '@/components/settings/rotationSnapPreferences';
 import type { GizmoAxis } from '../types';
 import { usePicking } from '@/components/picking';
 import type { GizmoHandleType } from '@/components/picking/types';
@@ -61,6 +68,10 @@ export function GizmoRotation({
   const rawAccumulatedAngleRef = useRef<number>(0);
   const lastSnappedAngleRef = useRef<number>(0);
   const prevSnapIncrementRef = useRef<number | null>(null);
+  // Configurable snap tiers (#104): state drives the tick render; the ref feeds
+  // the hot pointermove path without re-subscribing each render.
+  const [snapSettings, setSnapSettings] = useState<RotationSnapSettings>(getSavedRotationSnapSettings);
+  const snapSettingsRef = useRef<RotationSnapSettings>(snapSettings);
   // Callback refs to stabilize useEffect deps (prevents effect churn during drag)
   const onDragRef = useRef(onDrag);
   const onDragEndRef = useRef(onDragEnd);
@@ -117,6 +128,19 @@ export function GizmoRotation({
       }
     };
   }, [register, unregister, handleType]);
+
+  // Keep configurable snap tiers in sync (live preview + persisted changes).
+  useEffect(() => {
+    const apply = () => {
+      const next = getSavedRotationSnapSettings();
+      snapSettingsRef.current = next;
+      setSnapSettings(next);
+    };
+    apply();
+    return subscribeToRotationSnapSettings(apply);
+  }, []);
+
+  const snapTickConfig = useMemo(() => toSnapTickConfig(snapSettings), [snapSettings]);
   
   // Check if this handle is hovered via GPU picking
   const isPickingHovered = !suppressHover && hit.category === 'gizmo' && 
@@ -276,8 +300,9 @@ export function GizmoRotation({
       let snapToggled = false;
       try { snapToggled = localStorage.getItem(SNAP_STORAGE_KEY) === 'true'; } catch {}
       const isSnapActive = e.metaKey || e.ctrlKey || snapToggled;
+      const { coarse, fine } = getRotationSnapIncrements(snapSettingsRef.current);
       const currentIncrement = isSnapActive
-        ? (e.shiftKey ? SNAP_FINE : SNAP_COARSE)
+        ? (e.shiftKey ? fine : coarse)
         : null;
 
       // Reset accumulated on any transition (free↔snap, coarse↔fine)
@@ -499,6 +524,7 @@ export function GizmoRotation({
           hovered={!!effectiveHovered}
           active={ringIsActive}
           opacityScale={opacityScale}
+          config={snapTickConfig}
         />
       )}
 

--- a/src/components/gizmo/rotate/RotationHintTooltip.tsx
+++ b/src/components/gizmo/rotate/RotationHintTooltip.tsx
@@ -1,10 +1,19 @@
 import { useEffect, useState } from 'react';
 import { MouseTooltip } from '@/components/ui/MouseTooltip';
 import { usePlatformModifier } from '@/hooks/usePlatformModifier';
+import {
+  getSavedRotationSnapSettings,
+  subscribeToRotationSnapSettings,
+  getRotationSnapDegrees,
+  getRotationSnapPresetId,
+  ROTATION_SNAP_PRESET_LABELS,
+  type RotationSnapSettings,
+} from '@/components/settings/rotationSnapPreferences';
 
 /** Cursor-following tooltip shown on rotation ring hover with snap shortcut hints. */
 export function RotationHintTooltip() {
   const [visible, setVisible] = useState(false);
+  const [settings, setSettings] = useState<RotationSnapSettings>(() => getSavedRotationSnapSettings());
   const modKey = usePlatformModifier();
 
   useEffect(() => {
@@ -14,6 +23,16 @@ export function RotationHintTooltip() {
     window.addEventListener('dragonfruit:rotation-hint', handler);
     return () => window.removeEventListener('dragonfruit:rotation-hint', handler);
   }, []);
+
+  // Keep the displayed increments/preset in sync with the configured snap tiers.
+  useEffect(() => {
+    const apply = () => setSettings(getSavedRotationSnapSettings());
+    apply();
+    return subscribeToRotationSnapSettings(apply);
+  }, []);
+
+  const { coarse, fine } = getRotationSnapDegrees(settings);
+  const presetLabel = ROTATION_SNAP_PRESET_LABELS[getRotationSnapPresetId(settings)];
 
   return (
     <MouseTooltip visible={visible} offset={{ x: 20, y: -40 }}>
@@ -28,8 +47,9 @@ export function RotationHintTooltip() {
       >
         <div>Drag to rotate</div>
         <div className="mt-0.5 opacity-70">
-          {modKey}+Drag: 45° &nbsp;|&nbsp; +Shift: 15°
+          {modKey}+Drag: {coarse}° &nbsp;|&nbsp; +Shift: {fine}°
         </div>
+        <div className="mt-0.5 opacity-60">Snap preset: {presetLabel}</div>
       </div>
     </MouseTooltip>
   );

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -11,9 +11,10 @@ import { SceneAutosaveSettingsTab } from '@/components/settings/SceneAutosaveSet
 import { LoggingSettingsTab, getSavedLogLevel, saveLogLevel, type LogLevelFilter } from '@/components/settings/LoggingSettingsTab';
 import { SpaceMouseSettingsTab } from '@/components/settings/SpaceMouseSettingsTab';
 import { UISettingsTab } from './UISettingsTab';
+import { TransformSettingsTab } from './TransformSettingsTab';
 import { WorkspacesSettingsTab } from '@/components/settings/WorkspacesSettingsTab';
 import { PerformanceSettingsTab, type SlicingThumbnailRenderSettings } from '@/components/settings/PerformanceSettingsTab';
-import { AlertTriangle, Check, Edit3, ExternalLink, Gamepad2, Github, HardDrive, Info, Keyboard, MonitorCog, Palette, Plug, RotateCcw, Save, Settings2, Trash2, X, Camera, Grid3x3, ArchiveRestore, ScrollText } from 'lucide-react';
+import { AlertTriangle, Check, Compass, Edit3, ExternalLink, Gamepad2, Github, HardDrive, Info, Keyboard, MonitorCog, Palette, Plug, RotateCcw, Save, Settings2, Trash2, X, Camera, Grid3x3, ArchiveRestore, ScrollText } from 'lucide-react';
 import type { MatcapVariant, MeshShaderType } from '@/features/shaders/mesh';
 import {
   applyThemeCustomColors,
@@ -175,7 +176,7 @@ type SettingsModalProps = {
   activeOutputFormat?: string | null;
 };
 
-type SettingsTabKey = 'general' | 'camera' | 'workspaces' | 'mesh' | 'performance' | 'spacemouse' | 'plugins' | 'sceneAutosave' | 'backups' | 'ui' | 'hotkeys' | 'logging' | 'about';
+type SettingsTabKey = 'general' | 'camera' | 'workspaces' | 'transform' | 'mesh' | 'performance' | 'spacemouse' | 'plugins' | 'sceneAutosave' | 'backups' | 'ui' | 'hotkeys' | 'logging' | 'about';
 type SettingsTabTone = 'primary' | 'secondary';
 
 export function SettingsModal({
@@ -1024,6 +1025,12 @@ export function SettingsModal({
       icon: MonitorCog,
       tone: 'primary',
     },
+    transform: {
+      label: 'Transform',
+      description: 'Rotation snap increments and gizmo tick marks',
+      icon: Compass,
+      tone: 'primary',
+    },
     ui: {
       label: 'UI & Theme',
       description: 'Theme and custom UI token customization',
@@ -1074,7 +1081,7 @@ export function SettingsModal({
     },
   };
 
-  const sidebarTopTabs: SettingsTabKey[] = ['general', 'camera', 'workspaces', 'mesh', 'performance', 'spacemouse', 'ui', 'hotkeys'];
+  const sidebarTopTabs: SettingsTabKey[] = ['general', 'camera', 'workspaces', 'transform', 'mesh', 'performance', 'spacemouse', 'ui', 'hotkeys'];
   const sidebarBottomTabs: SettingsTabKey[] = ['plugins', 'sceneAutosave', 'backups', 'logging', 'about'];
 
   const ActiveTabIcon = tabMeta[activeTab].icon;
@@ -1317,6 +1324,7 @@ export function SettingsModal({
                   onView3dSettingsChange={setDraftView3dSettings}
                 />
               )}
+              {activeTab === 'transform' && <TransformSettingsTab />}
               {activeTab === 'mesh' && (
                 <MeshSettingsTab
                   shaderType={draftShaderType}

--- a/src/components/settings/TransformSettingsTab.tsx
+++ b/src/components/settings/TransformSettingsTab.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import React from 'react';
+import { Compass } from 'lucide-react';
+import { NumberInput } from '@/components/ui/NumberInput';
+import {
+  DEFAULT_ROTATION_SNAP_SETTINGS,
+  ROTATION_SNAP_PRESETS,
+  ROTATION_SNAP_PRESET_LABELS,
+  MIN_TIER_DEGREES,
+  MAX_TIER_DEGREES,
+  getSavedRotationSnapSettings,
+  saveRotationSnapSettings,
+  getRotationSnapPresetId,
+  toSnapTickConfig,
+  type RotationSnapSettings,
+  type RotationSnapPresetId,
+  type SnapTierRole,
+} from '@/components/settings/rotationSnapPreferences';
+import { getSnapTicks } from '@/components/gizmo/rotate/snapRotation';
+
+const PRESET_SUBTITLES: Record<keyof typeof ROTATION_SNAP_PRESETS, string> = {
+  standard: '45 / 15 / 5',
+  fine: '15 / 5 / 1',
+};
+
+const TIER_META: { role: SnapTierRole; label: string; hint: string }[] = [
+  { role: 'coarse', label: 'Coarse', hint: 'Cmd/Ctrl + Drag snap · longest tick' },
+  { role: 'fine', label: 'Fine', hint: 'Cmd/Ctrl + Shift + Drag snap · medium tick' },
+  { role: 'visual', label: 'Visual', hint: 'Ticks only, no snap · shortest tick' },
+];
+
+function degreesForRole(settings: RotationSnapSettings, role: SnapTierRole): number {
+  return settings.tiers.find((tier) => tier.role === role)?.degrees ?? 0;
+}
+
+/** Small top-down SVG of the ring showing tick positions for the current config. */
+function TickPreview({ settings }: { settings: RotationSnapSettings }) {
+  const size = 132;
+  const center = size / 2;
+  const outer = center - 6;
+  const ticks = getSnapTicks(toSnapTickConfig(settings));
+  const tierOpacity: Record<string, number> = { major: 1, medium: 0.72, minor: 0.4 };
+  const maxLen = outer * 0.42;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      role="img"
+      aria-label="Tick mark preview"
+    >
+      <circle
+        cx={center}
+        cy={center}
+        r={outer}
+        fill="none"
+        stroke="var(--border-strong)"
+        strokeWidth={1}
+      />
+      {ticks.map((tick, i) => {
+        const len = maxLen * tick.lengthMult;
+        const cos = Math.cos(tick.angleRad);
+        const sin = Math.sin(tick.angleRad);
+        return (
+          <line
+            key={i}
+            x1={center + cos * outer}
+            y1={center - sin * outer}
+            x2={center + cos * (outer - len)}
+            y2={center - sin * (outer - len)}
+            stroke="var(--accent)"
+            strokeWidth={tick.tier === 'major' ? 1.6 : tick.tier === 'medium' ? 1.1 : 0.7}
+            strokeOpacity={tierOpacity[tick.tier]}
+            strokeLinecap="round"
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+/**
+ * TransformSettingsTab — configure the rotation gizmo's snap increments and tick
+ * intervals. Self-contained (own state, saves on change like SceneAutosaveSettingsTab),
+ * so edits apply immediately and the gizmo subscribes for live updates. The live
+ * preview is rendered in-tab because the settings modal occludes the 3D gizmo.
+ *
+ * Preset mode (Standard / Fine) is an explicit selection; "Custom" is also a
+ * real choice that seeds 45/15/5 and lets the user type arbitrary whole-degree
+ * intervals. Editing any field switches the selection to Custom.
+ */
+export function TransformSettingsTab() {
+  const [settings, setSettings] = React.useState<RotationSnapSettings>(() =>
+    getSavedRotationSnapSettings(),
+  );
+  const [selected, setSelected] = React.useState<RotationSnapPresetId>(() =>
+    getRotationSnapPresetId(getSavedRotationSnapSettings()),
+  );
+
+  React.useEffect(() => {
+    saveRotationSnapSettings(settings);
+  }, [settings]);
+
+  const applyPreset = React.useCallback((key: keyof typeof ROTATION_SNAP_PRESETS) => {
+    setSettings(ROTATION_SNAP_PRESETS[key]);
+    setSelected(key);
+  }, []);
+
+  const enterCustom = React.useCallback(() => {
+    // Seed 45/15/5 when entering Custom from a preset; keep current values if
+    // already Custom (don't clobber the user's edits).
+    setSelected((prev) => {
+      if (prev !== 'custom') setSettings(DEFAULT_ROTATION_SNAP_SETTINGS);
+      return 'custom';
+    });
+  }, []);
+
+  const setRoleDegrees = React.useCallback((role: SnapTierRole, raw: number) => {
+    if (!Number.isFinite(raw)) return;
+    const degrees = Math.max(MIN_TIER_DEGREES, Math.min(MAX_TIER_DEGREES, Math.round(raw)));
+    setSettings((prev) => ({
+      tiers: prev.tiers.map((tier) => (tier.role === role ? { ...tier, degrees } : tier)),
+    }));
+    setSelected('custom'); // editing an interval is a custom configuration
+  }, []);
+
+  const presetButtons: { key: RotationSnapPresetId; label: string; subtitle?: string }[] = [
+    { key: 'standard', label: ROTATION_SNAP_PRESET_LABELS.standard, subtitle: PRESET_SUBTITLES.standard },
+    { key: 'fine', label: ROTATION_SNAP_PRESET_LABELS.fine, subtitle: PRESET_SUBTITLES.fine },
+    { key: 'custom', label: ROTATION_SNAP_PRESET_LABELS.custom },
+  ];
+
+  return (
+    <div className="space-y-3">
+      <section
+        className="rounded-lg border p-3"
+        style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+      >
+        <div className="flex items-start gap-2.5">
+          <span
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md border"
+            style={{
+              borderColor: 'var(--border-subtle)',
+              background: 'color-mix(in srgb, var(--surface-2), transparent 8%)',
+            }}
+          >
+            <Compass className="h-4 w-4" style={{ color: 'var(--accent)' }} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
+              Rotation Snap &amp; Tick Marks
+            </h3>
+            <p className="mt-0.5 text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+              Tick intervals around the rotation gizmo ring. Coarse and fine intervals also set the
+              snap increments held with Cmd/Ctrl (and Shift for fine). Custom intervals can be any
+              whole number of degrees.
+            </p>
+          </div>
+        </div>
+
+        {/* Preset shortcuts (incl. clickable Custom) */}
+        <div className="mt-3 flex flex-wrap gap-2">
+          {presetButtons.map(({ key, label, subtitle }) => {
+            const active = selected === key;
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => (key === 'custom' ? enterCustom() : applyPreset(key))}
+                className="h-8 rounded-md border px-3 text-[12px] font-semibold transition-colors"
+                aria-pressed={active}
+                style={
+                  active
+                    ? {
+                        borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
+                        background: 'color-mix(in srgb, var(--accent), var(--surface-0) 76%)',
+                        color: 'color-mix(in srgb, var(--accent), var(--text-strong) 25%)',
+                      }
+                    : {
+                        borderColor: 'var(--border-subtle)',
+                        background: 'var(--surface-1)',
+                        color: 'var(--text-muted)',
+                      }
+                }
+              >
+                {label}
+                {subtitle ? <span className="ml-1 opacity-70">({subtitle})</span> : null}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Per-tier interval inputs + live preview */}
+        <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-start">
+          <div className="flex-1 grid gap-2">
+            {TIER_META.map(({ role, label, hint }) => (
+              <div
+                key={role}
+                className="rounded-md border px-2.5 py-2 flex items-center justify-between gap-3"
+                style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}
+              >
+                <div className="min-w-0">
+                  <div className="text-xs font-semibold" style={{ color: 'var(--text-strong)' }}>
+                    {label}
+                  </div>
+                  <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                    {hint}
+                  </div>
+                </div>
+                <div className="inline-flex items-center gap-2">
+                  <NumberInput
+                    min={MIN_TIER_DEGREES}
+                    max={MAX_TIER_DEGREES}
+                    step={1}
+                    value={degreesForRole(settings, role)}
+                    onChange={(next) => setRoleDegrees(role, next)}
+                    className="ui-input h-[34px] w-[88px] pl-2.5 pr-5 py-1.5 text-sm"
+                    aria-label={`${label} interval in degrees`}
+                  />
+                  <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                    deg
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div
+            className="flex flex-col items-center gap-1.5 rounded-md border p-2.5"
+            style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}
+          >
+            <TickPreview settings={settings} />
+            <span className="text-[10px] uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+              Live preview
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/settings/__tests__/rotationSnapPreferences.test.ts
+++ b/src/components/settings/__tests__/rotationSnapPreferences.test.ts
@@ -1,0 +1,172 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_ROTATION_SNAP_SETTINGS,
+  ROTATION_SNAP_PRESETS,
+  normalizeRotationSnapSettings,
+  toSnapTickConfig,
+  getRotationSnapIncrements,
+  getRotationSnapPresetId,
+  type RotationSnapSettings,
+  type SnapTierRole,
+} from "@/components/settings/rotationSnapPreferences";
+import { getSnapTicks, SNAP_COARSE, SNAP_FINE } from "@/components/gizmo/rotate/snapRotation";
+
+const degOf = (s: RotationSnapSettings, role: SnapTierRole): number => {
+  const tier = s.tiers.find((t) => t.role === role);
+  assert.ok(tier, `missing role ${role}`);
+  return tier.degrees;
+};
+
+describe("normalizeRotationSnapSettings", () => {
+  it("round-trips the default settings", () => {
+    assert.deepEqual(
+      normalizeRotationSnapSettings(DEFAULT_ROTATION_SNAP_SETTINGS),
+      DEFAULT_ROTATION_SNAP_SETTINGS,
+    );
+  });
+
+  it("falls back to default for null / non-object / malformed input", () => {
+    assert.deepEqual(normalizeRotationSnapSettings(null), DEFAULT_ROTATION_SNAP_SETTINGS);
+    assert.deepEqual(normalizeRotationSnapSettings("nope"), DEFAULT_ROTATION_SNAP_SETTINGS);
+    assert.deepEqual(normalizeRotationSnapSettings({}), DEFAULT_ROTATION_SNAP_SETTINGS);
+    assert.deepEqual(normalizeRotationSnapSettings({ tiers: [] }), DEFAULT_ROTATION_SNAP_SETTINGS);
+  });
+
+  it("accepts arbitrary whole-degree intervals (need not divide 360)", () => {
+    const arbitrary = {
+      tiers: [
+        { degrees: 7, lengthMult: 1, role: "coarse" },
+        { degrees: 13, lengthMult: 0.6, role: "fine" },
+        { degrees: 2, lengthMult: 0.3, role: "visual" },
+      ],
+    };
+    const n = normalizeRotationSnapSettings(arbitrary);
+    assert.equal(degOf(n, "coarse"), 7);
+    assert.equal(degOf(n, "fine"), 13);
+    assert.equal(degOf(n, "visual"), 2);
+  });
+
+  it("rejects non-positive, non-integer, or out-of-range degrees", () => {
+    const mk = (deg: unknown) => ({
+      tiers: [
+        { degrees: deg, lengthMult: 1, role: "coarse" },
+        { degrees: 15, lengthMult: 0.6, role: "fine" },
+        { degrees: 5, lengthMult: 0.3, role: "visual" },
+      ],
+    });
+    for (const bad of [0, -5, 7.5, 361, Number.NaN]) {
+      assert.deepEqual(
+        normalizeRotationSnapSettings(mk(bad)),
+        DEFAULT_ROTATION_SNAP_SETTINGS,
+        `degrees=${String(bad)} should be rejected`,
+      );
+    }
+  });
+
+  it("rejects missing or duplicate roles", () => {
+    const dup = {
+      tiers: [
+        { degrees: 45, lengthMult: 1, role: "coarse" },
+        { degrees: 15, lengthMult: 0.6, role: "coarse" }, // duplicate role
+        { degrees: 5, lengthMult: 0.3, role: "visual" },
+      ],
+    };
+    assert.deepEqual(normalizeRotationSnapSettings(dup), DEFAULT_ROTATION_SNAP_SETTINGS);
+  });
+
+  it("derives lengthMult from role, ignoring any supplied lengthMult", () => {
+    const weird = {
+      tiers: [
+        { degrees: 45, lengthMult: 99, role: "coarse" },
+        { degrees: 15, lengthMult: 99, role: "fine" },
+        { degrees: 5, lengthMult: 99, role: "visual" },
+      ],
+    };
+    const n = normalizeRotationSnapSettings(weird);
+    const lenOf = (role: SnapTierRole) => {
+      const t = n.tiers.find((x) => x.role === role);
+      assert.ok(t);
+      return t.lengthMult;
+    };
+    assert.equal(lenOf("coarse"), 1.0);
+    assert.equal(lenOf("fine"), 0.6);
+    assert.equal(lenOf("visual"), 0.3);
+  });
+
+  it("ACCEPTS a non-nesting custom config (45/10/5) — Custom mode is intentionally free", () => {
+    const nonNesting = {
+      tiers: [
+        { degrees: 45, lengthMult: 1, role: "coarse" },
+        { degrees: 10, lengthMult: 0.6, role: "fine" }, // divides 360 but does not nest in 45
+        { degrees: 5, lengthMult: 0.3, role: "visual" },
+      ],
+    };
+    assert.equal(degOf(normalizeRotationSnapSettings(nonNesting), "fine"), 10);
+  });
+});
+
+describe("rotation snap presets", () => {
+  it("Standard preset equals the default (45/15/5)", () => {
+    assert.deepEqual(ROTATION_SNAP_PRESETS.standard, DEFAULT_ROTATION_SNAP_SETTINGS);
+  });
+
+  it("every built-in preset is nesting-valid (visual | fine | coarse | 360) and normalizes unchanged", () => {
+    for (const preset of Object.values(ROTATION_SNAP_PRESETS)) {
+      assert.equal(360 % degOf(preset, "coarse"), 0);
+      assert.equal(degOf(preset, "coarse") % degOf(preset, "fine"), 0);
+      assert.equal(degOf(preset, "fine") % degOf(preset, "visual"), 0);
+      assert.deepEqual(normalizeRotationSnapSettings(preset), preset);
+    }
+  });
+});
+
+describe("toSnapTickConfig + getSnapTicks integration", () => {
+  it("maps roles to tick config (coarse->major, fine->medium, visual->minor)", () => {
+    assert.deepEqual(toSnapTickConfig(ROTATION_SNAP_PRESETS.fine), {
+      majorDeg: 15,
+      mediumDeg: 5,
+      minorDeg: 1,
+    });
+  });
+
+  it("getSnapTicks(Fine 15/5/1) yields 360 ticks classified by the configured tiers", () => {
+    const ticks = getSnapTicks(toSnapTickConfig(ROTATION_SNAP_PRESETS.fine));
+    assert.equal(ticks.length, 360);
+    const counts = ticks.reduce(
+      (acc, t) => {
+        acc[t.tier] += 1;
+        return acc;
+      },
+      { major: 0, medium: 0, minor: 0 } as Record<string, number>,
+    );
+    // major = multiples of 15 (24); medium = multiples of 5 not 15 (48); minor = rest (288)
+    assert.deepEqual(counts, { major: 24, medium: 48, minor: 288 });
+  });
+});
+
+describe("getRotationSnapPresetId", () => {
+  it("identifies the built-in presets", () => {
+    assert.equal(getRotationSnapPresetId(ROTATION_SNAP_PRESETS.standard), "standard");
+    assert.equal(getRotationSnapPresetId(ROTATION_SNAP_PRESETS.fine), "fine");
+  });
+
+  it("returns 'custom' for arbitrary configs", () => {
+    const custom = normalizeRotationSnapSettings({
+      tiers: [
+        { degrees: 30, lengthMult: 1, role: "coarse" },
+        { degrees: 10, lengthMult: 0.6, role: "fine" },
+        { degrees: 2, lengthMult: 0.3, role: "visual" },
+      ],
+    });
+    assert.equal(getRotationSnapPresetId(custom), "custom");
+  });
+});
+
+describe("getRotationSnapIncrements", () => {
+  it("default increments equal SNAP_COARSE / SNAP_FINE so #39 snapping cannot regress", () => {
+    const inc = getRotationSnapIncrements(DEFAULT_ROTATION_SNAP_SETTINGS);
+    assert.ok(Math.abs(inc.coarse - SNAP_COARSE) < 1e-12, `coarse ${inc.coarse}`);
+    assert.ok(Math.abs(inc.fine - SNAP_FINE) < 1e-12, `fine ${inc.fine}`);
+  });
+});

--- a/src/components/settings/rotationSnapPreferences.ts
+++ b/src/components/settings/rotationSnapPreferences.ts
@@ -1,0 +1,217 @@
+import {
+  SNAP_COARSE,
+  SNAP_FINE,
+  type SnapTickConfig,
+} from '@/components/gizmo/rotate/snapRotation';
+
+/** Role of a tier: coarse/fine drive the snap increments; visual is ticks-only. */
+export type SnapTierRole = 'coarse' | 'fine' | 'visual';
+
+/** One configurable tier — pairs a tick interval with its snap/visual role. */
+export interface SnapTier {
+  /** Interval in whole degrees (must be a positive integer that divides 360). */
+  degrees: number;
+  /** Tick length as a fraction of the major tick length (derived from role). */
+  lengthMult: number;
+  role: SnapTierRole;
+}
+
+/** Rotation snap configuration: exactly one tier per role. */
+export interface RotationSnapSettings {
+  tiers: SnapTier[];
+}
+
+export const ROTATION_SNAP_STORAGE_KEY = 'dragonfruit:rotation-snap-ticks';
+const ROTATION_SNAP_EVENT = 'dragonfruit:rotation-snap-ticks-changed';
+
+const DEG_TO_RAD = Math.PI / 180;
+
+/** Tick length per role: coarse (major) longest, visual (minor) shortest. */
+const ROLE_LENGTH_MULT: Record<SnapTierRole, number> = {
+  coarse: 1.0,
+  fine: 0.6,
+  visual: 0.3,
+};
+
+const ROLES: SnapTierRole[] = ['coarse', 'fine', 'visual'];
+
+/** Default tiers: 45 / 15 / 5 degrees (the common slicer default; nesting-valid). */
+export const DEFAULT_ROTATION_SNAP_SETTINGS: RotationSnapSettings = {
+  tiers: [
+    { degrees: 45, lengthMult: 1.0, role: 'coarse' },
+    { degrees: 15, lengthMult: 0.6, role: 'fine' },
+    { degrees: 5, lengthMult: 0.3, role: 'visual' },
+  ],
+};
+
+/** Built-in presets. All nesting-valid; users wanting off-grid intervals use Custom. */
+export const ROTATION_SNAP_PRESETS = {
+  standard: DEFAULT_ROTATION_SNAP_SETTINGS,
+  fine: {
+    tiers: [
+      { degrees: 15, lengthMult: 1.0, role: 'coarse' },
+      { degrees: 5, lengthMult: 0.6, role: 'fine' },
+      { degrees: 1, lengthMult: 0.3, role: 'visual' },
+    ],
+  },
+} satisfies Record<string, RotationSnapSettings>;
+
+export type RotationSnapPresetId = keyof typeof ROTATION_SNAP_PRESETS | 'custom';
+
+/** Accepted interval bounds (degrees) for any tier. */
+export const MIN_TIER_DEGREES = 1;
+export const MAX_TIER_DEGREES = 360;
+
+/**
+ * A whole number of degrees within the accepted range. Custom tiers may be ANY
+ * such value — they need not divide 360. Non-tiling values just leave a small
+ * gap at the wrap; that is the user's choice and the preview reflects it.
+ */
+function isValidDegrees(degrees: unknown): degrees is number {
+  return (
+    typeof degrees === 'number' &&
+    Number.isInteger(degrees) &&
+    degrees >= MIN_TIER_DEGREES &&
+    degrees <= MAX_TIER_DEGREES
+  );
+}
+
+/**
+ * Validate untrusted settings (e.g. parsed from localStorage). Requires exactly
+ * three tiers — one each of coarse/fine/visual — whose degrees are whole numbers
+ * in [1, 360]. lengthMult is always derived from the role, so a tampered value
+ * cannot desync the visuals. Any violation falls back to the default. Arbitrary
+ * (non-360-dividing, non-nesting) Custom values are accepted by design.
+ */
+export function normalizeRotationSnapSettings(input: unknown): RotationSnapSettings {
+  if (!input || typeof input !== 'object') return DEFAULT_ROTATION_SNAP_SETTINGS;
+
+  const tiers = (input as Partial<RotationSnapSettings>).tiers;
+  if (!Array.isArray(tiers) || tiers.length !== 3) return DEFAULT_ROTATION_SNAP_SETTINGS;
+
+  const degreesByRole = new Map<SnapTierRole, number>();
+  for (const tier of tiers) {
+    if (!tier || typeof tier !== 'object') return DEFAULT_ROTATION_SNAP_SETTINGS;
+    const { role, degrees } = tier as Partial<SnapTier>;
+    if (role !== 'coarse' && role !== 'fine' && role !== 'visual') {
+      return DEFAULT_ROTATION_SNAP_SETTINGS;
+    }
+    if (degreesByRole.has(role)) return DEFAULT_ROTATION_SNAP_SETTINGS; // duplicate role
+    if (!isValidDegrees(degrees)) return DEFAULT_ROTATION_SNAP_SETTINGS;
+    degreesByRole.set(role, degrees);
+  }
+  if (degreesByRole.size !== 3) return DEFAULT_ROTATION_SNAP_SETTINGS; // a role was missing
+
+  return {
+    tiers: ROLES.map((role) => ({
+      role,
+      degrees: degreesByRole.get(role) as number,
+      lengthMult: ROLE_LENGTH_MULT[role],
+    })),
+  };
+}
+
+const degreesForRole = (settings: RotationSnapSettings, role: SnapTierRole): number | undefined =>
+  settings.tiers.find((tier) => tier.role === role)?.degrees;
+
+/** Map the role-based settings to the tier-interval shape getSnapTicks expects. */
+export function toSnapTickConfig(settings: RotationSnapSettings): SnapTickConfig {
+  return {
+    majorDeg: degreesForRole(settings, 'coarse') ?? 45,
+    mediumDeg: degreesForRole(settings, 'fine') ?? 15,
+    minorDeg: degreesForRole(settings, 'visual') ?? 5,
+  };
+}
+
+/**
+ * The active snap increments (radians) from the config. Falls back to the
+ * SNAP_COARSE/SNAP_FINE constants if a role is somehow absent, so the gizmo's
+ * modifier-key snapping (#39) can never regress to no-snap.
+ */
+export function getRotationSnapIncrements(settings: RotationSnapSettings): {
+  coarse: number;
+  fine: number;
+} {
+  const coarseDeg = degreesForRole(settings, 'coarse');
+  const fineDeg = degreesForRole(settings, 'fine');
+  return {
+    coarse: coarseDeg != null ? coarseDeg * DEG_TO_RAD : SNAP_COARSE,
+    fine: fineDeg != null ? fineDeg * DEG_TO_RAD : SNAP_FINE,
+  };
+}
+
+/** Per-role interval degrees, for display (tooltip, labels). */
+export function getRotationSnapDegrees(settings: RotationSnapSettings): {
+  coarse: number;
+  fine: number;
+  visual: number;
+} {
+  return {
+    coarse: degreesForRole(settings, 'coarse') ?? 45,
+    fine: degreesForRole(settings, 'fine') ?? 15,
+    visual: degreesForRole(settings, 'visual') ?? 5,
+  };
+}
+
+/** Which built-in preset these settings match, or 'custom'. */
+export function getRotationSnapPresetId(settings: RotationSnapSettings): RotationSnapPresetId {
+  for (const key of Object.keys(ROTATION_SNAP_PRESETS) as (keyof typeof ROTATION_SNAP_PRESETS)[]) {
+    const preset = ROTATION_SNAP_PRESETS[key];
+    const matchesAll = (['coarse', 'fine', 'visual'] as SnapTierRole[]).every(
+      (role) => degreesForRole(preset, role) === degreesForRole(settings, role),
+    );
+    if (matchesAll) return key;
+  }
+  return 'custom';
+}
+
+/** Human-readable preset labels. */
+export const ROTATION_SNAP_PRESET_LABELS: Record<RotationSnapPresetId, string> = {
+  standard: 'Standard',
+  fine: 'Fine',
+  custom: 'Custom',
+};
+
+export function getSavedRotationSnapSettings(): RotationSnapSettings {
+  if (typeof window === 'undefined') return DEFAULT_ROTATION_SNAP_SETTINGS;
+
+  try {
+    const raw = window.localStorage.getItem(ROTATION_SNAP_STORAGE_KEY);
+    if (!raw) return DEFAULT_ROTATION_SNAP_SETTINGS;
+    return normalizeRotationSnapSettings(JSON.parse(raw));
+  } catch {
+    return DEFAULT_ROTATION_SNAP_SETTINGS;
+  }
+}
+
+export function saveRotationSnapSettings(settings: RotationSnapSettings): void {
+  if (typeof window === 'undefined') return;
+
+  const normalized = normalizeRotationSnapSettings(settings);
+
+  try {
+    window.localStorage.setItem(ROTATION_SNAP_STORAGE_KEY, JSON.stringify(normalized));
+  } catch {
+    // ignore storage failures
+  }
+
+  window.dispatchEvent(new CustomEvent(ROTATION_SNAP_EVENT, { detail: normalized }));
+}
+
+export function subscribeToRotationSnapSettings(listener: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const onStorage = (event: StorageEvent) => {
+    if (event.key && event.key !== ROTATION_SNAP_STORAGE_KEY) return;
+    listener();
+  };
+  const onCustom = () => listener();
+
+  window.addEventListener('storage', onStorage);
+  window.addEventListener(ROTATION_SNAP_EVENT, onCustom as EventListener);
+
+  return () => {
+    window.removeEventListener('storage', onStorage);
+    window.removeEventListener(ROTATION_SNAP_EVENT, onCustom as EventListener);
+  };
+}


### PR DESCRIPTION
## Summary
Adds a **Transform** settings tab to configure the rotation gizmo's tick intervals and snap increments, building on #103.

## Implementation
- **`rotationSnapPreferences.ts`**: localStorage-backed config mirroring `view3dPreferences` (typed settings + defensive `normalize` + `getSaved`/`save`/`subscribe` + custom event). One `SnapTier` per role (coarse/fine/visual) is the single source of truth for **both** tick visuals and snap increments. `normalize()` accepts any whole-degree interval in `[1,360]`, requires exactly one of each role, and derives `lengthMult` from role so it cannot desync. Helpers: `getRotationSnapIncrements` / `toSnapTickConfig` / `getRotationSnapDegrees` / `getRotationSnapPresetId`.
- **`TransformSettingsTab.tsx`**: self-contained tab (SceneAutosave pattern) — **Standard** (45/15/5) / **Fine** (15/5/1) presets + clickable **Custom** (seeds 45/15/5, free whole-degree entry) + in-tab SVG live preview.
- **`SettingsModal.tsx`**: registers the Transform tab.
- **`GizmoRotation.tsx`**: reads configured coarse/fine increments via a synced ref in the pointermove path (falls back to `SNAP_COARSE`/`SNAP_FINE`, so #39 modifier-key snapping cannot regress) and passes the tick config to `SnapTickMarks`, subscribing for live updates.
- **`RotationHintTooltip.tsx`**: shows the live increments and current preset name.

## Notes
- **Stacked on #103** (base branch `feat/103-rotation-tick-marks`); GitHub will retarget this to `dev` once #103 merges.
- Custom mode permits arbitrary intervals by design; the in-tab preview is the feedback channel.

## Tests
`normalize` / preset / role-mapping / increment / preset-id units (`node:test`). Type-check + eslint clean. Built and ran in `tauri dev`.

Closes #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
