### PR TITLE
feat: Add toggleable auto-repair option and update related settings

### DIFF
--- a/src/components/settings/GeneralSettingsTab.tsx
+++ b/src/components/settings/GeneralSettingsTab.tsx
@@ -334,6 +334,37 @@ export function GeneralSettingsTab({
           <div className="flex items-center justify-between gap-3">
             <div>
               <div className="text-xs font-semibold" style={{ color: 'var(--text-strong)' }}>
+                Auto-Repair
+              </div>
+              <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                Automatically runs native mesh auto-repair for standard mesh imports.
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => onImportDefaultsChange({ ...importDefaults, autoRepair: !importDefaults.autoRepair })}
+              className="h-10 min-w-[92px] rounded-md border px-3 text-[12px] font-semibold uppercase tracking-wide transition-colors"
+              style={importDefaults.autoRepair
+                ? {
+                    borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
+                    background: 'color-mix(in srgb, var(--accent), var(--surface-0) 76%)',
+                    color: 'color-mix(in srgb, var(--accent), var(--text-strong) 25%)',
+                  }
+                : {
+                    borderColor: 'var(--border-subtle)',
+                    background: 'var(--surface-1)',
+                    color: 'var(--text-muted)',
+                  }}
+            >
+              {importDefaults.autoRepair ? 'ON' : 'OFF'}
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-2 rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-xs font-semibold" style={{ color: 'var(--text-strong)' }}>
                 Auto-Repair Scenes
               </div>
               <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>

--- a/src/features/scene/__tests__/importDefaultsPreferences.test.ts
+++ b/src/features/scene/__tests__/importDefaultsPreferences.test.ts
@@ -75,12 +75,14 @@ test('normalizeImportDefaultsSettings falls back to safe defaults', () => {
     raftBottomMode: 'invalid',
     raftWallEnabled: 'yes',
     rootsEnabled: 123,
+    autoRepair: 'no',
     autoRepairScenes: 'no',
   });
 
   assert.equal(normalized.raftBottomMode, 'solid');
   assert.equal(normalized.raftWallEnabled, true);
   assert.equal(normalized.rootsEnabled, true);
+  assert.equal(normalized.autoRepair, false);
   assert.equal(normalized.autoRepairScenes, false);
 });
 
@@ -89,9 +91,11 @@ test('normalizeImportDefaultsSettings preserves explicit auto repair toggle', ()
     raftBottomMode: 'solid',
     raftWallEnabled: true,
     rootsEnabled: true,
+    autoRepair: false,
     autoRepairScenes: false,
   });
 
+  assert.equal(normalized.autoRepair, false);
   assert.equal(normalized.autoRepairScenes, false);
 });
 
@@ -100,12 +104,14 @@ test('normalizeImportDefaultsSettings enforces roots enabled for line raft mode 
     raftBottomMode: 'line',
     raftWallEnabled: true,
     rootsEnabled: false,
+    autoRepair: false,
     autoRepairScenes: false,
   });
 
   assert.equal(normalized.raftBottomMode, 'line');
   assert.equal(normalized.raftWallEnabled, true);
   assert.equal(normalized.rootsEnabled, true);
+  assert.equal(normalized.autoRepair, false);
   assert.equal(normalized.autoRepairScenes, false);
 });
 
@@ -114,11 +120,13 @@ test('normalizeImportDefaultsSettings keeps wall preference when raft mode is no
     raftBottomMode: 'off',
     raftWallEnabled: false,
     rootsEnabled: true,
+    autoRepair: true,
     autoRepairScenes: true,
   });
 
   assert.equal(normalized.raftBottomMode, 'off');
   assert.equal(normalized.raftWallEnabled, false);
+  assert.equal(normalized.autoRepair, true);
   assert.equal(normalized.autoRepairScenes, true);
 });
 
@@ -128,6 +136,7 @@ test('applyImportDefaultsToSupportPayload keeps payload unchanged when roots are
     raftBottomMode: 'line',
     raftWallEnabled: true,
     rootsEnabled: true,
+    autoRepair: true,
     autoRepairScenes: true,
   };
 
@@ -141,6 +150,7 @@ test('applyImportDefaultsToSupportPayload aligns root diameter to trunk diameter
     raftBottomMode: 'line',
     raftWallEnabled: true,
     rootsEnabled: false,
+    autoRepair: true,
     autoRepairScenes: true,
   };
 
@@ -158,6 +168,7 @@ test('getImportDefaultsRaftPatch disables wall when raft base is off', () => {
     raftBottomMode: 'off',
     raftWallEnabled: true,
     rootsEnabled: false,
+    autoRepair: true,
     autoRepairScenes: true,
   });
 
@@ -170,6 +181,7 @@ test('getImportDefaultsRaftPatch disables wall when raft base is line', () => {
     raftBottomMode: 'line',
     raftWallEnabled: true,
     rootsEnabled: true,
+    autoRepair: true,
     autoRepairScenes: true,
   });
 

--- a/src/features/scene/importDefaultsPreferences.ts
+++ b/src/features/scene/importDefaultsPreferences.ts
@@ -5,6 +5,7 @@ export type ImportDefaultsSettings = {
   raftBottomMode: RaftBottomMode;
   raftWallEnabled: boolean;
   rootsEnabled: boolean;
+  autoRepair: boolean;
   autoRepairScenes: boolean;
 };
 
@@ -14,6 +15,7 @@ export const DEFAULT_IMPORT_DEFAULTS_SETTINGS: ImportDefaultsSettings = {
   raftBottomMode: 'solid',
   raftWallEnabled: true,
   rootsEnabled: true,
+  autoRepair: false,
   autoRepairScenes: false,
 };
 
@@ -42,6 +44,9 @@ export function normalizeImportDefaultsSettings(value: unknown): ImportDefaultsS
       ? raw.raftWallEnabled
       : DEFAULT_IMPORT_DEFAULTS_SETTINGS.raftWallEnabled,
     rootsEnabled,
+    autoRepair: typeof raw.autoRepair === 'boolean'
+      ? raw.autoRepair
+      : DEFAULT_IMPORT_DEFAULTS_SETTINGS.autoRepair,
     autoRepairScenes: typeof raw.autoRepairScenes === 'boolean'
       ? raw.autoRepairScenes
       : DEFAULT_IMPORT_DEFAULTS_SETTINGS.autoRepairScenes,

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -1942,6 +1942,7 @@ export function useSceneCollectionManager() {
         try {
           console.log(`[SceneCollection] Loading ${file.name}...`);
           const geom = await loadMeshGeometry(url, file.name, {
+            nativeProcessingMode: getSavedImportDefaultsSettings().autoRepair ? 'auto' : 'none',
             onNativeProcessingStage: (stage) => {
               if (stage === 'repairing') {
                 setImportProgress({


### PR DESCRIPTION
This PR adds the ability for the user to decide if auto-repairs should be executed for imported meshes. Auto-repair now defaults to Disabled.

<img width="1664" height="940" alt="image" src="https://github.com/user-attachments/assets/af266d5c-fa6d-46c4-9bc2-9d8c519bf289" />

Closes #174