### PR TITLE
feat: supports pathfinding v3

### DIFF
--- a/docs/dev/support-pathfinding-v3.md
+++ b/docs/dev/support-pathfinding-v3.md
@@ -1,0 +1,371 @@
+# Support Pathfinding V3
+
+This page documents the support pathfinding pipeline used by `SmartPlacementV2`.
+
+It focuses on:
+
+- the order in which rules run
+- what each rule is allowed to change
+- the mathematical criteria used during rescue and validation
+- how debug tuning changes the solver when enabled
+
+## Overview
+
+Support pathfinding resolves a placement from a user hover/click into a valid support chain:
+
+1. choose a socket position near the model contact point
+2. determine whether the cone is valid or needs rescue
+3. confirm the shaft can reach the roots plane without collision
+4. search for a routed chain when the straight path fails
+5. simplify and revalidate the route
+6. snap the base to a legal committed root location
+
+The solver is intentionally layered so cheaper checks run first and more expensive checks only run when necessary.
+
+## The pathfinding chain
+
+The main solver path is executed in this order:
+
+1. **Standard placement baseline**
+   - compute the default socket and bottom position
+   - if the placement is already invalid by a non-routing rule, return immediately
+
+2. **SDF cache refresh**
+   - refresh the per-mesh signed-distance cache matrix
+   - all subsequent collision checks reuse this cache
+
+3. **Cone feasibility and cone rescue**
+   - test whether the nominal contact cone is clear
+   - if blocked, try cone-clear socket seeds and rescue variants
+
+4. **Straight path checks**
+   - check direct shaft clearance
+   - check root disk fit at the base
+   - if both pass, return a straight support
+
+5. **Spatial fast-fail caches**
+   - if the current socket is already known to stagnate, skip A*
+   - if preview mode already exhausted budget near this position, skip A*
+
+6. **Fine A***
+   - run the 0.25 mm grid search with the fine budget
+
+7. **Wide A***
+   - if fine A* fails, retry with the 0.6 mm grid and a wider budget
+
+8. **Post-search simplification and straightening**
+   - remove unnecessary joints
+   - optionally attempt zero-joint or one-joint reductions
+
+9. **Final validation**
+   - ensure each chain segment is collision-free
+   - ensure final angles and crack-span rules still hold
+
+10. **Commit base snapping**
+    - resolve the best legal root position for the final chain
+
+## Rule ordering and priority
+
+The solver is deliberately greedy about cheap rejection first.
+
+### 1. Cone rules
+
+The cone is the first major gate because if the support cannot legally touch the model, routing effort is wasted.
+
+Cone rescue may shift the socket laterally before any routing work begins.
+
+### 2. Straight path rules
+
+If the cone is valid, the solver checks whether the shaft can go straight down without clipping and whether the roots disk fits at the base.
+
+This is the cheapest fully valid outcome, so it wins immediately if it passes.
+
+### 3. Routing rules
+
+Only after straight placement fails does the solver spend budget on A* and rescue geometry.
+
+### 4. Final safety gates
+
+Even a candidate that reaches the goal still gets rechecked segment-by-segment.
+
+This prevents a route from surviving due to search heuristics alone.
+
+## Core geometry rules
+
+### Shaft clearance
+
+The solver uses a clearance value:
+
+$$
+\text{clearance} = \frac{\text{shaft diameter}}{2} + \text{collision avoidance margin}
+$$
+
+This clearance is passed into segment collision checks.
+
+### Roots fit check
+
+The roots are valid at $(x, y)$ only if the swept root disk volume does not intersect the model.
+
+At a high level, the roots volume is sampled across the disk section and the cone section, and a position is rejected if any sampled point is blocked.
+
+### Straight path rule
+
+Let $S$ be the socket position and $R$ be the root-top target.
+
+The straight path is valid if:
+
+$$
+\neg \text{segmentBlocked}(S, R)
+$$
+
+and
+
+$$
+\neg \text{rootsBlocked}(R_{xy})
+$$
+
+If both are true, the support is returned with no routing joints.
+
+## Cone rescue math
+
+The cone rescue system tries to keep the tip shape short and near-normal while still finding a usable socket.
+
+### Cone length
+
+Let the cone start after tip thickness compensation be $C_0$ and the socket be $S$.
+
+$$
+L_{cone} = \lVert S - C_0 \rVert
+$$
+
+The added cone length is:
+
+$$
+\Delta L = \max(0, L_{cone} - L_{ref})
+$$
+
+where $L_{ref}$ is the original reference cone length.
+
+### Cone angle
+
+Let $n$ be the surface normal and $a$ be the final cone axis.
+
+The angle from surface normal is:
+
+$$
+\theta = \arccos\left(\operatorname{clamp}(a \cdot n, -1, 1)\right)
+$$
+
+converted to degrees.
+
+### Cone penalty score
+
+The cone rescue ranking uses a weighted score that prefers short, minimally distorted cones.
+
+In simplified form:
+
+$$
+J_{cone} = J_{angle} + J_{worsen} + J_{length} + J_{direction}
+$$
+
+where:
+
+$$
+J_{length} = w_1 d + w_2 d^2 + w_3 d^3
+$$
+
+with $d$ being the excess cone stretch above the reference length.
+
+The angular terms penalize both absolute shallowness and worsening relative to the nominal cone.
+
+### Stretch limit
+
+The cone is considered over-stretched if:
+
+$$
+\Delta L > L_{ref} \cdot r_{max}
+$$
+
+where $r_{max}$ is the cone stretch ratio cap.
+
+### Disk axis limit
+
+For disk tips, the final cone axis angle must also satisfy:
+
+$$
+\theta \le \theta_{max}
+$$
+
+where $\theta_{max}$ is the disk cone axis limit.
+
+## Search envelope math
+
+The routing envelope determines how far the solver is allowed to search laterally.
+
+### Envelope construction
+
+Let the vertical span be:
+
+$$
+V = \max(0, z_{socket} - z_{rootTop})
+$$
+
+The unclamped lateral limit is:
+
+$$
+L_{unclamped} = \max\left(L_{min},\; 15\,\text{spacing},\; 3V\right)
+$$
+
+The final lateral cap is:
+
+$$
+L_{max} = \min(L_{hard}, L_{unclamped})
+$$
+
+The rescue sweep radii are then generated from a fixed sweep table and clamped so they do not exceed $L_{max}$.
+
+## A* search math
+
+### Grid steps
+
+The solver uses two search grids:
+
+- **fine pass**: $0.25\,\text{mm}$
+- **wide pass**: $0.6\,\text{mm}$
+
+The wide pass is a fallback for large detours and rescue routes.
+
+### Expansion budgets
+
+The number of allowed expansions scales with grid step so the solver keeps roughly comparable search reach:
+
+$$
+E = \operatorname{round}\left(\frac{B_{2mm} \cdot 2}{s}\right)
+$$
+
+where:
+
+- $B_{2mm}$ is the base budget expressed at 2 mm step size
+- $s$ is the active grid step size
+
+### A* objective
+
+The search is still a feasibility search first and a quality search second.
+
+It prefers routes that:
+
+1. reach the root target
+2. stay collision-free
+3. avoid excessive lateral drift
+4. avoid upward motion where possible
+5. remain valid under the final angle gates
+
+## Final route validation
+
+After A* and simplification, the solver validates the final chain segment by segment.
+
+Let the final points be:
+
+$$
+[P_0, P_1, \dots, P_n]
+$$
+
+with $P_0$ the socket and $P_n$ the root-top target.
+
+For every segment $(P_i, P_{i+1})$:
+
+$$
+\neg \text{segmentBlocked}(P_i, P_{i+1})
+$$
+
+and
+
+$$
+\angle(P_i, P_{i+1}) \le \angle_{max}
+$$
+
+must hold.
+
+## Crack-span rule
+
+If the route has two or more joints, the solver checks the routing Z span:
+
+$$
+Z_{span} = z_{socket} - z_{lowestJoint}
+$$
+
+If:
+
+$$
+Z_{span} < Z_{min}
+$$
+
+the route is rejected as too crack-like.
+
+This prevents supports from being squeezed through narrow voids that are likely to be unstable or physically misleading.
+
+## Debug tuning behavior
+
+The debug tuning mode activated by `M` is intentionally separate from the baseline defaults.
+
+### Baseline defaults
+
+The current baseline already uses the tuned values for practical pathfinding.
+
+### Extra debug tuning
+
+When enabled, `M` applies an extra layer that makes the solver more forgiving:
+
+- slightly larger search envelope
+- slightly more rescue radii
+- slightly larger cone seed range
+- extra A* expansions
+- lower collision avoidance margin
+- slightly looser max segment angle
+- looser crack-span rejection
+- more permissive cone stretch and cone-axis gating
+
+This mode is for interactive exploration and tuning, not for permanently lowering production safety rules.
+
+## Blocked-path diagnostics
+
+When a path fails, the debug overlay records the main reason(s) and suggests which rule family to tune:
+
+- cone blocked
+- cone rescue failed
+- A* stagnated
+- A* hit expansion budget
+- no valid root target reached
+- base resolution failed
+- crack-span rejection
+- angle validation failure
+- segment collision in final validation
+
+These are designed to be actionable rather than just descriptive.
+
+## Practical tuning order
+
+If a model still fails, tune in this order:
+
+1. **cone rescue** first
+2. **search envelope and budgets** second
+3. **clearance and angle gates** third
+4. **crack-span rule** last
+
+That order gives the best chance of improving success without hiding real collision problems.
+
+## Implementation references
+
+- `src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts`
+- `src/supports/PlacementLogic/Pathfinding/pathfindingDebugState.ts`
+- `src/components/scene/SupportPathfindingDebugOverlay.tsx`
+
+## Summary
+
+Support Pathfinding V3 is a layered feasibility solver:
+
+- geometry first
+- routing second
+- simplification and validation last
+
+The new debug tooling makes it easier to see which rule blocked a placement and whether the solver should be tuned by adjusting cone rescue, search breadth, or final safety gates.

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,9 @@
+window.MathJax = {
+      tex: {
+            inlineMath: [['\\(', '\\)']],
+            displayMath: [['\\[', '\\]']],
+      },
+      options: {
+            skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code'],
+      },
+};

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,8 @@ extra_css:
   - stylesheets/dragonfruit-theme.css
 extra_javascript:
   - javascripts/homepage-release-feed.js
+  - javascripts/mathjax.js
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 plugins:
   - search
   - meta
@@ -39,6 +41,9 @@ markdown_extensions:
   - admonition
   - attr_list
   - tables
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.superfences
   - toc:
       permalink: true
 nav:
@@ -74,6 +79,7 @@ nav:
       - Plugin Framework: dev/plugins-framework.md
       - Complex Plugin Contributing: dev/plugins-complex-contributing.md
       - Support System: dev/support-system.md
+      - Support Pathfinding V3: dev/support-pathfinding-v3.md
       - Branch Supports: dev/branch-supports.md
       - Grid and Branching: dev/grid-and-branching.md
       - Raft Geometry: dev/raft-geometry.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dragonfruit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dragonfruit",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@msgpack/msgpack": "^3.1.2",
         "@react-three/drei": "^10.7.6",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
-import { AlertTriangle, CheckCircle2, ChevronDown, Download, LayoutGrid, Loader2, Maximize2, Minimize2, Play, Printer, Redo2, RefreshCw, Trash2, Undo2, Wrench, X } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, ChevronDown, Download, LayoutGrid, Loader2, Maximize2, Minimize2, Plus, Printer, Redo2, RefreshCw, Trash2, Undo2, Wrench, X } from 'lucide-react';
 import { SceneCanvas } from '@/components/scene/SceneCanvas';
 import { FloatingPanelStack } from '@/components/layout/FloatingPanelStack';
 import { TopBar } from '@/components/layout/TopBar';
@@ -156,12 +156,14 @@ import {
   savePrintArtifactWithNativeDialog,
   writeBytesToNativePath,
 } from '@/features/slicing/tauri/nativeSlicerBridge';
-import { subscribe as subscribeSupportState, getSnapshot as getSupportSnapshot, transformSupportsForModel } from '@/supports/state';
+import { subscribe as subscribeSupportState, getSnapshot as getSupportSnapshot, toggleSegmentCurve, transformSupportsForModel, updateTrunk, updateBranch, updateTwig, updateStick } from '@/supports/state';
 import {
   getKickstandSnapshot,
   subscribeToKickstandStore,
 } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 import { bracePlacementStore } from '@/supports/SupportTypes/Brace/bracePlacementState';
+import { splitShaft, splitBranchShaft, splitTwigShaft, splitStickShaft } from '@/supports/SupportPrimitives/Joint/jointUtils';
+import { captureSupportEditSnapshot, pushSupportEditHistory } from '@/supports/history/supportEditHistory';
 import { getRaftSettings, subscribeToRaftStore } from '@/supports/Rafts/Crenelated/RaftState';
 import { computeFootprint } from '@/supports/Rafts/Crenelated/geometry/computeFootprint';
 import { computeRaftOuterBoundary } from '@/supports/Rafts/Crenelated/geometry/computeRaftOuterBoundary';
@@ -1117,6 +1119,10 @@ export default function Home() {
   const [prepareSmoothingSettingsExpanded, setPrepareSmoothingSettingsExpanded] = React.useState(true);
   const [debugPrimitivesPanelVisible, setDebugPrimitivesPanelVisible] = React.useState<boolean>(false);
   const [editorContextMenuPos, setEditorContextMenuPos] = React.useState<{ x: number; y: number } | null>(null);
+  const [editorContextMenuSupportTarget, setEditorContextMenuSupportTarget] = React.useState<{
+    segmentId: string;
+    point: { x: number; y: number; z: number };
+  } | null>(null);
   const [manualRepairModelId, setManualRepairModelId] = React.useState<string | null>(null);
   const [isManualRepairing, setIsManualRepairing] = React.useState(false);
   const [isDiagnosticsOpen, setIsDiagnosticsOpen] = React.useState(false);
@@ -2594,6 +2600,83 @@ export default function Home() {
   const cameraResumeTimeoutRef = React.useRef<number | null>(null);
   const { getHotkey } = useHotkeyConfig();
   const supportSpotlightHoldHotkey = getHotkey('SUPPORTS', 'TEMP_SPOTLIGHT_HOLD');
+
+  const supportMenuSnapshot = React.useSyncExternalStore(
+    subscribeSupportState,
+    getSupportSnapshot,
+    getSupportSnapshot,
+  );
+
+  const supportMenuSelection = React.useMemo(() => {
+    const selectedId = supportMenuSnapshot.selectedId;
+    return {
+      selectedId,
+      selectedCategory: supportMenuSnapshot.selectedCategory,
+      isBraceSelected: Boolean(selectedId && supportMenuSnapshot.braces[selectedId]),
+    };
+  }, [supportMenuSnapshot]);
+
+  const supportsCanToggleCurve = React.useMemo(() => {
+    if (scene.mode !== 'support') return false;
+    if (supportMenuSelection.selectedCategory === 'segment' && supportMenuSelection.selectedId) return true;
+    return supportMenuSelection.isBraceSelected;
+  }, [scene.mode, supportMenuSelection.isBraceSelected, supportMenuSelection.selectedCategory, supportMenuSelection.selectedId]);
+
+  const supportContextMenuSegmentOwner = React.useMemo(() => {
+    const segmentId = editorContextMenuSupportTarget?.segmentId;
+    if (!segmentId) return null;
+
+    const trunk = Object.values(supportMenuSnapshot.trunks).find((item) => item.segments.some((segment) => segment.id === segmentId));
+    if (trunk) return { kind: 'trunk' as const, id: trunk.id };
+
+    const branch = Object.values(supportMenuSnapshot.branches).find((item) => item.segments.some((segment) => segment.id === segmentId));
+    if (branch) return { kind: 'branch' as const, id: branch.id };
+
+    const twig = Object.values(supportMenuSnapshot.twigs).find((item) => item.segments.some((segment) => segment.id === segmentId));
+    if (twig) return { kind: 'twig' as const, id: twig.id };
+
+    const stick = Object.values(supportMenuSnapshot.sticks).find((item) => item.segments.some((segment) => segment.id === segmentId));
+    if (stick) return { kind: 'stick' as const, id: stick.id };
+
+    return null;
+  }, [editorContextMenuSupportTarget?.segmentId, supportMenuSnapshot.branches, supportMenuSnapshot.sticks, supportMenuSnapshot.trunks, supportMenuSnapshot.twigs]);
+
+  const supportsCanAddJoint = React.useMemo(() => {
+    if (scene.mode !== 'support') return false;
+    if (!editorContextMenuSupportTarget?.segmentId || !editorContextMenuSupportTarget.point) return false;
+    return supportContextMenuSegmentOwner !== null;
+  }, [editorContextMenuSupportTarget, scene.mode, supportContextMenuSegmentOwner]);
+
+  const supportContextMenuItems = React.useMemo(() => {
+    return [
+      {
+        id: 'supports-toggle-curve' as const,
+        label: 'Toggle Curve',
+        icon: RefreshCw,
+      },
+      {
+        id: 'supports-add-joint' as const,
+        label: 'Add Joint',
+        icon: Plus,
+      },
+    ];
+  }, []);
+
+  const editorContextMenuTitle = scene.mode === 'support' ? 'Supports' : 'Editor';
+  const editorContextMenuItems = scene.mode === 'support' ? supportContextMenuItems : undefined;
+  const editorContextMenuDisabledActions = React.useMemo(() => {
+    if (scene.mode === 'support') {
+      return [
+        ...(!supportsCanToggleCurve ? (['supports-toggle-curve'] as const) : []),
+        ...(!supportsCanAddJoint ? (['supports-add-joint'] as const) : []),
+      ];
+    }
+
+    return [
+      ...(!scene.activeModelId ? (['delete', 'cut', 'copy', 'repair'] as const) : []),
+      ...(!scene.canPasteModel ? (['paste'] as const) : []),
+    ];
+  }, [scene.activeModelId, scene.canPasteModel, scene.mode, supportsCanAddJoint, supportsCanToggleCurve]);
 
   const clearPrintingLayerPreviewUrls = React.useCallback(() => {
     printingLayerPreviewLoadInFlightRef.current.clear();
@@ -9149,6 +9232,7 @@ export default function Home() {
 
   const closeEditorContextMenu = React.useCallback(() => {
     setEditorContextMenuPos(null);
+    setEditorContextMenuSupportTarget(null);
   }, []);
 
   const handleEditorContextMenu = React.useCallback((e: React.MouseEvent<HTMLDivElement>) => {
@@ -9651,6 +9735,14 @@ export default function Home() {
     const moved = Boolean(gesture?.moved);
     const shouldSuppress = performance.now() < suppressEditorContextMenuUntilRef.current;
     if (!moved && !shouldSuppress) {
+      if (scene.mode === 'support' && supportShaftHoverDebug.segmentId && supportShaftHoverDebug.point) {
+        setEditorContextMenuSupportTarget({
+          segmentId: supportShaftHoverDebug.segmentId,
+          point: supportShaftHoverDebug.point,
+        });
+      } else {
+        setEditorContextMenuSupportTarget(null);
+      }
       setEditorContextMenuPos({ x: e.clientX, y: e.clientY });
     }
 
@@ -9658,7 +9750,7 @@ export default function Home() {
     window.setTimeout(() => {
       rightClickGestureRef.current = null;
     }, 0);
-  }, []);
+  }, [scene.mode, supportShaftHoverDebug.point, supportShaftHoverDebug.segmentId]);
 
   React.useEffect(() => {
     const markSuppressed = (durationMs: number) => {
@@ -9678,7 +9770,186 @@ export default function Home() {
   }, []);
 
   const handleEditorMenuAction = React.useCallback((action: EditorMenuAction) => {
+    const projectSplitPoint = (
+      start: { x: number; y: number; z: number },
+      end: { x: number; y: number; z: number },
+      point: { x: number; y: number; z: number },
+    ) => {
+      const startVec = new THREE.Vector3(start.x, start.y, start.z);
+      const endVec = new THREE.Vector3(end.x, end.y, end.z);
+      const pointVec = new THREE.Vector3(point.x, point.y, point.z);
+      const lineDir = endVec.clone().sub(startVec);
+      const lenSq = lineDir.lengthSq();
+      if (lenSq <= 1e-10) {
+        return {
+          t: 0,
+          point: { x: startVec.x, y: startVec.y, z: startVec.z },
+        };
+      }
+
+      const rawT = pointVec.clone().sub(startVec).dot(lineDir) / lenSq;
+      const t = Math.max(0, Math.min(1, rawT));
+      const projected = startVec.clone().lerp(endVec, t);
+      return {
+        t,
+        point: { x: projected.x, y: projected.y, z: projected.z },
+      };
+    };
+
+    const projectBezierSplitPoint = (
+      start: { x: number; y: number; z: number },
+      control1: { x: number; y: number; z: number },
+      control2: { x: number; y: number; z: number },
+      end: { x: number; y: number; z: number },
+      point: { x: number; y: number; z: number },
+    ) => {
+      const target = new THREE.Vector3(point.x, point.y, point.z);
+      let bestT = 0;
+      let bestPoint = start;
+      let bestDistanceSq = Number.POSITIVE_INFINITY;
+
+      const steps = 40;
+      for (let i = 0; i <= steps; i++) {
+        const t = i / steps;
+        const sample = getBezierPointAtT(start, control1, control2, end, t);
+        const sampleVec = new THREE.Vector3(sample.x, sample.y, sample.z);
+        const distanceSq = sampleVec.distanceToSquared(target);
+        if (distanceSq < bestDistanceSq) {
+          bestDistanceSq = distanceSq;
+          bestT = t;
+          bestPoint = sample;
+        }
+      }
+
+      return {
+        t: bestT,
+        point: bestPoint,
+      };
+    };
+
     switch (action) {
+      case 'supports-toggle-curve': {
+        const state = getSupportSnapshot();
+        if (state.selectedCategory === 'segment' && state.selectedId) {
+          toggleSegmentCurve(state.selectedId);
+        } else if (state.selectedId && state.braces[state.selectedId]) {
+          toggleSegmentCurve(`braceSegment:${state.selectedId}`);
+        }
+        break;
+      }
+      case 'supports-add-joint': {
+        const target = editorContextMenuSupportTarget;
+        if (!target?.segmentId || !target.point) break;
+
+        const state = getSupportSnapshot();
+        const segmentId = target.segmentId;
+        const splitTargetPoint = target.point;
+        const beforeSnapshot = captureSupportEditSnapshot();
+
+        const trunk = Object.values(state.trunks).find((item) => item.segments.some((segment) => segment.id === segmentId));
+        if (trunk) {
+          const segmentIndex = trunk.segments.findIndex((segment) => segment.id === segmentId);
+          if (segmentIndex >= 0) {
+            const segment = trunk.segments[segmentIndex];
+            const root = state.roots[trunk.rootId];
+            let start = segment.bottomJoint?.pos;
+            if (!start) {
+              if (segmentIndex === 0 && root) {
+                start = {
+                  x: root.transform.pos.x,
+                  y: root.transform.pos.y,
+                  z: root.transform.pos.z + root.diskHeight + root.coneHeight,
+                };
+              } else {
+                start = trunk.segments[segmentIndex - 1]?.topJoint?.pos;
+              }
+            }
+
+            const end = segment.topJoint?.pos
+              ?? (trunk.contactCone ? getFinalSocketPosition(trunk.contactCone) : null)
+              ?? (start ? { x: start.x, y: start.y, z: start.z + 10 } : null);
+
+            if (start && end) {
+              const projected = segment.type === 'bezier'
+                ? projectBezierSplitPoint(start, segment.controlPoint1, segment.controlPoint2, end, splitTargetPoint)
+                : projectSplitPoint(start, end, splitTargetPoint);
+              const updated = splitShaft(trunk, segmentId, projected.point, projected.t, root);
+              updateTrunk(updated);
+              pushSupportEditHistory('Create trunk joint', beforeSnapshot, captureSupportEditSnapshot());
+            }
+          }
+          break;
+        }
+
+        const branch = Object.values(state.branches).find((item) => item.segments.some((segment) => segment.id === segmentId));
+        if (branch) {
+          const segmentIndex = branch.segments.findIndex((segment) => segment.id === segmentId);
+          if (segmentIndex >= 0) {
+            const segment = branch.segments[segmentIndex];
+            const parentKnot = state.knots[branch.parentKnotId];
+            const start = segmentIndex === 0
+              ? (parentKnot?.pos ?? segment.bottomJoint?.pos ?? null)
+              : (branch.segments[segmentIndex - 1]?.topJoint?.pos ?? segment.bottomJoint?.pos ?? null);
+            const end = segment.topJoint?.pos
+              ?? (branch.contactCone ? getFinalSocketPosition(branch.contactCone) : null)
+              ?? (start ? { x: start.x, y: start.y, z: start.z + 5 } : null);
+
+            if (start && end) {
+              const projected = segment.type === 'bezier'
+                ? projectBezierSplitPoint(start, segment.controlPoint1, segment.controlPoint2, end, splitTargetPoint)
+                : projectSplitPoint(start, end, splitTargetPoint);
+              const updated = splitBranchShaft(branch, segmentId, projected.point, projected.t, parentKnot);
+              updateBranch(updated);
+              pushSupportEditHistory('Create branch joint', beforeSnapshot, captureSupportEditSnapshot());
+            }
+          }
+          break;
+        }
+
+        const twig = Object.values(state.twigs).find((item) => item.segments.some((segment) => segment.id === segmentId));
+        if (twig) {
+          const segmentIndex = twig.segments.findIndex((segment) => segment.id === segmentId);
+          if (segmentIndex >= 0) {
+            const segment = twig.segments[segmentIndex];
+            const start = segmentIndex === 0
+              ? (segment.bottomJoint?.pos ?? null)
+              : (twig.segments[segmentIndex - 1]?.topJoint?.pos ?? segment.bottomJoint?.pos ?? null);
+            const end = segment.topJoint?.pos ?? (start ? { x: start.x, y: start.y, z: start.z + 5 } : null);
+
+            if (start && end) {
+              const projected = segment.type === 'bezier'
+                ? projectBezierSplitPoint(start, segment.controlPoint1, segment.controlPoint2, end, splitTargetPoint)
+                : projectSplitPoint(start, end, splitTargetPoint);
+              const updated = splitTwigShaft(twig, segmentId, projected.point, projected.t);
+              updateTwig(updated);
+              pushSupportEditHistory('Create twig joint', beforeSnapshot, captureSupportEditSnapshot());
+            }
+          }
+          break;
+        }
+
+        const stick = Object.values(state.sticks).find((item) => item.segments.some((segment) => segment.id === segmentId));
+        if (stick) {
+          const segmentIndex = stick.segments.findIndex((segment) => segment.id === segmentId);
+          if (segmentIndex >= 0) {
+            const segment = stick.segments[segmentIndex];
+            const start = segmentIndex === 0
+              ? (segment.bottomJoint?.pos ?? null)
+              : (stick.segments[segmentIndex - 1]?.topJoint?.pos ?? segment.bottomJoint?.pos ?? null);
+            const end = segment.topJoint?.pos ?? (start ? { x: start.x, y: start.y, z: start.z + 5 } : null);
+
+            if (start && end) {
+              const projected = segment.type === 'bezier'
+                ? projectBezierSplitPoint(start, segment.controlPoint1, segment.controlPoint2, end, splitTargetPoint)
+                : projectSplitPoint(start, end, splitTargetPoint);
+              const updated = splitStickShaft(stick, segmentId, projected.point, projected.t);
+              updateStick(updated);
+              pushSupportEditHistory('Create stick joint', beforeSnapshot, captureSupportEditSnapshot());
+            }
+          }
+        }
+        break;
+      }
       case 'delete':
         if (scene.activeModelId) {
           scene.deleteModel(scene.activeModelId);
@@ -15371,10 +15642,9 @@ export default function Home() {
       <EditorContextMenu
         position={editorContextMenuPos}
         onAction={handleEditorMenuAction}
-        disabledActions={[
-          ...(!scene.activeModelId ? (['delete', 'cut', 'copy', 'repair'] as const) : []),
-          ...(!scene.canPasteModel ? (['paste'] as const) : []),
-        ]}
+        title={editorContextMenuTitle}
+        items={editorContextMenuItems}
+        disabledActions={editorContextMenuDisabledActions}
       />
 
       <DiagnosticsModal

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
-import { AlertTriangle, CheckCircle2, ChevronDown, Download, LayoutGrid, Loader2, Maximize2, Minimize2, Plus, Printer, Redo2, RefreshCw, Trash2, Undo2, Wrench, X } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, ChevronDown, Download, LayoutGrid, Loader2, Maximize2, Minimize2, Play, Plus, Printer, Redo2, RefreshCw, Trash2, Undo2, Wrench, X } from 'lucide-react';
 import { SceneCanvas } from '@/components/scene/SceneCanvas';
 import { FloatingPanelStack } from '@/components/layout/FloatingPanelStack';
 import { TopBar } from '@/components/layout/TopBar';

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -126,7 +126,7 @@ import {
 import { computeLowestZ } from '@/utils/geometry';
 import { quaternionFromGlobalEuler } from '@/utils/rotation';
 import { emitImmediateModelHover } from '@/supports/interaction/pointerOcclusion';
-import { SupportPathfindingDebugOverlay } from '@/components/scene/SupportPathfindingDebugOverlay';
+import { SupportPathfindingDebugHud, SupportPathfindingDebugOverlay } from '@/components/scene/SupportPathfindingDebugOverlay';
 import {
   getSupportPathfindingDebugState,
   subscribeToSupportPathfindingDebugState,
@@ -6346,6 +6346,10 @@ export function SceneCanvas({
         {children}
       </Canvas>
 
+      {mode === 'support' && supportPathfindingDebugState.enabled && (
+        <SupportPathfindingDebugHud snapshot={supportPathfindingDebugState.snapshot} />
+      )}
+
       <SceneMoodOverlay />
 
       {frozenViewportDataUrl && freezeViewportActive && (
@@ -6410,9 +6414,9 @@ export function SceneCanvas({
 
       {/* Support Limitation Tooltip Overlay */}
       <SupportLimitationFeedback
-        error={suppressSupportPlacementPreviewRendering ? null : (leafPlacementPreview?.error ?? (isBranchPlacementActive ? branchPlacementPreview?.error : null) ?? trunkPlacementPreview?.error ?? null)}
+        error={suppressSupportPlacementPreviewRendering || supportPathfindingDebugState.enabled ? null : (leafPlacementPreview?.error ?? (isBranchPlacementActive ? branchPlacementPreview?.error : null) ?? trunkPlacementPreview?.error ?? null)}
         warning={
-          suppressSupportPlacementPreviewRendering
+          suppressSupportPlacementPreviewRendering || supportPathfindingDebugState.enabled
             ? null
             : (
               leafPlacementPreview?.warning ??

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -126,6 +126,12 @@ import {
 import { computeLowestZ } from '@/utils/geometry';
 import { quaternionFromGlobalEuler } from '@/utils/rotation';
 import { emitImmediateModelHover } from '@/supports/interaction/pointerOcclusion';
+import { SupportPathfindingDebugOverlay } from '@/components/scene/SupportPathfindingDebugOverlay';
+import {
+  getSupportPathfindingDebugState,
+  subscribeToSupportPathfindingDebugState,
+  toggleSupportPathfindingDebugEnabled,
+} from '@/supports/PlacementLogic/Pathfinding/pathfindingDebugState';
 
 const Canvas = dynamic(() => import('@react-three/fiber').then(m => m.Canvas), { ssr: false });
 
@@ -270,6 +276,7 @@ type CrossSectionCapDebugPanelState = {
 
 const CROSS_SECTION_CAP_DEBUG_STORAGE_KEY = 'df:cross-section-cap-debug:v4';
 const CROSS_SECTION_CAP_DEBUG_HOTKEY_ENABLED = false;
+const SUPPORT_PATHFINDING_DEBUG_DOUBLE_TAP_WINDOW_MS = 420;
 
 const DEFAULT_CROSS_SECTION_CAP_DEBUG_STATE: CrossSectionCapDebugPanelState = {
   enabled: false,
@@ -551,6 +558,12 @@ export function SceneCanvas({
   const LARGE_MODEL_DROP_DEFER_THRESHOLD_POLYS = 1_200_000;
   const BUILD_VOLUME_BOUNDS_EPS_MM = 0.01;
   const OUT_OF_BOUNDS_ROTATE_GRACE_MS = 320;
+  const supportPathfindingDebugState = React.useSyncExternalStore(
+    subscribeToSupportPathfindingDebugState,
+    getSupportPathfindingDebugState,
+    getSupportPathfindingDebugState,
+  );
+  const supportPathfindingDebugLastTapMsRef = React.useRef<number>(0);
 
   const [isLightTheme, setIsLightTheme] = React.useState(() => {
     if (typeof window === 'undefined') return false;
@@ -3625,6 +3638,48 @@ export function SceneCanvas({
     };
   }, [activeModelId, mode, onActiveModelChange, selectedModelIds]);
 
+  React.useEffect(() => {
+    if (mode !== 'support') {
+      supportPathfindingDebugLastTapMsRef.current = 0;
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.repeat) return;
+      if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;
+
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      const isTypingContext = !!target && (
+        target.isContentEditable
+        || tag === 'INPUT'
+        || tag === 'TEXTAREA'
+        || tag === 'SELECT'
+      );
+      if (isTypingContext) return;
+
+      const isJHotkey = event.code === 'KeyJ' || event.key.toLowerCase() === 'j';
+      if (!isJHotkey) return;
+
+      const nowMs = performance.now();
+      const elapsedMs = nowMs - supportPathfindingDebugLastTapMsRef.current;
+      supportPathfindingDebugLastTapMsRef.current = nowMs;
+
+      if (elapsedMs > SUPPORT_PATHFINDING_DEBUG_DOUBLE_TAP_WINDOW_MS) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      toggleSupportPathfindingDebugEnabled();
+      supportPathfindingDebugLastTapMsRef.current = 0;
+    };
+
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, true);
+    };
+  }, [mode]);
+
   // Handle canvas background clicks (deselect support)
   const handleCanvasClick = React.useCallback(
     (e: React.MouseEvent) => {
@@ -6284,6 +6339,9 @@ export function SceneCanvas({
           plateDepthMm={activeBuildVolumeSettings.depthMm}
         />
         <CameraFocusController selectedIslandId={overlaySelectedIslandId ?? null} islandMarkers={islandMarkers ?? []} />
+        {mode === 'support' && supportPathfindingDebugState.enabled && (
+          <SupportPathfindingDebugOverlay snapshot={supportPathfindingDebugState.snapshot} />
+        )}
         {/* Selection outline effect - rendered by SelectionOutlineRenderer inside SelectionProvider */}
         {children}
       </Canvas>

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -131,6 +131,7 @@ import {
   getSupportPathfindingDebugState,
   subscribeToSupportPathfindingDebugState,
   toggleSupportPathfindingDebugEnabled,
+  toggleSupportPathfindingDebugTuningEnabled,
 } from '@/supports/PlacementLogic/Pathfinding/pathfindingDebugState';
 
 const Canvas = dynamic(() => import('@react-three/fiber').then(m => m.Canvas), { ssr: false });
@@ -564,6 +565,7 @@ export function SceneCanvas({
     getSupportPathfindingDebugState,
   );
   const supportPathfindingDebugLastTapMsRef = React.useRef<number>(0);
+  const [showSupportPathfindingTuningSuggestions, setShowSupportPathfindingTuningSuggestions] = React.useState(false);
 
   const [isLightTheme, setIsLightTheme] = React.useState(() => {
     if (typeof window === 'undefined') return false;
@@ -3641,6 +3643,7 @@ export function SceneCanvas({
   React.useEffect(() => {
     if (mode !== 'support') {
       supportPathfindingDebugLastTapMsRef.current = 0;
+      setShowSupportPathfindingTuningSuggestions(false);
       return;
     }
 
@@ -3658,6 +3661,15 @@ export function SceneCanvas({
         || tag === 'SELECT'
       );
       if (isTypingContext) return;
+
+      const isMHotkey = event.code === 'KeyM' || event.key.toLowerCase() === 'm';
+      if (isMHotkey && supportPathfindingDebugState.enabled) {
+        event.preventDefault();
+        event.stopPropagation();
+        toggleSupportPathfindingDebugTuningEnabled();
+        setShowSupportPathfindingTuningSuggestions((prev) => !prev);
+        return;
+      }
 
       const isJHotkey = event.code === 'KeyJ' || event.key.toLowerCase() === 'j';
       if (!isJHotkey) return;
@@ -3678,7 +3690,12 @@ export function SceneCanvas({
     return () => {
       window.removeEventListener('keydown', onKeyDown, true);
     };
-  }, [mode]);
+  }, [mode, supportPathfindingDebugState.enabled]);
+
+  React.useEffect(() => {
+    if (supportPathfindingDebugState.enabled) return;
+    setShowSupportPathfindingTuningSuggestions(false);
+  }, [supportPathfindingDebugState.enabled]);
 
   // Handle canvas background clicks (deselect support)
   const handleCanvasClick = React.useCallback(
@@ -6347,7 +6364,11 @@ export function SceneCanvas({
       </Canvas>
 
       {mode === 'support' && supportPathfindingDebugState.enabled && (
-        <SupportPathfindingDebugHud snapshot={supportPathfindingDebugState.snapshot} />
+        <SupportPathfindingDebugHud
+          snapshot={supportPathfindingDebugState.snapshot}
+          showTuningSuggestions={showSupportPathfindingTuningSuggestions}
+          tuningApplied={supportPathfindingDebugState.tuningEnabled}
+        />
       )}
 
       <SceneMoodOverlay />

--- a/src/components/scene/SupportPathfindingDebugOverlay.tsx
+++ b/src/components/scene/SupportPathfindingDebugOverlay.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as THREE from 'three';
 import type { Vec3 } from '@/supports/types';
 import type { GridAStarDebugPassSnapshot, SupportPathfindingDebugSnapshot } from '@/supports/PlacementLogic/Pathfinding/pathfindingDebugState';
 
@@ -56,23 +57,147 @@ function DebugLine({
   color: string;
   opacity: number;
 }) {
-  const positions = React.useMemo(() => buildPositionArray(points), [points]);
+  const line = React.useMemo(() => {
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(buildPositionArray(points), 3));
+    const material = new THREE.LineBasicMaterial({
+      color,
+      transparent: true,
+      opacity,
+      depthWrite: false,
+      depthTest: false,
+      toneMapped: false,
+    });
+    const object = new THREE.Line(geometry, material);
+    object.renderOrder = 1001;
+    object.frustumCulled = false;
+    return object;
+  }, [color, opacity, points]);
+
+  React.useEffect(() => () => {
+    line.geometry.dispose();
+    (line.material as THREE.Material).dispose();
+  }, [line]);
+
   if (points.length < 2) return null;
 
+  return <primitive object={line} />;
+}
+
+function fmtMm(value: number | undefined): string {
+  return value === undefined || !Number.isFinite(value) ? 'n/a' : `${value.toFixed(2)}mm`;
+}
+
+function fmtDeg(value: number | undefined): string {
+  return value === undefined || !Number.isFinite(value) ? 'n/a' : `${value.toFixed(1)}deg`;
+}
+
+function severityColor(severity: 'info' | 'success' | 'warning' | 'error'): string {
+  if (severity === 'success') return '#86efac';
+  if (severity === 'warning') return '#fde68a';
+  if (severity === 'error') return '#fca5a5';
+  return '#bfdbfe';
+}
+
+export function SupportPathfindingDebugHud({ snapshot }: { snapshot: SupportPathfindingDebugSnapshot | null }) {
+  if (!snapshot) return null;
+
+  const passLines = snapshot.passes.map((pass) => {
+    const flags = [
+      pass.reached ? 'reached' : 'miss',
+      pass.stagnated ? 'stagnated' : null,
+      pass.hitExpansionLimit ? 'budget' : null,
+    ].filter(Boolean).join(', ');
+    return `${pass.label}: ${flags} | exp ${pass.expansions} | step ${pass.searchStepMm}mm | raw ${pass.rawPath.length} simp ${pass.simplifiedPath.length}`;
+  });
+  const latestEvents = (snapshot.events ?? []).slice(-8);
+  const cone = snapshot.cone;
+  const outcome = snapshot.outcome;
+  const socketShift = snapshot.nominalSocketPos
+    ? Math.hypot(
+      snapshot.socketPos.x - snapshot.nominalSocketPos.x,
+      snapshot.socketPos.y - snapshot.nominalSocketPos.y,
+      snapshot.socketPos.z - snapshot.nominalSocketPos.z,
+    )
+    : 0;
+
   return (
-    <line renderOrder={1001} frustumCulled={false}>
-      <bufferGeometry>
-        <bufferAttribute attach="attributes-position" args={[positions, 3]} />
-      </bufferGeometry>
-      <lineBasicMaterial
-        color={color}
-        transparent
-        opacity={opacity}
-        depthWrite={false}
-        depthTest={false}
-        toneMapped={false}
-      />
-    </line>
+    <div
+      style={{
+        pointerEvents: 'none',
+        position: 'absolute',
+        left: 12,
+        top: 12,
+        zIndex: 64,
+        color: '#e5eefb',
+        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+        fontSize: 11,
+        lineHeight: 1.35,
+        width: 'min(360px, calc(100vw - 24px))',
+        maxHeight: 'min(42vh, 360px)',
+        overflow: 'hidden',
+        padding: '10px 12px',
+        borderRadius: 10,
+        background: 'linear-gradient(135deg, rgba(9, 14, 26, 0.92), rgba(21, 33, 53, 0.82))',
+        border: '1px solid rgba(148, 163, 184, 0.45)',
+        boxShadow: '0 16px 48px rgba(0,0,0,0.36)',
+        backdropFilter: 'blur(6px)',
+        whiteSpace: 'normal',
+      }}
+    >
+      <div style={{ color: '#f8fafc', fontWeight: 700, marginBottom: 6 }}>
+        Support Pathfinding Debug
+      </div>
+      <div>
+        <span style={{ color: '#94a3b8' }}>outcome:</span>{' '}
+        <span style={{ color: outcome?.status === 'blocked' ? '#fca5a5' : '#86efac' }}>
+          {outcome ? `${outcome.status} (${outcome.reason})` : 'pending'}
+        </span>
+      </div>
+      {cone && (
+        <div style={{ marginTop: 6 }}>
+          <div><span style={{ color: '#94a3b8' }}>cone:</span> nominal {cone.nominalClear ? 'clear' : 'blocked'}, active {cone.activeClear ? 'clear' : 'blocked'}</div>
+          <div>
+            <span style={{ color: '#94a3b8' }}>disk angle:</span>{' '}
+            <span style={{ color: cone.diskAngleLimitExceeded ? '#fca5a5' : '#e5eefb' }}>
+              {fmtDeg(cone.activeDiskAngleDeg)} / {fmtDeg(cone.maxDiskAngleDeg)}
+            </span>
+            {' '}<span style={{ color: '#94a3b8' }}>length:</span> {fmtMm(cone.activeConeLengthMm)}
+          </div>
+          <div><span style={{ color: '#94a3b8' }}>socket shift:</span> {fmtMm(socketShift)} <span style={{ color: '#94a3b8' }}>added cone:</span> {fmtMm(cone.activeAddedLengthMm)}</div>
+        </div>
+      )}
+      {snapshot.envelope && (
+        <div style={{ marginTop: 6 }}>
+          <span style={{ color: '#94a3b8' }}>envelope:</span> lateral {fmtMm(snapshot.envelope.maxTotalLateralMm)}, clearance {fmtMm(snapshot.envelope.clearanceMm)}, rescue radii {snapshot.envelope.rescueRadiiMm.length}
+        </div>
+      )}
+      {passLines.length > 0 && (
+        <div style={{ marginTop: 6 }}>
+          <div style={{ color: '#94a3b8' }}>passes:</div>
+          {passLines.map((line) => <div key={line}>{line}</div>)}
+        </div>
+      )}
+      {latestEvents.length > 0 && (
+        <div
+          style={{
+            marginTop: 6,
+            maxHeight: '124px',
+            overflow: 'hidden',
+            WebkitMaskImage: 'linear-gradient(to bottom, black 82%, transparent)',
+            maskImage: 'linear-gradient(to bottom, black 82%, transparent)',
+          }}
+        >
+          <div style={{ color: '#94a3b8' }}>events:</div>
+          {latestEvents.map((event, index) => (
+            <div key={`${event.stage}-${index}`}>
+              <span style={{ color: severityColor(event.severity) }}>{event.stage}</span>: {event.message}
+              {event.details ? <span style={{ color: '#94a3b8' }}> | {event.details}</span> : null}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -110,8 +235,10 @@ export function SupportPathfindingDebugOverlay({
       ? [{ x: snapshot.socketPos.x, y: snapshot.socketPos.y, z: snapshot.rootTopZ }]
       : []
   ), [snapshot]);
+  const basePoint = React.useMemo(() => (snapshot?.basePos ? [snapshot.basePos] : []), [snapshot]);
+  const finalChain = snapshot?.finalChain ?? [];
 
-  if (!snapshot || snapshot.passes.length === 0) return null;
+  if (!snapshot) return null;
 
   const finePass = snapshot.passes.find((pass) => pass.label === 'fine') ?? null;
   const widePass = snapshot.passes.find((pass) => pass.label === 'wide') ?? null;
@@ -120,6 +247,8 @@ export function SupportPathfindingDebugOverlay({
     <group name="support-pathfinding-debug-overlay">
       <DebugPoints points={socketPoint} color="#ff4fd8" size={11} opacity={1} />
       <DebugPoints points={rootTargetPoint} color="#5eead4" size={9} opacity={0.95} />
+      <DebugPoints points={basePoint} color="#f8fafc" size={8} opacity={0.95} />
+      <DebugLine points={finalChain} color="#ffffff" opacity={0.9} />
 
       {finePass && (
         <PassOverlay

--- a/src/components/scene/SupportPathfindingDebugOverlay.tsx
+++ b/src/components/scene/SupportPathfindingDebugOverlay.tsx
@@ -99,7 +99,76 @@ function severityColor(severity: 'info' | 'success' | 'warning' | 'error'): stri
   return '#bfdbfe';
 }
 
-export function SupportPathfindingDebugHud({ snapshot }: { snapshot: SupportPathfindingDebugSnapshot | null }) {
+function buildTuningSuggestions(snapshot: SupportPathfindingDebugSnapshot): string[] {
+  const suggestions: string[] = [];
+  const seen = new Set<string>();
+  const blockedReasons = snapshot.outcome?.blockedReasons ?? [];
+  const lowerReasons = blockedReasons.map((reason) => reason.toLowerCase());
+
+  const hasReason = (needle: string) => lowerReasons.some((reason) => reason.includes(needle));
+  const pushSuggestion = (text: string) => {
+    if (!text || seen.has(text)) return;
+    seen.add(text);
+    suggestions.push(text);
+  };
+
+  if (hasReason('contact cone blocked') || hasReason('cone-clear socket seed')) {
+    pushSuggestion('Expand cone-clear seed search (more angular samples and slightly larger lateral seed radius).');
+    pushSuggestion('Relax cone rescue limits a bit (disk-angle/cone-stretch) for hard overhang starts.');
+  }
+
+  if (hasReason('socket rescue fallback failed')) {
+    pushSuggestion('Increase mixed/straight socket rescue sweep radii and retry count.');
+  }
+
+  if (hasReason('stagnation') || hasReason('stagnated')) {
+    pushSuggestion('Increase lateral envelope (maxTotalLateralMm) to escape local cavities before declaring stagnation.');
+  }
+
+  if (hasReason('expansion budget') || snapshot.passes.some((pass) => pass.hitExpansionLimit)) {
+    pushSuggestion('Raise A* expansion budgets (fine/wide) or trigger wide-step fallback earlier.');
+  }
+
+  if (hasReason('no valid path reached root target')) {
+    pushSuggestion('Increase rescue radii coverage and allow a slightly wider routing angle envelope.');
+  }
+
+  if (hasReason('no valid committed base candidate') || hasReason('base candidate resolution failed')) {
+    pushSuggestion('Loosen base resolution constraints (node search rings / snap tolerance) near reachable root targets.');
+  }
+
+  if (hasReason('too short to form a support chain') || hasReason('path result was too short')) {
+    pushSuggestion('Adjust short-path acceptance threshold to keep valid micro-routes that pass collision checks.');
+  }
+
+  if (hasReason('compressed') || hasReason('z span')) {
+    pushSuggestion('Lower crack-rejection strictness (MIN_ROUTING_Z_SPAN_MM) incrementally for tight-but-valid routes.');
+  }
+
+  if (hasReason('violates max angle') || hasReason('angle validation')) {
+    pushSuggestion('Slightly relax max segment angle-from-vertical for routed supports only (keep final collision checks strict).');
+  }
+
+  if (hasReason('segment') && hasReason('collides')) {
+    pushSuggestion('If failures are near-surface only, reduce clearance margin slightly or improve segment simplification heuristics.');
+  }
+
+  if (suggestions.length === 0 && snapshot.outcome?.status === 'blocked') {
+    pushSuggestion('Collect a few blocked snapshots and tune the dominant reason cluster first (cone, search budget, or quality gate).');
+  }
+
+  return suggestions;
+}
+
+export function SupportPathfindingDebugHud({
+  snapshot,
+  showTuningSuggestions = false,
+  tuningApplied = false,
+}: {
+  snapshot: SupportPathfindingDebugSnapshot | null;
+  showTuningSuggestions?: boolean;
+  tuningApplied?: boolean;
+}) {
   if (!snapshot) return null;
 
   const passLines = snapshot.passes.map((pass) => {
@@ -113,6 +182,8 @@ export function SupportPathfindingDebugHud({ snapshot }: { snapshot: SupportPath
   const latestEvents = (snapshot.events ?? []).slice(-8);
   const cone = snapshot.cone;
   const outcome = snapshot.outcome;
+  const blockedReasons = outcome?.status === 'blocked' ? (outcome.blockedReasons ?? []) : [];
+  const tuningSuggestions = showTuningSuggestions ? buildTuningSuggestions(snapshot) : [];
   const socketShift = snapshot.nominalSocketPos
     ? Math.hypot(
       snapshot.socketPos.x - snapshot.nominalSocketPos.x,
@@ -134,8 +205,9 @@ export function SupportPathfindingDebugHud({ snapshot }: { snapshot: SupportPath
         fontSize: 11,
         lineHeight: 1.35,
         width: 'min(360px, calc(100vw - 24px))',
-        maxHeight: 'min(42vh, 360px)',
-        overflow: 'hidden',
+        maxHeight: 'min(60vh, 520px)',
+        overflowY: 'auto',
+        overflowX: 'hidden',
         padding: '10px 12px',
         borderRadius: 10,
         background: 'linear-gradient(135deg, rgba(9, 14, 26, 0.92), rgba(21, 33, 53, 0.82))',
@@ -154,6 +226,36 @@ export function SupportPathfindingDebugHud({ snapshot }: { snapshot: SupportPath
           {outcome ? `${outcome.status} (${outcome.reason})` : 'pending'}
         </span>
       </div>
+      <div style={{ marginTop: 4, color: '#94a3b8' }}>
+        {tuningApplied
+          ? 'Press M to disable extra debug tuning'
+          : 'Press M to enable extra debug tuning + suggestions'}
+      </div>
+      <div style={{ marginTop: 2, color: tuningApplied ? '#93c5fd' : '#64748b' }}>
+        defaults: tuned, extra tuning: {tuningApplied ? 'on' : 'off'}
+      </div>
+      {blockedReasons.length > 0 && (
+        <div style={{ marginTop: 6 }}>
+          <div style={{ color: '#fca5a5' }}>blocked reasons:</div>
+          {blockedReasons.slice(0, 5).map((reason) => (
+            <div key={reason} style={{ color: '#fecaca' }}>• {reason}</div>
+          ))}
+          {blockedReasons.length > 5 && (
+            <div style={{ color: '#94a3b8' }}>…and {blockedReasons.length - 5} more</div>
+          )}
+        </div>
+      )}
+      {showTuningSuggestions && tuningSuggestions.length > 0 && (
+        <div style={{ marginTop: 6 }}>
+          <div style={{ color: '#93c5fd' }}>tuning suggestions:</div>
+          {tuningSuggestions.slice(0, 6).map((suggestion) => (
+            <div key={suggestion} style={{ color: '#dbeafe' }}>• {suggestion}</div>
+          ))}
+          {tuningSuggestions.length > 6 && (
+            <div style={{ color: '#94a3b8' }}>…and {tuningSuggestions.length - 6} more</div>
+          )}
+        </div>
+      )}
       {cone && (
         <div style={{ marginTop: 6 }}>
           <div><span style={{ color: '#94a3b8' }}>cone:</span> nominal {cone.nominalClear ? 'clear' : 'blocked'}, active {cone.activeClear ? 'clear' : 'blocked'}</div>
@@ -183,9 +285,8 @@ export function SupportPathfindingDebugHud({ snapshot }: { snapshot: SupportPath
           style={{
             marginTop: 6,
             maxHeight: '124px',
-            overflow: 'hidden',
-            WebkitMaskImage: 'linear-gradient(to bottom, black 82%, transparent)',
-            maskImage: 'linear-gradient(to bottom, black 82%, transparent)',
+            overflowY: 'auto',
+            overflowX: 'hidden',
           }}
         >
           <div style={{ color: '#94a3b8' }}>events:</div>

--- a/src/components/scene/SupportPathfindingDebugOverlay.tsx
+++ b/src/components/scene/SupportPathfindingDebugOverlay.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import type { Vec3 } from '@/supports/types';
+import type { GridAStarDebugPassSnapshot, SupportPathfindingDebugSnapshot } from '@/supports/PlacementLogic/Pathfinding/pathfindingDebugState';
+
+function buildPositionArray(points: Vec3[]): Float32Array {
+  const positions = new Float32Array(points.length * 3);
+  for (let i = 0; i < points.length; i += 1) {
+    const point = points[i];
+    const base = i * 3;
+    positions[base] = point.x;
+    positions[base + 1] = point.y;
+    positions[base + 2] = point.z;
+  }
+  return positions;
+}
+
+function DebugPoints({
+  points,
+  color,
+  size,
+  opacity,
+}: {
+  points: Vec3[];
+  color: string;
+  size: number;
+  opacity: number;
+}) {
+  const positions = React.useMemo(() => buildPositionArray(points), [points]);
+  if (points.length === 0) return null;
+
+  return (
+    <points renderOrder={1000} frustumCulled={false}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[positions, 3]} />
+      </bufferGeometry>
+      <pointsMaterial
+        color={color}
+        size={size}
+        sizeAttenuation={false}
+        transparent
+        opacity={opacity}
+        depthWrite={false}
+        depthTest={false}
+        toneMapped={false}
+      />
+    </points>
+  );
+}
+
+function DebugLine({
+  points,
+  color,
+  opacity,
+}: {
+  points: Vec3[];
+  color: string;
+  opacity: number;
+}) {
+  const positions = React.useMemo(() => buildPositionArray(points), [points]);
+  if (points.length < 2) return null;
+
+  return (
+    <line renderOrder={1001} frustumCulled={false}>
+      <bufferGeometry>
+        <bufferAttribute attach="attributes-position" args={[positions, 3]} />
+      </bufferGeometry>
+      <lineBasicMaterial
+        color={color}
+        transparent
+        opacity={opacity}
+        depthWrite={false}
+        depthTest={false}
+        toneMapped={false}
+      />
+    </line>
+  );
+}
+
+function PassOverlay({
+  pass,
+  expandedColor,
+  frontierColor,
+  rawPathColor,
+  simplifiedPathColor,
+}: {
+  pass: GridAStarDebugPassSnapshot;
+  expandedColor: string;
+  frontierColor: string;
+  rawPathColor: string;
+  simplifiedPathColor: string;
+}) {
+  return (
+    <>
+      <DebugPoints points={pass.expandedNodes} color={expandedColor} size={4.5} opacity={0.22} />
+      <DebugPoints points={pass.frontierNodes} color={frontierColor} size={6.5} opacity={0.8} />
+      <DebugLine points={pass.rawPath} color={rawPathColor} opacity={0.45} />
+      <DebugLine points={pass.simplifiedPath} color={simplifiedPathColor} opacity={0.95} />
+    </>
+  );
+}
+
+export function SupportPathfindingDebugOverlay({
+  snapshot,
+}: {
+  snapshot: SupportPathfindingDebugSnapshot | null;
+}) {
+  const socketPoint = React.useMemo(() => (snapshot ? [snapshot.socketPos] : []), [snapshot]);
+  const rootTargetPoint = React.useMemo(() => (
+    snapshot
+      ? [{ x: snapshot.socketPos.x, y: snapshot.socketPos.y, z: snapshot.rootTopZ }]
+      : []
+  ), [snapshot]);
+
+  if (!snapshot || snapshot.passes.length === 0) return null;
+
+  const finePass = snapshot.passes.find((pass) => pass.label === 'fine') ?? null;
+  const widePass = snapshot.passes.find((pass) => pass.label === 'wide') ?? null;
+
+  return (
+    <group name="support-pathfinding-debug-overlay">
+      <DebugPoints points={socketPoint} color="#ff4fd8" size={11} opacity={1} />
+      <DebugPoints points={rootTargetPoint} color="#5eead4" size={9} opacity={0.95} />
+
+      {finePass && (
+        <PassOverlay
+          pass={finePass}
+          expandedColor="#f59e0b"
+          frontierColor="#fde68a"
+          rawPathColor="#f97316"
+          simplifiedPathColor="#22c55e"
+        />
+      )}
+
+      {widePass && (
+        <PassOverlay
+          pass={widePass}
+          expandedColor="#38bdf8"
+          frontierColor="#bfdbfe"
+          rawPathColor="#60a5fa"
+          simplifiedPathColor="#a855f7"
+        />
+      )}
+    </group>
+  );
+}

--- a/src/components/ui/EditorContextMenu.tsx
+++ b/src/components/ui/EditorContextMenu.tsx
@@ -15,7 +15,9 @@ export type EditorMenuAction =
   | 'cut'
   | 'copy'
   | 'paste'
-  | 'repair';
+  | 'repair'
+  | 'supports-toggle-curve'
+  | 'supports-add-joint';
 
 export type EditorContextMenuPosition = {
   x: number;
@@ -26,6 +28,8 @@ type EditorContextMenuProps = {
   position: EditorContextMenuPosition | null;
   onAction: (action: EditorMenuAction) => void;
   disabledActions?: EditorMenuAction[];
+  title?: string;
+  items?: MenuItemDef[];
 };
 
 type MenuItemDef = {
@@ -43,16 +47,18 @@ const MENU_ITEMS: MenuItemDef[] = [
 ];
 
 const MENU_WIDTH = 176;
-const MENU_HEIGHT = 200;
+const BASE_MENU_HEIGHT = 44;
+const MENU_ITEM_HEIGHT = 32;
 
-export function EditorContextMenu({ position, onAction, disabledActions = [] }: EditorContextMenuProps) {
+export function EditorContextMenu({ position, onAction, disabledActions = [], title = 'Editor', items = MENU_ITEMS }: EditorContextMenuProps) {
   if (!position) return null;
 
   const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1920;
   const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 1080;
 
+  const menuHeight = BASE_MENU_HEIGHT + (items.length * MENU_ITEM_HEIGHT);
   const left = Math.max(8, Math.min(position.x, viewportWidth - MENU_WIDTH - 8));
-  const top = Math.max(8, Math.min(position.y, viewportHeight - MENU_HEIGHT - 8));
+  const top = Math.max(8, Math.min(position.y, viewportHeight - menuHeight - 8));
 
   return (
     <div
@@ -70,10 +76,10 @@ export function EditorContextMenu({ position, onAction, disabledActions = [] }: 
       aria-label="Editor context menu"
     >
       <div className="mb-1 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-        Editor
+        {title}
       </div>
       <div className="space-y-0.5">
-        {MENU_ITEMS.map((item) => {
+        {items.map((item) => {
           const Icon = item.icon;
           const isDisabled = disabledActions.includes(item.id);
           return (

--- a/src/features/export/logic/ExportManager.ts
+++ b/src/features/export/logic/ExportManager.ts
@@ -919,11 +919,27 @@ export class ExportManager {
       const globalRaftSettings = getRaftSettings();
       if (globalRaftSettings.bottomMode !== 'off') {
         const supportState = getSnapshot();
+        const kickstandState = getKickstandSnapshot();
         const allRoots = Object.values(supportState.roots);
+        const allKickstandRoots = Object.values(kickstandState.roots);
 
         // Group roots by modelId so each model gets a separate raft
         const rootsByModel = new Map<string, typeof allRoots>();
         for (const root of allRoots) {
+          const rootModelId = root.modelId ?? null;
+          if (hasScopedModelFilter) {
+            if (!rootModelId || !scopedModelIds.has(rootModelId)) {
+              continue;
+            }
+          }
+
+          const mid = rootModelId ?? '__orphan__';
+          let arr = rootsByModel.get(mid);
+          if (!arr) { arr = []; rootsByModel.set(mid, arr); }
+          arr.push(root);
+        }
+
+        for (const root of allKickstandRoots) {
           const rootModelId = root.modelId ?? null;
           if (hasScopedModelFilter) {
             if (!rootModelId || !scopedModelIds.has(rootModelId)) {

--- a/src/features/scene/__tests__/importDefaultsPreferences.test.ts
+++ b/src/features/scene/__tests__/importDefaultsPreferences.test.ts
@@ -67,6 +67,50 @@ function makePayload(): DragonfruitImportFormat {
     sticks: [],
     braces: [],
     knots: [],
+    kickstands: [
+      {
+        root: {
+          id: 'kick-root-a',
+          modelId: 'm1',
+          transform: { pos: { x: -5, y: 0, z: 0 }, rot: { x: 0, y: 0, z: 0, w: 1 } },
+          diameter: 5,
+          diskHeight: 1,
+          coneHeight: 1,
+        },
+        hostKnot: {
+          id: 'kick-knot-a',
+          parentShaftId: 'seg-a',
+          t: 0.5,
+          pos: { x: 0, y: 0, z: 4 },
+          diameter: 1,
+        },
+        kickstand: {
+          id: 'kickstand-a',
+          modelId: 'm1',
+          rootId: 'kick-root-a',
+          hostKnotId: 'kick-knot-a',
+          hostSegmentId: 'seg-a',
+          hostMinT: 0,
+          segments: [
+            {
+              id: 'kick-seg-a',
+              type: 'straight',
+              diameter: 0.9,
+              topJoint: {
+                id: 'kick-ja',
+                pos: { x: -2, y: 0, z: 4 },
+                diameter: 0.9,
+              },
+            },
+          ],
+          profile: {
+            bodyDiameterMm: 0.9,
+            terminalStartDiameterMm: 0.9,
+            terminalEndDiameterMm: 1,
+          },
+        },
+      },
+    ],
   };
 }
 
@@ -159,8 +203,10 @@ test('applyImportDefaultsToSupportPayload aligns root diameter to trunk diameter
   assert.notEqual(next, payload);
   assert.equal(next.roots[0].diameter, 1.25);
   assert.equal(next.roots[1].diameter, 2.1);
+  assert.equal(next.kickstands?.[0]?.root.diameter, 0.9);
   assert.equal(payload.roots[0].diameter, 4, 'original payload must not be mutated');
   assert.equal(payload.roots[1].diameter, 7, 'original payload must not be mutated');
+  assert.equal(payload.kickstands?.[0]?.root.diameter, 5, 'original kickstand root must not be mutated');
 });
 
 test('getImportDefaultsRaftPatch disables wall when raft base is off', () => {

--- a/src/features/scene/importDefaultsPreferences.ts
+++ b/src/features/scene/importDefaultsPreferences.ts
@@ -92,11 +92,29 @@ function resolveTrunkDiameterMm(trunk: Trunk): number | null {
   return null;
 }
 
+function resolveKickstandDiameterMm(
+  build: NonNullable<DragonfruitImportFormat['kickstands']>[number],
+): number | null {
+  const firstSegmentDiameter = build.kickstand.segments[0]?.diameter;
+  if (typeof firstSegmentDiameter === 'number' && Number.isFinite(firstSegmentDiameter) && firstSegmentDiameter > 0) {
+    return firstSegmentDiameter;
+  }
+
+  const bodyDiameter = build.kickstand.profile.bodyDiameterMm;
+  if (typeof bodyDiameter === 'number' && Number.isFinite(bodyDiameter) && bodyDiameter > 0) {
+    return bodyDiameter;
+  }
+
+  return null;
+}
+
 export function applyImportDefaultsToSupportPayload(
   payload: DragonfruitImportFormat,
   defaults: ImportDefaultsSettings,
 ): DragonfruitImportFormat {
-  if (defaults.rootsEnabled || payload.roots.length === 0 || payload.trunks.length === 0) {
+  const kickstandBuilds = payload.kickstands ?? [];
+
+  if (defaults.rootsEnabled || (payload.roots.length === 0 && kickstandBuilds.length === 0)) {
     return payload;
   }
 
@@ -107,6 +125,15 @@ export function applyImportDefaultsToSupportPayload(
     const existing = rootDiameterById.get(trunk.rootId);
     if (existing == null || diameter > existing) {
       rootDiameterById.set(trunk.rootId, diameter);
+    }
+  }
+
+  for (const build of kickstandBuilds) {
+    const diameter = resolveKickstandDiameterMm(build);
+    if (diameter == null) continue;
+    const existing = rootDiameterById.get(build.root.id);
+    if (existing == null || diameter > existing) {
+      rootDiameterById.set(build.root.id, diameter);
     }
   }
 
@@ -128,6 +155,22 @@ export function applyImportDefaultsToSupportPayload(
     };
   });
 
+  const nextKickstands = kickstandBuilds.map((build) => {
+    const kickstandDiameter = rootDiameterById.get(build.root.id);
+    if (kickstandDiameter == null || build.root.diameter === kickstandDiameter) {
+      return build;
+    }
+
+    changed = true;
+    return {
+      ...build,
+      root: {
+        ...build.root,
+        diameter: kickstandDiameter,
+      },
+    };
+  });
+
   if (!changed) {
     return payload;
   }
@@ -135,6 +178,7 @@ export function applyImportDefaultsToSupportPayload(
   return {
     ...payload,
     roots: nextRoots,
+    kickstands: nextKickstands,
   };
 }
 

--- a/src/features/scene/voxl/__tests__/voxlSupportRoundtrip.test.ts
+++ b/src/features/scene/voxl/__tests__/voxlSupportRoundtrip.test.ts
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildSupportExportFromStores, buildVoxlDocumentV1, parseVoxlDocument, serializeVoxlDocument } from '../codec';
+import { getSnapshot, loadFromImportFormat, resetStore } from '@/supports/state';
+import { getKickstandSnapshot, resetKickstandStore } from '@/supports/SupportTypes/Kickstand/kickstandStore';
+import type { DragonfruitImportFormat } from '@/supports/types';
+
+function almostEqual(a: number, b: number, epsilon = 1e-6): boolean {
+    return Math.abs(a - b) <= epsilon;
+}
+
+test('VOXL support roundtrip preserves imported leaf and brace normalization intent', () => {
+    resetStore();
+    resetKickstandStore();
+
+    const imported: DragonfruitImportFormat = {
+        version: 1,
+        meta: {
+            source: 'unit-test',
+            objectCenter: { x: 0, y: 0, z: 0 },
+        },
+        roots: [
+            {
+                id: 'root-left',
+                modelId: 'model-1',
+                transform: { pos: { x: 0, y: 0, z: 0 }, rot: { x: 0, y: 0, z: 0, w: 1 } },
+                diameter: 6,
+                diskHeight: 1,
+                coneHeight: 1,
+            },
+            {
+                id: 'root-right',
+                modelId: 'model-1',
+                transform: { pos: { x: 12, y: 0, z: 0 }, rot: { x: 0, y: 0, z: 0, w: 1 } },
+                diameter: 6,
+                diskHeight: 1,
+                coneHeight: 1,
+            },
+        ],
+        trunks: [
+            {
+                id: 'trunk-left',
+                modelId: 'model-1',
+                rootId: 'root-left',
+                segments: [
+                    {
+                        id: 'seg-left',
+                        type: 'straight',
+                        diameter: 0.8,
+                        topJoint: { id: 'joint-left-top', pos: { x: 0, y: 0, z: 10 }, diameter: 0.9 },
+                    },
+                ],
+            },
+            {
+                id: 'trunk-right',
+                modelId: 'model-1',
+                rootId: 'root-right',
+                segments: [
+                    {
+                        id: 'seg-right',
+                        type: 'straight',
+                        diameter: 1.6,
+                        topJoint: { id: 'joint-right-top', pos: { x: 12, y: 0, z: 10 }, diameter: 1.7 },
+                    },
+                ],
+            },
+        ],
+        branches: [
+            {
+                id: 'branch-1',
+                modelId: 'model-1',
+                parentKnotId: 'k-parent',
+                segments: [
+                    {
+                        id: 'branch-seg-1',
+                        type: 'straight',
+                        diameter: 1,
+                        topJoint: {
+                            id: 'branch-top',
+                            pos: { x: 0, y: 0, z: 10 },
+                            diameter: 1,
+                        },
+                    },
+                ],
+            },
+        ],
+        leaves: [
+            {
+                id: 'leaf-1',
+                modelId: 'model-1',
+                parentKnotId: 'k-leaf',
+                contactCone: {
+                    id: 'cone-1',
+                    pos: { x: 2, y: 0, z: 12 },
+                    normal: { x: 0, y: 0, z: -1 },
+                    surfaceNormal: { x: 0, y: 0, z: -1 },
+                    profile: {
+                        type: 'disk',
+                        contactDiameterMm: 0.4,
+                        bodyDiameterMm: 1.2,
+                        lengthMm: 3,
+                        penetrationMm: 0.05,
+                        diskThicknessMm: 0.1,
+                        maxStandoffMm: 0.25,
+                        standoffAngleThreshold: Math.PI / 4,
+                    },
+                },
+            },
+        ],
+        twigs: [],
+        sticks: [],
+        braces: [
+            {
+                id: 'brace-1',
+                modelId: 'model-1',
+                startKnotId: 'k-left',
+                endKnotId: 'k-right',
+                profile: { diameter: 1.0 },
+            },
+        ],
+        anchors: [],
+        knots: [
+            {
+                id: 'k-parent',
+                parentShaftId: 'external-host',
+                pos: { x: 0, y: 0, z: 0 },
+                diameter: 1.1,
+            },
+            {
+                id: 'k-leaf',
+                parentShaftId: 'branch-seg-1',
+                t: 0,
+                pos: { x: 4, y: 2, z: 5 },
+                diameter: 1.1,
+                _importHint: 'project',
+            },
+            {
+                id: 'k-left',
+                parentShaftId: 'seg-left',
+                t: 0.5,
+                pos: { x: 0, y: 0, z: 5 },
+                diameter: 1.1,
+                _importHint: 'braceImported',
+            },
+            {
+                id: 'k-right',
+                parentShaftId: 'seg-right',
+                t: 0.5,
+                pos: { x: 12, y: 0, z: 5 },
+                diameter: 1.1,
+                _importHint: 'braceImported',
+            },
+        ],
+        kickstands: [],
+    };
+
+    loadFromImportFormat(imported);
+    const normalizedSnapshot = getSnapshot();
+
+    assert.strictEqual(normalizedSnapshot.knots['k-leaf']?.normalizationHint, 'project', 'Leaf knot should persist project intent after initial load');
+    assert.strictEqual(normalizedSnapshot.knots['k-left']?.normalizationHint, 'braceImported', 'Brace start knot should persist brace intent after initial load');
+    assert.strictEqual(normalizedSnapshot.knots['k-right']?.normalizationHint, 'braceImported', 'Brace end knot should persist brace intent after initial load');
+
+    const supports = buildSupportExportFromStores(normalizedSnapshot, getKickstandSnapshot());
+    const document = buildVoxlDocumentV1({
+        models: [
+            {
+                id: 'model-1',
+                name: 'Model 1',
+                visible: true,
+                color: '#ffffff',
+                polygonCount: 0,
+                transform: {
+                    position: { x: 0, y: 0, z: 0 },
+                    rotation: { x: 0, y: 0, z: 0 },
+                    scale: { x: 1, y: 1, z: 1 },
+                },
+            },
+        ],
+        activeModelId: 'model-1',
+        selectedModelIds: ['model-1'],
+        supports,
+    });
+
+    const serialized = serializeVoxlDocument(document, true, { compression: 'none' });
+    const parsed = parseVoxlDocument(serialized);
+
+    resetStore();
+    resetKickstandStore();
+    loadFromImportFormat(parsed.supports);
+
+    const roundTripped = getSnapshot();
+    const leafKnot = roundTripped.knots['k-leaf'];
+    const leftBraceKnot = roundTripped.knots['k-left'];
+    const rightBraceKnot = roundTripped.knots['k-right'];
+
+    assert.ok(leafKnot, 'Expected leaf host knot after VOXL roundtrip');
+    assert.ok(leftBraceKnot, 'Expected left brace host knot after VOXL roundtrip');
+    assert.ok(rightBraceKnot, 'Expected right brace host knot after VOXL roundtrip');
+
+    assert.strictEqual(leafKnot.normalizationHint, 'project', 'Leaf knot project intent should survive VOXL roundtrip');
+    assert.strictEqual(leftBraceKnot.normalizationHint, 'braceImported', 'Brace start knot intent should survive VOXL roundtrip');
+    assert.strictEqual(rightBraceKnot.normalizationHint, 'braceImported', 'Brace end knot intent should survive VOXL roundtrip');
+    assert.ok(almostEqual(leafKnot.pos.x, 0), 'Leaf knot X should stay projected after VOXL roundtrip');
+    assert.ok(almostEqual(leafKnot.pos.y, 0), 'Leaf knot Y should stay projected after VOXL roundtrip');
+    assert.ok(almostEqual(leafKnot.pos.z, 5), 'Leaf knot Z should stay projected after VOXL roundtrip');
+    assert.ok(almostEqual(leftBraceKnot.diameter ?? 0, 1.1), 'Brace start knot diameter should stay uniform after VOXL roundtrip');
+    assert.ok(almostEqual(rightBraceKnot.diameter ?? 0, 1.1), 'Brace end knot diameter should stay uniform after VOXL roundtrip');
+
+    resetStore();
+    resetKickstandStore();
+});

--- a/src/features/slicing/rasterLayerZipExport.ts
+++ b/src/features/slicing/rasterLayerZipExport.ts
@@ -1012,6 +1012,17 @@ function buildSupportAndRaftWorldTriangles(
       rootsByModel.set(modelKey, arr);
     }
 
+    for (const root of Object.values(kickstandState.roots)) {
+      const rootVisibleByModel = visibleModelIds.has(root.modelId);
+      const rootVisibleByLink = visibleRootIds.has(root.id);
+      if (!rootVisibleByModel && !rootVisibleByLink) continue;
+
+      const modelKey = rootModelKeyById.get(root.id) ?? root.modelId ?? `__root_${root.id}`;
+      const arr = rootsByModel.get(modelKey) ?? [];
+      arr.push({ x: root.transform.pos.x, y: root.transform.pos.y, r: root.diameter * 0.5 });
+      rootsByModel.set(modelKey, arr);
+    }
+
     for (const circles of rootsByModel.values()) {
       if (circles.length === 0) continue;
       const clampedChamfer = Math.min(90, Math.max(45, raft.chamferAngle));

--- a/src/hotkeys/hotkeyConfig.ts
+++ b/src/hotkeys/hotkeyConfig.ts
@@ -62,6 +62,10 @@ export const DEFAULT_KEYBINDINGS: HotkeyConfig = {
         TEMP_SPOTLIGHT_HOLD: {
             key: 'p',
             description: 'Hold to temporarily enable Spotlight highlight in Support mode'
+        },
+        FORCE_PLACE_SUPPORT: {
+            key: 'q',
+            description: 'Hold to force placing support'
         }
     },
     CAMERA: {

--- a/src/supports/PlacementLogic/CollisionAvoidance.ts
+++ b/src/supports/PlacementLogic/CollisionAvoidance.ts
@@ -1,6 +1,50 @@
 import * as THREE from 'three';
 import { Vec3 } from '../types';
 import { checkShaftCollision } from './CollisionUtils';
+import { SDFCache } from './Pathfinding/SDFCache';
+
+const sdfCacheByMeshUuid = new Map<string, SDFCache>();
+
+function getOrCreateCollisionSdf(mesh: THREE.Mesh): SDFCache | null {
+    const geometry = mesh.geometry as any;
+    if (!geometry?.boundsTree) {
+        return null;
+    }
+
+    const existing = sdfCacheByMeshUuid.get(mesh.uuid);
+    if (existing) {
+        existing.refreshMatrix();
+        return existing;
+    }
+
+    const sdf = new SDFCache(mesh, { cellSize: 0.25 });
+    sdf.refreshMatrix();
+    sdfCacheByMeshUuid.set(mesh.uuid, sdf);
+    return sdf;
+}
+
+function segmentBlockedWithBestAvailableMethod(
+    start: Vec3,
+    end: Vec3,
+    collisionRadius: number,
+    mesh: THREE.Mesh,
+): boolean {
+    const sdf = getOrCreateCollisionSdf(mesh);
+    if (sdf) {
+        return sdf.segmentBlocked(start.x, start.y, start.z, end.x, end.y, end.z, collisionRadius);
+    }
+
+    return checkShaftCollision(start, end, collisionRadius, mesh).hit;
+}
+
+export function isCollisionSegmentBlocked(
+    start: Vec3,
+    end: Vec3,
+    collisionRadius: number,
+    mesh: THREE.Mesh,
+): boolean {
+    return segmentBlockedWithBestAvailableMethod(start, end, collisionRadius, mesh);
+}
 
 /**
  * Calculates the required standoff distance (offset) from a surface to ensure
@@ -26,34 +70,43 @@ export function calculateSafeOffset(
     maxOffset: number,
     step: number = 0.2
 ): number {
-    let safeOffset = minOffset;
-    
     const start = new THREE.Vector3(surfacePos.x, surfacePos.y, surfacePos.z);
     const normal = new THREE.Vector3(surfaceNormal.x, surfaceNormal.y, surfaceNormal.z).normalize();
-    const target = new THREE.Vector3(targetPos.x, targetPos.y, targetPos.z); // Not used directly in loop but good for ref
-    
-    // Check initial position first
-    // Note: checkShaftCollision expects Vec3 inputs
-    
-    for (let t = minOffset; t <= maxOffset; t += step) {
+    const normalizedStep = Math.max(0.025, step);
+    let previousBlockedOffset = minOffset;
+
+    const testOffset = (offset: number): boolean => {
         // Calculate proposed start position: Surface + (Normal * t)
-        const testStartVec = start.clone().add(normal.clone().multiplyScalar(t));
+        const testStartVec = start.clone().add(normal.clone().multiplyScalar(offset));
         const testStart: Vec3 = { x: testStartVec.x, y: testStartVec.y, z: testStartVec.z };
-        
-        // Check collision from TestStart -> Target
-        const col = checkShaftCollision(testStart, targetPos, collisionRadius, mesh);
-        
-        if (!col.hit) {
-            // Found a safe path!
-            return t;
-        }
-        
-        // If hit, we continue loop to try next thickness
-        safeOffset = t;
+
+        return segmentBlockedWithBestAvailableMethod(testStart, targetPos, collisionRadius, mesh);
+    };
+
+    if (!testOffset(minOffset)) {
+        return minOffset;
     }
-    
-    // If we exhausted the loop without finding a clear path, returns the last checked (max) offset.
-    // Alternatively, return maxOffset explicitly if we want to cap it.
-    // Depending on step, safeOffset might be slightly less than maxOffset.
-    return Math.min(safeOffset + step, maxOffset); 
+
+    for (let t = minOffset + normalizedStep; t <= maxOffset + 0.000001; t += normalizedStep) {
+        const clampedOffset = Math.min(t, maxOffset);
+        if (!testOffset(clampedOffset)) {
+            let low = previousBlockedOffset;
+            let high = clampedOffset;
+
+            for (let i = 0; i < 6; i++) {
+                const mid = (low + high) / 2;
+                if (testOffset(mid)) {
+                    low = mid;
+                } else {
+                    high = mid;
+                }
+            }
+
+            return high;
+        }
+
+        previousBlockedOffset = clampedOffset;
+    }
+
+    return maxOffset;
 }

--- a/src/supports/PlacementLogic/CollisionAvoidance.ts
+++ b/src/supports/PlacementLogic/CollisionAvoidance.ts
@@ -4,6 +4,13 @@ import { checkShaftCollision } from './CollisionUtils';
 import { SDFCache } from './Pathfinding/SDFCache';
 
 const sdfCacheByMeshUuid = new Map<string, SDFCache>();
+const DEFAULT_FRUSTUM_SEGMENT_COUNT = 5;
+
+export interface CollisionFrustumProfile {
+    startRadius: number;
+    endRadius: number;
+    segmentCount?: number;
+}
 
 function getOrCreateCollisionSdf(mesh: THREE.Mesh): SDFCache | null {
     const geometry = mesh.geometry as any;
@@ -46,6 +53,47 @@ export function isCollisionSegmentBlocked(
     return segmentBlockedWithBestAvailableMethod(start, end, collisionRadius, mesh);
 }
 
+export function isCollisionFrustumBlocked(
+    start: Vec3,
+    end: Vec3,
+    startRadius: number,
+    endRadius: number,
+    mesh: THREE.Mesh,
+    segmentCount: number = DEFAULT_FRUSTUM_SEGMENT_COUNT,
+): boolean {
+    const normalizedStartRadius = Math.max(0.001, startRadius);
+    const normalizedEndRadius = Math.max(0.001, endRadius);
+
+    if (Math.abs(normalizedStartRadius - normalizedEndRadius) <= 0.000001) {
+        return segmentBlockedWithBestAvailableMethod(start, end, normalizedEndRadius, mesh);
+    }
+
+    const startVec = new THREE.Vector3(start.x, start.y, start.z);
+    const endVec = new THREE.Vector3(end.x, end.y, end.z);
+    const segmentTotal = Math.max(1, Math.round(segmentCount));
+
+    for (let i = 0; i < segmentTotal; i++) {
+        const t0 = i / segmentTotal;
+        const t1 = (i + 1) / segmentTotal;
+        const segStart = startVec.clone().lerp(endVec, t0);
+        const segEnd = startVec.clone().lerp(endVec, t1);
+        const radius0 = THREE.MathUtils.lerp(normalizedStartRadius, normalizedEndRadius, t0);
+        const radius1 = THREE.MathUtils.lerp(normalizedStartRadius, normalizedEndRadius, t1);
+        const sliceRadius = Math.max(radius0, radius1);
+
+        if (segmentBlockedWithBestAvailableMethod(
+            { x: segStart.x, y: segStart.y, z: segStart.z },
+            { x: segEnd.x, y: segEnd.y, z: segEnd.z },
+            sliceRadius,
+            mesh,
+        )) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 /**
  * Calculates the required standoff distance (offset) from a surface to ensure
  * a connecting element (like a cone) does not collide with the mesh.
@@ -68,7 +116,8 @@ export function calculateSafeOffset(
     mesh: THREE.Mesh,
     minOffset: number,
     maxOffset: number,
-    step: number = 0.2
+    step: number = 0.2,
+    collisionFrustum?: CollisionFrustumProfile,
 ): number {
     const start = new THREE.Vector3(surfacePos.x, surfacePos.y, surfacePos.z);
     const normal = new THREE.Vector3(surfaceNormal.x, surfaceNormal.y, surfaceNormal.z).normalize();
@@ -79,6 +128,17 @@ export function calculateSafeOffset(
         // Calculate proposed start position: Surface + (Normal * t)
         const testStartVec = start.clone().add(normal.clone().multiplyScalar(offset));
         const testStart: Vec3 = { x: testStartVec.x, y: testStartVec.y, z: testStartVec.z };
+
+        if (collisionFrustum) {
+            return isCollisionFrustumBlocked(
+                testStart,
+                targetPos,
+                collisionFrustum.startRadius,
+                collisionFrustum.endRadius,
+                mesh,
+                collisionFrustum.segmentCount,
+            );
+        }
 
         return segmentBlockedWithBestAvailableMethod(testStart, targetPos, collisionRadius, mesh);
     };

--- a/src/supports/PlacementLogic/ConeAxisPolicy.ts
+++ b/src/supports/PlacementLogic/ConeAxisPolicy.ts
@@ -1,6 +1,8 @@
 import * as THREE from 'three';
 import { Vec3 } from '../types';
 
+const MAX_CONE_AXIS_DEVIATION_FROM_SURFACE_NORMAL_DEG = 35;
+
 export interface ConeAxisPolicyInput {
     surfaceNormal: Vec3;
     coneAngleMode: 'normal' | 'locked' | 'adaptive';
@@ -89,6 +91,20 @@ export function resolveConeAxisPolicy(input: ConeAxisPolicyInput): ConeAxisPolic
                     .normalize();
             }
         }
+    }
+
+    const maxDeviationRad = THREE.MathUtils.degToRad(MAX_CONE_AXIS_DEVIATION_FROM_SURFACE_NORMAL_DEG);
+    const deviationRad = coneAxisVec.angleTo(normal);
+    if (deviationRad > maxDeviationRad + 1e-6) {
+        const rotationAxis = new THREE.Vector3().crossVectors(normal, coneAxisVec);
+        if (rotationAxis.lengthSq() < 1e-10) {
+            rotationAxis.copy(new THREE.Vector3(0, 0, 1).cross(normal));
+            if (rotationAxis.lengthSq() < 1e-10) {
+                rotationAxis.copy(new THREE.Vector3(1, 0, 0).cross(normal));
+            }
+        }
+        rotationAxis.normalize();
+        coneAxisVec = normal.clone().applyAxisAngle(rotationAxis, maxDeviationRad).normalize();
     }
 
     const coneAxis: Vec3 = { x: coneAxisVec.x, y: coneAxisVec.y, z: coneAxisVec.z };

--- a/src/supports/PlacementLogic/Grid/gridPlacement.ts
+++ b/src/supports/PlacementLogic/Grid/gridPlacement.ts
@@ -20,7 +20,7 @@ import { generateUuid } from '../../../utils/uuid';
 import { buildAnchorData } from '../../SupportTypes/Anchor/anchorBuilder';
 import { buildLeafData } from '../../SupportTypes/Leaf/leafBuilder';
 
-const MIN_TRUNK_CLEARANCE_MM = 0.5;
+const MIN_TRUNK_CLEARANCE_MM = 0.8;
 const MAX_NEAREST_NODE_SEARCH_RINGS = 4;
 const ANCHOR_HEIGHT_THRESHOLD_MM = 5.0;
 const MAX_AUTO_LEAF_SPAN_MM = 2.5;

--- a/src/supports/PlacementLogic/Grid/gridPlacement.ts
+++ b/src/supports/PlacementLogic/Grid/gridPlacement.ts
@@ -242,7 +242,7 @@ function branchCollidesWithMesh(
     mesh: THREE.Mesh,
     shaftDiameterMm: number
 ): boolean {
-    const { branch } = buildBranchData({ tipPos, tipNormal, modelId, parentKnot: knot });
+    const { branch } = buildBranchData({ tipPos, tipNormal, modelId, parentKnot: knot, mesh });
     const radius = shaftDiameterMm / 2 + 0.25;
 
     const raycaster = new THREE.Raycaster();
@@ -278,8 +278,9 @@ function tryBuildAutoLeafDecision(args: {
     tipNormal: Vec3;
     modelId: string;
     settings: DecideGridPlacementArgs['settings'];
+    mesh?: THREE.Mesh;
 }): GridPlacementDecision | null {
-    const { nodeKey, hostTrunkId, knot, tipPos, tipNormal, modelId, settings } = args;
+    const { nodeKey, hostTrunkId, knot, tipPos, tipNormal, modelId, settings, mesh } = args;
     const dx = tipPos.x - knot.pos.x;
     const dy = tipPos.y - knot.pos.y;
     const dz = tipPos.z - knot.pos.z;
@@ -302,6 +303,7 @@ function tryBuildAutoLeafDecision(args: {
         modelId,
         parentKnot: knot,
         hostDiameterMm,
+        mesh,
     });
 
     return {
@@ -496,7 +498,7 @@ export function decideGridPlacement(args: DecideGridPlacementArgs): GridPlacemen
 
     // Near-plate contacts get a minimal anchor support instead of trunk/branch
     if (tipPos.z < ANCHOR_HEIGHT_THRESHOLD_MM) {
-        const { anchor, supportData } = buildAnchorData({ tipPos, tipNormal, modelId });
+        const { anchor, supportData } = buildAnchorData({ tipPos, tipNormal, modelId, mesh });
         return { kind: 'place_anchor', anchor, supportData };
     }
 
@@ -599,6 +601,7 @@ export function decideGridPlacement(args: DecideGridPlacementArgs): GridPlacemen
                 tipNormal,
                 modelId,
                 parentKnot: fallbackHost.knot,
+                mesh,
             });
             return {
                 kind: 'place_branch',
@@ -669,6 +672,7 @@ export function decideGridPlacement(args: DecideGridPlacementArgs): GridPlacemen
                 tipNormal,
                 modelId,
                 parentKnot: fallbackHost.knot,
+                mesh,
             });
             return {
                 kind: 'place_branch',
@@ -698,6 +702,7 @@ export function decideGridPlacement(args: DecideGridPlacementArgs): GridPlacemen
         tipNormal,
         modelId,
         parentKnot: selectedKnot,
+        mesh,
     });
 
     const hostTrunkContactZ = host.trunk.contactCone?.pos.z ?? Number.NEGATIVE_INFINITY;

--- a/src/supports/PlacementLogic/Grid/gridPlacement.ts
+++ b/src/supports/PlacementLogic/Grid/gridPlacement.ts
@@ -18,10 +18,12 @@ import { checkShaftCollision } from '../CollisionUtils';
 import * as THREE from 'three';
 import { generateUuid } from '../../../utils/uuid';
 import { buildAnchorData } from '../../SupportTypes/Anchor/anchorBuilder';
+import { buildLeafData } from '../../SupportTypes/Leaf/leafBuilder';
 
 const MIN_TRUNK_CLEARANCE_MM = 0.5;
 const MAX_NEAREST_NODE_SEARCH_RINGS = 4;
 const ANCHOR_HEIGHT_THRESHOLD_MM = 5.0;
+const MAX_AUTO_LEAF_SPAN_MM = 2.5;
 
 function withResolvedSnappedRoute(
     candidate: TrunkBuildResult,
@@ -262,6 +264,54 @@ function branchCollidesWithMesh(
     }
 
     return false;
+}
+
+function getHostDiameterMmFromKnot(knot: Knot, settings: DecideGridPlacementArgs['settings']): number {
+    return Math.max(0.001, (knot.diameter ?? (settings.shaft.diameterMm + 0.1)) - 0.1);
+}
+
+function tryBuildAutoLeafDecision(args: {
+    nodeKey: string;
+    hostTrunkId: string;
+    knot: Knot;
+    tipPos: Vec3;
+    tipNormal: Vec3;
+    modelId: string;
+    settings: DecideGridPlacementArgs['settings'];
+}): GridPlacementDecision | null {
+    const { nodeKey, hostTrunkId, knot, tipPos, tipNormal, modelId, settings } = args;
+    const dx = tipPos.x - knot.pos.x;
+    const dy = tipPos.y - knot.pos.y;
+    const dz = tipPos.z - knot.pos.z;
+    const spanSq = dx * dx + dy * dy + dz * dz;
+    const spanMm = Math.sqrt(spanSq);
+    const epsilonZ = 0.0001;
+    if (knot.pos.z > tipPos.z + epsilonZ) return null;
+    if (spanMm > MAX_AUTO_LEAF_SPAN_MM) return null;
+
+    const angleFromUpDeg = spanSq < 0.000001
+        ? 0
+        : THREE.MathUtils.radToDeg(Math.acos(Math.min(1, Math.max(-1, dz / spanMm))));
+    const maxAngleDeg = settings.shaft.maxAngleDeg ?? 80;
+    if (angleFromUpDeg > maxAngleDeg) return null;
+
+    const hostDiameterMm = getHostDiameterMmFromKnot(knot, settings);
+    const { leaf, supportData } = buildLeafData({
+        tipPos,
+        surfaceNormal: tipNormal,
+        modelId,
+        parentKnot: knot,
+        hostDiameterMm,
+    });
+
+    return {
+        kind: 'place_leaf',
+        nodeKey,
+        hostTrunkId,
+        knot,
+        leaf,
+        supportData,
+    };
 }
 
 function selectHighestValidAttachment(args: {
@@ -531,6 +581,19 @@ export function decideGridPlacement(args: DecideGridPlacementArgs): GridPlacemen
             tipNormal,
         });
         if (fallbackHost) {
+            const leafDecision = tryBuildAutoLeafDecision({
+                nodeKey: fallbackHost.nodeKey,
+                hostTrunkId: fallbackHost.trunkId,
+                knot: fallbackHost.knot,
+                tipPos,
+                tipNormal,
+                modelId,
+                settings,
+            });
+            if (leafDecision) {
+                return leafDecision;
+            }
+
             const { branch, supportData } = buildBranchData({
                 tipPos,
                 tipNormal,
@@ -654,6 +717,19 @@ export function decideGridPlacement(args: DecideGridPlacementArgs): GridPlacemen
             oldTrunkKnot: null,
             oldTrunkBranch: null,
         };
+    }
+
+    const leafDecision = tryBuildAutoLeafDecision({
+        nodeKey,
+        hostTrunkId: host.trunkId,
+        knot: selectedKnot,
+        tipPos,
+        tipNormal,
+        modelId,
+        settings,
+    });
+    if (leafDecision) {
+        return leafDecision;
     }
 
     return {

--- a/src/supports/PlacementLogic/Grid/types.ts
+++ b/src/supports/PlacementLogic/Grid/types.ts
@@ -1,4 +1,4 @@
-import type { Anchor, Branch, Knot, SupportState, Vec3 } from '../../types';
+import type { Anchor, Branch, Knot, Leaf, SupportState, Vec3 } from '../../types';
 import type { SupportData } from '../../rendering/SupportBuilder';
 import type { SupportSettings } from '../../Settings/types';
 import type { TrunkBuildResult } from '../../SupportTypes/Trunk/trunkBuilder';
@@ -35,6 +35,14 @@ export type GridPlacementDecision =
         hostTrunkId: string;
         knot: Knot;
         branch: Branch;
+        supportData: SupportData;
+    }
+    | {
+        kind: 'place_leaf';
+        nodeKey: GridNodeKey;
+        hostTrunkId: string;
+        knot: Knot;
+        leaf: Leaf;
         supportData: SupportData;
     }
     | {

--- a/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
+++ b/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
@@ -129,6 +129,12 @@ interface AStarEntry {
     g: number;
 }
 
+interface NodeRuntimeState {
+    g: number;
+    cameFrom?: number;
+    closed: boolean;
+}
+
 interface NeighborRuntime {
     dx: number;
     dy: number;
@@ -294,9 +300,7 @@ export function gridAStar(
 
     // ---- Warm-start or fresh ----
     let openSet: AStarEntry[];
-    const gScore: Map<number, number> = new Map();
-    const cameFrom: Map<number, number> = new Map();
-    const closedSet = new Set<number>();
+    const nodeState = new Map<number, NodeRuntimeState>();
 
     const canWarmStart = warmStart &&
         Math.abs(warmStart.socketPos.x - startPos.x) < step * 2 &&
@@ -306,14 +310,28 @@ export function gridAStar(
     if (canWarmStart && warmStart) {
         // Re-seed from previous search state
         openSet = [...warmStart.openEntries];
-        for (const [k, v] of warmStart.gScores) gScore.set(k, v);
-        for (const [k, v] of warmStart.cameFrom) cameFrom.set(k, v);
+        for (const [k, v] of warmStart.gScores) {
+            const existing = nodeState.get(k);
+            if (existing) {
+                existing.g = v;
+            } else {
+                nodeState.set(k, { g: v, closed: false });
+            }
+        }
+        for (const [k, v] of warmStart.cameFrom) {
+            const existing = nodeState.get(k);
+            if (existing) {
+                existing.cameFrom = v;
+            } else {
+                nodeState.set(k, { g: Infinity, cameFrom: v, closed: false });
+            }
+        }
     } else {
         const startKey = cellKeyInt(sqx, sqy, sqz);
         const h = goalPlaneHeuristic(sqz);
         openSet = [];
         heapPush(openSet, { key: startKey, x: sqx, y: sqy, z: sqz, g: 0, f: h });
-        gScore.set(startKey, 0);
+        nodeState.set(startKey, { g: 0, closed: false });
     }
 
     let expansions = 0;
@@ -373,10 +391,11 @@ export function gridAStar(
 
     while (openSet.length > 0 && expansions < maxExp) {
         const current = heapPop(openSet)!;
-        const bestKnownG = gScore.get(current.key);
-        if (bestKnownG !== undefined && current.g > bestKnownG) continue;
-        if (closedSet.has(current.key)) continue;
-        closedSet.add(current.key);
+        const currentState = nodeState.get(current.key);
+        if (!currentState) continue;
+        if (current.g > currentState.g) continue;
+        if (currentState.closed) continue;
+        currentState.closed = true;
         expansions++;
         if (captureDebug) {
             debugExpandedNodes.push({
@@ -393,7 +412,7 @@ export function gridAStar(
         if (expansions - lastZProgressAt > STAGNATION_LIMIT) break;
 
         if (current.z <= gqz) {
-            const parentKey = cameFrom.get(current.key);
+            const parentKey = currentState.cameFrom;
             const parentPos = parentKey === undefined
                 ? null
                 : (() => {
@@ -423,7 +442,8 @@ export function gridAStar(
             if (n.dz > 0 && nz > sqz + maxClimbCells) continue;
 
             const nKey = cellKeyInt(nx, ny, nz);
-            if (closedSet.has(nKey)) continue;
+            const existingState = nodeState.get(nKey);
+            if (existingState?.closed) continue;
 
             const latX = (nx - sqx) * step;
             const latY = (ny - sqy) * step;
@@ -452,11 +472,15 @@ export function gridAStar(
             const clearancePenalty = dist < clearance * 2 ? (clearance * 2 - dist) * 0.5 : 0;
             const tentativeG = current.g + neighborStaticCosts[ni] + clearancePenalty;
 
-            const existingG = gScore.get(nKey);
+            const existingG = existingState?.g;
             if (existingG !== undefined && tentativeG >= existingG) continue;
 
-            gScore.set(nKey, tentativeG);
-            cameFrom.set(nKey, current.key);
+            if (existingState) {
+                existingState.g = tentativeG;
+                existingState.cameFrom = current.key;
+            } else {
+                nodeState.set(nKey, { g: tentativeG, cameFrom: current.key, closed: false });
+            }
 
             const h = goalPlaneHeuristic(nz);
             heapPush(openSet, { key: nKey, x: nx, y: ny, z: nz, g: tentativeG, f: tentativeG + h });
@@ -497,8 +521,14 @@ export function gridAStar(
             warmState: stagnated ? null : {
                 socketPos: { ...startPos },
                 openEntries: openSet.slice(0, 64),
-                gScores: gScore,
-                cameFrom,
+                gScores: new Map(
+                    Array.from(nodeState.entries(), ([key, state]) => [key, state.g]),
+                ),
+                cameFrom: new Map(
+                    Array.from(nodeState.entries(), ([key, state]) =>
+                        state.cameFrom === undefined ? null : ([key, state.cameFrom] as [number, number]),
+                    ).filter((entry): entry is [number, number] => entry !== null),
+                ),
             },
         };
     }
@@ -513,7 +543,7 @@ export function gridAStar(
             y: coords.y * step,
             z: coords.z * step,
         });
-        const parent = cameFrom.get(traceKey);
+        const parent = nodeState.get(traceKey)?.cameFrom;
         if (parent === undefined) break;
         traceKey = parent;
     }
@@ -532,8 +562,14 @@ export function gridAStar(
         warmState: {
             socketPos: { ...startPos },
             openEntries: [],
-            gScores: gScore,
-            cameFrom,
+            gScores: new Map(
+                Array.from(nodeState.entries(), ([key, state]) => [key, state.g]),
+            ),
+            cameFrom: new Map(
+                Array.from(nodeState.entries(), ([key, state]) =>
+                    state.cameFrom === undefined ? null : ([key, state.cameFrom] as [number, number]),
+                ).filter((entry): entry is [number, number] => entry !== null),
+            ),
         },
     };
 }

--- a/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
+++ b/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
@@ -73,6 +73,8 @@ export interface GridAStarOptions {
     endpointOnlyCollisionCheck?: boolean;
     /** Optional label used by the pathfinding debug overlay. */
     debugLabel?: string;
+    /** When true, capture expanded/frontier/path snapshots for the debug overlay. */
+    captureDebug?: boolean;
 }
 
 export interface GridAStarResult {
@@ -249,12 +251,14 @@ export function gridAStar(
     const occupancy = opts.occupancy;
     const ignoreSupportId = opts.ignoreSupportId;
     const endpointOnlyCollisionCheck = !!opts.endpointOnlyCollisionCheck;
+    const captureDebug = !!opts.captureDebug;
 
     // Angle constraint: minimum angle from vertical in degrees
     // Converted to maximum lateral-per-vertical ratio
     const minAngleFromVertDeg = opts.minAngleFromVerticalDeg ?? 15;
     const maxLateralPerDrop = Math.tan((minAngleFromVertDeg * Math.PI) / 180);
     const goalValidator = opts.goalValidator;
+    const goalPlaneHeuristic = (qz: number): number => Math.max(0, qz - gqz) * step;
 
     // Per-neighbor static costs (independent of node position).
     const neighborStaticCosts = new Array<number>(NEIGHBOR_RUNTIME.length);
@@ -306,7 +310,7 @@ export function gridAStar(
         for (const [k, v] of warmStart.cameFrom) cameFrom.set(k, v);
     } else {
         const startKey = cellKeyInt(sqx, sqy, sqz);
-        const h = Math.max(0, sqz - gqz); // pure vertical heuristic
+        const h = goalPlaneHeuristic(sqz);
         openSet = [];
         heapPush(openSet, { key: startKey, x: sqx, y: sqy, z: sqz, g: 0, f: h });
         gScore.set(startKey, 0);
@@ -315,6 +319,9 @@ export function gridAStar(
     let expansions = 0;
     let goalEntry: AStarEntry | null = null;
     const debugExpandedNodes: Vec3[] = [];
+    const edgeBlockedCache = new Map<number, Map<number, boolean>>();
+    const nodeDistanceCache = new Map<number, number>();
+    const occupancyCache = new Map<number, boolean>();
 
     const STAGNATION_LIMIT = 600;
     let bestZReached = sqz;
@@ -328,16 +335,56 @@ export function gridAStar(
         return { x: ux - 0x4000, y: uy - 0x4000, z: uz - 0x4000 };
     }
 
+    function getNodeDistance(key: number, wx: number, wy: number, wz: number): number {
+        const cached = nodeDistanceCache.get(key);
+        if (cached !== undefined) return cached;
+        const distance = sdf.distanceAt(wx, wy, wz);
+        nodeDistanceCache.set(key, distance);
+        return distance;
+    }
+
+    function getEdgeBlocked(
+        aKey: number,
+        bKey: number,
+        compute: () => boolean,
+    ): boolean {
+        const lowKey = aKey < bKey ? aKey : bKey;
+        const highKey = aKey < bKey ? bKey : aKey;
+        let highMap = edgeBlockedCache.get(lowKey);
+        if (!highMap) {
+            highMap = new Map<number, boolean>();
+            edgeBlockedCache.set(lowKey, highMap);
+        } else {
+            const cached = highMap.get(highKey);
+            if (cached !== undefined) return cached;
+        }
+        const blocked = compute();
+        highMap.set(highKey, blocked);
+        return blocked;
+    }
+
+    function getNodeOccupied(key: number, wx: number, wy: number, wz: number): boolean {
+        const cached = occupancyCache.get(key);
+        if (cached !== undefined) return cached;
+        const occupied = occupancy ? occupancy.isOccupied(wx, wy, wz, ignoreSupportId) : false;
+        occupancyCache.set(key, occupied);
+        return occupied;
+    }
+
     while (openSet.length > 0 && expansions < maxExp) {
         const current = heapPop(openSet)!;
+        const bestKnownG = gScore.get(current.key);
+        if (bestKnownG !== undefined && current.g > bestKnownG) continue;
         if (closedSet.has(current.key)) continue;
         closedSet.add(current.key);
         expansions++;
-        debugExpandedNodes.push({
-            x: current.x * step,
-            y: current.y * step,
-            z: current.z * step,
-        });
+        if (captureDebug) {
+            debugExpandedNodes.push({
+                x: current.x * step,
+                y: current.y * step,
+                z: current.z * step,
+            });
+        }
 
         if (current.z < bestZReached) {
             bestZReached = current.z;
@@ -389,14 +436,19 @@ export function gridAStar(
             const wy = ny * step;
             const wz = nz * step;
 
-            if (endpointOnlyCollisionCheck
-                ? sdf.isBlocked(wx, wy, wz, clearance)
-                : sdf.segmentBlocked(cwx, cwy, cwz, wx, wy, wz, clearance)
-            ) continue;
+            if (occupancy && getNodeOccupied(nKey, wx, wy, wz)) continue;
 
-            if (occupancy && occupancy.isOccupied(wx, wy, wz, ignoreSupportId)) continue;
+            const dist = getNodeDistance(nKey, wx, wy, wz);
+            if (endpointOnlyCollisionCheck) {
+                if (dist < clearance) continue;
+            } else if (getEdgeBlocked(
+                current.key,
+                nKey,
+                () => sdf.segmentBlocked(cwx, cwy, cwz, wx, wy, wz, clearance),
+            )) {
+                continue;
+            }
 
-            const dist = sdf.distanceAt(wx, wy, wz);
             const clearancePenalty = dist < clearance * 2 ? (clearance * 2 - dist) * 0.5 : 0;
             const tentativeG = current.g + neighborStaticCosts[ni] + clearancePenalty;
 
@@ -406,7 +458,7 @@ export function gridAStar(
             gScore.set(nKey, tentativeG);
             cameFrom.set(nKey, current.key);
 
-            const h = Math.max(0, nz - gqz);
+            const h = goalPlaneHeuristic(nz);
             heapPush(openSet, { key: nKey, x: nx, y: ny, z: nz, g: tentativeG, f: tentativeG + h });
         }
     }
@@ -417,7 +469,7 @@ export function gridAStar(
         reached: boolean,
         rawPath: Vec3[],
         simplifiedPath: Vec3[],
-    ): GridAStarDebugSnapshot => ({
+    ): GridAStarDebugSnapshot | undefined => captureDebug ? ({
         label: opts.debugLabel ?? 'astar',
         searchStepMm: step,
         expansions,
@@ -432,7 +484,7 @@ export function gridAStar(
         })),
         rawPath,
         simplifiedPath,
-    });
+    }) : undefined;
 
     if (!goalEntry) {
         return {

--- a/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
+++ b/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
@@ -71,6 +71,8 @@ export interface GridAStarOptions {
      * Acceptable for hover preview — click-time always uses full resolution.
      */
     endpointOnlyCollisionCheck?: boolean;
+    /** Optional label used by the pathfinding debug overlay. */
+    debugLabel?: string;
 }
 
 export interface GridAStarResult {
@@ -88,6 +90,8 @@ export interface GridAStarResult {
     hitExpansionLimit: boolean;
     /** Reusable warm-start state for the next frame. */
     warmState: WarmStartState | null;
+    /** Optional debug snapshot of the explored cells and solved path. */
+    debug?: GridAStarDebugSnapshot;
 }
 
 export interface WarmStartState {
@@ -97,6 +101,19 @@ export interface WarmStartState {
     openEntries: AStarEntry[];
     gScores: Map<number, number>;
     cameFrom: Map<number, number>;
+}
+
+export interface GridAStarDebugSnapshot {
+    label: string;
+    searchStepMm: number;
+    expansions: number;
+    reached: boolean;
+    stagnated: boolean;
+    hitExpansionLimit: boolean;
+    expandedNodes: Vec3[];
+    frontierNodes: Vec3[];
+    rawPath: Vec3[];
+    simplifiedPath: Vec3[];
 }
 
 // ---------- Internal ----------
@@ -297,6 +314,7 @@ export function gridAStar(
 
     let expansions = 0;
     let goalEntry: AStarEntry | null = null;
+    const debugExpandedNodes: Vec3[] = [];
 
     const STAGNATION_LIMIT = 600;
     let bestZReached = sqz;
@@ -315,6 +333,11 @@ export function gridAStar(
         if (closedSet.has(current.key)) continue;
         closedSet.add(current.key);
         expansions++;
+        debugExpandedNodes.push({
+            x: current.x * step,
+            y: current.y * step,
+            z: current.z * step,
+        });
 
         if (current.z < bestZReached) {
             bestZReached = current.z;
@@ -390,6 +413,26 @@ export function gridAStar(
 
     const stagnated = !goalEntry && (expansions - lastZProgressAt > STAGNATION_LIMIT);
     const hitExpansionLimit = !goalEntry && !stagnated && expansions >= maxExp;
+    const toDebugSnapshot = (
+        reached: boolean,
+        rawPath: Vec3[],
+        simplifiedPath: Vec3[],
+    ): GridAStarDebugSnapshot => ({
+        label: opts.debugLabel ?? 'astar',
+        searchStepMm: step,
+        expansions,
+        reached,
+        stagnated,
+        hitExpansionLimit,
+        expandedNodes: debugExpandedNodes,
+        frontierNodes: openSet.slice(0, 128).map((entry) => ({
+            x: entry.x * step,
+            y: entry.y * step,
+            z: entry.z * step,
+        })),
+        rawPath,
+        simplifiedPath,
+    });
 
     if (!goalEntry) {
         return {
@@ -398,6 +441,7 @@ export function gridAStar(
             reached: false,
             stagnated,
             hitExpansionLimit,
+            debug: toDebugSnapshot(false, [], []),
             warmState: stagnated ? null : {
                 socketPos: { ...startPos },
                 openEntries: openSet.slice(0, 64),
@@ -432,6 +476,7 @@ export function gridAStar(
         reached: true,
         stagnated: false,
         hitExpansionLimit: false,
+        debug: toDebugSnapshot(true, rawPath, simplified),
         warmState: {
             socketPos: { ...startPos },
             openEntries: [],

--- a/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
+++ b/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
@@ -50,7 +50,7 @@ export interface GridAStarOptions {
      * but the roots volume at that XY may intersect the mesh. The validator
      * rejects those positions so the A* keeps searching.
      */
-    goalValidator?: (wx: number, wy: number, wz: number) => boolean;
+    goalValidator?: (wx: number, wy: number, wz: number, parentPos: Vec3 | null) => boolean;
     /**
      * When true, each neighbor edge collision check uses `sdf.isBlocked` on
      * the endpoint cell only instead of the full `sdf.segmentBlocked` sweep.
@@ -302,6 +302,14 @@ export function gridAStar(
     let bestZReached = sqz;
     let lastZProgressAt = 0;
 
+    function decodeKey(key: number): { x: number; y: number; z: number } {
+        const uz = key % 0x8000;
+        const rem = (key - uz) / 0x8000;
+        const uy = rem % 0x8000;
+        const ux = (rem - uy) / 0x8000;
+        return { x: ux - 0x4000, y: uy - 0x4000, z: uz - 0x4000 };
+    }
+
     while (openSet.length > 0 && expansions < maxExp) {
         const current = heapPop(openSet)!;
         if (closedSet.has(current.key)) continue;
@@ -315,7 +323,18 @@ export function gridAStar(
         if (expansions - lastZProgressAt > STAGNATION_LIMIT) break;
 
         if (current.z <= gqz) {
-            if (!goalValidator || goalValidator(current.x * step, current.y * step, current.z * step)) {
+            const parentKey = cameFrom.get(current.key);
+            const parentPos = parentKey === undefined
+                ? null
+                : (() => {
+                    const parent = decodeKey(parentKey);
+                    return {
+                        x: parent.x * step,
+                        y: parent.y * step,
+                        z: parent.z * step,
+                    };
+                })();
+            if (!goalValidator || goalValidator(current.x * step, current.y * step, current.z * step, parentPos)) {
                 goalEntry = current;
                 break;
             }
@@ -390,14 +409,6 @@ export function gridAStar(
 
     const rawPath: Vec3[] = [];
     let traceKey = goalEntry.key;
-
-    function decodeKey(key: number): { x: number; y: number; z: number } {
-        const uz = key % 0x8000;
-        const rem = (key - uz) / 0x8000;
-        const uy = rem % 0x8000;
-        const ux = (rem - uy) / 0x8000;
-        return { x: ux - 0x4000, y: uy - 0x4000, z: uz - 0x4000 };
-    }
 
     while (traceKey !== undefined) {
         const coords = decodeKey(traceKey);

--- a/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
+++ b/src/supports/PlacementLogic/Pathfinding/GridAStar.ts
@@ -213,6 +213,84 @@ function heapPop(heap: AStarEntry[]): AStarEntry | undefined {
     return top;
 }
 
+type HeapCompare = (a: AStarEntry, b: AStarEntry) => number;
+
+function heapSwap(heap: AStarEntry[], heapIndexByKey: Map<number, number>, i: number, j: number): void {
+    const a = heap[i];
+    const b = heap[j];
+    heap[i] = b;
+    heap[j] = a;
+    heapIndexByKey.set(a.key, j);
+    heapIndexByKey.set(b.key, i);
+}
+
+function heapSiftUp(heap: AStarEntry[], heapIndexByKey: Map<number, number>, startIndex: number, compare: HeapCompare): void {
+    let i = startIndex;
+    while (i > 0) {
+        const pi = (i - 1) >> 1;
+        if (compare(heap[pi], heap[i]) <= 0) break;
+        heapSwap(heap, heapIndexByKey, pi, i);
+        i = pi;
+    }
+}
+
+function heapSiftDown(heap: AStarEntry[], heapIndexByKey: Map<number, number>, startIndex: number, compare: HeapCompare): void {
+    let i = startIndex;
+    const len = heap.length;
+    while (true) {
+        const l = i * 2 + 1;
+        const r = l + 1;
+        let smallest = i;
+        if (l < len && compare(heap[l], heap[smallest]) < 0) smallest = l;
+        if (r < len && compare(heap[r], heap[smallest]) < 0) smallest = r;
+        if (smallest === i) break;
+        heapSwap(heap, heapIndexByKey, i, smallest);
+        i = smallest;
+    }
+}
+
+function heapPushOrUpdate(
+    heap: AStarEntry[],
+    heapIndexByKey: Map<number, number>,
+    entry: AStarEntry,
+    compare: HeapCompare,
+): void {
+    const existingIndex = heapIndexByKey.get(entry.key);
+    if (existingIndex !== undefined) {
+        const existing = heap[existingIndex];
+        if (compare(entry, existing) >= 0) {
+            return;
+        }
+        heap[existingIndex] = entry;
+        heapIndexByKey.set(entry.key, existingIndex);
+        heapSiftUp(heap, heapIndexByKey, existingIndex, compare);
+        heapSiftDown(heap, heapIndexByKey, heapIndexByKey.get(entry.key)!, compare);
+        return;
+    }
+
+    heap.push(entry);
+    const index = heap.length - 1;
+    heapIndexByKey.set(entry.key, index);
+    heapSiftUp(heap, heapIndexByKey, index, compare);
+}
+
+function heapPopIndexed(heap: AStarEntry[], heapIndexByKey: Map<number, number>, compare: HeapCompare): AStarEntry | undefined {
+    if (heap.length === 0) return undefined;
+    const top = heap[0];
+    heapIndexByKey.delete(top.key);
+
+    if (heap.length === 1) {
+        heap.pop();
+        return top;
+    }
+
+    const last = heap.pop()!;
+    heap[0] = last;
+    heapIndexByKey.set(last.key, 0);
+    heapSiftDown(heap, heapIndexByKey, 0, compare);
+    return top;
+}
+
 // ---------- Heuristic ----------
 
 /** Octile-distance heuristic in 3D (admissible for 26-connected grids). */
@@ -291,6 +369,17 @@ export function gridAStar(
     const maxClimbCells = Math.max(5, Math.ceil(20 / step)); // up to ~20mm above start
 
     const q = (v: number) => Math.round(v * invStep);
+    const compareHeapEntries: HeapCompare = (a, b) => {
+        const fDiff = a.f - b.f;
+        if (Math.abs(fDiff) > 1e-12) return fDiff;
+
+        const zDiff = a.z - b.z;
+        if (zDiff !== 0) return zDiff;
+
+        const aLatSq = (a.x - sqx) * (a.x - sqx) + (a.y - sqy) * (a.y - sqy);
+        const bLatSq = (b.x - sqx) * (b.x - sqx) + (b.y - sqy) * (b.y - sqy);
+        return aLatSq - bLatSq;
+    };
 
     // Quantized start / goal
     const sqx = q(startPos.x);
@@ -300,6 +389,7 @@ export function gridAStar(
 
     // ---- Warm-start or fresh ----
     let openSet: AStarEntry[];
+    const openSetIndexByKey = new Map<number, number>();
     const nodeState = new Map<number, NodeRuntimeState>();
 
     const canWarmStart = warmStart &&
@@ -309,7 +399,7 @@ export function gridAStar(
 
     if (canWarmStart && warmStart) {
         // Re-seed from previous search state
-        openSet = [...warmStart.openEntries];
+        openSet = [];
         for (const [k, v] of warmStart.gScores) {
             const existing = nodeState.get(k);
             if (existing) {
@@ -326,11 +416,14 @@ export function gridAStar(
                 nodeState.set(k, { g: Infinity, cameFrom: v, closed: false });
             }
         }
+        for (const entry of warmStart.openEntries) {
+            heapPushOrUpdate(openSet, openSetIndexByKey, entry, compareHeapEntries);
+        }
     } else {
         const startKey = cellKeyInt(sqx, sqy, sqz);
         const h = goalPlaneHeuristic(sqz);
         openSet = [];
-        heapPush(openSet, { key: startKey, x: sqx, y: sqy, z: sqz, g: 0, f: h });
+        heapPushOrUpdate(openSet, openSetIndexByKey, { key: startKey, x: sqx, y: sqy, z: sqz, g: 0, f: h }, compareHeapEntries);
         nodeState.set(startKey, { g: 0, closed: false });
     }
 
@@ -390,7 +483,7 @@ export function gridAStar(
     }
 
     while (openSet.length > 0 && expansions < maxExp) {
-        const current = heapPop(openSet)!;
+        const current = heapPopIndexed(openSet, openSetIndexByKey, compareHeapEntries)!;
         const currentState = nodeState.get(current.key);
         if (!currentState) continue;
         if (current.g > currentState.g) continue;
@@ -483,7 +576,7 @@ export function gridAStar(
             }
 
             const h = goalPlaneHeuristic(nz);
-            heapPush(openSet, { key: nKey, x: nx, y: ny, z: nz, g: tentativeG, f: tentativeG + h });
+            heapPushOrUpdate(openSet, openSetIndexByKey, { key: nKey, x: nx, y: ny, z: nz, g: tentativeG, f: tentativeG + h }, compareHeapEntries);
         }
     }
 

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -1452,6 +1452,14 @@ export function calculateSmartPlacementV2(
     };
 
     if (!coneClear) {
+        if (isPreview) {
+            publishPathfindingDebugSnapshot();
+            return {
+                ...standard,
+                error: 'COLLISION_WITH_MODEL',
+            };
+        }
+
         const straightRescueFallback = buildStraightRescueFallback();
         if (straightRescueFallback) {
             return straightRescueFallback;

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -1646,7 +1646,17 @@ export function calculateSmartPlacementV2(
  * Iteratively removes joints whose removal still produces a collision-free
  * and angle-valid chain.
  */
-function simplifyJointsSDF(
+function buildShortcutCandidateRoute(routeJoints: Vec3[], startPointIndex: number, endPointIndex: number): Vec3[] {
+    const prefixJointCount = Math.max(0, startPointIndex);
+    const suffixJointStart = Math.max(0, endPointIndex - 1);
+
+    return [
+        ...routeJoints.slice(0, prefixJointCount),
+        ...routeJoints.slice(suffixJointStart),
+    ];
+}
+
+export function simplifyJointsSDF(
     routeJoints: Vec3[],
     socketPos: Vec3,
     rootTopTarget: Vec3,
@@ -1654,7 +1664,7 @@ function simplifyJointsSDF(
     clearance: number,
     maxAngleFromVerticalDeg: number,
 ): Vec3[] {
-    if (routeJoints.length < 2) return routeJoints;
+    if (routeJoints.length === 0) return routeJoints;
 
     let simplified = [...routeJoints];
     let changed = true;
@@ -1698,6 +1708,45 @@ function simplifyJointsSDF(
             simplified = candidateRoute;
             changed = true;
             break; // Restart from beginning
+        }
+
+        if (changed) {
+            continue;
+        }
+
+        const chainPoints = [socketPos, ...simplified, rootTopTarget];
+        const currentMetrics = getResolvedChainMetrics(socketPos, simplified, rootTopTarget);
+
+        outerShortcut:
+        for (let startPointIndex = 0; startPointIndex < chainPoints.length - 2; startPointIndex++) {
+            const start = chainPoints[startPointIndex];
+
+            for (let endPointIndex = chainPoints.length - 1; endPointIndex > startPointIndex + 1; endPointIndex--) {
+                const removedJointCount = endPointIndex - startPointIndex - 1;
+                if (removedJointCount <= 0) {
+                    continue;
+                }
+
+                const end = chainPoints[endPointIndex];
+
+                if (sdf.segmentBlocked(start.x, start.y, start.z, end.x, end.y, end.z, clearance)) {
+                    continue;
+                }
+
+                if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(start, end, maxAngleFromVerticalDeg)) {
+                    continue;
+                }
+
+                const candidateRoute = buildShortcutCandidateRoute(simplified, startPointIndex, endPointIndex);
+                const candidateMetrics = getResolvedChainMetrics(socketPos, candidateRoute, rootTopTarget);
+                if (!isResolvedChainReplacementBetter(candidateMetrics, currentMetrics)) {
+                    continue;
+                }
+
+                simplified = candidateRoute;
+                changed = true;
+                break outerShortcut;
+            }
         }
     }
 

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -65,7 +65,7 @@ const MAX_NEAREST_NODE_SEARCH_RINGS = 4;
 
 // Global standoff distance from model geometry to reduce resin overexposure
 // fusion risk when supports are placed close to surfaces.
-const COLLISION_AVOIDANCE_MM = 0.4;
+const COLLISION_AVOIDANCE_MM = 0.8;
 
 /** Number of XY perimeter samples around the roots cone at each height slice. */
 const ROOTS_DISK_PERIMETER_SAMPLES = 16;

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -26,6 +26,8 @@ import { gridAStar, type WarmStartState } from './GridAStar';
 import type { SupportOccupancy } from './SupportOccupancy';
 import {
     distanceXY,
+    distance3D,
+    segmentAngleFromVerticalDeg,
     segmentSatisfiesLengthAwareMaxAngleFromVertical,
     segmentSatisfiesMaxAngleFromVertical,
 } from '../smartPlacementSearchUtils';
@@ -77,6 +79,7 @@ const STRAIGHT_SOCKET_RESCUE_RADII_MM = [0, 0.5, 1, 1.5, 2, 3, 4, 6];
 const STRAIGHT_SOCKET_RESCUE_DIRECTIONS = 16;
 const BASE_WIDE_PASS_EXPANSIONS_AT_2MM = 600;
 const BASE_PREVIEW_WIDE_PASS_EXPANSIONS_AT_2MM = 250;
+const ENABLE_AGGRESSIVE_POST_PATH_STRAIGHTENING = false;
 
 // Minimum vertical span (mm) that routing joints must cover.
 // If 2+ joints are all crammed into a small Z band at the tip (< this value),
@@ -210,6 +213,75 @@ function getWidePassBaseExpansionsAt2mm(maxTotalLateralMm: number, isPreview: bo
         : BASE_WIDE_PASS_EXPANSIONS_AT_2MM;
     const radiusScale = Math.min(2, Math.max(1, maxTotalLateralMm / MIN_ROUTING_SEARCH_LATERAL_MM));
     return Math.round(baseBudget * radiusScale);
+}
+
+export interface ResolvedChainMetrics {
+    firstSegmentAngleFromVerticalDeg: number;
+    firstSegmentLateral: number;
+    totalLateral: number;
+    totalLength: number;
+    jointCount: number;
+}
+
+export function getResolvedChainMetrics(
+    socketPos: Vec3,
+    joints: Vec3[],
+    rootTopTarget: Vec3,
+): ResolvedChainMetrics {
+    const points = [socketPos, ...joints, rootTopTarget];
+    const firstTarget = joints[0] ?? rootTopTarget;
+    let totalLateral = 0;
+    let totalLength = 0;
+
+    for (let i = 0; i < points.length - 1; i++) {
+        totalLateral += distanceXY(points[i], points[i + 1]);
+        totalLength += distance3D(points[i], points[i + 1]);
+    }
+
+    return {
+        firstSegmentAngleFromVerticalDeg: segmentAngleFromVerticalDeg(socketPos, firstTarget),
+        firstSegmentLateral: distanceXY(socketPos, firstTarget),
+        totalLateral,
+        totalLength,
+        jointCount: joints.length,
+    };
+}
+
+export function isResolvedChainReplacementBetter(
+    candidate: ResolvedChainMetrics,
+    current: ResolvedChainMetrics,
+): boolean {
+    const eps = 0.000001;
+
+    if (candidate.firstSegmentAngleFromVerticalDeg < current.firstSegmentAngleFromVerticalDeg - eps) {
+        return true;
+    }
+    if (candidate.firstSegmentAngleFromVerticalDeg > current.firstSegmentAngleFromVerticalDeg + eps) {
+        return false;
+    }
+
+    if (candidate.firstSegmentLateral < current.firstSegmentLateral - eps) {
+        return true;
+    }
+    if (candidate.firstSegmentLateral > current.firstSegmentLateral + eps) {
+        return false;
+    }
+
+    if (candidate.totalLateral < current.totalLateral - eps) {
+        return true;
+    }
+    if (candidate.totalLateral > current.totalLateral + eps) {
+        return false;
+    }
+
+    if (candidate.totalLength < current.totalLength - eps) {
+        return true;
+    }
+    if (candidate.totalLength > current.totalLength + eps) {
+        return false;
+    }
+
+    return candidate.jointCount < current.jointCount;
 }
 
 // ---------- Roots cone volume check ----------
@@ -561,11 +633,11 @@ export function calculateSmartPlacementV2(
             y: input.tipPos.y - Math.round(input.tipPos.y / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
         } : null,
     });
-
-    if (straightRescue) {
+    const buildStraightRescueFallback = (): TrunkPlacementResult | null => {
+        if (!straightRescue) return null;
         if (!isPreview) {
             console.log(
-                `[SmartPlacementV2] STRAIGHT rescue — socket=(${straightRescue.socketPos.x.toFixed(2)},${straightRescue.socketPos.y.toFixed(2)},${straightRescue.socketPos.z.toFixed(2)}) base=(${straightRescue.base.basePos.x.toFixed(2)},${straightRescue.base.basePos.y.toFixed(2)},${straightRescue.base.basePos.z.toFixed(2)})`,
+                `[SmartPlacementV2] STRAIGHT rescue fallback — socket=(${straightRescue.socketPos.x.toFixed(2)},${straightRescue.socketPos.y.toFixed(2)},${straightRescue.socketPos.z.toFixed(2)}) base=(${straightRescue.base.basePos.x.toFixed(2)},${straightRescue.base.basePos.y.toFixed(2)},${straightRescue.base.basePos.z.toFixed(2)})`,
             );
         }
         return {
@@ -578,7 +650,7 @@ export function calculateSmartPlacementV2(
             constructionJoints: [],
             error: undefined,
         };
-    }
+    };
 
     // 3b. Spatial caches: skip A* if a previous search from a nearby socketPos
     //     already stagnated (cavity) or exhausted the preview budget.
@@ -779,8 +851,13 @@ export function calculateSmartPlacementV2(
             let _finalBase = _best;
             let _finalRootTop = _wideRootTop;
             let _oneJointStats: string | null = null;
+            const _currentChainIsBetterThan = (candidateJoints: Vec3[], candidateRootTop: Vec3) => {
+                const candidateMetrics = getResolvedChainMetrics(socketPos, candidateJoints, candidateRootTop);
+                const currentMetrics = getResolvedChainMetrics(socketPos, _finalJoints, _finalRootTop);
+                return isResolvedChainReplacementBetter(candidateMetrics, currentMetrics);
+            };
 
-            if (_finalJoints.length > 0) {
+            if (ENABLE_AGGRESSIVE_POST_PATH_STRAIGHTENING && _finalJoints.length > 0) {
                 // Zero-joint sweep: try straight lines from socket to candidate bases,
                 // expanding outward ring-by-ring with early termination once no ring
                 // can improve the best distance found so far.
@@ -792,6 +869,7 @@ export function calculateSmartPlacementV2(
                     if (rootsDiskBlocked(sdf, sc.x, sc.y, diskHeight, coneHeight, rootsRadius, shaftRadius)) return false;
                     if (sdf.segmentBlocked(socketPos.x, socketPos.y, socketPos.z, _crt.x, _crt.y, _crt.z, clearance)) return false;
                     if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(socketPos, _crt, maxSegmentAngleFromVerticalDeg)) return false;
+                    if (!_currentChainIsBetterThan([], _crt)) return false;
                     const _dxy0 = distanceXY(socketPos, _crt);
                     if (_dxy0 < _bestZeroDxy) {
                         _bestZeroDxy = _dxy0;
@@ -982,7 +1060,11 @@ export function calculateSmartPlacementV2(
                             socketPos,
                             { x: _bestOneJoint.baseXY.x, y: _bestOneJoint.baseXY.y, z: socketPos.z },
                         );
-                        const _skipOneJoint = _finalJoints.length === 0 && _oneJointBaseDxy >= _zeroLateral;
+                        let _skipOneJoint = _finalJoints.length === 0 && _oneJointBaseDxy >= _zeroLateral;
+                        const _candidateRootTop: Vec3 = { x: _bestOneJoint.baseXY.x, y: _bestOneJoint.baseXY.y, z: rootTopZ };
+                        if (!_skipOneJoint && !_currentChainIsBetterThan([_bestOneJoint.joint], _candidateRootTop)) {
+                            _skipOneJoint = true;
+                        }
                         if (!_skipOneJoint) {
                         // Base pull: the search found the best joint position for clearing the
                         // obstacle, but the base was chosen from A*-discovered candidates that
@@ -1105,15 +1187,18 @@ export function calculateSmartPlacementV2(
                             }
 
                             if (_bestTJ) {
-                                _twoJointFound = true;
-                                _finalJoints = [_j1u, _bestTJ.j2];
-                                _finalBase = {
-                                    basePos: { x: _bestTJ.baseXY.x, y: _bestTJ.baseXY.y, z: 0 },
-                                    rootTopTarget: { x: _bestTJ.baseXY.x, y: _bestTJ.baseXY.y, z: rootTopZ },
-                                    snapDistance: 0,
-                                    nodeKey: null,
-                                };
-                                _finalRootTop = { x: _bestTJ.baseXY.x, y: _bestTJ.baseXY.y, z: rootTopZ };
+                                const _candidateRootTop2: Vec3 = { x: _bestTJ.baseXY.x, y: _bestTJ.baseXY.y, z: rootTopZ };
+                                if (_currentChainIsBetterThan([_j1u, _bestTJ.j2], _candidateRootTop2)) {
+                                    _twoJointFound = true;
+                                    _finalJoints = [_j1u, _bestTJ.j2];
+                                    _finalBase = {
+                                        basePos: { x: _bestTJ.baseXY.x, y: _bestTJ.baseXY.y, z: 0 },
+                                        rootTopTarget: { x: _bestTJ.baseXY.x, y: _bestTJ.baseXY.y, z: rootTopZ },
+                                        snapDistance: 0,
+                                        nodeKey: null,
+                                    };
+                                    _finalRootTop = { x: _bestTJ.baseXY.x, y: _bestTJ.baseXY.y, z: rootTopZ };
+                                }
                             }
                         }
                         } // !_skipOneJoint
@@ -1207,6 +1292,10 @@ export function calculateSmartPlacementV2(
     }
 
     if (!result.reached || result.path.length < 2) {
+        const straightRescueFallback = buildStraightRescueFallback();
+        if (straightRescueFallback) {
+            return straightRescueFallback;
+        }
         return {
             ...standard,
             error: 'COLLISION_WITH_MODEL',
@@ -1280,6 +1369,10 @@ export function calculateSmartPlacementV2(
     });
 
     if (!bestBase) {
+        const straightRescueFallback = buildStraightRescueFallback();
+        if (straightRescueFallback) {
+            return straightRescueFallback;
+        }
         // No valid grid-snapped base found
         return {
             ...standard,
@@ -1326,7 +1419,13 @@ export function calculateSmartPlacementV2(
     let finalJoints = simplifiedJoints;
     let finalBase = bestBase;
 
-    if (finalJoints.length > 0) {
+    if (ENABLE_AGGRESSIVE_POST_PATH_STRAIGHTENING && finalJoints.length > 0) {
+        const currentChainIsBetterThan = (candidateJoints: Vec3[], candidateRootTop: Vec3) => {
+            const candidateMetrics = getResolvedChainMetrics(socketPos, candidateJoints, candidateRootTop);
+            const currentMetrics = getResolvedChainMetrics(socketPos, finalJoints, finalBase.rootTopTarget);
+            return isResolvedChainReplacementBetter(candidateMetrics, currentMetrics);
+        };
+
         // ---------- Zero-joint radial sweep ----------
         // Search for ANY base position where a straight socket→rootTop line
         // is collision-free and angle-valid.  Start with the obvious candidates
@@ -1388,6 +1487,7 @@ export function calculateSmartPlacementV2(
             // Final angle gate: enforce length-aware tightened constraint before commit
             // so we never return a geometrically invalid support.
             if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(socketPos, candRootTop, maxSegmentAngleFromVerticalDeg)) continue;
+            if (!currentChainIsBetterThan([], candRootTop)) continue;
 
             // Winner — zero joints, straight support
             finalJoints = [];
@@ -1428,6 +1528,7 @@ export function calculateSmartPlacementV2(
                 const seg2Ok = !sdf.segmentBlocked(oc.joint.x, oc.joint.y, oc.joint.z, candRootTop.x, candRootTop.y, candRootTop.z, clearance)
                     && segmentSatisfiesLengthAwareMaxAngleFromVertical(oc.joint, candRootTop, maxSegmentAngleFromVerticalDeg);
                 if (!seg2Ok) continue;
+                if (!currentChainIsBetterThan([oc.joint], candRootTop)) continue;
 
                 finalJoints = [oc.joint];
                 finalBase = {
@@ -1446,6 +1547,10 @@ export function calculateSmartPlacementV2(
     if (finalJoints.length >= 2) {
         const routingZSpan = socketPos.z - finalJoints[finalJoints.length - 1].z;
         if (routingZSpan < MIN_ROUTING_Z_SPAN_MM) {
+            const straightRescueFallback = buildStraightRescueFallback();
+            if (straightRescueFallback) {
+                return straightRescueFallback;
+            }
             return {
                 ...standard,
                 error: 'COLLISION_WITH_MODEL',
@@ -1469,6 +1574,10 @@ export function calculateSmartPlacementV2(
         const b = finalChainPoints[i + 1];
 
         if (sdf.segmentBlocked(a.x, a.y, a.z, b.x, b.y, b.z, clearance)) {
+            const straightRescueFallback = buildStraightRescueFallback();
+            if (straightRescueFallback) {
+                return straightRescueFallback;
+            }
             return {
                 ...standard,
                 error: 'COLLISION_WITH_MODEL',
@@ -1476,6 +1585,10 @@ export function calculateSmartPlacementV2(
         }
 
         if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(a, b, maxSegmentAngleFromVerticalDeg)) {
+            const straightRescueFallback = buildStraightRescueFallback();
+            if (straightRescueFallback) {
+                return straightRescueFallback;
+            }
             return {
                 ...standard,
                 error: 'COLLISION_WITH_MODEL',
@@ -1553,7 +1666,16 @@ function simplifyJointsSDF(
             // Chain runs high-Z (socketPos) → low-Z (rootTopTarget) so each
             // segment descends and the angle helper sees positive vertical drop.
             const prev = i === 0 ? socketPos : simplified[i - 1];
+            const current = simplified[i];
             const next = i === simplified.length - 1 ? rootTopTarget : simplified[i + 1];
+
+            if (
+                !jointsAreNearCollinear(prev, current, next)
+                && !jointAddsNegligibleLateralDetour(prev, current, next)
+                && !jointAddsNegligibleLengthDetour(prev, current, next)
+            ) {
+                continue;
+            }
 
             // Check if the direct segment (skipping this joint) is clear
             if (sdf.segmentBlocked(prev.x, prev.y, prev.z, next.x, next.y, next.z, clearance)) {
@@ -1565,14 +1687,48 @@ function simplifyJointsSDF(
                 continue; // Can't remove — angle too steep
             }
 
+            const candidateRoute = simplified.filter((_, idx) => idx !== i);
+            const currentMetrics = getResolvedChainMetrics(socketPos, simplified, rootTopTarget);
+            const candidateMetrics = getResolvedChainMetrics(socketPos, candidateRoute, rootTopTarget);
+            if (!isResolvedChainReplacementBetter(candidateMetrics, currentMetrics)) {
+                continue;
+            }
+
             // Safe to remove this joint
-            simplified = simplified.filter((_, idx) => idx !== i);
+            simplified = candidateRoute;
             changed = true;
             break; // Restart from beginning
         }
     }
 
     return simplified;
+}
+
+function jointsAreNearCollinear(a: Vec3, b: Vec3, c: Vec3): boolean {
+    const ab = { x: b.x - a.x, y: b.y - a.y, z: b.z - a.z };
+    const bc = { x: c.x - b.x, y: c.y - b.y, z: c.z - b.z };
+    const abLength = Math.sqrt(ab.x * ab.x + ab.y * ab.y + ab.z * ab.z);
+    const bcLength = Math.sqrt(bc.x * bc.x + bc.y * bc.y + bc.z * bc.z);
+    if (abLength < 0.0001 || bcLength < 0.0001) {
+        return true;
+    }
+
+    const abNorm = { x: ab.x / abLength, y: ab.y / abLength, z: ab.z / abLength };
+    const bcNorm = { x: bc.x / bcLength, y: bc.y / bcLength, z: bc.z / bcLength };
+    const dot = abNorm.x * bcNorm.x + abNorm.y * bcNorm.y + abNorm.z * bcNorm.z;
+    return dot >= 0.995;
+}
+
+function jointAddsNegligibleLateralDetour(a: Vec3, b: Vec3, c: Vec3): boolean {
+    const splitLateral = distanceXY(a, b) + distanceXY(b, c);
+    const directLateral = distanceXY(a, c);
+    return splitLateral - directLateral <= 0.75;
+}
+
+function jointAddsNegligibleLengthDetour(a: Vec3, b: Vec3, c: Vec3): boolean {
+    const splitLength = distance3D(a, b) + distance3D(b, c);
+    const directLength = distance3D(a, c);
+    return splitLength - directLength <= 1.0;
 }
 
 /**

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -73,6 +73,8 @@ const MIN_ROUTING_SEARCH_LATERAL_MM = 60;
 const MAX_ROUTING_SEARCH_LATERAL_MM = 120;
 const ROUTING_SEARCH_LATERAL_PER_VERTICAL_MM = 3.0;
 const ROUTING_SEARCH_SWEEP_RADII_MM = [1, 2, 3, 4, 6, 8, 10, 14, 18, 24, 30, 36, 44, 52, 60, 72, 84, 96, 108];
+const STRAIGHT_SOCKET_RESCUE_RADII_MM = [0, 0.5, 1, 1.5, 2, 3, 4, 6];
+const STRAIGHT_SOCKET_RESCUE_DIRECTIONS = 16;
 const BASE_WIDE_PASS_EXPANSIONS_AT_2MM = 600;
 const BASE_PREVIEW_WIDE_PASS_EXPANSIONS_AT_2MM = 250;
 
@@ -129,6 +131,77 @@ export function getSmartPlacementV2SearchEnvelope(args: {
         maxTotalLateralMm,
         rescueSweepRadiiMm,
     };
+}
+
+export function buildStraightSocketRescueCandidates(args: {
+    socketPos: Vec3;
+    maxTotalLateralMm: number;
+}): Vec3[] {
+    const maxRadius = Math.max(0, Math.min(args.maxTotalLateralMm, STRAIGHT_SOCKET_RESCUE_RADII_MM[STRAIGHT_SOCKET_RESCUE_RADII_MM.length - 1]));
+    const candidates: Vec3[] = [{ ...args.socketPos }];
+
+    for (const radius of STRAIGHT_SOCKET_RESCUE_RADII_MM) {
+        if (radius <= 0 || radius > maxRadius + 0.000001) continue;
+        for (let dir = 0; dir < STRAIGHT_SOCKET_RESCUE_DIRECTIONS; dir++) {
+            const angle = (dir / STRAIGHT_SOCKET_RESCUE_DIRECTIONS) * Math.PI * 2;
+            candidates.push({
+                x: args.socketPos.x + Math.cos(angle) * radius,
+                y: args.socketPos.y + Math.sin(angle) * radius,
+                z: args.socketPos.z,
+            });
+        }
+    }
+
+    return candidates;
+}
+
+export function findStraightSocketRescueCandidate(args: {
+    socketPos: Vec3;
+    rootTopZ: number;
+    maxTotalLateralMm: number;
+    gridEnabled: boolean;
+    spacingMm: number;
+    maxNearestNodeSearchRings: number;
+    sdf: SDFCache;
+    diskHeight: number;
+    coneHeight: number;
+    rootsRadius: number;
+    shaftRadius: number;
+    clearance: number;
+    buildNearestCandidateNodeKeys?: (preferredKey: string, maxRings: number) => string[];
+    subGridOffset?: { x: number; y: number } | null;
+}): { socketPos: Vec3; base: ResolvedBaseCandidate } | null {
+    const candidates = buildStraightSocketRescueCandidates({
+        socketPos: args.socketPos,
+        maxTotalLateralMm: args.maxTotalLateralMm,
+    });
+
+    for (const candidateSocketPos of candidates) {
+        const resolved = resolveCommittedBaseCandidate({
+            preferredBottomPos: { x: candidateSocketPos.x, y: candidateSocketPos.y, z: 0 },
+            lastSegmentStart: candidateSocketPos,
+            rootTopZ: args.rootTopZ,
+            gridEnabled: args.gridEnabled,
+            spacingMm: args.spacingMm,
+            maxNearestNodeSearchRings: args.maxNearestNodeSearchRings,
+            sdf: args.sdf,
+            diskHeight: args.diskHeight,
+            coneHeight: args.coneHeight,
+            rootsRadius: args.rootsRadius,
+            shaftRadius: args.shaftRadius,
+            clearance: args.clearance,
+            buildNearestCandidateNodeKeys: args.buildNearestCandidateNodeKeys,
+            subGridOffset: args.subGridOffset,
+        });
+        if (resolved) {
+            return {
+                socketPos: candidateSocketPos,
+                base: resolved,
+            };
+        }
+    }
+
+    return null;
 }
 
 function getWidePassBaseExpansionsAt2mm(maxTotalLateralMm: number, isPreview: boolean): number {
@@ -469,6 +542,44 @@ export function calculateSmartPlacementV2(
         return standard; // Shaft is clear and roots fit — no routing needed
     }
 
+    const straightRescue = findStraightSocketRescueCandidate({
+        socketPos,
+        rootTopZ,
+        maxTotalLateralMm,
+        gridEnabled: settings.grid.enabled,
+        spacingMm: settings.grid.spacingMm,
+        maxNearestNodeSearchRings: MAX_NEAREST_NODE_SEARCH_RINGS,
+        sdf,
+        diskHeight,
+        coneHeight,
+        rootsRadius,
+        shaftRadius,
+        clearance,
+        buildNearestCandidateNodeKeys,
+        subGridOffset: !settings.grid.enabled ? {
+            x: input.tipPos.x - Math.round(input.tipPos.x / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
+            y: input.tipPos.y - Math.round(input.tipPos.y / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
+        } : null,
+    });
+
+    if (straightRescue) {
+        if (!isPreview) {
+            console.log(
+                `[SmartPlacementV2] STRAIGHT rescue — socket=(${straightRescue.socketPos.x.toFixed(2)},${straightRescue.socketPos.y.toFixed(2)},${straightRescue.socketPos.z.toFixed(2)}) base=(${straightRescue.base.basePos.x.toFixed(2)},${straightRescue.base.basePos.y.toFixed(2)},${straightRescue.base.basePos.z.toFixed(2)})`,
+            );
+        }
+        return {
+            ...standard,
+            socketPos: straightRescue.socketPos,
+            basePos: straightRescue.base.basePos,
+            unsnappedBottomPos: { x: straightRescue.socketPos.x, y: straightRescue.socketPos.y, z: 0 },
+            snappedNodeKey: straightRescue.base.nodeKey,
+            joints: [],
+            constructionJoints: [],
+            error: undefined,
+        };
+    }
+
     // 3b. Spatial caches: skip A* if a previous search from a nearby socketPos
     //     already stagnated (cavity) or exhausted the preview budget.
     //     This turns repeated probes at similar positions from ~600 A* expansions
@@ -685,7 +796,12 @@ export function calculateSmartPlacementV2(
                     if (_dxy0 < _bestZeroDxy) {
                         _bestZeroDxy = _dxy0;
                         _finalJoints = [];
-                        _finalBase = { basePos: { x: sc.x, y: sc.y, z: 0 }, snapDistance: 0, nodeKey: null };
+                        _finalBase = {
+                            basePos: { x: sc.x, y: sc.y, z: 0 },
+                            rootTopTarget: _crt,
+                            snapDistance: 0,
+                            nodeKey: null,
+                        };
                         _finalRootTop = _crt;
                     }
                     return true;
@@ -904,6 +1020,7 @@ export function calculateSmartPlacementV2(
                         _finalJoints = [_bestOneJoint.joint];
                         _finalBase = {
                             basePos: { x: _bestOneJoint.baseXY.x, y: _bestOneJoint.baseXY.y, z: 0 },
+                            rootTopTarget: { x: _bestOneJoint.baseXY.x, y: _bestOneJoint.baseXY.y, z: rootTopZ },
                             snapDistance: 0,
                             nodeKey: null,
                         };
@@ -992,6 +1109,7 @@ export function calculateSmartPlacementV2(
                                 _finalJoints = [_j1u, _bestTJ.j2];
                                 _finalBase = {
                                     basePos: { x: _bestTJ.baseXY.x, y: _bestTJ.baseXY.y, z: 0 },
+                                    rootTopTarget: { x: _bestTJ.baseXY.x, y: _bestTJ.baseXY.y, z: rootTopZ },
                                     snapDistance: 0,
                                     nodeKey: null,
                                 };

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -1963,6 +1963,7 @@ export function calculateSmartPlacementV2(
         // visit, dropping first-frame cold cost from ~30k to ~600 BVH calls.
         endpointOnlyCollisionCheck: isPreview,
         debugLabel: 'fine',
+        captureDebug: debugEnabled,
     }, warmStart);
     if (debugEnabled && result.debug) {
         debugPasses = [result.debug];
@@ -2005,6 +2006,7 @@ export function calculateSmartPlacementV2(
             goalValidator,
             endpointOnlyCollisionCheck: isPreview,
             debugLabel: 'wide',
+            captureDebug: debugEnabled,
         }, null); // always cold-start wide search (different grid quantisation)
         if (debugEnabled && wideResult.debug) {
             debugPasses = [...debugPasses, wideResult.debug];

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -75,8 +75,13 @@ const MIN_ROUTING_SEARCH_LATERAL_MM = 60;
 const MAX_ROUTING_SEARCH_LATERAL_MM = 120;
 const ROUTING_SEARCH_LATERAL_PER_VERTICAL_MM = 3.0;
 const ROUTING_SEARCH_SWEEP_RADII_MM = [1, 2, 3, 4, 6, 8, 10, 14, 18, 24, 30, 36, 44, 52, 60, 72, 84, 96, 108];
-const STRAIGHT_SOCKET_RESCUE_RADII_MM = [0, 0.5, 1, 1.5, 2, 3, 4, 6];
+const STRAIGHT_SOCKET_RESCUE_RADII_MM = [0, 0.5, 1, 1.5, 2, 3, 4];
 const STRAIGHT_SOCKET_RESCUE_DIRECTIONS = 16;
+const MIXED_SOCKET_RESCUE_RADII_MM = [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6];
+const MIXED_SOCKET_RESCUE_DIRECTIONS = 8;
+const MIXED_SOCKET_RESCUE_JOINT_RADII_MM = [0, 0.6, 1.2, 1.8];
+const MIXED_SOCKET_RESCUE_JOINT_DIRECTIONS = 12;
+const MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM = 2.0;
 const BASE_WIDE_PASS_EXPANSIONS_AT_2MM = 600;
 const BASE_PREVIEW_WIDE_PASS_EXPANSIONS_AT_2MM = 250;
 const ENABLE_AGGRESSIVE_POST_PATH_STRAIGHTENING = false;
@@ -156,6 +161,173 @@ export function buildStraightSocketRescueCandidates(args: {
     }
 
     return candidates;
+}
+
+function buildMixedSocketRescueCandidates(args: {
+    socketPos: Vec3;
+    maxTotalLateralMm: number;
+}): Vec3[] {
+    const maxRadius = Math.max(0, Math.min(args.maxTotalLateralMm, MIXED_SOCKET_RESCUE_RADII_MM[MIXED_SOCKET_RESCUE_RADII_MM.length - 1]));
+    const candidates: Vec3[] = [{ ...args.socketPos }];
+
+    for (const radius of MIXED_SOCKET_RESCUE_RADII_MM) {
+        if (radius <= 0 || radius > maxRadius + 0.000001) continue;
+        for (let dir = 0; dir < MIXED_SOCKET_RESCUE_DIRECTIONS; dir++) {
+            const angle = (dir / MIXED_SOCKET_RESCUE_DIRECTIONS) * Math.PI * 2;
+            candidates.push({
+                x: args.socketPos.x + Math.cos(angle) * radius,
+                y: args.socketPos.y + Math.sin(angle) * radius,
+                z: args.socketPos.z,
+            });
+        }
+    }
+
+    return candidates;
+}
+
+interface MixedSocketRescueCandidate {
+    socketPos: Vec3;
+    base: ResolvedBaseCandidate;
+    joints: Vec3[];
+    socketShiftMm: number;
+    metrics: ResolvedChainMetrics;
+}
+
+function isMixedSocketRescueCandidateBetter(
+    candidate: MixedSocketRescueCandidate,
+    current: MixedSocketRescueCandidate,
+): boolean {
+    const eps = 0.000001;
+
+    if (candidate.socketShiftMm < current.socketShiftMm - eps) {
+        return true;
+    }
+    if (candidate.socketShiftMm > current.socketShiftMm + eps) {
+        return false;
+    }
+
+    return isResolvedChainReplacementBetter(candidate.metrics, current.metrics);
+}
+
+export function findMixedSocketRescueCandidate(args: {
+    socketPos: Vec3;
+    rootTopZ: number;
+    maxTotalLateralMm: number;
+    gridEnabled: boolean;
+    spacingMm: number;
+    maxNearestNodeSearchRings: number;
+    sdf: SDFCache;
+    diskHeight: number;
+    coneHeight: number;
+    rootsRadius: number;
+    shaftRadius: number;
+    clearance: number;
+    maxAngleFromVerticalDeg: number;
+    buildNearestCandidateNodeKeys?: (preferredKey: string, maxRings: number) => string[];
+    subGridOffset?: { x: number; y: number } | null;
+}): { socketPos: Vec3; base: ResolvedBaseCandidate; joints: Vec3[] } | null {
+    const candidates = buildMixedSocketRescueCandidates({
+        socketPos: args.socketPos,
+        maxTotalLateralMm: args.maxTotalLateralMm,
+    });
+
+    let best: MixedSocketRescueCandidate | null = null;
+
+    for (const candidateSocketPos of candidates) {
+        const resolvedBase = resolveCommittedBaseCandidate({
+            preferredBottomPos: { x: candidateSocketPos.x, y: candidateSocketPos.y, z: 0 },
+            lastSegmentStart: null,
+            rootTopZ: args.rootTopZ,
+            gridEnabled: args.gridEnabled,
+            spacingMm: args.spacingMm,
+            maxNearestNodeSearchRings: args.maxNearestNodeSearchRings,
+            sdf: args.sdf,
+            diskHeight: args.diskHeight,
+            coneHeight: args.coneHeight,
+            rootsRadius: args.rootsRadius,
+            shaftRadius: args.shaftRadius,
+            clearance: args.clearance,
+            buildNearestCandidateNodeKeys: args.buildNearestCandidateNodeKeys,
+            subGridOffset: args.subGridOffset,
+        });
+        if (!resolvedBase) {
+            continue;
+        }
+
+        const rootTopTarget = resolvedBase.rootTopTarget;
+        const socketShiftMm = distanceXY(candidateSocketPos, args.socketPos);
+
+        const considerCandidate = (joints: Vec3[]): void => {
+            const chainPoints = [candidateSocketPos, ...joints, rootTopTarget];
+            for (let i = 0; i < chainPoints.length - 1; i++) {
+                const start = chainPoints[i];
+                const end = chainPoints[i + 1];
+                if (args.sdf.segmentBlocked(start.x, start.y, start.z, end.x, end.y, end.z, args.clearance)) {
+                    return;
+                }
+                if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(start, end, args.maxAngleFromVerticalDeg)) {
+                    return;
+                }
+            }
+
+            const candidate: MixedSocketRescueCandidate = {
+                socketPos: candidateSocketPos,
+                base: resolvedBase,
+                joints,
+                socketShiftMm,
+                metrics: getResolvedChainMetrics(candidateSocketPos, joints, rootTopTarget),
+            };
+
+            if (!best || isMixedSocketRescueCandidateBetter(candidate, best)) {
+                best = candidate;
+            }
+        };
+
+        considerCandidate([]);
+
+        const availableDrop = candidateSocketPos.z - args.rootTopZ;
+        if (availableDrop <= MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM + 0.000001) {
+            continue;
+        }
+
+        for (
+            let jointZ = candidateSocketPos.z - MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM;
+            jointZ > args.rootTopZ + MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM;
+            jointZ -= MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM
+        ) {
+            const t = (candidateSocketPos.z - jointZ) / availableDrop;
+            const centerX = candidateSocketPos.x + (rootTopTarget.x - candidateSocketPos.x) * t;
+            const centerY = candidateSocketPos.y + (rootTopTarget.y - candidateSocketPos.y) * t;
+
+            for (const jointRadius of MIXED_SOCKET_RESCUE_JOINT_RADII_MM) {
+                if (jointRadius === 0) {
+                    considerCandidate([{ x: centerX, y: centerY, z: jointZ }]);
+                    continue;
+                }
+
+                for (let dir = 0; dir < MIXED_SOCKET_RESCUE_JOINT_DIRECTIONS; dir++) {
+                    const angle = (dir / MIXED_SOCKET_RESCUE_JOINT_DIRECTIONS) * Math.PI * 2;
+                    considerCandidate([{
+                        x: centerX + Math.cos(angle) * jointRadius,
+                        y: centerY + Math.sin(angle) * jointRadius,
+                        z: jointZ,
+                    }]);
+                }
+            }
+        }
+    }
+
+    if (!best) {
+        return null;
+    }
+
+    const resolvedBest = best as unknown as MixedSocketRescueCandidate;
+
+    return {
+        socketPos: resolvedBest.socketPos,
+        base: resolvedBest.base,
+        joints: resolvedBest.joints,
+    };
 }
 
 export function findStraightSocketRescueCandidate(args: {
@@ -348,8 +520,42 @@ function rootsDiskBlocked(
 export interface ResolvedBaseCandidate {
     basePos: Vec3;
     rootTopTarget: Vec3;
+    inboundLateralMm?: number;
     snapDistance: number;
     nodeKey: string | null;
+}
+
+function isResolvedBaseCandidateBetter(
+    candidate: ResolvedBaseCandidate,
+    current: ResolvedBaseCandidate | null,
+    lastSegmentStart: Vec3 | null,
+): boolean {
+    if (!current) {
+        return true;
+    }
+
+    const eps = 0.000001;
+
+    if (lastSegmentStart) {
+        const candidateInboundLateralMm = candidate.inboundLateralMm ?? 0;
+        const currentInboundLateralMm = current.inboundLateralMm ?? 0;
+
+        if (candidateInboundLateralMm < currentInboundLateralMm - eps) {
+            return true;
+        }
+        if (candidateInboundLateralMm > currentInboundLateralMm + eps) {
+            return false;
+        }
+    }
+
+    if (candidate.snapDistance < current.snapDistance - eps) {
+        return true;
+    }
+    if (candidate.snapDistance > current.snapDistance + eps) {
+        return false;
+    }
+
+    return (candidate.inboundLateralMm ?? 0) < (current.inboundLateralMm ?? 0) - eps;
 }
 
 export function resolveCommittedBaseCandidate(args: {
@@ -418,13 +624,18 @@ export function resolveCommittedBaseCandidate(args: {
         }
 
         const snapDistance = distanceXY(basePos, args.preferredBottomPos);
-        if (!bestBase || snapDistance < bestBase.snapDistance) {
-            bestBase = {
-                basePos,
-                rootTopTarget,
-                snapDistance,
-                nodeKey: args.gridEnabled ? nodeKey : null,
-            };
+        const inboundLateralMm = args.lastSegmentStart
+            ? distanceXY(rootTopTarget, args.lastSegmentStart)
+            : 0;
+        const candidateBase: ResolvedBaseCandidate = {
+            basePos,
+            rootTopTarget,
+            inboundLateralMm,
+            snapDistance,
+            nodeKey: args.gridEnabled ? nodeKey : null,
+        };
+        if (isResolvedBaseCandidateBetter(candidateBase, bestBase, args.lastSegmentStart)) {
+            bestBase = candidateBase;
         }
     }
 
@@ -633,7 +844,59 @@ export function calculateSmartPlacementV2(
             y: input.tipPos.y - Math.round(input.tipPos.y / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
         } : null,
     });
+    let mixedSocketRescueCache:
+        | { socketPos: Vec3; base: ResolvedBaseCandidate; joints: Vec3[] }
+        | null
+        | undefined;
+    const getMixedSocketRescueFallback = () => {
+        if (mixedSocketRescueCache !== undefined) {
+            return mixedSocketRescueCache;
+        }
+
+        mixedSocketRescueCache = findMixedSocketRescueCandidate({
+            socketPos,
+            rootTopZ,
+            maxTotalLateralMm,
+            gridEnabled: settings.grid.enabled,
+            spacingMm: settings.grid.spacingMm,
+            maxNearestNodeSearchRings: MAX_NEAREST_NODE_SEARCH_RINGS,
+            sdf,
+            diskHeight,
+            coneHeight,
+            rootsRadius,
+            shaftRadius,
+            clearance,
+            maxAngleFromVerticalDeg: maxSegmentAngleFromVerticalDeg,
+            buildNearestCandidateNodeKeys,
+            subGridOffset: !settings.grid.enabled ? {
+                x: input.tipPos.x - Math.round(input.tipPos.x / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
+                y: input.tipPos.y - Math.round(input.tipPos.y / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
+            } : null,
+        });
+
+        return mixedSocketRescueCache;
+    };
     const buildStraightRescueFallback = (): TrunkPlacementResult | null => {
+        const mixedSocketRescue = getMixedSocketRescueFallback();
+        if (mixedSocketRescue) {
+            if (!isPreview) {
+                console.log(
+                    `[SmartPlacementV2] MIXED socket rescue fallback — socket=(${mixedSocketRescue.socketPos.x.toFixed(2)},${mixedSocketRescue.socketPos.y.toFixed(2)},${mixedSocketRescue.socketPos.z.toFixed(2)}) joints=[${mixedSocketRescue.joints.map((joint) => `(${joint.x.toFixed(2)},${joint.y.toFixed(2)},${joint.z.toFixed(2)})`).join(' ')}] base=(${mixedSocketRescue.base.basePos.x.toFixed(2)},${mixedSocketRescue.base.basePos.y.toFixed(2)},${mixedSocketRescue.base.basePos.z.toFixed(2)})`,
+                );
+            }
+
+            return {
+                ...standard,
+                socketPos: mixedSocketRescue.socketPos,
+                basePos: mixedSocketRescue.base.basePos,
+                unsnappedBottomPos: mixedSocketRescue.base.basePos,
+                snappedNodeKey: mixedSocketRescue.base.nodeKey,
+                joints: mixedSocketRescue.joints,
+                constructionJoints: [],
+                error: undefined,
+            };
+        }
+
         if (!straightRescue) return null;
         if (!isPreview) {
             console.log(
@@ -808,6 +1071,7 @@ export function calculateSmartPlacementV2(
                     nodeKey: null,
                 };
             }
+            const _resolvedWideBase = _best as ResolvedBaseCandidate;
             // Z-monotonicity filter (wide A* also allows limited upward moves)
             const _rawJoints = widePathJoints.map((j: Vec3) => ({ x: j.x, y: j.y, z: j.z }));
             const _zJoints: Vec3[] = [];
@@ -816,7 +1080,7 @@ export function calculateSmartPlacementV2(
                 if (_wj.z < _prevZ) { _zJoints.push(_wj); _prevZ = _wj.z; }
             }
 
-            const _wideRootTop: Vec3 = { x: _best.basePos.x, y: _best.basePos.y, z: rootTopZ };
+            const _wideRootTop: Vec3 = { x: _resolvedWideBase.basePos.x, y: _resolvedWideBase.basePos.y, z: rootTopZ };
             const _warning = standard.warning;
 
             // Preview fast-path: skip expensive simplification/straightening passes.
@@ -825,9 +1089,9 @@ export function calculateSmartPlacementV2(
                 return {
                     ...standard,
                     joints: _zJoints,
-                    basePos: _best.basePos,
+                    basePos: _resolvedWideBase.basePos,
                     unsnappedBottomPos: _ubp,
-                    snappedNodeKey: _best.nodeKey ?? null,
+                    snappedNodeKey: _resolvedWideBase.nodeKey ?? null,
                     warning: _warning,
                     error: undefined,
                 };
@@ -848,7 +1112,7 @@ export function calculateSmartPlacementV2(
             // Zero-joint sweep: try a straight line to the current base, below
             // the socket, and at small radial offsets.
             let _finalJoints = _simplifiedJoints;
-            let _finalBase = _best;
+            let _finalBase: ResolvedBaseCandidate = _resolvedWideBase;
             let _finalRootTop = _wideRootTop;
             let _oneJointStats: string | null = null;
             const _currentChainIsBetterThan = (candidateJoints: Vec3[], candidateRootTop: Vec3) => {
@@ -861,7 +1125,7 @@ export function calculateSmartPlacementV2(
                 // Zero-joint sweep: try straight lines from socket to candidate bases,
                 // expanding outward ring-by-ring with early termination once no ring
                 // can improve the best distance found so far.
-                const _distSA = distanceXY(socketPos, _best.basePos);
+                const _distSA = distanceXY(socketPos, _resolvedWideBase.basePos);
 
                 const _tryZeroCandidate = (sc: { x: number; y: number }): boolean => {
                     const _crt: Vec3 = { x: sc.x, y: sc.y, z: rootTopZ };
@@ -889,7 +1153,7 @@ export function calculateSmartPlacementV2(
 
                 // Try seed candidates first (socket XY = dist 0, A* base).
                 _tryZeroCandidate({ x: socketPos.x, y: socketPos.y });
-                _tryZeroCandidate({ x: _best.basePos.x, y: _best.basePos.y });
+                _tryZeroCandidate({ x: _resolvedWideBase.basePos.x, y: _resolvedWideBase.basePos.y });
 
                 // Expand rings outward; terminate when no candidate in this ring
                 // or any larger ring can beat the current best.
@@ -902,7 +1166,7 @@ export function calculateSmartPlacementV2(
                     for (let _d = 0; _d < 16; _d++) {
                         const _a = (_d / 16) * Math.PI * 2;
                         _tryZeroCandidate({ x: socketPos.x + Math.cos(_a) * _r, y: socketPos.y + Math.sin(_a) * _r });
-                        _tryZeroCandidate({ x: _best.basePos.x + Math.cos(_a) * _r, y: _best.basePos.y + Math.sin(_a) * _r });
+                        _tryZeroCandidate({ x: _resolvedWideBase.basePos.x + Math.cos(_a) * _r, y: _resolvedWideBase.basePos.y + Math.sin(_a) * _r });
                     }
                 }
 

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -26,7 +26,12 @@ import { buildNearestCandidateNodeKeys } from '../Grid/nearestCandidateNodeKeys'
 import { SDFCache } from './SDFCache';
 import { gridAStar, type GridAStarDebugSnapshot, type WarmStartState } from './GridAStar';
 import type { SupportOccupancy } from './SupportOccupancy';
-import { getSupportPathfindingDebugEnabled, setSupportPathfindingDebugSnapshot } from './pathfindingDebugState';
+import {
+    getSupportPathfindingDebugEnabled,
+    setSupportPathfindingDebugSnapshot,
+    type SupportPathfindingDebugEvent,
+    type SupportPathfindingDebugOutcome,
+} from './pathfindingDebugState';
 import {
     distanceXY,
     distance3D,
@@ -111,6 +116,7 @@ const CONTACT_CONE_MAX_STRETCH_RATIO = 0.40;
 const CONTACT_DISK_IDEAL_DIRECTION_DEVIATION_DEG = 20;
 const CONTACT_DISK_DIRECTION_DEVIATION_WEIGHT = 0.06;
 const CONTACT_DISK_DIRECTION_DEVIATION_QUADRATIC_WEIGHT = 0.04;
+const CONTACT_DISK_MAX_CONE_AXIS_ANGLE_DEG = 70;
 
 function buildUnitCircleDirections(count: number): Array<{ x: number; y: number }> {
     const directions: Array<{ x: number; y: number }> = [];
@@ -246,6 +252,7 @@ interface ContactConeRescuePenaltyMetrics {
     addedLengthMm: number;
     directionDeviationDeg: number;
     exceedsStretchLimit: boolean;
+    exceedsDiskAngleLimit: boolean;
 }
 
 interface ContactConeClearSocketSeed {
@@ -353,6 +360,8 @@ function getContactConeRescuePenaltyMetrics(args: {
         addedLengthMm,
         directionDeviationDeg,
         exceedsStretchLimit: addedLengthMm > referenceLengthMm * CONTACT_CONE_MAX_STRETCH_RATIO + 0.000001,
+        exceedsDiskAngleLimit: coneScoring.tipProfile.type === 'disk'
+            && angleFromSurfaceNormalDeg > CONTACT_DISK_MAX_CONE_AXIS_ANGLE_DEG + 0.000001,
     };
 }
 
@@ -504,7 +513,7 @@ function findContactConeClearSocketSeed(args: {
             coneScoring: args.coneScoring,
             reference: baselineConePenaltyMetrics,
         });
-        if (metrics.exceedsStretchLimit) {
+        if (metrics.exceedsStretchLimit || metrics.exceedsDiskAngleLimit) {
             continue;
         }
         const candidate: ContactConeClearSocketSeed = {
@@ -597,6 +606,7 @@ export function findMixedSocketRescueCandidate(args: {
     rootsDiskBlockedAt?: RootsDiskBlockedAt;
     segmentBlockedBetween?: SegmentBlockedBetween;
     contactConeBlockedAt?: ContactConeBlockedAt;
+    requireJoint?: boolean;
 }): { socketPos: Vec3; base: ResolvedBaseCandidate; joints: Vec3[] } | null {
     const candidates = buildMixedSocketRescueCandidates({
         socketPos: args.socketPos,
@@ -678,6 +688,10 @@ export function findMixedSocketRescueCandidate(args: {
         const preferNominalReachAround = socketShiftMm <= 0.000001;
 
         const considerCandidate = (joints: Vec3[]): void => {
+            if (args.requireJoint && joints.length === 0) {
+                return;
+            }
+
             const chainPrefix = [candidateSocketPos, ...joints];
             for (let i = 0; i < chainPrefix.length - 1; i++) {
                 const start = chainPrefix[i];
@@ -705,7 +719,7 @@ export function findMixedSocketRescueCandidate(args: {
             }
 
             const conePenaltyMetrics = getConePenaltyMetrics(candidateSocketPos);
-            if (conePenaltyMetrics.exceedsStretchLimit) {
+            if (conePenaltyMetrics.exceedsStretchLimit || conePenaltyMetrics.exceedsDiskAngleLimit) {
                 return;
             }
 
@@ -825,6 +839,7 @@ export function findStraightSocketRescueCandidate(args: {
                 addedLengthMm: 0,
                 directionDeviationDeg: 0,
                 exceedsStretchLimit: false,
+                exceedsDiskAngleLimit: false,
             };
         }
 
@@ -849,7 +864,7 @@ export function findStraightSocketRescueCandidate(args: {
         }
 
         const conePenaltyMetrics = getConePenaltyMetrics(candidateSocketPos);
-        if (conePenaltyMetrics.exceedsStretchLimit) {
+        if (conePenaltyMetrics.exceedsStretchLimit || conePenaltyMetrics.exceedsDiskAngleLimit) {
             continue;
         }
         const conePenaltyScore = conePenaltyMetrics.score;
@@ -1401,6 +1416,24 @@ export function calculateSmartPlacementV2(
     const clearance = shaftRadius + COLLISION_AVOIDANCE_MM;
     const debugEnabled = getSupportPathfindingDebugEnabled();
     let debugPasses: GridAStarDebugSnapshot[] = [];
+    const debugEvents: SupportPathfindingDebugEvent[] = [];
+    let debugOutcome: SupportPathfindingDebugOutcome = {
+        status: 'pending',
+        reason: 'search in progress',
+    };
+    let debugBasePos: Vec3 | undefined;
+    let debugFinalChain: Vec3[] | undefined;
+    const recordDebugEvent = (event: SupportPathfindingDebugEvent): void => {
+        if (!debugEnabled) return;
+        debugEvents.push(event);
+        if (debugEvents.length > 24) {
+            debugEvents.splice(0, debugEvents.length - 24);
+        }
+    };
+    const setDebugOutcome = (status: SupportPathfindingDebugOutcome['status'], reason: string): void => {
+        if (!debugEnabled) return;
+        debugOutcome = { status, reason };
+    };
     const rootsRadius = settings.roots.diameterMm / 2;
     const diskHeight = settings.roots.diskHeightMm;
     const coneHeight = settings.roots.coneHeightMm;
@@ -1435,28 +1468,55 @@ export function calculateSmartPlacementV2(
     }
     const publishPathfindingDebugSnapshot = () => {
         if (!debugEnabled) return;
+        const activeConeMetrics = getContactConeRescuePenaltyMetrics({
+            socketPos,
+            coneScoring: {
+                tipPos: input.tipPos,
+                tipNormal: input.tipNormal,
+                tipProfile: input.tipProfile,
+            },
+        });
         setSupportPathfindingDebugSnapshot(
-            debugPasses.length > 0
-                ? {
-                    modelId,
-                    socketPos,
+            {
+                modelId,
+                socketPos,
+                nominalSocketPos,
+                rootTopZ,
+                clearanceMm: clearance,
+                basePos: debugBasePos,
+                finalChain: debugFinalChain,
+                outcome: debugOutcome,
+                cone: {
+                    nominalClear: coneClear,
+                    activeClear: activeConeClear,
+                    activeDiskAngleDeg: activeConeMetrics.angleFromSurfaceNormalDeg,
+                    maxDiskAngleDeg: CONTACT_DISK_MAX_CONE_AXIS_ANGLE_DEG,
+                    activeConeLengthMm: activeConeMetrics.lengthMm,
+                    activeAddedLengthMm: activeConeMetrics.addedLengthMm,
+                    stretchLimitExceeded: activeConeMetrics.exceedsStretchLimit,
+                    diskAngleLimitExceeded: activeConeMetrics.exceedsDiskAngleLimit,
+                },
+                envelope: {
+                    maxTotalLateralMm,
+                    rescueRadiiMm: rescueSweepRadiiMm,
                     rootTopZ,
                     clearanceMm: clearance,
-                    passes: debugPasses.map((pass) => ({
-                        label: pass.label,
-                        searchStepMm: pass.searchStepMm,
-                        expansions: pass.expansions,
-                        reached: pass.reached,
-                        stagnated: pass.stagnated,
-                        hitExpansionLimit: pass.hitExpansionLimit,
-                        expandedNodes: pass.expandedNodes,
-                        frontierNodes: pass.frontierNodes,
-                        rawPath: pass.rawPath,
-                        simplifiedPath: pass.simplifiedPath,
-                    })),
-                    updatedAtMs: typeof performance !== 'undefined' ? performance.now() : Date.now(),
-                }
-                : null,
+                },
+                events: [...debugEvents],
+                passes: debugPasses.map((pass) => ({
+                    label: pass.label,
+                    searchStepMm: pass.searchStepMm,
+                    expansions: pass.expansions,
+                    reached: pass.reached,
+                    stagnated: pass.stagnated,
+                    hitExpansionLimit: pass.hitExpansionLimit,
+                    expandedNodes: pass.expandedNodes,
+                    frontierNodes: pass.frontierNodes,
+                    rawPath: pass.rawPath,
+                    simplifiedPath: pass.simplifiedPath,
+                })),
+                updatedAtMs: typeof performance !== 'undefined' ? performance.now() : Date.now(),
+            },
         );
     };
     const isPreview = context?.isPreview ?? false;
@@ -1482,6 +1542,11 @@ export function calculateSmartPlacementV2(
     });
 
     const coneClear = !contactConeBlockedAt(nominalSocketPos);
+    recordDebugEvent({
+        stage: 'cone',
+        severity: coneClear ? 'success' : 'warning',
+        message: coneClear ? 'Nominal contact cone is clear' : 'Nominal contact cone intersects model',
+    });
 
     let straightRescueCache:
         | { socketPos: Vec3; base: ResolvedBaseCandidate }
@@ -1545,6 +1610,10 @@ export function calculateSmartPlacementV2(
         | { socketPos: Vec3; base: ResolvedBaseCandidate; joints: Vec3[] }
         | null
         | undefined;
+    let jointedMixedSocketRescueCache:
+        | { socketPos: Vec3; base: ResolvedBaseCandidate; joints: Vec3[] }
+        | null
+        | undefined;
     const getMixedSocketRescueFallback = () => {
         if (mixedSocketRescueCache !== undefined) {
             return mixedSocketRescueCache;
@@ -1581,9 +1650,59 @@ export function calculateSmartPlacementV2(
 
         return mixedSocketRescueCache;
     };
+    const getJointedMixedSocketRescueFallback = () => {
+        if (jointedMixedSocketRescueCache !== undefined) {
+            return jointedMixedSocketRescueCache;
+        }
+
+        jointedMixedSocketRescueCache = findMixedSocketRescueCandidate({
+            socketPos: nominalSocketPos,
+            rootTopZ,
+            maxTotalLateralMm: nominalMaxTotalLateralMm,
+            gridEnabled: settings.grid.enabled,
+            spacingMm: settings.grid.spacingMm,
+            maxNearestNodeSearchRings: MAX_NEAREST_NODE_SEARCH_RINGS,
+            sdf,
+            diskHeight,
+            coneHeight,
+            rootsRadius,
+            shaftRadius,
+            clearance,
+            maxAngleFromVerticalDeg: maxSegmentAngleFromVerticalDeg,
+            coneScoring: {
+                tipPos: input.tipPos,
+                tipNormal: input.tipNormal,
+                tipProfile: input.tipProfile,
+            },
+            buildNearestCandidateNodeKeys,
+            subGridOffset: !settings.grid.enabled ? {
+                x: input.tipPos.x - Math.round(input.tipPos.x / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
+                y: input.tipPos.y - Math.round(input.tipPos.y / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
+            } : null,
+            rootsDiskBlockedAt,
+            segmentBlockedBetween,
+            contactConeBlockedAt,
+            requireJoint: true,
+        });
+
+        return jointedMixedSocketRescueCache;
+    };
     const buildStraightRescueFallback = (): TrunkPlacementResult | null => {
         const mixedSocketRescue = getMixedSocketRescueFallback();
         if (mixedSocketRescue) {
+            setDebugOutcome('fallback', 'mixed socket rescue');
+            debugBasePos = mixedSocketRescue.base.basePos;
+            debugFinalChain = [
+                mixedSocketRescue.socketPos,
+                ...mixedSocketRescue.joints,
+                mixedSocketRescue.base.rootTopTarget,
+            ];
+            recordDebugEvent({
+                stage: 'fallback',
+                severity: 'success',
+                message: `Mixed rescue accepted (${mixedSocketRescue.joints.length} joint${mixedSocketRescue.joints.length === 1 ? '' : 's'})`,
+                details: `base=(${mixedSocketRescue.base.basePos.x.toFixed(2)}, ${mixedSocketRescue.base.basePos.y.toFixed(2)})`,
+            });
             if (!isPreview) {
                 console.log(
                     `[SmartPlacementV2] MIXED socket rescue fallback — socket=(${mixedSocketRescue.socketPos.x.toFixed(2)},${mixedSocketRescue.socketPos.y.toFixed(2)},${mixedSocketRescue.socketPos.z.toFixed(2)}) joints=[${mixedSocketRescue.joints.map((joint) => `(${joint.x.toFixed(2)},${joint.y.toFixed(2)},${joint.z.toFixed(2)})`).join(' ')}] base=(${mixedSocketRescue.base.basePos.x.toFixed(2)},${mixedSocketRescue.base.basePos.y.toFixed(2)},${mixedSocketRescue.base.basePos.z.toFixed(2)})`,
@@ -1605,6 +1724,18 @@ export function calculateSmartPlacementV2(
 
         const straightRescue = getStraightSocketRescueFallback();
         if (!straightRescue) return null;
+        setDebugOutcome('fallback', 'straight socket rescue');
+        debugBasePos = straightRescue.base.basePos;
+        debugFinalChain = [
+            straightRescue.socketPos,
+            straightRescue.base.rootTopTarget,
+        ];
+        recordDebugEvent({
+            stage: 'fallback',
+            severity: 'success',
+            message: 'Straight rescue accepted',
+            details: `socket shift=${distanceXY(straightRescue.socketPos, nominalSocketPos).toFixed(2)}mm`,
+        });
         if (!isPreview) {
             console.log(
                 `[SmartPlacementV2] STRAIGHT rescue fallback — socket=(${straightRescue.socketPos.x.toFixed(2)},${straightRescue.socketPos.y.toFixed(2)},${straightRescue.socketPos.z.toFixed(2)}) base=(${straightRescue.base.basePos.x.toFixed(2)},${straightRescue.base.basePos.y.toFixed(2)},${straightRescue.base.basePos.z.toFixed(2)})`,
@@ -1625,8 +1756,21 @@ export function calculateSmartPlacementV2(
 
     let activeConeClear = coneClear;
     if (!coneClear) {
-        const mixedSocketRescue = getMixedSocketRescueFallback();
-        if (mixedSocketRescue && mixedSocketRescue.joints.length > 0) {
+        const mixedSocketRescue = getJointedMixedSocketRescueFallback();
+        if (mixedSocketRescue) {
+            setDebugOutcome('fallback', 'cone-blocked jointed rescue');
+            debugBasePos = mixedSocketRescue.base.basePos;
+            debugFinalChain = [
+                mixedSocketRescue.socketPos,
+                ...mixedSocketRescue.joints,
+                mixedSocketRescue.base.rootTopTarget,
+            ];
+            recordDebugEvent({
+                stage: 'cone',
+                severity: 'success',
+                message: 'Cone-blocked placement rescued with a shaft bend',
+                details: `joints=${mixedSocketRescue.joints.length}`,
+            });
             if (!isPreview) {
                 console.log(
                     `[SmartPlacementV2] cone-blocked mixed rescue — socket=(${mixedSocketRescue.socketPos.x.toFixed(2)},${mixedSocketRescue.socketPos.y.toFixed(2)},${mixedSocketRescue.socketPos.z.toFixed(2)}) joints=[${mixedSocketRescue.joints.map((joint) => `(${joint.x.toFixed(2)},${joint.y.toFixed(2)},${joint.z.toFixed(2)})`).join(' ')}] base=(${mixedSocketRescue.base.basePos.x.toFixed(2)},${mixedSocketRescue.base.basePos.y.toFixed(2)},${mixedSocketRescue.base.basePos.z.toFixed(2)})`,
@@ -1651,6 +1795,12 @@ export function calculateSmartPlacementV2(
         if (rescuedSocketPos) {
             socketPos = rescuedSocketPos;
             activeConeClear = true;
+            recordDebugEvent({
+                stage: 'cone',
+                severity: 'warning',
+                message: 'Used cone-clear socket seed',
+                details: `shift=${coneClearSeed?.socketShiftMm.toFixed(2) ?? '0.00'}mm added cone=${coneClearSeed?.addedLengthMm.toFixed(2) ?? '0.00'}mm`,
+            });
             ({ maxTotalLateralMm, rescueSweepRadiiMm } = getSmartPlacementV2SearchEnvelope({
                 socketPos,
                 rootTopZ,
@@ -1663,6 +1813,12 @@ export function calculateSmartPlacementV2(
             }
         } else {
             if (isPreview) {
+                setDebugOutcome('blocked', 'contact cone blocked during preview');
+                recordDebugEvent({
+                    stage: 'cone',
+                    severity: 'error',
+                    message: 'No clear contact-cone seed found',
+                });
                 publishPathfindingDebugSnapshot();
                 return {
                     ...standard,
@@ -1674,6 +1830,12 @@ export function calculateSmartPlacementV2(
             if (straightRescueFallback) {
                 return straightRescueFallback;
             }
+            setDebugOutcome('blocked', 'contact cone blocked');
+            recordDebugEvent({
+                stage: 'cone',
+                severity: 'error',
+                message: 'Cone blocked and all socket rescues failed',
+            });
         }
     }
 
@@ -1687,9 +1849,24 @@ export function calculateSmartPlacementV2(
     if (!isPreview) {
         console.log(`[SmartPlacementV2] called — nominalSocket=(${nominalSocketPos.x.toFixed(2)},${nominalSocketPos.y.toFixed(2)},${nominalSocketPos.z.toFixed(2)}) activeSocket=(${socketPos.x.toFixed(2)},${socketPos.y.toFixed(2)},${socketPos.z.toFixed(2)}) rootTopZ=${rootTopZ.toFixed(2)} nominalConeClear=${coneClear} activeConeClear=${activeConeClear} straightClear=${straightClear} rootsFit=${rootsFitStandard}`);
     }
+    recordDebugEvent({
+        stage: 'preflight',
+        severity: straightClear && rootsFitStandard ? 'success' : 'info',
+        message: `straight=${straightClear ? 'clear' : 'blocked'} roots=${rootsFitStandard ? 'fit' : 'blocked'}`,
+        details: `active socket=(${socketPos.x.toFixed(2)}, ${socketPos.y.toFixed(2)}, ${socketPos.z.toFixed(2)})`,
+    });
 
     if (activeConeClear && straightClear && rootsFitStandard) {
         if (!isPreview) console.log(`[SmartPlacementV2] STRAIGHT path — no routing needed`);
+        setDebugOutcome('straight', 'straight path clear');
+        debugBasePos = baseXY;
+        debugFinalChain = [socketPos, { x: socketPos.x, y: socketPos.y, z: rootTopZ }];
+        recordDebugEvent({
+            stage: 'result',
+            severity: 'success',
+            message: 'Placed straight support',
+        });
+        publishPathfindingDebugSnapshot();
         return {
             ...standard,
             socketPos,
@@ -1790,6 +1967,14 @@ export function calculateSmartPlacementV2(
     if (debugEnabled && result.debug) {
         debugPasses = [result.debug];
     }
+    recordDebugEvent({
+        stage: 'astar:fine',
+        severity: result.reached ? 'success' : result.stagnated || result.hitExpansionLimit ? 'warning' : 'info',
+        message: result.reached
+            ? `Fine A* reached in ${result.expansions} expansions`
+            : `Fine A* failed after ${result.expansions} expansions`,
+        details: result.stagnated ? 'stagnated' : result.hitExpansionLimit ? 'hit expansion limit' : undefined,
+    });
 
     // ---------- Wide-step fallback (V1 parity for large-detour overhangs) ----------
     //
@@ -1824,6 +2009,14 @@ export function calculateSmartPlacementV2(
         if (debugEnabled && wideResult.debug) {
             debugPasses = [...debugPasses, wideResult.debug];
         }
+        recordDebugEvent({
+            stage: 'astar:wide',
+            severity: wideResult.reached ? 'success' : wideResult.stagnated || wideResult.hitExpansionLimit ? 'warning' : 'info',
+            message: wideResult.reached
+                ? `Wide A* reached in ${wideResult.expansions} expansions`
+                : `Wide A* failed after ${wideResult.expansions} expansions`,
+            details: wideResult.stagnated ? 'stagnated' : wideResult.hitExpansionLimit ? 'hit expansion limit' : undefined,
+        });
         if (wideResult.reached) {
             // Wide-step succeeded — use its result. Don't write to warm-start maps
             // since the 0.6mm grid state is incompatible with the normal 0.25mm warm-start.
@@ -2710,6 +2903,15 @@ export function calculateSmartPlacementV2(
         angle: standard.angle,
         coneAxis: standard.coneAxis,
     };
+    setDebugOutcome(finalJoints.length === 0 ? 'straight' : 'routed', 'final validated chain');
+    debugBasePos = finalBase.basePos;
+    debugFinalChain = [socketPos, ...finalJoints, finalBase.rootTopTarget];
+    recordDebugEvent({
+        stage: 'result',
+        severity: 'success',
+        message: `Placed ${finalJoints.length === 0 ? 'straight' : 'routed'} support`,
+        details: `joints=${finalJoints.length} base=(${finalBase.basePos.x.toFixed(2)}, ${finalBase.basePos.y.toFixed(2)})`,
+    });
 
     if (!isPreview) {
         // Build the full chain for logging: socket → joints → rootTop

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -88,6 +88,19 @@ const BASE_WIDE_PASS_EXPANSIONS_AT_2MM = 600;
 const BASE_PREVIEW_WIDE_PASS_EXPANSIONS_AT_2MM = 250;
 const ENABLE_AGGRESSIVE_POST_PATH_STRAIGHTENING = false;
 
+function buildUnitCircleDirections(count: number): Array<{ x: number; y: number }> {
+    const directions: Array<{ x: number; y: number }> = [];
+    for (let dir = 0; dir < count; dir++) {
+        const angle = (dir / count) * Math.PI * 2;
+        directions.push({ x: Math.cos(angle), y: Math.sin(angle) });
+    }
+    return directions;
+}
+
+const STRAIGHT_SOCKET_RESCUE_DIRECTION_VECTORS = buildUnitCircleDirections(STRAIGHT_SOCKET_RESCUE_DIRECTIONS);
+const MIXED_SOCKET_RESCUE_DIRECTION_VECTORS = buildUnitCircleDirections(MIXED_SOCKET_RESCUE_DIRECTIONS);
+const MIXED_SOCKET_RESCUE_JOINT_DIRECTION_VECTORS = buildUnitCircleDirections(MIXED_SOCKET_RESCUE_JOINT_DIRECTIONS);
+
 // Minimum vertical span (mm) that routing joints must cover.
 // If 2+ joints are all crammed into a small Z band at the tip (< this value),
 // the path is squeezing through a model crack and should be rejected rather
@@ -152,11 +165,10 @@ export function buildStraightSocketRescueCandidates(args: {
 
     for (const radius of STRAIGHT_SOCKET_RESCUE_RADII_MM) {
         if (radius <= 0 || radius > maxRadius + 0.000001) continue;
-        for (let dir = 0; dir < STRAIGHT_SOCKET_RESCUE_DIRECTIONS; dir++) {
-            const angle = (dir / STRAIGHT_SOCKET_RESCUE_DIRECTIONS) * Math.PI * 2;
+        for (const direction of STRAIGHT_SOCKET_RESCUE_DIRECTION_VECTORS) {
             candidates.push({
-                x: args.socketPos.x + Math.cos(angle) * radius,
-                y: args.socketPos.y + Math.sin(angle) * radius,
+                x: args.socketPos.x + direction.x * radius,
+                y: args.socketPos.y + direction.y * radius,
                 z: args.socketPos.z,
             });
         }
@@ -174,11 +186,10 @@ function buildMixedSocketRescueCandidates(args: {
 
     for (const radius of MIXED_SOCKET_RESCUE_RADII_MM) {
         if (radius <= 0 || radius > maxRadius + 0.000001) continue;
-        for (let dir = 0; dir < MIXED_SOCKET_RESCUE_DIRECTIONS; dir++) {
-            const angle = (dir / MIXED_SOCKET_RESCUE_DIRECTIONS) * Math.PI * 2;
+        for (const direction of MIXED_SOCKET_RESCUE_DIRECTION_VECTORS) {
             candidates.push({
-                x: args.socketPos.x + Math.cos(angle) * radius,
-                y: args.socketPos.y + Math.sin(angle) * radius,
+                x: args.socketPos.x + direction.x * radius,
+                y: args.socketPos.y + direction.y * radius,
                 z: args.socketPos.z,
             });
         }
@@ -207,6 +218,19 @@ interface ContactConeRescuePenaltyMetrics {
     score: number;
     angleFromSurfaceNormalDeg: number;
     addedLengthMm: number;
+}
+
+type RootsDiskBlockedAt = (centerX: number, centerY: number) => boolean;
+type SegmentBlockedBetween = (start: Vec3, end: Vec3) => boolean;
+
+function vec3CacheKey(point: Vec3): string {
+    return `${point.x}|${point.y}|${point.z}`;
+}
+
+function segmentCacheKey(start: Vec3, end: Vec3): string {
+    const startKey = vec3CacheKey(start);
+    const endKey = vec3CacheKey(end);
+    return startKey <= endKey ? `${startKey}->${endKey}` : `${endKey}->${startKey}`;
 }
 
 function normalizeVectorOrFallback(vector: THREE.Vector3, fallback: THREE.Vector3): THREE.Vector3 {
@@ -316,6 +340,8 @@ export function findMixedSocketRescueCandidate(args: {
     coneScoring: ContactConeRescueScoringInput;
     buildNearestCandidateNodeKeys?: (preferredKey: string, maxRings: number) => string[];
     subGridOffset?: { x: number; y: number } | null;
+    rootsDiskBlockedAt?: RootsDiskBlockedAt;
+    segmentBlockedBetween?: SegmentBlockedBetween;
 }): { socketPos: Vec3; base: ResolvedBaseCandidate; joints: Vec3[] } | null {
     const candidates = buildMixedSocketRescueCandidates({
         socketPos: args.socketPos,
@@ -326,6 +352,36 @@ export function findMixedSocketRescueCandidate(args: {
         coneScoring: args.coneScoring,
     });
     const resolvedBaseCache = new Map<string, ResolvedBaseCandidate | null>();
+    const segmentBlockedCache = new Map<string, boolean>();
+    const conePenaltyCache = new Map<string, ContactConeRescuePenaltyMetrics>();
+
+    const segmentBlockedBetween: SegmentBlockedBetween = args.segmentBlockedBetween ?? ((start, end) => {
+        const key = segmentCacheKey(start, end);
+        const cached = segmentBlockedCache.get(key);
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const blocked = args.sdf.segmentBlocked(start.x, start.y, start.z, end.x, end.y, end.z, args.clearance);
+        segmentBlockedCache.set(key, blocked);
+        return blocked;
+    });
+
+    const getConePenaltyMetrics = (candidateSocketPos: Vec3): ContactConeRescuePenaltyMetrics => {
+        const key = vec3CacheKey(candidateSocketPos);
+        const cached = conePenaltyCache.get(key);
+        if (cached) {
+            return cached;
+        }
+
+        const metrics = getContactConeRescuePenaltyMetrics({
+            socketPos: candidateSocketPos,
+            coneScoring: args.coneScoring,
+            reference: baselineConePenaltyMetrics,
+        });
+        conePenaltyCache.set(key, metrics);
+        return metrics;
+    };
 
     const getResolvedBaseForTerminalPoint = (terminalPoint: Vec3): ResolvedBaseCandidate | null => {
         const key = `${terminalPoint.x.toFixed(4)}|${terminalPoint.y.toFixed(4)}|${terminalPoint.z.toFixed(4)}`;
@@ -348,6 +404,8 @@ export function findMixedSocketRescueCandidate(args: {
             clearance: args.clearance,
             buildNearestCandidateNodeKeys: args.buildNearestCandidateNodeKeys,
             subGridOffset: args.subGridOffset,
+            rootsDiskBlockedAt: args.rootsDiskBlockedAt,
+            segmentBlockedBetween,
         });
 
         resolvedBaseCache.set(key, resolvedBase);
@@ -358,20 +416,16 @@ export function findMixedSocketRescueCandidate(args: {
 
     for (const candidateSocketPos of candidates) {
         const socketShiftMm = distanceXY(candidateSocketPos, args.socketPos);
+        if (best && socketShiftMm > best.socketShiftMm + 0.000001) {
+            break;
+        }
 
         const considerCandidate = (joints: Vec3[]): void => {
-            const terminalPoint = joints[joints.length - 1] ?? candidateSocketPos;
-            const resolvedBase = getResolvedBaseForTerminalPoint(terminalPoint);
-            if (!resolvedBase) {
-                return;
-            }
-
-            const rootTopTarget = resolvedBase.rootTopTarget;
-            const chainPoints = [candidateSocketPos, ...joints, rootTopTarget];
-            for (let i = 0; i < chainPoints.length - 1; i++) {
-                const start = chainPoints[i];
-                const end = chainPoints[i + 1];
-                if (args.sdf.segmentBlocked(start.x, start.y, start.z, end.x, end.y, end.z, args.clearance)) {
+            const chainPrefix = [candidateSocketPos, ...joints];
+            for (let i = 0; i < chainPrefix.length - 1; i++) {
+                const start = chainPrefix[i];
+                const end = chainPrefix[i + 1];
+                if (segmentBlockedBetween(start, end)) {
                     return;
                 }
                 if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(start, end, args.maxAngleFromVerticalDeg)) {
@@ -379,11 +433,21 @@ export function findMixedSocketRescueCandidate(args: {
                 }
             }
 
-            const conePenaltyMetrics = getContactConeRescuePenaltyMetrics({
-                socketPos: candidateSocketPos,
-                coneScoring: args.coneScoring,
-                reference: baselineConePenaltyMetrics,
-            });
+            const terminalPoint = joints[joints.length - 1] ?? candidateSocketPos;
+            const resolvedBase = getResolvedBaseForTerminalPoint(terminalPoint);
+            if (!resolvedBase) {
+                return;
+            }
+
+            const rootTopTarget = resolvedBase.rootTopTarget;
+            if (segmentBlockedBetween(terminalPoint, rootTopTarget)) {
+                return;
+            }
+            if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(terminalPoint, rootTopTarget, args.maxAngleFromVerticalDeg)) {
+                return;
+            }
+
+            const conePenaltyMetrics = getConePenaltyMetrics(candidateSocketPos);
 
             const candidate: MixedSocketRescueCandidate = {
                 socketPos: candidateSocketPos,
@@ -420,11 +484,10 @@ export function findMixedSocketRescueCandidate(args: {
                     continue;
                 }
 
-                for (let dir = 0; dir < MIXED_SOCKET_RESCUE_JOINT_DIRECTIONS; dir++) {
-                    const angle = (dir / MIXED_SOCKET_RESCUE_JOINT_DIRECTIONS) * Math.PI * 2;
+                for (const direction of MIXED_SOCKET_RESCUE_JOINT_DIRECTION_VECTORS) {
                     considerCandidate([{
-                        x: centerX + Math.cos(angle) * jointRadius,
-                        y: centerY + Math.sin(angle) * jointRadius,
+                        x: centerX + direction.x * jointRadius,
+                        y: centerY + direction.y * jointRadius,
                         z: jointZ,
                     }]);
                 }
@@ -461,6 +524,8 @@ export function findStraightSocketRescueCandidate(args: {
     coneScoring?: ContactConeRescueScoringInput;
     buildNearestCandidateNodeKeys?: (preferredKey: string, maxRings: number) => string[];
     subGridOffset?: { x: number; y: number } | null;
+    rootsDiskBlockedAt?: RootsDiskBlockedAt;
+    segmentBlockedBetween?: SegmentBlockedBetween;
 }): { socketPos: Vec3; base: ResolvedBaseCandidate } | null {
     const candidates = buildStraightSocketRescueCandidates({
         socketPos: args.socketPos,
@@ -474,8 +539,44 @@ export function findStraightSocketRescueCandidate(args: {
         : null;
 
     let bestCandidate: { socketPos: Vec3; base: ResolvedBaseCandidate; conePenaltyScore: number; socketShiftMm: number } | null = null;
+    const conePenaltyCache = new Map<string, number>();
+
+    const getConePenaltyScore = (candidateSocketPos: Vec3): number => {
+        if (!args.coneScoring) {
+            return 0;
+        }
+
+        const key = vec3CacheKey(candidateSocketPos);
+        const cached = conePenaltyCache.get(key);
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const score = getContactConeRescuePenaltyMetrics({
+            socketPos: candidateSocketPos,
+            coneScoring: args.coneScoring,
+            reference: baselineConePenaltyMetrics ?? undefined,
+        }).score;
+        conePenaltyCache.set(key, score);
+        return score;
+    };
 
     for (const candidateSocketPos of candidates) {
+        const conePenaltyScore = getConePenaltyScore(candidateSocketPos);
+        const socketShiftMm = distanceXY(candidateSocketPos, args.socketPos);
+        const eps = 0.000001;
+        if (bestCandidate) {
+            if (conePenaltyScore > bestCandidate.conePenaltyScore + eps) {
+                continue;
+            }
+            if (
+                Math.abs(conePenaltyScore - bestCandidate.conePenaltyScore) <= eps
+                && socketShiftMm > bestCandidate.socketShiftMm + eps
+            ) {
+                continue;
+            }
+        }
+
         const resolved = resolveCommittedBaseCandidate({
             preferredBottomPos: { x: candidateSocketPos.x, y: candidateSocketPos.y, z: 0 },
             lastSegmentStart: candidateSocketPos,
@@ -491,20 +592,15 @@ export function findStraightSocketRescueCandidate(args: {
             clearance: args.clearance,
             buildNearestCandidateNodeKeys: args.buildNearestCandidateNodeKeys,
             subGridOffset: args.subGridOffset,
+            rootsDiskBlockedAt: args.rootsDiskBlockedAt,
+            segmentBlockedBetween: args.segmentBlockedBetween,
         });
         if (resolved) {
-            const conePenaltyScore = args.coneScoring
-                ? getContactConeRescuePenaltyMetrics({
-                    socketPos: candidateSocketPos,
-                    coneScoring: args.coneScoring,
-                    reference: baselineConePenaltyMetrics ?? undefined,
-                }).score
-                : 0;
             const candidate = {
                 socketPos: candidateSocketPos,
                 base: resolved,
                 conePenaltyScore,
-                socketShiftMm: distanceXY(candidateSocketPos, args.socketPos),
+                socketShiftMm,
             };
 
             if (!bestCandidate) {
@@ -512,7 +608,6 @@ export function findStraightSocketRescueCandidate(args: {
                 continue;
             }
 
-            const eps = 0.000001;
             if (candidate.conePenaltyScore < bestCandidate.conePenaltyScore - eps) {
                 bestCandidate = candidate;
                 continue;
@@ -683,6 +778,55 @@ function rootsDiskBlocked(
     return false;
 }
 
+function createRootsDiskBlockedMemo(args: {
+    sdf: SDFCache;
+    diskHeight: number;
+    coneHeight: number;
+    rootsRadius: number;
+    shaftRadius: number;
+}): RootsDiskBlockedAt {
+    const cache = new Map<string, boolean>();
+
+    return (centerX: number, centerY: number): boolean => {
+        const key = `${centerX}|${centerY}`;
+        const cached = cache.get(key);
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const blocked = rootsDiskBlocked(
+            args.sdf,
+            centerX,
+            centerY,
+            args.diskHeight,
+            args.coneHeight,
+            args.rootsRadius,
+            args.shaftRadius,
+        );
+        cache.set(key, blocked);
+        return blocked;
+    };
+}
+
+function createSegmentBlockedMemo(args: {
+    sdf: SDFCache;
+    clearance: number;
+}): SegmentBlockedBetween {
+    const cache = new Map<string, boolean>();
+
+    return (start: Vec3, end: Vec3): boolean => {
+        const key = segmentCacheKey(start, end);
+        const cached = cache.get(key);
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const blocked = args.sdf.segmentBlocked(start.x, start.y, start.z, end.x, end.y, end.z, args.clearance);
+        cache.set(key, blocked);
+        return blocked;
+    };
+}
+
 export interface ResolvedBaseCandidate {
     basePos: Vec3;
     rootTopTarget: Vec3;
@@ -739,6 +883,8 @@ export function resolveCommittedBaseCandidate(args: {
     clearance: number;
     buildNearestCandidateNodeKeys?: (preferredKey: string, maxRings: number) => string[];
     subGridOffset?: { x: number; y: number } | null;
+    rootsDiskBlockedAt?: RootsDiskBlockedAt;
+    segmentBlockedBetween?: SegmentBlockedBetween;
 }): ResolvedBaseCandidate | null {
     const candidateNodeKeys = args.gridEnabled
         ? args.buildNearestCandidateNodeKeys?.(
@@ -762,28 +908,35 @@ export function resolveCommittedBaseCandidate(args: {
 
         const basePos: Vec3 = { x: snappedXY.x, y: snappedXY.y, z: 0 };
         const rootTopTarget: Vec3 = { x: snappedXY.x, y: snappedXY.y, z: args.rootTopZ };
-        if (rootsDiskBlocked(
-            args.sdf,
-            basePos.x,
-            basePos.y,
-            args.diskHeight,
-            args.coneHeight,
-            args.rootsRadius,
-            args.shaftRadius,
-        )) {
+        const baseBlocked = args.rootsDiskBlockedAt
+            ? args.rootsDiskBlockedAt(basePos.x, basePos.y)
+            : rootsDiskBlocked(
+                args.sdf,
+                basePos.x,
+                basePos.y,
+                args.diskHeight,
+                args.coneHeight,
+                args.rootsRadius,
+                args.shaftRadius,
+            );
+        if (baseBlocked) {
             continue;
         }
 
         if (
             args.lastSegmentStart
-            && args.sdf.segmentBlocked(
-                args.lastSegmentStart.x,
-                args.lastSegmentStart.y,
-                args.lastSegmentStart.z,
-                rootTopTarget.x,
-                rootTopTarget.y,
-                rootTopTarget.z,
-                args.clearance,
+            && (
+                args.segmentBlockedBetween
+                    ? args.segmentBlockedBetween(args.lastSegmentStart, rootTopTarget)
+                    : args.sdf.segmentBlocked(
+                        args.lastSegmentStart.x,
+                        args.lastSegmentStart.y,
+                        args.lastSegmentStart.z,
+                        rootTopTarget.x,
+                        rootTopTarget.y,
+                        rootTopTarget.z,
+                        args.clearance,
+                    )
             )
         ) {
             continue;
@@ -973,14 +1126,22 @@ export function calculateSmartPlacementV2(
         rootTopZ,
         spacingMm: settings.grid.spacingMm,
     });
+    const rootsDiskBlockedAt = createRootsDiskBlockedMemo({
+        sdf,
+        diskHeight,
+        coneHeight,
+        rootsRadius,
+        shaftRadius,
+    });
+    const segmentBlockedBetween = createSegmentBlockedMemo({ sdf, clearance });
 
     // Shaft + roots checks now use SDF sphere-tracing and bounding-ball
     // early-outs, so preview no longer needs the old coarse approximations —
     // the accurate versions are fast in open space and equally accurate.
-    const straightClear = !sdf.segmentBlocked(socketPos.x, socketPos.y, socketPos.z, socketPos.x, socketPos.y, rootTopZ, clearance);
+    const straightClear = !segmentBlockedBetween(socketPos, { x: socketPos.x, y: socketPos.y, z: rootTopZ });
 
     const baseXY = standard.basePos;
-    const rootsFitStandard = !rootsDiskBlocked(sdf, baseXY.x, baseXY.y, diskHeight, coneHeight, rootsRadius, shaftRadius);
+    const rootsFitStandard = !rootsDiskBlockedAt(baseXY.x, baseXY.y);
 
     if (!isPreview) {
         console.log(`[SmartPlacementV2] called — socket=(${socketPos.x.toFixed(2)},${socketPos.y.toFixed(2)},${socketPos.z.toFixed(2)}) rootTopZ=${rootTopZ.toFixed(2)} straightClear=${straightClear} rootsFit=${rootsFitStandard}`);
@@ -991,30 +1152,44 @@ export function calculateSmartPlacementV2(
         return standard; // Shaft is clear and roots fit — no routing needed
     }
 
-    const straightRescue = findStraightSocketRescueCandidate({
-        socketPos,
-        rootTopZ,
-        maxTotalLateralMm,
-        gridEnabled: settings.grid.enabled,
-        spacingMm: settings.grid.spacingMm,
-        maxNearestNodeSearchRings: MAX_NEAREST_NODE_SEARCH_RINGS,
-        sdf,
-        diskHeight,
-        coneHeight,
-        rootsRadius,
-        shaftRadius,
-        clearance,
-        coneScoring: {
-            tipPos: input.tipPos,
-            tipNormal: input.tipNormal,
-            tipProfile: input.tipProfile,
-        },
-        buildNearestCandidateNodeKeys,
-        subGridOffset: !settings.grid.enabled ? {
-            x: input.tipPos.x - Math.round(input.tipPos.x / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
-            y: input.tipPos.y - Math.round(input.tipPos.y / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
-        } : null,
-    });
+    let straightRescueCache:
+        | { socketPos: Vec3; base: ResolvedBaseCandidate }
+        | null
+        | undefined;
+    const getStraightSocketRescueFallback = () => {
+        if (straightRescueCache !== undefined) {
+            return straightRescueCache;
+        }
+
+        straightRescueCache = findStraightSocketRescueCandidate({
+            socketPos,
+            rootTopZ,
+            maxTotalLateralMm,
+            gridEnabled: settings.grid.enabled,
+            spacingMm: settings.grid.spacingMm,
+            maxNearestNodeSearchRings: MAX_NEAREST_NODE_SEARCH_RINGS,
+            sdf,
+            diskHeight,
+            coneHeight,
+            rootsRadius,
+            shaftRadius,
+            clearance,
+            coneScoring: {
+                tipPos: input.tipPos,
+                tipNormal: input.tipNormal,
+                tipProfile: input.tipProfile,
+            },
+            buildNearestCandidateNodeKeys,
+            subGridOffset: !settings.grid.enabled ? {
+                x: input.tipPos.x - Math.round(input.tipPos.x / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
+                y: input.tipPos.y - Math.round(input.tipPos.y / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
+            } : null,
+            rootsDiskBlockedAt,
+            segmentBlockedBetween,
+        });
+
+        return straightRescueCache;
+    };
     let mixedSocketRescueCache:
         | { socketPos: Vec3; base: ResolvedBaseCandidate; joints: Vec3[] }
         | null
@@ -1048,6 +1223,8 @@ export function calculateSmartPlacementV2(
                 x: input.tipPos.x - Math.round(input.tipPos.x / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
                 y: input.tipPos.y - Math.round(input.tipPos.y / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
             } : null,
+            rootsDiskBlockedAt,
+            segmentBlockedBetween,
         });
 
         return mixedSocketRescueCache;
@@ -1073,6 +1250,7 @@ export function calculateSmartPlacementV2(
             };
         }
 
+        const straightRescue = getStraightSocketRescueFallback();
         if (!straightRescue) return null;
         if (!isPreview) {
             console.log(
@@ -1134,7 +1312,7 @@ export function calculateSmartPlacementV2(
     // the SDF bounding-ball early-out makes open slices effectively free.
     const goalValidator = (wx: number, wy: number, wz: number, parentPos: Vec3 | null) => {
         if (!settings.grid.enabled) {
-            return !rootsDiskBlocked(sdf, wx, wy, diskHeight, coneHeight, rootsRadius, shaftRadius);
+            return !rootsDiskBlockedAt(wx, wy);
         }
 
         return resolveCommittedBaseCandidate({
@@ -1151,6 +1329,8 @@ export function calculateSmartPlacementV2(
             shaftRadius,
             clearance,
             buildNearestCandidateNodeKeys,
+            rootsDiskBlockedAt,
+            segmentBlockedBetween,
         }) != null;
     };
 
@@ -1238,6 +1418,8 @@ export function calculateSmartPlacementV2(
                 clearance,
                 buildNearestCandidateNodeKeys: _bncCached,
                 subGridOffset: _wideSubGridOffset,
+                rootsDiskBlockedAt,
+                segmentBlockedBetween,
             });
             if (!_best) {
                 _best = {
@@ -1283,6 +1465,7 @@ export function calculateSmartPlacementV2(
                 sdf,
                 clearance,
                 maxSegmentAngleFromVerticalDeg,
+                segmentBlockedBetween,
             );
 
             // Zero-joint sweep: try a straight line to the current base, below
@@ -1306,8 +1489,8 @@ export function calculateSmartPlacementV2(
                 const _tryZeroCandidate = (sc: { x: number; y: number }): boolean => {
                     const _crt: Vec3 = { x: sc.x, y: sc.y, z: rootTopZ };
                     if (!segmentSatisfiesMaxAngleFromVertical(socketPos, _crt, ROUTING_ANGLE_FROM_VERTICAL_DEG)) return false;
-                    if (rootsDiskBlocked(sdf, sc.x, sc.y, diskHeight, coneHeight, rootsRadius, shaftRadius)) return false;
-                    if (sdf.segmentBlocked(socketPos.x, socketPos.y, socketPos.z, _crt.x, _crt.y, _crt.z, clearance)) return false;
+                    if (rootsDiskBlockedAt(sc.x, sc.y)) return false;
+                    if (segmentBlockedBetween(socketPos, _crt)) return false;
                     if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(socketPos, _crt, maxSegmentAngleFromVerticalDeg)) return false;
                     if (!_currentChainIsBetterThan([], _crt)) return false;
                     const _dxy0 = distanceXY(socketPos, _crt);
@@ -1418,7 +1601,7 @@ export function calculateSmartPlacementV2(
                         const _k = `${x.toFixed(3)},${y.toFixed(3)}`;
                         const _c = _rootsFitCache.get(_k);
                         if (_c !== undefined) return _c;
-                        const _ok = !rootsDiskBlocked(sdf, x, y, diskHeight, coneHeight, rootsRadius, shaftRadius);
+                        const _ok = !rootsDiskBlockedAt(x, y);
                         _rootsFitCache.set(_k, _ok);
                         return _ok;
                     };
@@ -1442,7 +1625,7 @@ export function calculateSmartPlacementV2(
                         if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(socketPos, _j, maxSegmentAngleFromVerticalDeg)) { _skipAngle++; continue; }
 
                         // socket → joint: evaluated once per joint, not once per base×joint.
-                        if (sdf.segmentBlocked(socketPos.x, socketPos.y, socketPos.z, _j.x, _j.y, _j.z, clearance)) { _skipSeg1++; continue; }
+                        if (segmentBlockedBetween(socketPos, _j)) { _skipSeg1++; continue; }
 
                         for (const _vb of _validBases) {
                             _testedPairs++;
@@ -1452,7 +1635,7 @@ export function calculateSmartPlacementV2(
                             if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(_j, _crt, maxSegmentAngleFromVerticalDeg)) { _skipAngle++; continue; }
 
                             // joint → rootTop
-                            if (sdf.segmentBlocked(_j.x, _j.y, _j.z, _crt.x, _crt.y, _crt.z, clearance)) { _skipSeg2++; continue; }
+                            if (segmentBlockedBetween(_j, _crt)) { _skipSeg2++; continue; }
 
                             // Score: prefer straighter + shorter-lateral supports.
                             // Include seg2Lateral (joint→base XY distance) so joints that
@@ -1530,7 +1713,7 @@ export function calculateSmartPlacementV2(
                         for (const _pb of _pullCandidates) {
                             if (!_rootsFitAt(_pb.x, _pb.y)) continue;
                             const _pcrt: Vec3 = { x: _pb.x, y: _pb.y, z: rootTopZ };
-                            if (sdf.segmentBlocked(_jFixed.x, _jFixed.y, _jFixed.z, _pcrt.x, _pcrt.y, _pcrt.z, clearance)) continue;
+                            if (segmentBlockedBetween(_jFixed, _pcrt)) continue;
                             if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(_jFixed, _pcrt, maxSegmentAngleFromVerticalDeg)) continue;
                             const _pdxy = distanceXY({ x: _pb.x, y: _pb.y, z: 0 }, { x: _jFixed.x, y: _jFixed.y, z: 0 });
                             if (_pdxy < _bestPullDxy) {
@@ -1610,13 +1793,13 @@ export function calculateSmartPlacementV2(
                                 for (let _z2 = _j1u.z - _j2ZStep; _z2 > rootTopZ + _j2ZStep; _z2 -= _j2ZStep) {
                                     const _j2c: Vec3 = { x: _j2xy.x, y: _j2xy.y, z: _z2 };
                                     // seg1b: j1 → j2
-                                    if (sdf.segmentBlocked(_j1u.x, _j1u.y, _j1u.z, _j2c.x, _j2c.y, _j2c.z, clearance)) continue;
+                                    if (segmentBlockedBetween(_j1u, _j2c)) continue;
                                     // IMPORTANT: for fixed XY, lowering z2 increases vertical
                                     // drop on seg1b, so an angle failure at a higher z2 can
                                     // become valid at a lower z2. Keep scanning downward.
                                     if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(_j1u, _j2c, maxSegmentAngleFromVerticalDeg)) continue;
                                     // seg2: j2 → base (straight down)
-                                    if (sdf.segmentBlocked(_j2c.x, _j2c.y, _j2c.z, _crt2.x, _crt2.y, _crt2.z, clearance)) continue;
+                                    if (segmentBlockedBetween(_j2c, _crt2)) continue;
                                     if (!segmentSatisfiesLengthAwareMaxAngleFromVertical(_j2c, _crt2, maxSegmentAngleFromVerticalDeg)) break;
                                     const _dxy2 = distanceXY({ x: _j2xy.x, y: _j2xy.y, z: 0 }, { x: _j1u.x, y: _j1u.y, z: 0 });
                                     if (!_bestTJ || _dxy2 < _bestTJ.dxy || (_dxy2 === _bestTJ.dxy && _z2 > _bestTJ.j2.z)) {
@@ -1806,6 +1989,8 @@ export function calculateSmartPlacementV2(
         clearance,
         buildNearestCandidateNodeKeys: buildNearestCandidateNodeKeysCached,
         subGridOffset,
+        rootsDiskBlockedAt,
+        segmentBlockedBetween,
     });
 
     if (!bestBase) {
@@ -1849,6 +2034,7 @@ export function calculateSmartPlacementV2(
         sdf,
         clearance,
         maxSegmentAngleFromVerticalDeg,
+        segmentBlockedBetween,
     );
 
     // 7b. Path straightening — eliminate zigzag by finding a base position
@@ -1919,10 +2105,10 @@ export function calculateSmartPlacementV2(
             if (!segmentSatisfiesMaxAngleFromVertical(socketPos, candRootTop, ROUTING_ANGLE_FROM_VERTICAL_DEG)) continue;
 
             // Roots must fit
-            if (rootsDiskBlocked(sdf, bxy.x, bxy.y, diskHeight, coneHeight, rootsRadius, shaftRadius)) continue;
+            if (rootsDiskBlockedAt(bxy.x, bxy.y)) continue;
 
             // Straight shaft must be clear
-            if (sdf.segmentBlocked(socketPos.x, socketPos.y, socketPos.z, candRootTop.x, candRootTop.y, candRootTop.z, clearance)) continue;
+            if (segmentBlockedBetween(socketPos, candRootTop)) continue;
 
             // Final angle gate: enforce length-aware tightened constraint before commit
             // so we never return a geometrically invalid support.
@@ -1958,14 +2144,14 @@ export function calculateSmartPlacementV2(
             for (const oc of oneJointCandidates) {
                 const candRootTop: Vec3 = { x: oc.baseXY.x, y: oc.baseXY.y, z: rootTopZ };
 
-                if (rootsDiskBlocked(sdf, oc.baseXY.x, oc.baseXY.y, diskHeight, coneHeight, rootsRadius, shaftRadius)) continue;
+                if (rootsDiskBlockedAt(oc.baseXY.x, oc.baseXY.y)) continue;
 
                 // Check both segments: socket→joint and joint→rootTop
-                const seg1Ok = !sdf.segmentBlocked(socketPos.x, socketPos.y, socketPos.z, oc.joint.x, oc.joint.y, oc.joint.z, clearance)
+                const seg1Ok = !segmentBlockedBetween(socketPos, oc.joint)
                     && segmentSatisfiesLengthAwareMaxAngleFromVertical(socketPos, oc.joint, maxSegmentAngleFromVerticalDeg);
                 if (!seg1Ok) continue;
 
-                const seg2Ok = !sdf.segmentBlocked(oc.joint.x, oc.joint.y, oc.joint.z, candRootTop.x, candRootTop.y, candRootTop.z, clearance)
+                const seg2Ok = !segmentBlockedBetween(oc.joint, candRootTop)
                     && segmentSatisfiesLengthAwareMaxAngleFromVertical(oc.joint, candRootTop, maxSegmentAngleFromVerticalDeg);
                 if (!seg2Ok) continue;
                 if (!currentChainIsBetterThan([oc.joint], candRootTop)) continue;
@@ -2013,7 +2199,7 @@ export function calculateSmartPlacementV2(
         const a = finalChainPoints[i];
         const b = finalChainPoints[i + 1];
 
-        if (sdf.segmentBlocked(a.x, a.y, a.z, b.x, b.y, b.z, clearance)) {
+        if (segmentBlockedBetween(a, b)) {
             const straightRescueFallback = buildStraightRescueFallback();
             if (straightRescueFallback) {
                 return straightRescueFallback;
@@ -2103,6 +2289,7 @@ export function simplifyJointsSDF(
     sdf: SDFCache,
     clearance: number,
     maxAngleFromVerticalDeg: number,
+    segmentBlockedBetween?: SegmentBlockedBetween,
 ): Vec3[] {
     if (routeJoints.length === 0) return routeJoints;
 
@@ -2128,7 +2315,10 @@ export function simplifyJointsSDF(
             }
 
             // Check if the direct segment (skipping this joint) is clear
-            if (sdf.segmentBlocked(prev.x, prev.y, prev.z, next.x, next.y, next.z, clearance)) {
+            const directSegmentBlocked = segmentBlockedBetween
+                ? segmentBlockedBetween(prev, next)
+                : sdf.segmentBlocked(prev.x, prev.y, prev.z, next.x, next.y, next.z, clearance);
+            if (directSegmentBlocked) {
                 continue; // Can't remove — direct path clips geometry
             }
 
@@ -2169,7 +2359,10 @@ export function simplifyJointsSDF(
 
                 const end = chainPoints[endPointIndex];
 
-                if (sdf.segmentBlocked(start.x, start.y, start.z, end.x, end.y, end.z, clearance)) {
+                const shortcutBlocked = segmentBlockedBetween
+                    ? segmentBlockedBetween(start, end)
+                    : sdf.segmentBlocked(start.x, start.y, start.z, end.x, end.y, end.z, clearance);
+                if (shortcutBlocked) {
                     continue;
                 }
 

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -69,6 +69,12 @@ const ROOTS_DISK_PERIMETER_SAMPLES = 16;
 const ROOTS_DISK_SAFETY_MM = COLLISION_AVOIDANCE_MM;
 
 const ROUTED_DETOUR_ANGLE_SLACK_DEG = 10;
+const MIN_ROUTING_SEARCH_LATERAL_MM = 60;
+const MAX_ROUTING_SEARCH_LATERAL_MM = 120;
+const ROUTING_SEARCH_LATERAL_PER_VERTICAL_MM = 3.0;
+const ROUTING_SEARCH_SWEEP_RADII_MM = [1, 2, 3, 4, 6, 8, 10, 14, 18, 24, 30, 36, 44, 52, 60, 72, 84, 96, 108];
+const BASE_WIDE_PASS_EXPANSIONS_AT_2MM = 600;
+const BASE_PREVIEW_WIDE_PASS_EXPANSIONS_AT_2MM = 250;
 
 // Minimum vertical span (mm) that routing joints must cover.
 // If 2+ joints are all crammed into a small Z band at the tip (< this value),
@@ -89,6 +95,48 @@ function scaleExpansionsForStep(baseExpansionsAt2mm: number, stepMm: number): nu
     // Keep approximate travel reach comparable to historical 2mm tuning by
     // scaling expansion budget with inverse step size.
     return Math.max(1, Math.round((baseExpansionsAt2mm * LEGACY_BASE_STEP_MM) / stepMm));
+}
+
+export interface SmartPlacementV2SearchEnvelope {
+    maxTotalLateralMm: number;
+    rescueSweepRadiiMm: number[];
+}
+
+export function getSmartPlacementV2SearchEnvelope(args: {
+    socketPos: Vec3;
+    rootTopZ: number;
+    spacingMm: number;
+}): SmartPlacementV2SearchEnvelope {
+    const verticalSpanMm = Math.max(0, args.socketPos.z - args.rootTopZ);
+    const unclampedLateralLimit = Math.max(
+        MIN_ROUTING_SEARCH_LATERAL_MM,
+        args.spacingMm * 15,
+        verticalSpanMm * ROUTING_SEARCH_LATERAL_PER_VERTICAL_MM,
+    );
+    const maxTotalLateralMm = Math.round(
+        Math.min(MAX_ROUTING_SEARCH_LATERAL_MM, unclampedLateralLimit) * 2,
+    ) / 2;
+
+    const rescueSweepRadiiMm = ROUTING_SEARCH_SWEEP_RADII_MM.filter((radius) => radius < maxTotalLateralMm - 0.000001);
+    if (
+        rescueSweepRadiiMm.length === 0
+        || Math.abs(rescueSweepRadiiMm[rescueSweepRadiiMm.length - 1] - maxTotalLateralMm) > 0.000001
+    ) {
+        rescueSweepRadiiMm.push(maxTotalLateralMm);
+    }
+
+    return {
+        maxTotalLateralMm,
+        rescueSweepRadiiMm,
+    };
+}
+
+function getWidePassBaseExpansionsAt2mm(maxTotalLateralMm: number, isPreview: boolean): number {
+    const baseBudget = isPreview
+        ? BASE_PREVIEW_WIDE_PASS_EXPANSIONS_AT_2MM
+        : BASE_WIDE_PASS_EXPANSIONS_AT_2MM;
+    const radiusScale = Math.min(2, Math.max(1, maxTotalLateralMm / MIN_ROUTING_SEARCH_LATERAL_MM));
+    return Math.round(baseBudget * radiusScale);
 }
 
 // ---------- Roots cone volume check ----------
@@ -150,6 +198,92 @@ function rootsDiskBlocked(
     }
 
     return false;
+}
+
+export interface ResolvedBaseCandidate {
+    basePos: Vec3;
+    rootTopTarget: Vec3;
+    snapDistance: number;
+    nodeKey: string | null;
+}
+
+export function resolveCommittedBaseCandidate(args: {
+    preferredBottomPos: Vec3;
+    lastSegmentStart: Vec3 | null;
+    rootTopZ: number;
+    gridEnabled: boolean;
+    spacingMm: number;
+    maxNearestNodeSearchRings: number;
+    sdf: SDFCache;
+    diskHeight: number;
+    coneHeight: number;
+    rootsRadius: number;
+    shaftRadius: number;
+    clearance: number;
+    buildNearestCandidateNodeKeys?: (preferredKey: string, maxRings: number) => string[];
+    subGridOffset?: { x: number; y: number } | null;
+}): ResolvedBaseCandidate | null {
+    const candidateNodeKeys = args.gridEnabled
+        ? args.buildNearestCandidateNodeKeys?.(
+            gridNodeKeyFromXY(args.preferredBottomPos.x, args.preferredBottomPos.y, args.spacingMm),
+            args.maxNearestNodeSearchRings,
+        ) ?? []
+        : ['disabled'];
+
+    let bestBase: ResolvedBaseCandidate | null = null;
+    for (const nodeKey of candidateNodeKeys) {
+        let snappedXY = args.gridEnabled
+            ? gridSnappedXYFromKey(nodeKey, args.spacingMm)
+            : { x: args.preferredBottomPos.x, y: args.preferredBottomPos.y };
+
+        if (!args.gridEnabled && args.subGridOffset) {
+            snappedXY = {
+                x: snappedXY.x + args.subGridOffset.x,
+                y: snappedXY.y + args.subGridOffset.y,
+            };
+        }
+
+        const basePos: Vec3 = { x: snappedXY.x, y: snappedXY.y, z: 0 };
+        const rootTopTarget: Vec3 = { x: snappedXY.x, y: snappedXY.y, z: args.rootTopZ };
+        if (rootsDiskBlocked(
+            args.sdf,
+            basePos.x,
+            basePos.y,
+            args.diskHeight,
+            args.coneHeight,
+            args.rootsRadius,
+            args.shaftRadius,
+        )) {
+            continue;
+        }
+
+        if (
+            args.lastSegmentStart
+            && args.sdf.segmentBlocked(
+                args.lastSegmentStart.x,
+                args.lastSegmentStart.y,
+                args.lastSegmentStart.z,
+                rootTopTarget.x,
+                rootTopTarget.y,
+                rootTopTarget.z,
+                args.clearance,
+            )
+        ) {
+            continue;
+        }
+
+        const snapDistance = distanceXY(basePos, args.preferredBottomPos);
+        if (!bestBase || snapDistance < bestBase.snapDistance) {
+            bestBase = {
+                basePos,
+                rootTopTarget,
+                snapDistance,
+                nodeKey: args.gridEnabled ? nodeKey : null,
+            };
+        }
+    }
+
+    return bestBase;
 }
 
 // ---------- SDF Cache Pool ----------
@@ -296,7 +430,6 @@ export function calculateSmartPlacementV2(
     // can take lateral steps to navigate around overhangs. Final trunk angle is
     // validated via maxSegmentAngleFromVerticalDeg after the path is resolved.
     const ROUTING_ANGLE_FROM_VERTICAL_DEG = 80;
-    const maxTotalLateralMm = Math.max(60, settings.grid.spacingMm * 15);
 
     // 1. Standard placement (baseline — no collision check)
     const standard = calculateStandardPlacement(input);
@@ -313,6 +446,11 @@ export function calculateSmartPlacementV2(
     const rootTopZ = input.rootsTopZ;
     const socketPos = standard.socketPos;
     const isPreview = context?.isPreview ?? false;
+    const { maxTotalLateralMm, rescueSweepRadiiMm } = getSmartPlacementV2SearchEnvelope({
+        socketPos,
+        rootTopZ,
+        spacingMm: settings.grid.spacingMm,
+    });
 
     // Shaft + roots checks now use SDF sphere-tracing and bounding-ball
     // early-outs, so preview no longer needs the old coarse approximations —
@@ -372,9 +510,26 @@ export function calculateSmartPlacementV2(
 
     // Full-resolution roots validation for both preview and click-time —
     // the SDF bounding-ball early-out makes open slices effectively free.
-    const goalValidator = (wx: number, wy: number, wz: number) => {
-        void wz;
-        return !rootsDiskBlocked(sdf, wx, wy, diskHeight, coneHeight, rootsRadius, shaftRadius);
+    const goalValidator = (wx: number, wy: number, wz: number, parentPos: Vec3 | null) => {
+        if (!settings.grid.enabled) {
+            return !rootsDiskBlocked(sdf, wx, wy, diskHeight, coneHeight, rootsRadius, shaftRadius);
+        }
+
+        return resolveCommittedBaseCandidate({
+            preferredBottomPos: { x: wx, y: wy, z: 0 },
+            lastSegmentStart: parentPos,
+            rootTopZ,
+            gridEnabled: true,
+            spacingMm: settings.grid.spacingMm,
+            maxNearestNodeSearchRings: MAX_NEAREST_NODE_SEARCH_RINGS,
+            sdf,
+            diskHeight,
+            coneHeight,
+            rootsRadius,
+            shaftRadius,
+            clearance,
+            buildNearestCandidateNodeKeys,
+        }) != null;
     };
 
     const result = gridAStar(sdf, socketPos, rootTopZ, {
@@ -403,10 +558,10 @@ export function calculateSmartPlacementV2(
     // complex overhangs before finding the clear corridor.
     //
     // When the fine-step search fails (exhausted budget, stagnated, or simply hit
-    // a pathfinding ceiling), retry with a 6mm grid and 600 expansions. The coarser
-    // grid gives V1-equivalent reach (10 cells × 6mm = 60mm per axis), while keeping
-    // SDF-backed precision for each edge validation. Any directed path that V1 would
-    // find in macro-jumps, V2 at 6mm step will find in similar expansion counts.
+    // a pathfinding ceiling), retry with a coarser 0.6mm grid and a budget that
+    // scales with the current lateral envelope. This rescue pass explores much
+    // farther per unit of work than the 0.25mm fine pass while still keeping the
+    // base position tight and validating every edge against the SDF.
     // Only retry if we didn't already reach a goal — don't double-process successes.
     if (!result.reached) {
         const wideResult = gridAStar(sdf, socketPos, rootTopZ, {
@@ -416,14 +571,17 @@ export function calculateSmartPlacementV2(
             occupancy: context?.occupancy,
             ignoreSupportId: context?.placingSupportId,
             // Preview should remain responsive; use a smaller wide-step budget.
-            maxExpansions: scaleExpansionsForStep(isPreview ? 250 : 600, WIDE_ASTAR_STEP_MM),
+            maxExpansions: scaleExpansionsForStep(
+                getWidePassBaseExpansionsAt2mm(maxTotalLateralMm, isPreview),
+                WIDE_ASTAR_STEP_MM,
+            ),
             stepMm: WIDE_ASTAR_STEP_MM,
             goalValidator,
             endpointOnlyCollisionCheck: isPreview,
         }, null); // always cold-start wide search (different grid quantisation)
         if (wideResult.reached) {
             // Wide-step succeeded — use its result. Don't write to warm-start maps
-            // since the 6mm grid state is incompatible with the normal 2mm warm-start.
+            // since the 0.6mm grid state is incompatible with the normal 0.25mm warm-start.
             const widePathJoints = wideResult.path.slice(1, -1);
             const widePathEnd = wideResult.path[wideResult.path.length - 1];
             // Grid-snap the base and validate angle using the routing angle (looser than final)
@@ -439,30 +597,30 @@ export function calculateSmartPlacementV2(
             const _ge = settings.grid.enabled;
             const _sp = settings.grid.spacingMm;
             const _ubp: Vec3 = { x: widePathEnd.x, y: widePathEnd.y, z: 0 };
-            const _cnk = _ge
-                ? _bncCached(gridNodeKeyFromXY(_ubp.x, _ubp.y, _sp), MAX_NEAREST_NODE_SEARCH_RINGS)
-                : ['disabled'];
-            let _best: { basePos: Vec3; snapDistance: number; nodeKey: string | null } | null = null;
             const _wideSubGridOffset = !_ge ? {
                 x: input.tipPos.x - Math.round(input.tipPos.x / WIDE_ASTAR_STEP_MM) * WIDE_ASTAR_STEP_MM,
                 y: input.tipPos.y - Math.round(input.tipPos.y / WIDE_ASTAR_STEP_MM) * WIDE_ASTAR_STEP_MM,
             } : null;
-            for (const nk of _cnk) {
-                let sxy = _ge ? gridSnappedXYFromKey(nk, _sp) : { x: _ubp.x, y: _ubp.y };
-                if (!_ge && _wideSubGridOffset) {
-                    sxy = {
-                        x: sxy.x + _wideSubGridOffset.x,
-                        y: sxy.y + _wideSubGridOffset.y,
-                    };
-                }
-                const bp: Vec3 = { x: sxy.x, y: sxy.y, z: 0 };
-                if (rootsDiskBlocked(sdf, bp.x, bp.y, diskHeight, coneHeight, rootsRadius, shaftRadius)) continue;
-                const sd = distanceXY(bp, _ubp);
-                if (!_best || sd < _best.snapDistance) _best = { basePos: bp, snapDistance: sd, nodeKey: nk };
-            }
+            let _best = resolveCommittedBaseCandidate({
+                preferredBottomPos: _ubp,
+                lastSegmentStart: widePathJoints.length > 0 ? widePathJoints[widePathJoints.length - 1] : widePathEnd,
+                rootTopZ,
+                gridEnabled: _ge,
+                spacingMm: _sp,
+                maxNearestNodeSearchRings: MAX_NEAREST_NODE_SEARCH_RINGS,
+                sdf,
+                diskHeight,
+                coneHeight,
+                rootsRadius,
+                shaftRadius,
+                clearance,
+                buildNearestCandidateNodeKeys: _bncCached,
+                subGridOffset: _wideSubGridOffset,
+            });
             if (!_best) {
                 _best = {
                     basePos: { x: _ubp.x, y: _ubp.y, z: 0 },
+                    rootTopTarget: { x: _ubp.x, y: _ubp.y, z: rootTopZ },
                     snapDistance: 0,
                     nodeKey: null,
                 };
@@ -541,8 +699,7 @@ export function calculateSmartPlacementV2(
 
                 // Expand rings outward; terminate when no candidate in this ring
                 // or any larger ring can beat the current best.
-                const _sr = [1, 2, 3, 4, 6, 8, 10, 14, 18, 24, 30];
-                for (const _r of _sr) {
+                for (const _r of rescueSweepRadiiMm) {
                     if (_r > maxTotalLateralMm) break;
                     // Socket-centered candidates at this ring have distance _r from socket.
                     // A*-base-centered candidates have minimum distance max(0, _distSA - _r).
@@ -987,50 +1144,22 @@ export function calculateSmartPlacementV2(
     } : null;
 
     // Find best grid node for the base
-    let bestBase: {
-        basePos: Vec3;
-        rootTopTarget: Vec3;
-        snapDistance: number;
-        nodeKey: string | null;
-    } | null = null;
-
-    const candidateNodeKeys = gridEnabled
-        ? buildNearestCandidateNodeKeysCached(
-            gridNodeKeyFromXY(unsnappedBottomPos.x, unsnappedBottomPos.y, spacingMm),
-            MAX_NEAREST_NODE_SEARCH_RINGS,
-        )
-        : ['disabled'];
-
-    for (const nodeKey of candidateNodeKeys) {
-        let snappedXY = gridEnabled
-            ? gridSnappedXYFromKey(nodeKey, spacingMm)
-            : { x: unsnappedBottomPos.x, y: unsnappedBottomPos.y };
-
-        // When grid is disabled, apply the sub-grid offset to preserve uniqueness
-        if (!gridEnabled && subGridOffset) {
-            snappedXY = {
-                x: snappedXY.x + subGridOffset.x,
-                y: snappedXY.y + subGridOffset.y,
-            };
-        }
-
-        const basePos: Vec3 = { x: snappedXY.x, y: snappedXY.y, z: 0 };
-        const rootTopTarget: Vec3 = { x: snappedXY.x, y: snappedXY.y, z: rootTopZ };
-        const snapDistance = distanceXY(basePos, unsnappedBottomPos);
-
-        // Volumetric roots check at this grid-snapped base position.
-        // Grid snapping shifts XY, so a position the A* validated may not
-        // hold after snapping — recheck the full cone/disk volume.
-        if (rootsDiskBlocked(sdf, basePos.x, basePos.y, diskHeight, coneHeight, rootsRadius, shaftRadius)) continue;
-
-        // Check that the last shaft segment (lowest joint → rootTopTarget) is also clear
-        const lastJoint = pathJoints.length > 0 ? pathJoints[pathJoints.length - 1] : pathEnd;
-        if (sdf.segmentBlocked(lastJoint.x, lastJoint.y, lastJoint.z, rootTopTarget.x, rootTopTarget.y, rootTopTarget.z, clearance)) continue;
-
-        if (!bestBase || snapDistance < bestBase.snapDistance) {
-            bestBase = { basePos, rootTopTarget, snapDistance, nodeKey: gridEnabled ? nodeKey : null };
-        }
-    }
+    const bestBase = resolveCommittedBaseCandidate({
+        preferredBottomPos: unsnappedBottomPos,
+        lastSegmentStart: pathJoints.length > 0 ? pathJoints[pathJoints.length - 1] : pathEnd,
+        rootTopZ,
+        gridEnabled,
+        spacingMm,
+        maxNearestNodeSearchRings: MAX_NEAREST_NODE_SEARCH_RINGS,
+        sdf,
+        diskHeight,
+        coneHeight,
+        rootsRadius,
+        shaftRadius,
+        clearance,
+        buildNearestCandidateNodeKeys: buildNearestCandidateNodeKeysCached,
+        subGridOffset,
+    });
 
     if (!bestBase) {
         // No valid grid-snapped base found
@@ -1106,8 +1235,7 @@ export function calculateSmartPlacementV2(
         // search isn't limited to ~9mm radius by length-aware tightening
         // on 22mm-tall supports. The tightened angle is enforced at commit time.
         const sweepDirs = 16;
-        const sweepRadii = [1, 2, 3, 4, 6, 8, 10, 14, 18, 24, 30];
-        for (const r of sweepRadii) {
+        for (const r of rescueSweepRadiiMm) {
             if (r > maxTotalLateralMm) break;
             for (let d = 0; d < sweepDirs; d++) {
                 const a = (d / sweepDirs) * Math.PI * 2;

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -282,17 +282,17 @@ function isMixedSocketRescueCandidateBetter(
 ): boolean {
     const eps = 0.000001;
 
-    if (candidate.conePenaltyScore < current.conePenaltyScore - eps) {
-        return true;
-    }
-    if (candidate.conePenaltyScore > current.conePenaltyScore + eps) {
-        return false;
-    }
-
     if (candidate.socketShiftMm < current.socketShiftMm - eps) {
         return true;
     }
     if (candidate.socketShiftMm > current.socketShiftMm + eps) {
+        return false;
+    }
+
+    if (candidate.conePenaltyScore < current.conePenaltyScore - eps) {
+        return true;
+    }
+    if (candidate.conePenaltyScore > current.conePenaltyScore + eps) {
         return false;
     }
 
@@ -325,13 +325,17 @@ export function findMixedSocketRescueCandidate(args: {
         socketPos: args.socketPos,
         coneScoring: args.coneScoring,
     });
+    const resolvedBaseCache = new Map<string, ResolvedBaseCandidate | null>();
 
-    let best: MixedSocketRescueCandidate | null = null;
+    const getResolvedBaseForTerminalPoint = (terminalPoint: Vec3): ResolvedBaseCandidate | null => {
+        const key = `${terminalPoint.x.toFixed(4)}|${terminalPoint.y.toFixed(4)}|${terminalPoint.z.toFixed(4)}`;
+        if (resolvedBaseCache.has(key)) {
+            return resolvedBaseCache.get(key) ?? null;
+        }
 
-    for (const candidateSocketPos of candidates) {
         const resolvedBase = resolveCommittedBaseCandidate({
-            preferredBottomPos: { x: candidateSocketPos.x, y: candidateSocketPos.y, z: 0 },
-            lastSegmentStart: null,
+            preferredBottomPos: { x: terminalPoint.x, y: terminalPoint.y, z: 0 },
+            lastSegmentStart: terminalPoint,
             rootTopZ: args.rootTopZ,
             gridEnabled: args.gridEnabled,
             spacingMm: args.spacingMm,
@@ -345,14 +349,24 @@ export function findMixedSocketRescueCandidate(args: {
             buildNearestCandidateNodeKeys: args.buildNearestCandidateNodeKeys,
             subGridOffset: args.subGridOffset,
         });
-        if (!resolvedBase) {
-            continue;
-        }
 
-        const rootTopTarget = resolvedBase.rootTopTarget;
+        resolvedBaseCache.set(key, resolvedBase);
+        return resolvedBase;
+    };
+
+    let best: MixedSocketRescueCandidate | null = null;
+
+    for (const candidateSocketPos of candidates) {
         const socketShiftMm = distanceXY(candidateSocketPos, args.socketPos);
 
         const considerCandidate = (joints: Vec3[]): void => {
+            const terminalPoint = joints[joints.length - 1] ?? candidateSocketPos;
+            const resolvedBase = getResolvedBaseForTerminalPoint(terminalPoint);
+            if (!resolvedBase) {
+                return;
+            }
+
+            const rootTopTarget = resolvedBase.rootTopTarget;
             const chainPoints = [candidateSocketPos, ...joints, rootTopTarget];
             for (let i = 0; i < chainPoints.length - 1; i++) {
                 const start = chainPoints[i];
@@ -397,9 +411,8 @@ export function findMixedSocketRescueCandidate(args: {
             jointZ > args.rootTopZ + MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM;
             jointZ -= MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM
         ) {
-            const t = (candidateSocketPos.z - jointZ) / availableDrop;
-            const centerX = candidateSocketPos.x + (rootTopTarget.x - candidateSocketPos.x) * t;
-            const centerY = candidateSocketPos.y + (rootTopTarget.y - candidateSocketPos.y) * t;
+            const centerX = candidateSocketPos.x;
+            const centerY = candidateSocketPos.y;
 
             for (const jointRadius of MIXED_SOCKET_RESCUE_JOINT_RADII_MM) {
                 if (jointRadius === 0) {

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -91,9 +91,26 @@ const MIXED_SOCKET_RESCUE_DIRECTIONS = 8;
 const MIXED_SOCKET_RESCUE_JOINT_RADII_MM = [0, 0.6, 1.2, 1.8];
 const MIXED_SOCKET_RESCUE_JOINT_DIRECTIONS = 12;
 const MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM = 2.0;
+const MIXED_SOCKET_RESCUE_NOMINAL_JOINT_RADII_MM = [0, 0.5, 1, 1.5, 2.2, 3.0, 3.8];
+const MIXED_SOCKET_RESCUE_NOMINAL_JOINT_Z_STEP_MM = 1.0;
 const BASE_WIDE_PASS_EXPANSIONS_AT_2MM = 600;
 const BASE_PREVIEW_WIDE_PASS_EXPANSIONS_AT_2MM = 250;
 const ENABLE_AGGRESSIVE_POST_PATH_STRAIGHTENING = false;
+
+// Cone rescue scoring is intentionally biased toward preserving a short,
+// near-normal tip.  Stretching the cone should be expensive enough that the
+// solver prefers moving the socket/base instead of distorting the tip geometry.
+const CONTACT_CONE_STRETCH_LINEAR_WEIGHT = 7.5;
+const CONTACT_CONE_STRETCH_QUADRATIC_WEIGHT = 4.0;
+const CONTACT_CONE_STRETCH_CUBIC_WEIGHT = 0.75;
+const CONTACT_CONE_ANGLE_WEIGHT = 0.04;
+const CONTACT_CONE_ANGLE_OVER_45_WEIGHT = 0.18;
+const CONTACT_CONE_WORSENING_WEIGHT = 0.16;
+const CONTACT_CONE_WORSENING_OVER_45_WEIGHT = 0.3;
+const CONTACT_CONE_MAX_STRETCH_RATIO = 0.40;
+const CONTACT_DISK_IDEAL_DIRECTION_DEVIATION_DEG = 20;
+const CONTACT_DISK_DIRECTION_DEVIATION_WEIGHT = 0.06;
+const CONTACT_DISK_DIRECTION_DEVIATION_QUADRATIC_WEIGHT = 0.04;
 
 function buildUnitCircleDirections(count: number): Array<{ x: number; y: number }> {
     const directions: Array<{ x: number; y: number }> = [];
@@ -209,6 +226,7 @@ interface MixedSocketRescueCandidate {
     socketPos: Vec3;
     base: ResolvedBaseCandidate;
     joints: Vec3[];
+    coneAddedLengthMm: number;
     conePenaltyScore: number;
     socketShiftMm: number;
     metrics: ResolvedChainMetrics;
@@ -221,10 +239,20 @@ interface ContactConeRescueScoringInput {
 }
 
 interface ContactConeRescuePenaltyMetrics {
+    axis: Vec3;
     lengthMm: number;
     score: number;
     angleFromSurfaceNormalDeg: number;
     addedLengthMm: number;
+    directionDeviationDeg: number;
+    exceedsStretchLimit: boolean;
+}
+
+interface ContactConeClearSocketSeed {
+    socketPos: Vec3;
+    addedLengthMm: number;
+    score: number;
+    socketShiftMm: number;
 }
 
 type RootsDiskBlockedAt = (centerX: number, centerY: number) => boolean;
@@ -252,7 +280,7 @@ function normalizeVectorOrFallback(vector: THREE.Vector3, fallback: THREE.Vector
 function getContactConeRescuePenaltyMetrics(args: {
     socketPos: Vec3;
     coneScoring: ContactConeRescueScoringInput;
-    reference?: Pick<ContactConeRescuePenaltyMetrics, 'lengthMm' | 'angleFromSurfaceNormalDeg'>;
+    reference?: Pick<ContactConeRescuePenaltyMetrics, 'lengthMm' | 'angleFromSurfaceNormalDeg' | 'axis'>;
 }): ContactConeRescuePenaltyMetrics {
     const { socketPos, coneScoring, reference } = args;
     const surfaceNormal = normalizeVectorOrFallback(
@@ -288,23 +316,43 @@ function getContactConeRescuePenaltyMetrics(args: {
     const referenceLengthMm = reference?.lengthMm ?? coneScoring.tipProfile.lengthMm;
     const referenceAngleDeg = reference?.angleFromSurfaceNormalDeg ?? 0;
     const addedLengthMm = Math.max(0, coneLengthMm - referenceLengthMm);
+    const stretchMm = Math.max(0, addedLengthMm - 0.05);
     const worsenedAngleDeg = Math.max(0, angleFromSurfaceNormalDeg - referenceAngleDeg);
     const shallownessScale = angleFromSurfaceNormalDeg / 90;
+    const referenceAxis = reference
+        ? normalizeVectorOrFallback(
+            new THREE.Vector3(reference.axis.x, reference.axis.y, reference.axis.z),
+            finalAxis,
+        )
+        : finalAxis;
+    const directionDeviationDeg = reference
+        ? THREE.MathUtils.radToDeg(Math.acos(THREE.MathUtils.clamp(finalAxis.dot(referenceAxis), -1, 1)))
+        : 0;
+    const directionDeviationOverIdealDeg = coneScoring.tipProfile.type === 'disk'
+        ? Math.max(0, directionDeviationDeg - CONTACT_DISK_IDEAL_DIRECTION_DEVIATION_DEG)
+        : 0;
     const absoluteShallownessPenalty =
-        angleFromSurfaceNormalDeg * 0.025
-        + Math.max(0, angleFromSurfaceNormalDeg - 45) * 0.12;
+        angleFromSurfaceNormalDeg * CONTACT_CONE_ANGLE_WEIGHT
+        + Math.max(0, angleFromSurfaceNormalDeg - 45) * CONTACT_CONE_ANGLE_OVER_45_WEIGHT;
     const worsenedShallownessPenalty =
-        worsenedAngleDeg * 0.09
-        + Math.max(0, angleFromSurfaceNormalDeg - Math.max(referenceAngleDeg, 45)) * 0.14;
+        worsenedAngleDeg * CONTACT_CONE_WORSENING_WEIGHT
+        + Math.max(0, angleFromSurfaceNormalDeg - Math.max(referenceAngleDeg, 45)) * CONTACT_CONE_WORSENING_OVER_45_WEIGHT;
     const addedLengthPenalty =
-        addedLengthMm * (2.8 + shallownessScale * 5.4)
-        + addedLengthMm * addedLengthMm * (0.7 + shallownessScale * 1.1);
+        stretchMm * CONTACT_CONE_STRETCH_LINEAR_WEIGHT
+        + stretchMm * stretchMm * (CONTACT_CONE_STRETCH_QUADRATIC_WEIGHT + shallownessScale * 1.75)
+        + stretchMm * stretchMm * stretchMm * CONTACT_CONE_STRETCH_CUBIC_WEIGHT;
+    const directionDeviationPenalty =
+        directionDeviationOverIdealDeg * CONTACT_DISK_DIRECTION_DEVIATION_WEIGHT
+        + directionDeviationOverIdealDeg * directionDeviationOverIdealDeg * CONTACT_DISK_DIRECTION_DEVIATION_QUADRATIC_WEIGHT;
 
     return {
+        axis: { x: finalAxis.x, y: finalAxis.y, z: finalAxis.z },
         lengthMm: coneLengthMm,
-        score: absoluteShallownessPenalty + worsenedShallownessPenalty + addedLengthPenalty,
+        score: absoluteShallownessPenalty + worsenedShallownessPenalty + addedLengthPenalty + directionDeviationPenalty,
         angleFromSurfaceNormalDeg,
         addedLengthMm,
+        directionDeviationDeg,
+        exceedsStretchLimit: addedLengthMm > referenceLengthMm * CONTACT_CONE_MAX_STRETCH_RATIO + 0.000001,
     };
 }
 
@@ -428,23 +476,101 @@ function createContactConeBlockedMemo(args: {
     };
 }
 
+function findContactConeClearSocketSeed(args: {
+    socketPos: Vec3;
+    maxTotalLateralMm: number;
+    coneScoring: ContactConeRescueScoringInput;
+    contactConeBlockedAt: ContactConeBlockedAt;
+}): ContactConeClearSocketSeed | null {
+    const candidates = buildMixedSocketRescueCandidates({
+        socketPos: args.socketPos,
+        maxTotalLateralMm: args.maxTotalLateralMm,
+    });
+    const baselineConePenaltyMetrics = getContactConeRescuePenaltyMetrics({
+        socketPos: args.socketPos,
+        coneScoring: args.coneScoring,
+    });
+
+    let best: ContactConeClearSocketSeed | null = null;
+    const eps = 0.000001;
+
+    for (const candidateSocketPos of candidates) {
+        if (args.contactConeBlockedAt(candidateSocketPos)) {
+            continue;
+        }
+
+        const metrics = getContactConeRescuePenaltyMetrics({
+            socketPos: candidateSocketPos,
+            coneScoring: args.coneScoring,
+            reference: baselineConePenaltyMetrics,
+        });
+        if (metrics.exceedsStretchLimit) {
+            continue;
+        }
+        const candidate: ContactConeClearSocketSeed = {
+            socketPos: candidateSocketPos,
+            addedLengthMm: metrics.addedLengthMm,
+            score: metrics.score,
+            socketShiftMm: distanceXY(candidateSocketPos, args.socketPos),
+        };
+
+        if (!best) {
+            best = candidate;
+            continue;
+        }
+
+        if (candidate.addedLengthMm < best.addedLengthMm - eps) {
+            best = candidate;
+            continue;
+        }
+        if (candidate.addedLengthMm > best.addedLengthMm + eps) {
+            continue;
+        }
+
+        if (candidate.score < best.score - eps) {
+            best = candidate;
+            continue;
+        }
+        if (candidate.score > best.score + eps) {
+            continue;
+        }
+
+        if (candidate.socketShiftMm < best.socketShiftMm - eps) {
+            best = candidate;
+        }
+    }
+
+    return best;
+}
+
 function isMixedSocketRescueCandidateBetter(
     candidate: MixedSocketRescueCandidate,
     current: MixedSocketRescueCandidate,
 ): boolean {
     const eps = 0.000001;
 
-    if (candidate.socketShiftMm < current.socketShiftMm - eps) {
+    // Hard preference: keep the cone as close as possible to nominal length.
+    if (candidate.coneAddedLengthMm < current.coneAddedLengthMm - eps) {
         return true;
     }
-    if (candidate.socketShiftMm > current.socketShiftMm + eps) {
+    if (candidate.coneAddedLengthMm > current.coneAddedLengthMm + eps) {
         return false;
     }
 
+    // Prefer preserving contact-cone quality over minimizing socket shift.
+    // This lets the solver choose an extra shaft bend/joint when needed
+    // rather than accepting an over-stretched cone just to keep XY shift tiny.
     if (candidate.conePenaltyScore < current.conePenaltyScore - eps) {
         return true;
     }
     if (candidate.conePenaltyScore > current.conePenaltyScore + eps) {
+        return false;
+    }
+
+    if (candidate.socketShiftMm < current.socketShiftMm - eps) {
+        return true;
+    }
+    if (candidate.socketShiftMm > current.socketShiftMm + eps) {
         return false;
     }
 
@@ -542,7 +668,6 @@ export function findMixedSocketRescueCandidate(args: {
     };
 
     let best: MixedSocketRescueCandidate | null = null;
-    let bestSocketShiftMm: number | null = null;
 
     for (const candidateSocketPos of candidates) {
         if (args.contactConeBlockedAt?.(candidateSocketPos)) {
@@ -550,9 +675,7 @@ export function findMixedSocketRescueCandidate(args: {
         }
 
         const socketShiftMm = distanceXY(candidateSocketPos, args.socketPos);
-        if (bestSocketShiftMm !== null && socketShiftMm > bestSocketShiftMm + 0.000001) {
-            break;
-        }
+        const preferNominalReachAround = socketShiftMm <= 0.000001;
 
         const considerCandidate = (joints: Vec3[]): void => {
             const chainPrefix = [candidateSocketPos, ...joints];
@@ -582,11 +705,15 @@ export function findMixedSocketRescueCandidate(args: {
             }
 
             const conePenaltyMetrics = getConePenaltyMetrics(candidateSocketPos);
+            if (conePenaltyMetrics.exceedsStretchLimit) {
+                return;
+            }
 
             const candidate: MixedSocketRescueCandidate = {
                 socketPos: candidateSocketPos,
                 base: resolvedBase,
                 joints,
+                coneAddedLengthMm: conePenaltyMetrics.addedLengthMm,
                 conePenaltyScore: conePenaltyMetrics.score,
                 socketShiftMm,
                 metrics: getResolvedChainMetrics(candidateSocketPos, joints, rootTopTarget),
@@ -594,26 +721,31 @@ export function findMixedSocketRescueCandidate(args: {
 
             if (!best || isMixedSocketRescueCandidateBetter(candidate, best)) {
                 best = candidate;
-                bestSocketShiftMm = candidate.socketShiftMm;
             }
         };
 
         considerCandidate([]);
 
+        const jointZStepMm = preferNominalReachAround
+            ? MIXED_SOCKET_RESCUE_NOMINAL_JOINT_Z_STEP_MM
+            : MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM;
+        const jointRadii = preferNominalReachAround
+            ? MIXED_SOCKET_RESCUE_NOMINAL_JOINT_RADII_MM
+            : MIXED_SOCKET_RESCUE_JOINT_RADII_MM;
         const availableDrop = candidateSocketPos.z - args.rootTopZ;
-        if (availableDrop <= MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM + 0.000001) {
+        if (availableDrop <= jointZStepMm + 0.000001) {
             continue;
         }
 
         for (
-            let jointZ = candidateSocketPos.z - MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM;
-            jointZ > args.rootTopZ + MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM;
-            jointZ -= MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM
+            let jointZ = candidateSocketPos.z - jointZStepMm;
+            jointZ > args.rootTopZ + jointZStepMm;
+            jointZ -= jointZStepMm
         ) {
             const centerX = candidateSocketPos.x;
             const centerY = candidateSocketPos.y;
 
-            for (const jointRadius of MIXED_SOCKET_RESCUE_JOINT_RADII_MM) {
+            for (const jointRadius of jointRadii) {
                 if (jointRadius === 0) {
                     considerCandidate([{ x: centerX, y: centerY, z: jointZ }]);
                     continue;
@@ -674,27 +806,41 @@ export function findStraightSocketRescueCandidate(args: {
         })
         : null;
 
-    let bestCandidate: { socketPos: Vec3; base: ResolvedBaseCandidate; conePenaltyScore: number; socketShiftMm: number } | null = null;
-    const conePenaltyCache = new Map<string, number>();
+    let bestCandidate: {
+        socketPos: Vec3;
+        base: ResolvedBaseCandidate;
+        coneAddedLengthMm: number;
+        conePenaltyScore: number;
+        socketShiftMm: number;
+    } | null = null;
+    const conePenaltyCache = new Map<string, ContactConeRescuePenaltyMetrics>();
 
-    const getConePenaltyScore = (candidateSocketPos: Vec3): number => {
+    const getConePenaltyMetrics = (candidateSocketPos: Vec3): ContactConeRescuePenaltyMetrics => {
         if (!args.coneScoring) {
-            return 0;
+            return {
+                axis: { x: 0, y: 0, z: 1 },
+                lengthMm: 0,
+                score: 0,
+                angleFromSurfaceNormalDeg: 0,
+                addedLengthMm: 0,
+                directionDeviationDeg: 0,
+                exceedsStretchLimit: false,
+            };
         }
 
         const key = vec3CacheKey(candidateSocketPos);
         const cached = conePenaltyCache.get(key);
-        if (cached !== undefined) {
+        if (cached) {
             return cached;
         }
 
-        const score = getContactConeRescuePenaltyMetrics({
+        const metrics = getContactConeRescuePenaltyMetrics({
             socketPos: candidateSocketPos,
             coneScoring: args.coneScoring,
             reference: baselineConePenaltyMetrics ?? undefined,
-        }).score;
-        conePenaltyCache.set(key, score);
-        return score;
+        });
+        conePenaltyCache.set(key, metrics);
+        return metrics;
     };
 
     for (const candidateSocketPos of candidates) {
@@ -702,10 +848,23 @@ export function findStraightSocketRescueCandidate(args: {
             continue;
         }
 
-        const conePenaltyScore = getConePenaltyScore(candidateSocketPos);
+        const conePenaltyMetrics = getConePenaltyMetrics(candidateSocketPos);
+        if (conePenaltyMetrics.exceedsStretchLimit) {
+            continue;
+        }
+        const conePenaltyScore = conePenaltyMetrics.score;
+        const coneAddedLengthMm = conePenaltyMetrics.addedLengthMm;
         const socketShiftMm = distanceXY(candidateSocketPos, args.socketPos);
         const eps = 0.000001;
         if (bestCandidate) {
+            if (coneAddedLengthMm > bestCandidate.coneAddedLengthMm + eps) {
+                continue;
+            }
+            if (coneAddedLengthMm < bestCandidate.coneAddedLengthMm - eps) {
+                // continue evaluating this better-length candidate
+            } else if (conePenaltyScore > bestCandidate.conePenaltyScore + eps) {
+                continue;
+            }
             if (conePenaltyScore > bestCandidate.conePenaltyScore + eps) {
                 continue;
             }
@@ -739,6 +898,7 @@ export function findStraightSocketRescueCandidate(args: {
             const candidate = {
                 socketPos: candidateSocketPos,
                 base: resolved,
+                coneAddedLengthMm,
                 conePenaltyScore,
                 socketShiftMm,
             };
@@ -748,6 +908,13 @@ export function findStraightSocketRescueCandidate(args: {
                 continue;
             }
 
+            if (candidate.coneAddedLengthMm < bestCandidate.coneAddedLengthMm - eps) {
+                bestCandidate = candidate;
+                continue;
+            }
+            if (candidate.coneAddedLengthMm > bestCandidate.coneAddedLengthMm + eps) {
+                continue;
+            }
             if (candidate.conePenaltyScore < bestCandidate.conePenaltyScore - eps) {
                 bestCandidate = candidate;
                 continue;
@@ -1261,7 +1428,8 @@ export function calculateSmartPlacementV2(
 
     // 3. Quick check: is the straight-down path clear AND do the roots fit at the base?
     const rootTopZ = input.rootsTopZ;
-    const socketPos = standard.socketPos;
+    const nominalSocketPos = standard.socketPos;
+    let socketPos = nominalSocketPos;
     if (debugEnabled) {
         setSupportPathfindingDebugSnapshot(null);
     }
@@ -1292,11 +1460,12 @@ export function calculateSmartPlacementV2(
         );
     };
     const isPreview = context?.isPreview ?? false;
-    const { maxTotalLateralMm, rescueSweepRadiiMm } = getSmartPlacementV2SearchEnvelope({
-        socketPos,
+    let { maxTotalLateralMm, rescueSweepRadiiMm } = getSmartPlacementV2SearchEnvelope({
+        socketPos: nominalSocketPos,
         rootTopZ,
         spacingMm: settings.grid.spacingMm,
     });
+    const nominalMaxTotalLateralMm = maxTotalLateralMm;
     const rootsDiskBlockedAt = createRootsDiskBlockedMemo({
         sdf,
         diskHeight,
@@ -1312,37 +1481,40 @@ export function calculateSmartPlacementV2(
         tipProfile: input.tipProfile,
     });
 
-    // Shaft + roots checks now use SDF sphere-tracing and bounding-ball
-    // early-outs, so preview no longer needs the old coarse approximations —
-    // the accurate versions are fast in open space and equally accurate.
-    const straightClear = !segmentBlockedBetween(socketPos, { x: socketPos.x, y: socketPos.y, z: rootTopZ });
-    const coneClear = !contactConeBlockedAt(socketPos);
-
-    const baseXY = standard.basePos;
-    const rootsFitStandard = !rootsDiskBlockedAt(baseXY.x, baseXY.y);
-
-    if (!isPreview) {
-        console.log(`[SmartPlacementV2] called — socket=(${socketPos.x.toFixed(2)},${socketPos.y.toFixed(2)},${socketPos.z.toFixed(2)}) rootTopZ=${rootTopZ.toFixed(2)} coneClear=${coneClear} straightClear=${straightClear} rootsFit=${rootsFitStandard}`);
-    }
-
-    if (coneClear && straightClear && rootsFitStandard) {
-        if (!isPreview) console.log(`[SmartPlacementV2] STRAIGHT path — no routing needed`);
-        return standard; // Cone, shaft, and roots are all clear — no routing needed
-    }
+    const coneClear = !contactConeBlockedAt(nominalSocketPos);
 
     let straightRescueCache:
         | { socketPos: Vec3; base: ResolvedBaseCandidate }
         | null
         | undefined;
+    let coneClearSocketSeedCache: ContactConeClearSocketSeed | null | undefined;
+    const getConeClearSocketSeed = () => {
+        if (coneClearSocketSeedCache !== undefined) {
+            return coneClearSocketSeedCache;
+        }
+
+        coneClearSocketSeedCache = findContactConeClearSocketSeed({
+            socketPos: nominalSocketPos,
+            maxTotalLateralMm: nominalMaxTotalLateralMm,
+            coneScoring: {
+                tipPos: input.tipPos,
+                tipNormal: input.tipNormal,
+                tipProfile: input.tipProfile,
+            },
+            contactConeBlockedAt,
+        });
+
+        return coneClearSocketSeedCache;
+    };
     const getStraightSocketRescueFallback = () => {
         if (straightRescueCache !== undefined) {
             return straightRescueCache;
         }
 
         straightRescueCache = findStraightSocketRescueCandidate({
-            socketPos,
+            socketPos: nominalSocketPos,
             rootTopZ,
-            maxTotalLateralMm,
+            maxTotalLateralMm: nominalMaxTotalLateralMm,
             gridEnabled: settings.grid.enabled,
             spacingMm: settings.grid.spacingMm,
             maxNearestNodeSearchRings: MAX_NEAREST_NODE_SEARCH_RINGS,
@@ -1379,9 +1551,9 @@ export function calculateSmartPlacementV2(
         }
 
         mixedSocketRescueCache = findMixedSocketRescueCandidate({
-            socketPos,
+            socketPos: nominalSocketPos,
             rootTopZ,
-            maxTotalLateralMm,
+            maxTotalLateralMm: nominalMaxTotalLateralMm,
             gridEnabled: settings.grid.enabled,
             spacingMm: settings.grid.spacingMm,
             maxNearestNodeSearchRings: MAX_NEAREST_NODE_SEARCH_RINGS,
@@ -1451,19 +1623,83 @@ export function calculateSmartPlacementV2(
         };
     };
 
+    let activeConeClear = coneClear;
     if (!coneClear) {
-        if (isPreview) {
+        const mixedSocketRescue = getMixedSocketRescueFallback();
+        if (mixedSocketRescue && mixedSocketRescue.joints.length > 0) {
+            if (!isPreview) {
+                console.log(
+                    `[SmartPlacementV2] cone-blocked mixed rescue — socket=(${mixedSocketRescue.socketPos.x.toFixed(2)},${mixedSocketRescue.socketPos.y.toFixed(2)},${mixedSocketRescue.socketPos.z.toFixed(2)}) joints=[${mixedSocketRescue.joints.map((joint) => `(${joint.x.toFixed(2)},${joint.y.toFixed(2)},${joint.z.toFixed(2)})`).join(' ')}] base=(${mixedSocketRescue.base.basePos.x.toFixed(2)},${mixedSocketRescue.base.basePos.y.toFixed(2)},${mixedSocketRescue.base.basePos.z.toFixed(2)})`,
+                );
+            }
             publishPathfindingDebugSnapshot();
             return {
                 ...standard,
-                error: 'COLLISION_WITH_MODEL',
+                socketPos: mixedSocketRescue.socketPos,
+                basePos: mixedSocketRescue.base.basePos,
+                unsnappedBottomPos: mixedSocketRescue.base.basePos,
+                snappedNodeKey: mixedSocketRescue.base.nodeKey,
+                joints: mixedSocketRescue.joints,
+                constructionJoints: [],
+                error: undefined,
             };
         }
 
-        const straightRescueFallback = buildStraightRescueFallback();
-        if (straightRescueFallback) {
-            return straightRescueFallback;
+        const coneClearSeed = getConeClearSocketSeed();
+        const rescuedSocketPos = coneClearSeed?.socketPos ?? null;
+
+        if (rescuedSocketPos) {
+            socketPos = rescuedSocketPos;
+            activeConeClear = true;
+            ({ maxTotalLateralMm, rescueSweepRadiiMm } = getSmartPlacementV2SearchEnvelope({
+                socketPos,
+                rootTopZ,
+                spacingMm: settings.grid.spacingMm,
+            }));
+            if (!isPreview) {
+                console.log(
+                    `[SmartPlacementV2] cone-clear seed — nominal=(${nominalSocketPos.x.toFixed(2)},${nominalSocketPos.y.toFixed(2)},${nominalSocketPos.z.toFixed(2)}) seed=(${socketPos.x.toFixed(2)},${socketPos.y.toFixed(2)},${socketPos.z.toFixed(2)}) addedLength=${coneClearSeed?.addedLengthMm.toFixed(2) ?? '0.00'} shift=${coneClearSeed?.socketShiftMm.toFixed(2) ?? '0.00'}`,
+                );
+            }
+        } else {
+            if (isPreview) {
+                publishPathfindingDebugSnapshot();
+                return {
+                    ...standard,
+                    error: 'COLLISION_WITH_MODEL',
+                };
+            }
+
+            const straightRescueFallback = buildStraightRescueFallback();
+            if (straightRescueFallback) {
+                return straightRescueFallback;
+            }
         }
+    }
+
+    // Shaft + roots checks now use SDF sphere-tracing and bounding-ball
+    // early-outs, so preview no longer needs the old coarse approximations —
+    // the accurate versions are fast in open space and equally accurate.
+    const straightClear = !segmentBlockedBetween(socketPos, { x: socketPos.x, y: socketPos.y, z: rootTopZ });
+    const baseXY: Vec3 = { x: socketPos.x, y: socketPos.y, z: 0 };
+    const rootsFitStandard = !rootsDiskBlockedAt(baseXY.x, baseXY.y);
+
+    if (!isPreview) {
+        console.log(`[SmartPlacementV2] called — nominalSocket=(${nominalSocketPos.x.toFixed(2)},${nominalSocketPos.y.toFixed(2)},${nominalSocketPos.z.toFixed(2)}) activeSocket=(${socketPos.x.toFixed(2)},${socketPos.y.toFixed(2)},${socketPos.z.toFixed(2)}) rootTopZ=${rootTopZ.toFixed(2)} nominalConeClear=${coneClear} activeConeClear=${activeConeClear} straightClear=${straightClear} rootsFit=${rootsFitStandard}`);
+    }
+
+    if (activeConeClear && straightClear && rootsFitStandard) {
+        if (!isPreview) console.log(`[SmartPlacementV2] STRAIGHT path — no routing needed`);
+        return {
+            ...standard,
+            socketPos,
+            basePos: baseXY,
+            unsnappedBottomPos: baseXY,
+            snappedNodeKey: null,
+            joints: [],
+            constructionJoints: [],
+            error: undefined,
+        }; // Cone, shaft, and roots are all clear — no routing needed
     }
 
     // 3b. Spatial caches: skip A* if a previous search from a nearby socketPos

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -413,10 +413,11 @@ export function findMixedSocketRescueCandidate(args: {
     };
 
     let best: MixedSocketRescueCandidate | null = null;
+    let bestSocketShiftMm: number | null = null;
 
     for (const candidateSocketPos of candidates) {
         const socketShiftMm = distanceXY(candidateSocketPos, args.socketPos);
-        if (best && socketShiftMm > best.socketShiftMm + 0.000001) {
+        if (bestSocketShiftMm !== null && socketShiftMm > bestSocketShiftMm + 0.000001) {
             break;
         }
 
@@ -460,6 +461,7 @@ export function findMixedSocketRescueCandidate(args: {
 
             if (!best || isMixedSocketRescueCandidateBetter(candidate, best)) {
                 best = candidate;
+                bestSocketShiftMm = candidate.socketShiftMm;
             }
         };
 

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -13,6 +13,8 @@
 
 import * as THREE from 'three';
 import { Vec3 } from '../../types';
+import type { SupportTipProfile } from '../../SupportPrimitives/ContactCone/types';
+import { calculateDiskThickness } from '../../SupportPrimitives/ContactDisk/contactDiskUtils';
 import {
     calculateStandardPlacement,
     type TrunkPlacementInput,
@@ -189,8 +191,89 @@ interface MixedSocketRescueCandidate {
     socketPos: Vec3;
     base: ResolvedBaseCandidate;
     joints: Vec3[];
+    conePenaltyScore: number;
     socketShiftMm: number;
     metrics: ResolvedChainMetrics;
+}
+
+interface ContactConeRescueScoringInput {
+    tipPos: Vec3;
+    tipNormal: Vec3;
+    tipProfile: SupportTipProfile;
+}
+
+interface ContactConeRescuePenaltyMetrics {
+    lengthMm: number;
+    score: number;
+    angleFromSurfaceNormalDeg: number;
+    addedLengthMm: number;
+}
+
+function normalizeVectorOrFallback(vector: THREE.Vector3, fallback: THREE.Vector3): THREE.Vector3 {
+    if (vector.lengthSq() < 0.000001) {
+        return fallback.clone().normalize();
+    }
+
+    return vector.clone().normalize();
+}
+
+function getContactConeRescuePenaltyMetrics(args: {
+    socketPos: Vec3;
+    coneScoring: ContactConeRescueScoringInput;
+    reference?: Pick<ContactConeRescuePenaltyMetrics, 'lengthMm' | 'angleFromSurfaceNormalDeg'>;
+}): ContactConeRescuePenaltyMetrics {
+    const { socketPos, coneScoring, reference } = args;
+    const surfaceNormal = normalizeVectorOrFallback(
+        new THREE.Vector3(coneScoring.tipNormal.x, coneScoring.tipNormal.y, coneScoring.tipNormal.z),
+        new THREE.Vector3(0, 0, 1),
+    );
+    const approxAxis = normalizeVectorOrFallback(
+        new THREE.Vector3(
+            socketPos.x - coneScoring.tipPos.x,
+            socketPos.y - coneScoring.tipPos.y,
+            socketPos.z - coneScoring.tipPos.z,
+        ),
+        surfaceNormal,
+    );
+    const thickness = coneScoring.tipProfile.type === 'disk'
+        ? calculateDiskThickness(
+            { x: surfaceNormal.x, y: surfaceNormal.y, z: surfaceNormal.z },
+            { x: approxAxis.x, y: approxAxis.y, z: approxAxis.z },
+            coneScoring.tipProfile,
+        )
+        : 0;
+    const coneStart = new THREE.Vector3(
+        coneScoring.tipPos.x + surfaceNormal.x * thickness,
+        coneScoring.tipPos.y + surfaceNormal.y * thickness,
+        coneScoring.tipPos.z + surfaceNormal.z * thickness,
+    );
+    const finalAxis = normalizeVectorOrFallback(
+        new THREE.Vector3(socketPos.x, socketPos.y, socketPos.z).sub(coneStart),
+        approxAxis,
+    );
+    const coneLengthMm = Math.max(0.05, coneStart.distanceTo(new THREE.Vector3(socketPos.x, socketPos.y, socketPos.z)));
+    const angleFromSurfaceNormalDeg = THREE.MathUtils.radToDeg(Math.acos(THREE.MathUtils.clamp(finalAxis.dot(surfaceNormal), -1, 1)));
+    const referenceLengthMm = reference?.lengthMm ?? coneScoring.tipProfile.lengthMm;
+    const referenceAngleDeg = reference?.angleFromSurfaceNormalDeg ?? 0;
+    const addedLengthMm = Math.max(0, coneLengthMm - referenceLengthMm);
+    const worsenedAngleDeg = Math.max(0, angleFromSurfaceNormalDeg - referenceAngleDeg);
+    const shallownessScale = angleFromSurfaceNormalDeg / 90;
+    const absoluteShallownessPenalty =
+        angleFromSurfaceNormalDeg * 0.025
+        + Math.max(0, angleFromSurfaceNormalDeg - 45) * 0.12;
+    const worsenedShallownessPenalty =
+        worsenedAngleDeg * 0.09
+        + Math.max(0, angleFromSurfaceNormalDeg - Math.max(referenceAngleDeg, 45)) * 0.14;
+    const addedLengthPenalty =
+        addedLengthMm * (2.8 + shallownessScale * 5.4)
+        + addedLengthMm * addedLengthMm * (0.7 + shallownessScale * 1.1);
+
+    return {
+        lengthMm: coneLengthMm,
+        score: absoluteShallownessPenalty + worsenedShallownessPenalty + addedLengthPenalty,
+        angleFromSurfaceNormalDeg,
+        addedLengthMm,
+    };
 }
 
 function isMixedSocketRescueCandidateBetter(
@@ -198,6 +281,13 @@ function isMixedSocketRescueCandidateBetter(
     current: MixedSocketRescueCandidate,
 ): boolean {
     const eps = 0.000001;
+
+    if (candidate.conePenaltyScore < current.conePenaltyScore - eps) {
+        return true;
+    }
+    if (candidate.conePenaltyScore > current.conePenaltyScore + eps) {
+        return false;
+    }
 
     if (candidate.socketShiftMm < current.socketShiftMm - eps) {
         return true;
@@ -223,12 +313,17 @@ export function findMixedSocketRescueCandidate(args: {
     shaftRadius: number;
     clearance: number;
     maxAngleFromVerticalDeg: number;
+    coneScoring: ContactConeRescueScoringInput;
     buildNearestCandidateNodeKeys?: (preferredKey: string, maxRings: number) => string[];
     subGridOffset?: { x: number; y: number } | null;
 }): { socketPos: Vec3; base: ResolvedBaseCandidate; joints: Vec3[] } | null {
     const candidates = buildMixedSocketRescueCandidates({
         socketPos: args.socketPos,
         maxTotalLateralMm: args.maxTotalLateralMm,
+    });
+    const baselineConePenaltyMetrics = getContactConeRescuePenaltyMetrics({
+        socketPos: args.socketPos,
+        coneScoring: args.coneScoring,
     });
 
     let best: MixedSocketRescueCandidate | null = null;
@@ -270,10 +365,17 @@ export function findMixedSocketRescueCandidate(args: {
                 }
             }
 
+            const conePenaltyMetrics = getContactConeRescuePenaltyMetrics({
+                socketPos: candidateSocketPos,
+                coneScoring: args.coneScoring,
+                reference: baselineConePenaltyMetrics,
+            });
+
             const candidate: MixedSocketRescueCandidate = {
                 socketPos: candidateSocketPos,
                 base: resolvedBase,
                 joints,
+                conePenaltyScore: conePenaltyMetrics.score,
                 socketShiftMm,
                 metrics: getResolvedChainMetrics(candidateSocketPos, joints, rootTopTarget),
             };
@@ -343,6 +445,7 @@ export function findStraightSocketRescueCandidate(args: {
     rootsRadius: number;
     shaftRadius: number;
     clearance: number;
+    coneScoring?: ContactConeRescueScoringInput;
     buildNearestCandidateNodeKeys?: (preferredKey: string, maxRings: number) => string[];
     subGridOffset?: { x: number; y: number } | null;
 }): { socketPos: Vec3; base: ResolvedBaseCandidate } | null {
@@ -350,6 +453,14 @@ export function findStraightSocketRescueCandidate(args: {
         socketPos: args.socketPos,
         maxTotalLateralMm: args.maxTotalLateralMm,
     });
+    const baselineConePenaltyMetrics = args.coneScoring
+        ? getContactConeRescuePenaltyMetrics({
+            socketPos: args.socketPos,
+            coneScoring: args.coneScoring,
+        })
+        : null;
+
+    let bestCandidate: { socketPos: Vec3; base: ResolvedBaseCandidate; conePenaltyScore: number; socketShiftMm: number } | null = null;
 
     for (const candidateSocketPos of candidates) {
         const resolved = resolveCommittedBaseCandidate({
@@ -369,14 +480,56 @@ export function findStraightSocketRescueCandidate(args: {
             subGridOffset: args.subGridOffset,
         });
         if (resolved) {
-            return {
+            const conePenaltyScore = args.coneScoring
+                ? getContactConeRescuePenaltyMetrics({
+                    socketPos: candidateSocketPos,
+                    coneScoring: args.coneScoring,
+                    reference: baselineConePenaltyMetrics ?? undefined,
+                }).score
+                : 0;
+            const candidate = {
                 socketPos: candidateSocketPos,
                 base: resolved,
+                conePenaltyScore,
+                socketShiftMm: distanceXY(candidateSocketPos, args.socketPos),
             };
+
+            if (!bestCandidate) {
+                bestCandidate = candidate;
+                continue;
+            }
+
+            const eps = 0.000001;
+            if (candidate.conePenaltyScore < bestCandidate.conePenaltyScore - eps) {
+                bestCandidate = candidate;
+                continue;
+            }
+            if (candidate.conePenaltyScore > bestCandidate.conePenaltyScore + eps) {
+                continue;
+            }
+            if (candidate.socketShiftMm < bestCandidate.socketShiftMm - eps) {
+                bestCandidate = candidate;
+                continue;
+            }
+            if (candidate.socketShiftMm > bestCandidate.socketShiftMm + eps) {
+                continue;
+            }
+            if ((candidate.base.inboundLateralMm ?? 0) < (bestCandidate.base.inboundLateralMm ?? 0) - eps) {
+                bestCandidate = candidate;
+                continue;
+            }
+            if (candidate.base.snapDistance < bestCandidate.base.snapDistance - eps) {
+                bestCandidate = candidate;
+            }
         }
     }
 
-    return null;
+    return bestCandidate
+        ? {
+            socketPos: bestCandidate.socketPos,
+            base: bestCandidate.base,
+        }
+        : null;
 }
 
 function getWidePassBaseExpansionsAt2mm(maxTotalLateralMm: number, isPreview: boolean): number {
@@ -838,6 +991,11 @@ export function calculateSmartPlacementV2(
         rootsRadius,
         shaftRadius,
         clearance,
+        coneScoring: {
+            tipPos: input.tipPos,
+            tipNormal: input.tipNormal,
+            tipProfile: input.tipProfile,
+        },
         buildNearestCandidateNodeKeys,
         subGridOffset: !settings.grid.enabled ? {
             x: input.tipPos.x - Math.round(input.tipPos.x / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,
@@ -867,6 +1025,11 @@ export function calculateSmartPlacementV2(
             shaftRadius,
             clearance,
             maxAngleFromVerticalDeg: maxSegmentAngleFromVerticalDeg,
+            coneScoring: {
+                tipPos: input.tipPos,
+                tipNormal: input.tipNormal,
+                tipProfile: input.tipProfile,
+            },
             buildNearestCandidateNodeKeys,
             subGridOffset: !settings.grid.enabled ? {
                 x: input.tipPos.x - Math.round(input.tipPos.x / FINE_ASTAR_STEP_MM) * FINE_ASTAR_STEP_MM,

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -28,6 +28,7 @@ import { gridAStar, type GridAStarDebugSnapshot, type WarmStartState } from './G
 import type { SupportOccupancy } from './SupportOccupancy';
 import {
     getSupportPathfindingDebugEnabled,
+    getSupportPathfindingDebugTuningEnabled,
     setSupportPathfindingDebugSnapshot,
     type SupportPathfindingDebugEvent,
     type SupportPathfindingDebugOutcome,
@@ -71,7 +72,7 @@ const MAX_NEAREST_NODE_SEARCH_RINGS = 4;
 
 // Global standoff distance from model geometry to reduce resin overexposure
 // fusion risk when supports are placed close to surfaces.
-const COLLISION_AVOIDANCE_MM = 0.8;
+const COLLISION_AVOIDANCE_MM = 0.48;
 
 /** Number of XY perimeter samples around the roots cone at each height slice. */
 const ROOTS_DISK_PERIMETER_SAMPLES = 16;
@@ -85,9 +86,9 @@ const CONTACT_CONE_TIP_IGNORE_MM = 0.25;
 const CONTACT_CONE_COLLISION_SAMPLE_STEP_MM = 0.2;
 
 const ROUTED_DETOUR_ANGLE_SLACK_DEG = 10;
-const MIN_ROUTING_SEARCH_LATERAL_MM = 60;
-const MAX_ROUTING_SEARCH_LATERAL_MM = 120;
-const ROUTING_SEARCH_LATERAL_PER_VERTICAL_MM = 3.0;
+const MIN_ROUTING_SEARCH_LATERAL_MM = 72;
+const MAX_ROUTING_SEARCH_LATERAL_MM = 144;
+const ROUTING_SEARCH_LATERAL_PER_VERTICAL_MM = 3.6;
 const ROUTING_SEARCH_SWEEP_RADII_MM = [1, 2, 3, 4, 6, 8, 10, 14, 18, 24, 30, 36, 44, 52, 60, 72, 84, 96, 108];
 const STRAIGHT_SOCKET_RESCUE_RADII_MM = [0, 0.5, 1, 1.5, 2, 3, 4];
 const STRAIGHT_SOCKET_RESCUE_DIRECTIONS = 16;
@@ -98,8 +99,8 @@ const MIXED_SOCKET_RESCUE_JOINT_DIRECTIONS = 12;
 const MIXED_SOCKET_RESCUE_JOINT_Z_STEP_MM = 2.0;
 const MIXED_SOCKET_RESCUE_NOMINAL_JOINT_RADII_MM = [0, 0.5, 1, 1.5, 2.2, 3.0, 3.8];
 const MIXED_SOCKET_RESCUE_NOMINAL_JOINT_Z_STEP_MM = 1.0;
-const BASE_WIDE_PASS_EXPANSIONS_AT_2MM = 600;
-const BASE_PREVIEW_WIDE_PASS_EXPANSIONS_AT_2MM = 250;
+const BASE_WIDE_PASS_EXPANSIONS_AT_2MM = 810;
+const BASE_PREVIEW_WIDE_PASS_EXPANSIONS_AT_2MM = 338;
 const ENABLE_AGGRESSIVE_POST_PATH_STRAIGHTENING = false;
 
 // Cone rescue scoring is intentionally biased toward preserving a short,
@@ -112,11 +113,71 @@ const CONTACT_CONE_ANGLE_WEIGHT = 0.04;
 const CONTACT_CONE_ANGLE_OVER_45_WEIGHT = 0.18;
 const CONTACT_CONE_WORSENING_WEIGHT = 0.16;
 const CONTACT_CONE_WORSENING_OVER_45_WEIGHT = 0.3;
-const CONTACT_CONE_MAX_STRETCH_RATIO = 0.40;
+const CONTACT_CONE_MAX_STRETCH_RATIO = 0.52;
 const CONTACT_DISK_IDEAL_DIRECTION_DEVIATION_DEG = 20;
 const CONTACT_DISK_DIRECTION_DEVIATION_WEIGHT = 0.06;
 const CONTACT_DISK_DIRECTION_DEVIATION_QUADRATIC_WEIGHT = 0.04;
-const CONTACT_DISK_MAX_CONE_AXIS_ANGLE_DEG = 70;
+const CONTACT_DISK_MAX_CONE_AXIS_ANGLE_DEG = 78;
+
+interface DebugAutoTuneProfile {
+    envelopeLateralScale: number;
+    rescueRadiusScale: number;
+    coneSeedLateralScale: number;
+    fineExpansionScale: number;
+    wideExpansionScale: number;
+    collisionAvoidanceScale: number;
+    maxSegmentAngleBonusDeg: number;
+    minRoutingZSpanScale: number;
+    coneStretchRatioScale: number;
+    coneAxisAngleBonusDeg: number;
+}
+
+const DEFAULT_PATHFINDING_PROFILE: DebugAutoTuneProfile = {
+    envelopeLateralScale: 1,
+    rescueRadiusScale: 1,
+    coneSeedLateralScale: 1,
+    fineExpansionScale: 1,
+    wideExpansionScale: 1,
+    collisionAvoidanceScale: 1,
+    maxSegmentAngleBonusDeg: 0,
+    minRoutingZSpanScale: 1,
+    coneStretchRatioScale: 1,
+    coneAxisAngleBonusDeg: 0,
+};
+
+const EXTRA_DEBUG_TUNE_PROFILE: DebugAutoTuneProfile = {
+    envelopeLateralScale: 1.1,
+    rescueRadiusScale: 1.1,
+    coneSeedLateralScale: 1.1,
+    fineExpansionScale: 1.2,
+    wideExpansionScale: 1.15,
+    collisionAvoidanceScale: 0.85,
+    maxSegmentAngleBonusDeg: 2,
+    minRoutingZSpanScale: 0.85,
+    coneStretchRatioScale: 1.15,
+    coneAxisAngleBonusDeg: 4,
+};
+
+interface ConeAutoTuneProfile {
+    stretchRatioScale: number;
+    axisAngleBonusDeg: number;
+}
+
+function combineDebugAutoTuneProfiles(base: DebugAutoTuneProfile, extra?: DebugAutoTuneProfile | null): DebugAutoTuneProfile {
+    if (!extra) return base;
+    return {
+        envelopeLateralScale: base.envelopeLateralScale * extra.envelopeLateralScale,
+        rescueRadiusScale: base.rescueRadiusScale * extra.rescueRadiusScale,
+        coneSeedLateralScale: base.coneSeedLateralScale * extra.coneSeedLateralScale,
+        fineExpansionScale: base.fineExpansionScale * extra.fineExpansionScale,
+        wideExpansionScale: base.wideExpansionScale * extra.wideExpansionScale,
+        collisionAvoidanceScale: base.collisionAvoidanceScale * extra.collisionAvoidanceScale,
+        maxSegmentAngleBonusDeg: base.maxSegmentAngleBonusDeg + extra.maxSegmentAngleBonusDeg,
+        minRoutingZSpanScale: base.minRoutingZSpanScale * extra.minRoutingZSpanScale,
+        coneStretchRatioScale: base.coneStretchRatioScale * extra.coneStretchRatioScale,
+        coneAxisAngleBonusDeg: base.coneAxisAngleBonusDeg + extra.coneAxisAngleBonusDeg,
+    };
+}
 
 function buildUnitCircleDirections(count: number): Array<{ x: number; y: number }> {
     const directions: Array<{ x: number; y: number }> = [];
@@ -183,6 +244,34 @@ export function getSmartPlacementV2SearchEnvelope(args: {
     return {
         maxTotalLateralMm,
         rescueSweepRadiiMm,
+    };
+}
+
+function applyDebugTunedSearchEnvelope(
+    envelope: SmartPlacementV2SearchEnvelope,
+    tuning: DebugAutoTuneProfile | null,
+): SmartPlacementV2SearchEnvelope {
+    if (!tuning) return envelope;
+
+    const tunedMaxLateral = Math.min(
+        MAX_ROUTING_SEARCH_LATERAL_MM,
+        Math.round(envelope.maxTotalLateralMm * tuning.envelopeLateralScale * 2) / 2,
+    );
+    const tunedRescueRadii = ROUTING_SEARCH_SWEEP_RADII_MM
+        .map((radius) => Math.round(radius * tuning.rescueRadiusScale * 2) / 2)
+        .filter((radius, index, arr) => radius > 0 && arr.indexOf(radius) === index)
+        .filter((radius) => radius < tunedMaxLateral - 0.000001);
+
+    if (
+        tunedRescueRadii.length === 0
+        || Math.abs(tunedRescueRadii[tunedRescueRadii.length - 1] - tunedMaxLateral) > 0.000001
+    ) {
+        tunedRescueRadii.push(tunedMaxLateral);
+    }
+
+    return {
+        maxTotalLateralMm: tunedMaxLateral,
+        rescueSweepRadiiMm: tunedRescueRadii,
     };
 }
 
@@ -288,8 +377,9 @@ function getContactConeRescuePenaltyMetrics(args: {
     socketPos: Vec3;
     coneScoring: ContactConeRescueScoringInput;
     reference?: Pick<ContactConeRescuePenaltyMetrics, 'lengthMm' | 'angleFromSurfaceNormalDeg' | 'axis'>;
+    tuning?: ConeAutoTuneProfile | null;
 }): ContactConeRescuePenaltyMetrics {
-    const { socketPos, coneScoring, reference } = args;
+    const { socketPos, coneScoring, reference, tuning } = args;
     const surfaceNormal = normalizeVectorOrFallback(
         new THREE.Vector3(coneScoring.tipNormal.x, coneScoring.tipNormal.y, coneScoring.tipNormal.z),
         new THREE.Vector3(0, 0, 1),
@@ -352,6 +442,9 @@ function getContactConeRescuePenaltyMetrics(args: {
         directionDeviationOverIdealDeg * CONTACT_DISK_DIRECTION_DEVIATION_WEIGHT
         + directionDeviationOverIdealDeg * directionDeviationOverIdealDeg * CONTACT_DISK_DIRECTION_DEVIATION_QUADRATIC_WEIGHT;
 
+    const stretchRatioScale = tuning?.stretchRatioScale ?? 1;
+    const axisAngleBonusDeg = tuning?.axisAngleBonusDeg ?? 0;
+
     return {
         axis: { x: finalAxis.x, y: finalAxis.y, z: finalAxis.z },
         lengthMm: coneLengthMm,
@@ -359,9 +452,9 @@ function getContactConeRescuePenaltyMetrics(args: {
         angleFromSurfaceNormalDeg,
         addedLengthMm,
         directionDeviationDeg,
-        exceedsStretchLimit: addedLengthMm > referenceLengthMm * CONTACT_CONE_MAX_STRETCH_RATIO + 0.000001,
+        exceedsStretchLimit: addedLengthMm > referenceLengthMm * CONTACT_CONE_MAX_STRETCH_RATIO * stretchRatioScale + 0.000001,
         exceedsDiskAngleLimit: coneScoring.tipProfile.type === 'disk'
-            && angleFromSurfaceNormalDeg > CONTACT_DISK_MAX_CONE_AXIS_ANGLE_DEG + 0.000001,
+            && angleFromSurfaceNormalDeg > CONTACT_DISK_MAX_CONE_AXIS_ANGLE_DEG + axisAngleBonusDeg + 0.000001,
     };
 }
 
@@ -490,6 +583,7 @@ function findContactConeClearSocketSeed(args: {
     maxTotalLateralMm: number;
     coneScoring: ContactConeRescueScoringInput;
     contactConeBlockedAt: ContactConeBlockedAt;
+    coneTuning?: ConeAutoTuneProfile | null;
 }): ContactConeClearSocketSeed | null {
     const candidates = buildMixedSocketRescueCandidates({
         socketPos: args.socketPos,
@@ -498,6 +592,7 @@ function findContactConeClearSocketSeed(args: {
     const baselineConePenaltyMetrics = getContactConeRescuePenaltyMetrics({
         socketPos: args.socketPos,
         coneScoring: args.coneScoring,
+        tuning: args.coneTuning,
     });
 
     let best: ContactConeClearSocketSeed | null = null;
@@ -512,6 +607,7 @@ function findContactConeClearSocketSeed(args: {
             socketPos: candidateSocketPos,
             coneScoring: args.coneScoring,
             reference: baselineConePenaltyMetrics,
+            tuning: args.coneTuning,
         });
         if (metrics.exceedsStretchLimit || metrics.exceedsDiskAngleLimit) {
             continue;
@@ -607,6 +703,7 @@ export function findMixedSocketRescueCandidate(args: {
     segmentBlockedBetween?: SegmentBlockedBetween;
     contactConeBlockedAt?: ContactConeBlockedAt;
     requireJoint?: boolean;
+    coneTuning?: ConeAutoTuneProfile | null;
 }): { socketPos: Vec3; base: ResolvedBaseCandidate; joints: Vec3[] } | null {
     const candidates = buildMixedSocketRescueCandidates({
         socketPos: args.socketPos,
@@ -615,6 +712,7 @@ export function findMixedSocketRescueCandidate(args: {
     const baselineConePenaltyMetrics = getContactConeRescuePenaltyMetrics({
         socketPos: args.socketPos,
         coneScoring: args.coneScoring,
+        tuning: args.coneTuning,
     });
     const resolvedBaseCache = new Map<string, ResolvedBaseCandidate | null>();
     const segmentBlockedCache = new Map<string, boolean>();
@@ -643,6 +741,7 @@ export function findMixedSocketRescueCandidate(args: {
             socketPos: candidateSocketPos,
             coneScoring: args.coneScoring,
             reference: baselineConePenaltyMetrics,
+            tuning: args.coneTuning,
         });
         conePenaltyCache.set(key, metrics);
         return metrics;
@@ -808,6 +907,7 @@ export function findStraightSocketRescueCandidate(args: {
     rootsDiskBlockedAt?: RootsDiskBlockedAt;
     segmentBlockedBetween?: SegmentBlockedBetween;
     contactConeBlockedAt?: ContactConeBlockedAt;
+    coneTuning?: ConeAutoTuneProfile | null;
 }): { socketPos: Vec3; base: ResolvedBaseCandidate } | null {
     const candidates = buildStraightSocketRescueCandidates({
         socketPos: args.socketPos,
@@ -817,6 +917,7 @@ export function findStraightSocketRescueCandidate(args: {
         ? getContactConeRescuePenaltyMetrics({
             socketPos: args.socketPos,
             coneScoring: args.coneScoring,
+            tuning: args.coneTuning,
         })
         : null;
 
@@ -853,6 +954,7 @@ export function findStraightSocketRescueCandidate(args: {
             socketPos: candidateSocketPos,
             coneScoring: args.coneScoring,
             reference: baselineConePenaltyMetrics ?? undefined,
+            tuning: args.coneTuning,
         });
         conePenaltyCache.set(key, metrics);
         return metrics;
@@ -1413,14 +1515,27 @@ export function calculateSmartPlacementV2(
     const { mesh, modelId } = input;
     const settings = getSettings();
     const shaftRadius = settings.shaft.diameterMm / 2;
-    const clearance = shaftRadius + COLLISION_AVOIDANCE_MM;
     const debugEnabled = getSupportPathfindingDebugEnabled();
+    const debugTuningEnabled = getSupportPathfindingDebugTuningEnabled();
+    const debugAutoTuneProfile = combineDebugAutoTuneProfiles(
+        DEFAULT_PATHFINDING_PROFILE,
+        debugTuningEnabled ? EXTRA_DEBUG_TUNE_PROFILE : null,
+    );
+        const debugConeTuning: ConeAutoTuneProfile | null = debugAutoTuneProfile
+            ? {
+                stretchRatioScale: debugAutoTuneProfile.coneStretchRatioScale,
+                axisAngleBonusDeg: debugAutoTuneProfile.coneAxisAngleBonusDeg,
+            }
+            : null;
+    const collisionAvoidanceMm = COLLISION_AVOIDANCE_MM * (debugAutoTuneProfile?.collisionAvoidanceScale ?? 1);
+    const clearance = shaftRadius + collisionAvoidanceMm;
     let debugPasses: GridAStarDebugSnapshot[] = [];
     const debugEvents: SupportPathfindingDebugEvent[] = [];
     let debugOutcome: SupportPathfindingDebugOutcome = {
         status: 'pending',
         reason: 'search in progress',
     };
+    const debugBlockedReasons: string[] = [];
     let debugBasePos: Vec3 | undefined;
     let debugFinalChain: Vec3[] | undefined;
     const recordDebugEvent = (event: SupportPathfindingDebugEvent): void => {
@@ -1430,9 +1545,28 @@ export function calculateSmartPlacementV2(
             debugEvents.splice(0, debugEvents.length - 24);
         }
     };
-    const setDebugOutcome = (status: SupportPathfindingDebugOutcome['status'], reason: string): void => {
+    const addBlockedReason = (reason: string): void => {
         if (!debugEnabled) return;
-        debugOutcome = { status, reason };
+        if (!reason) return;
+        if (debugBlockedReasons.includes(reason)) return;
+        debugBlockedReasons.push(reason);
+    };
+    const setDebugOutcome = (
+        status: SupportPathfindingDebugOutcome['status'],
+        reason: string,
+        blockedReasons?: string[],
+    ): void => {
+        if (!debugEnabled) return;
+        const resolvedBlockedReasons = status === 'blocked'
+            ? (blockedReasons ?? debugBlockedReasons)
+            : undefined;
+        debugOutcome = {
+            status,
+            reason,
+            blockedReasons: resolvedBlockedReasons && resolvedBlockedReasons.length > 0
+                ? [...resolvedBlockedReasons]
+                : undefined,
+        };
     };
     const rootsRadius = settings.roots.diameterMm / 2;
     const diskHeight = settings.roots.diskHeightMm;
@@ -1442,7 +1576,13 @@ export function calculateSmartPlacementV2(
     // the configured trunk angle on the resolved route.  A* exploration uses a
     // separate, more generous angle so the pathfinder can route around overhangs
     // without being artificially constrained by the same value.
-    const maxSegmentAngleFromVerticalDeg = Math.min(88, (90 - minRoutedTrunkAngleDeg) + ROUTED_DETOUR_ANGLE_SLACK_DEG);
+    const maxSegmentAngleFromVerticalDeg = Math.min(
+        89,
+        (90 - minRoutedTrunkAngleDeg)
+            + ROUTED_DETOUR_ANGLE_SLACK_DEG
+            + (debugAutoTuneProfile?.maxSegmentAngleBonusDeg ?? 0),
+    );
+    const minRoutingZSpanMm = MIN_ROUTING_Z_SPAN_MM * (debugAutoTuneProfile?.minRoutingZSpanScale ?? 1);
     // ROUTING_ANGLE_FROM_VERTICAL_DEG: generous A* budget (80°) so the pathfinder
     // can take lateral steps to navigate around overhangs. Final trunk angle is
     // validated via maxSegmentAngleFromVerticalDeg after the path is resolved.
@@ -1475,6 +1615,7 @@ export function calculateSmartPlacementV2(
                 tipNormal: input.tipNormal,
                 tipProfile: input.tipProfile,
             },
+            tuning: debugConeTuning,
         });
         setSupportPathfindingDebugSnapshot(
             {
@@ -1520,12 +1661,19 @@ export function calculateSmartPlacementV2(
         );
     };
     const isPreview = context?.isPreview ?? false;
-    let { maxTotalLateralMm, rescueSweepRadiiMm } = getSmartPlacementV2SearchEnvelope({
+    const initialSearchEnvelope = getSmartPlacementV2SearchEnvelope({
         socketPos: nominalSocketPos,
         rootTopZ,
         spacingMm: settings.grid.spacingMm,
     });
+    let {
+        maxTotalLateralMm,
+        rescueSweepRadiiMm,
+    } = applyDebugTunedSearchEnvelope(initialSearchEnvelope, debugAutoTuneProfile);
     const nominalMaxTotalLateralMm = maxTotalLateralMm;
+    const coneSeedMaxTotalLateralMm = debugAutoTuneProfile
+        ? Math.min(MAX_ROUTING_SEARCH_LATERAL_MM, Math.round(nominalMaxTotalLateralMm * debugAutoTuneProfile.coneSeedLateralScale * 2) / 2)
+        : nominalMaxTotalLateralMm;
     const rootsDiskBlockedAt = createRootsDiskBlockedMemo({
         sdf,
         diskHeight,
@@ -1542,6 +1690,15 @@ export function calculateSmartPlacementV2(
     });
 
     const coneClear = !contactConeBlockedAt(nominalSocketPos);
+    if (debugTuningEnabled) {
+        const activeTuningProfile = EXTRA_DEBUG_TUNE_PROFILE;
+        recordDebugEvent({
+            stage: 'tuning',
+            severity: 'info',
+            message: 'Extra debug tuning profile active',
+            details: `envelope×${activeTuningProfile.envelopeLateralScale.toFixed(2)} fine×${activeTuningProfile.fineExpansionScale.toFixed(2)} wide×${activeTuningProfile.wideExpansionScale.toFixed(2)} clearance×${activeTuningProfile.collisionAvoidanceScale.toFixed(2)} angle+${activeTuningProfile.maxSegmentAngleBonusDeg.toFixed(0)}deg zSpan×${activeTuningProfile.minRoutingZSpanScale.toFixed(2)}`,
+        });
+    }
     recordDebugEvent({
         stage: 'cone',
         severity: coneClear ? 'success' : 'warning',
@@ -1560,13 +1717,14 @@ export function calculateSmartPlacementV2(
 
         coneClearSocketSeedCache = findContactConeClearSocketSeed({
             socketPos: nominalSocketPos,
-            maxTotalLateralMm: nominalMaxTotalLateralMm,
+            maxTotalLateralMm: coneSeedMaxTotalLateralMm,
             coneScoring: {
                 tipPos: input.tipPos,
                 tipNormal: input.tipNormal,
                 tipProfile: input.tipProfile,
             },
             contactConeBlockedAt,
+            coneTuning: debugConeTuning,
         });
 
         return coneClearSocketSeedCache;
@@ -1602,6 +1760,7 @@ export function calculateSmartPlacementV2(
             rootsDiskBlockedAt,
             segmentBlockedBetween,
             contactConeBlockedAt,
+            coneTuning: debugConeTuning,
         });
 
         return straightRescueCache;
@@ -1646,6 +1805,7 @@ export function calculateSmartPlacementV2(
             rootsDiskBlockedAt,
             segmentBlockedBetween,
             contactConeBlockedAt,
+            coneTuning: debugConeTuning,
         });
 
         return mixedSocketRescueCache;
@@ -1683,6 +1843,7 @@ export function calculateSmartPlacementV2(
             segmentBlockedBetween,
             contactConeBlockedAt,
             requireJoint: true,
+            coneTuning: debugConeTuning,
         });
 
         return jointedMixedSocketRescueCache;
@@ -1801,11 +1962,12 @@ export function calculateSmartPlacementV2(
                 message: 'Used cone-clear socket seed',
                 details: `shift=${coneClearSeed?.socketShiftMm.toFixed(2) ?? '0.00'}mm added cone=${coneClearSeed?.addedLengthMm.toFixed(2) ?? '0.00'}mm`,
             });
-            ({ maxTotalLateralMm, rescueSweepRadiiMm } = getSmartPlacementV2SearchEnvelope({
+            const rescuedEnvelope = getSmartPlacementV2SearchEnvelope({
                 socketPos,
                 rootTopZ,
                 spacingMm: settings.grid.spacingMm,
-            }));
+            });
+            ({ maxTotalLateralMm, rescueSweepRadiiMm } = applyDebugTunedSearchEnvelope(rescuedEnvelope, debugAutoTuneProfile));
             if (!isPreview) {
                 console.log(
                     `[SmartPlacementV2] cone-clear seed — nominal=(${nominalSocketPos.x.toFixed(2)},${nominalSocketPos.y.toFixed(2)},${nominalSocketPos.z.toFixed(2)}) seed=(${socketPos.x.toFixed(2)},${socketPos.y.toFixed(2)},${socketPos.z.toFixed(2)}) addedLength=${coneClearSeed?.addedLengthMm.toFixed(2) ?? '0.00'} shift=${coneClearSeed?.socketShiftMm.toFixed(2) ?? '0.00'}`,
@@ -1813,6 +1975,8 @@ export function calculateSmartPlacementV2(
             }
         } else {
             if (isPreview) {
+                addBlockedReason('Contact cone blocked at nominal socket position');
+                addBlockedReason('No cone-clear socket seed found');
                 setDebugOutcome('blocked', 'contact cone blocked during preview');
                 recordDebugEvent({
                     stage: 'cone',
@@ -1830,6 +1994,9 @@ export function calculateSmartPlacementV2(
             if (straightRescueFallback) {
                 return straightRescueFallback;
             }
+            addBlockedReason('Contact cone blocked at nominal socket position');
+            addBlockedReason('Cone-clear socket seed search failed');
+            addBlockedReason('Socket rescue fallback failed');
             setDebugOutcome('blocked', 'contact cone blocked');
             recordDebugEvent({
                 stage: 'cone',
@@ -1884,6 +2051,8 @@ export function calculateSmartPlacementV2(
     //     This turns repeated probes at similar positions from ~600 A* expansions
     //     to a single distance check — the primary performance win for interior hovers.
     if (isNearStagnationPoint(mesh.uuid, socketPos)) {
+        addBlockedReason('Nearby stagnation cache hit');
+        setDebugOutcome('blocked', 'nearby stagnation cache');
         publishPathfindingDebugSnapshot();
         return { ...standard, error: 'COLLISION_WITH_MODEL', stagnated: true };
     }
@@ -1892,6 +2061,8 @@ export function calculateSmartPlacementV2(
     // Uses a tighter radius (PREVIEW_EXHAUSTED_RADIUS_SQ) than true stagnation so
     // we don't block valid positions 1-2mm away from an exhausted query.
     if (context?.isPreview && isNearSpatialPoint(previewExhaustedCache, mesh.uuid, socketPos, PREVIEW_EXHAUSTED_RADIUS_SQ)) {
+        addBlockedReason('Nearby preview query already exhausted expansion budget');
+        setDebugOutcome('blocked', 'nearby preview budget exhausted');
         publishPathfindingDebugSnapshot();
         return { ...standard, error: 'COLLISION_WITH_MODEL', exhaustedBudget: true };
     }
@@ -1952,7 +2123,10 @@ export function calculateSmartPlacementV2(
         minAngleFromVerticalDeg: ROUTING_ANGLE_FROM_VERTICAL_DEG,
         occupancy: context?.occupancy,
         ignoreSupportId: context?.placingSupportId,
-        maxExpansions: scaleExpansionsForStep(context?.maxExpansions ?? 2000, FINE_ASTAR_STEP_MM),
+        maxExpansions: scaleExpansionsForStep(
+            Math.round((context?.maxExpansions ?? 2000) * (debugAutoTuneProfile?.fineExpansionScale ?? 1)),
+            FINE_ASTAR_STEP_MM,
+        ),
         stepMm: FINE_ASTAR_STEP_MM,
         goalValidator,
         // For hover preview, use endpoint-only SDF checks in the A* neighbor loop.
@@ -1999,7 +2173,7 @@ export function calculateSmartPlacementV2(
             ignoreSupportId: context?.placingSupportId,
             // Preview should remain responsive; use a smaller wide-step budget.
             maxExpansions: scaleExpansionsForStep(
-                getWidePassBaseExpansionsAt2mm(maxTotalLateralMm, isPreview),
+                Math.round(getWidePassBaseExpansionsAt2mm(maxTotalLateralMm, isPreview) * (debugAutoTuneProfile?.wideExpansionScale ?? 1)),
                 WIDE_ASTAR_STEP_MM,
             ),
             stepMm: WIDE_ASTAR_STEP_MM,
@@ -2084,6 +2258,9 @@ export function calculateSmartPlacementV2(
                 if (straightRescueFallback) {
                     return straightRescueFallback;
                 }
+                addBlockedReason('Contact cone blocked after wide-pass route resolution');
+                addBlockedReason('Socket rescue fallback failed');
+                setDebugOutcome('blocked', 'contact cone blocked after wide pass');
                 publishPathfindingDebugSnapshot();
                 return {
                     ...standard,
@@ -2488,13 +2665,15 @@ export function calculateSmartPlacementV2(
             // through a model crack — reject it rather than embed the support.
             if (_finalJoints.length >= 2) {
                 const _routingSpan = socketPos.z - _finalJoints[_finalJoints.length - 1].z;
-                if (_routingSpan < MIN_ROUTING_Z_SPAN_MM) {
+                if (_routingSpan < minRoutingZSpanMm) {
                     if (!isPreview) {
                         console.log(
-                            `[SmartPlacementV2] WIDE-STEP rejected — tight crack (routingSpan=${_routingSpan.toFixed(2)}mm < ${MIN_ROUTING_Z_SPAN_MM}mm with ${_finalJoints.length} joints)`,
+                            `[SmartPlacementV2] WIDE-STEP rejected — tight crack (routingSpan=${_routingSpan.toFixed(2)}mm < ${minRoutingZSpanMm.toFixed(2)}mm with ${_finalJoints.length} joints)`,
                         );
                     }
                     // No usable path — fall through to COLLISION_WITH_MODEL.
+                    addBlockedReason(`Routing Z span too small (${_routingSpan.toFixed(2)}mm)`);
+                    setDebugOutcome('blocked', 'wide-pass route squeezed through a crack');
                     publishPathfindingDebugSnapshot();
                     return {
                         ...standard,
@@ -2572,6 +2751,11 @@ export function calculateSmartPlacementV2(
         if (straightRescueFallback) {
             return straightRescueFallback;
         }
+        if (result.stagnated) addBlockedReason('A* stagnated before reaching root target');
+        if (result.hitExpansionLimit) addBlockedReason('A* hit expansion budget before reaching root target');
+        if (!result.reached) addBlockedReason('No valid path reached root target');
+        if (result.path.length < 2) addBlockedReason('Path result was too short to form a support chain');
+        setDebugOutcome('blocked', 'pathfinding failed to reach a valid root target');
         publishPathfindingDebugSnapshot();
         return {
             ...standard,
@@ -2653,6 +2837,8 @@ export function calculateSmartPlacementV2(
             return straightRescueFallback;
         }
         // No valid grid-snapped base found
+        addBlockedReason('No valid committed base candidate found');
+        setDebugOutcome('blocked', 'base candidate resolution failed');
         publishPathfindingDebugSnapshot();
         return {
             ...standard,
@@ -2665,6 +2851,8 @@ export function calculateSmartPlacementV2(
         if (straightRescueFallback) {
             return straightRescueFallback;
         }
+        addBlockedReason('Contact cone became blocked before commit');
+        setDebugOutcome('blocked', 'contact cone blocked before commit');
         publishPathfindingDebugSnapshot();
         return {
             ...standard,
@@ -2839,11 +3027,13 @@ export function calculateSmartPlacementV2(
     //    tight Z band near the socket — signature of squeezing through a crack.
     if (finalJoints.length >= 2) {
         const routingZSpan = socketPos.z - finalJoints[finalJoints.length - 1].z;
-        if (routingZSpan < MIN_ROUTING_Z_SPAN_MM) {
+        if (routingZSpan < minRoutingZSpanMm) {
             const straightRescueFallback = buildStraightRescueFallback();
             if (straightRescueFallback) {
                 return straightRescueFallback;
             }
+            addBlockedReason(`Routing joints compressed into ${routingZSpan.toFixed(2)}mm Z span`);
+            setDebugOutcome('blocked', 'route compressed into crack-like span');
             publishPathfindingDebugSnapshot();
             return {
                 ...standard,
@@ -2874,6 +3064,8 @@ export function calculateSmartPlacementV2(
             if (straightRescueFallback) {
                 return straightRescueFallback;
             }
+            addBlockedReason(`Final chain segment ${i} collides with model`);
+            setDebugOutcome('blocked', 'final chain collision check failed');
             publishPathfindingDebugSnapshot();
             return {
                 ...standard,
@@ -2886,6 +3078,9 @@ export function calculateSmartPlacementV2(
             if (straightRescueFallback) {
                 return straightRescueFallback;
             }
+            addBlockedReason(`Final chain segment ${i} violates max angle constraint`);
+            setDebugOutcome('blocked', 'final chain angle validation failed');
+            publishPathfindingDebugSnapshot();
             return {
                 ...standard,
                 error: 'COLLISION_WITH_MODEL',

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -72,6 +72,12 @@ const COLLISION_AVOIDANCE_MM = 0.8;
 const ROOTS_DISK_PERIMETER_SAMPLES = 16;
 /** Safety margin in mm added to all roots volume checks. */
 const ROOTS_DISK_SAFETY_MM = COLLISION_AVOIDANCE_MM;
+/** Small extra margin used only for contact-cone body collision sampling. */
+const CONTACT_CONE_COLLISION_SAFETY_MM = 0.05;
+/** Ignore the first tip-adjacent region so contact attachment is still allowed. */
+const CONTACT_CONE_TIP_IGNORE_MM = 0.25;
+/** Target sampling stride for cone frustum checks (adaptive with SDF cell size). */
+const CONTACT_CONE_COLLISION_SAMPLE_STEP_MM = 0.2;
 
 const ROUTED_DETOUR_ANGLE_SLACK_DEG = 10;
 const MIN_ROUTING_SEARCH_LATERAL_MM = 60;
@@ -223,6 +229,7 @@ interface ContactConeRescuePenaltyMetrics {
 
 type RootsDiskBlockedAt = (centerX: number, centerY: number) => boolean;
 type SegmentBlockedBetween = (start: Vec3, end: Vec3) => boolean;
+type ContactConeBlockedAt = (socketPos: Vec3) => boolean;
 
 function vec3CacheKey(point: Vec3): string {
     return `${point.x}|${point.y}|${point.z}`;
@@ -301,6 +308,126 @@ function getContactConeRescuePenaltyMetrics(args: {
     };
 }
 
+interface ContactConeGeometry {
+    coneStart: Vec3;
+    socketPos: Vec3;
+    coneLengthMm: number;
+    coneStartRadiusMm: number;
+    coneEndRadiusMm: number;
+}
+
+function resolveContactConeGeometry(args: {
+    tipPos: Vec3;
+    tipNormal: Vec3;
+    tipProfile: SupportTipProfile;
+    socketPos: Vec3;
+}): ContactConeGeometry {
+    const surfaceNormal = normalizeVectorOrFallback(
+        new THREE.Vector3(args.tipNormal.x, args.tipNormal.y, args.tipNormal.z),
+        new THREE.Vector3(0, 0, 1),
+    );
+    const approxAxis = normalizeVectorOrFallback(
+        new THREE.Vector3(
+            args.socketPos.x - args.tipPos.x,
+            args.socketPos.y - args.tipPos.y,
+            args.socketPos.z - args.tipPos.z,
+        ),
+        surfaceNormal,
+    );
+
+    const diskThickness = args.tipProfile.type === 'disk'
+        ? calculateDiskThickness(
+            { x: surfaceNormal.x, y: surfaceNormal.y, z: surfaceNormal.z },
+            { x: approxAxis.x, y: approxAxis.y, z: approxAxis.z },
+            args.tipProfile,
+        )
+        : 0;
+
+    const coneStart: Vec3 = {
+        x: args.tipPos.x + surfaceNormal.x * diskThickness,
+        y: args.tipPos.y + surfaceNormal.y * diskThickness,
+        z: args.tipPos.z + surfaceNormal.z * diskThickness,
+    };
+
+    const coneEnd = new THREE.Vector3(args.socketPos.x, args.socketPos.y, args.socketPos.z);
+    const coneLengthMm = Math.max(0.05, coneEnd.distanceTo(new THREE.Vector3(coneStart.x, coneStart.y, coneStart.z)));
+
+    return {
+        coneStart,
+        socketPos: args.socketPos,
+        coneLengthMm,
+        coneStartRadiusMm: args.tipProfile.contactDiameterMm / 2,
+        coneEndRadiusMm: args.tipProfile.bodyDiameterMm / 2,
+    };
+}
+
+function contactConeBlocked(args: {
+    sdf: SDFCache;
+    cone: ContactConeGeometry;
+}): boolean {
+    const cone = args.cone;
+    const length = cone.coneLengthMm;
+    if (length <= 0.000001) {
+        return false;
+    }
+
+    const start = cone.coneStart;
+    const end = cone.socketPos;
+    const dirX = end.x - start.x;
+    const dirY = end.y - start.y;
+    const dirZ = end.z - start.z;
+
+    const minStep = Math.max(
+        Math.min(CONTACT_CONE_COLLISION_SAMPLE_STEP_MM, args.sdf.cellSize * 0.8),
+        0.1,
+    );
+    const startT = Math.min(1, CONTACT_CONE_TIP_IGNORE_MM / length);
+    const sampleCount = Math.max(1, Math.ceil((1 - startT) * length / minStep));
+
+    for (let i = 0; i <= sampleCount; i++) {
+        const t = startT + ((1 - startT) * i) / sampleCount;
+        const px = start.x + dirX * t;
+        const py = start.y + dirY * t;
+        const pz = start.z + dirZ * t;
+        const radius = THREE.MathUtils.lerp(cone.coneStartRadiusMm, cone.coneEndRadiusMm, t) + CONTACT_CONE_COLLISION_SAFETY_MM;
+        if (args.sdf.isBlocked(px, py, pz, radius)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function createContactConeBlockedMemo(args: {
+    sdf: SDFCache;
+    tipPos: Vec3;
+    tipNormal: Vec3;
+    tipProfile: SupportTipProfile;
+}): ContactConeBlockedAt {
+    const cache = new Map<string, boolean>();
+
+    return (socketPos: Vec3): boolean => {
+        const key = vec3CacheKey(socketPos);
+        const cached = cache.get(key);
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const blocked = contactConeBlocked({
+            sdf: args.sdf,
+            cone: resolveContactConeGeometry({
+                tipPos: args.tipPos,
+                tipNormal: args.tipNormal,
+                tipProfile: args.tipProfile,
+                socketPos,
+            }),
+        });
+
+        cache.set(key, blocked);
+        return blocked;
+    };
+}
+
 function isMixedSocketRescueCandidateBetter(
     candidate: MixedSocketRescueCandidate,
     current: MixedSocketRescueCandidate,
@@ -343,6 +470,7 @@ export function findMixedSocketRescueCandidate(args: {
     subGridOffset?: { x: number; y: number } | null;
     rootsDiskBlockedAt?: RootsDiskBlockedAt;
     segmentBlockedBetween?: SegmentBlockedBetween;
+    contactConeBlockedAt?: ContactConeBlockedAt;
 }): { socketPos: Vec3; base: ResolvedBaseCandidate; joints: Vec3[] } | null {
     const candidates = buildMixedSocketRescueCandidates({
         socketPos: args.socketPos,
@@ -417,6 +545,10 @@ export function findMixedSocketRescueCandidate(args: {
     let bestSocketShiftMm: number | null = null;
 
     for (const candidateSocketPos of candidates) {
+        if (args.contactConeBlockedAt?.(candidateSocketPos)) {
+            continue;
+        }
+
         const socketShiftMm = distanceXY(candidateSocketPos, args.socketPos);
         if (bestSocketShiftMm !== null && socketShiftMm > bestSocketShiftMm + 0.000001) {
             break;
@@ -529,6 +661,7 @@ export function findStraightSocketRescueCandidate(args: {
     subGridOffset?: { x: number; y: number } | null;
     rootsDiskBlockedAt?: RootsDiskBlockedAt;
     segmentBlockedBetween?: SegmentBlockedBetween;
+    contactConeBlockedAt?: ContactConeBlockedAt;
 }): { socketPos: Vec3; base: ResolvedBaseCandidate } | null {
     const candidates = buildStraightSocketRescueCandidates({
         socketPos: args.socketPos,
@@ -565,6 +698,10 @@ export function findStraightSocketRescueCandidate(args: {
     };
 
     for (const candidateSocketPos of candidates) {
+        if (args.contactConeBlockedAt?.(candidateSocketPos)) {
+            continue;
+        }
+
         const conePenaltyScore = getConePenaltyScore(candidateSocketPos);
         const socketShiftMm = distanceXY(candidateSocketPos, args.socketPos);
         const eps = 0.000001;
@@ -1168,22 +1305,29 @@ export function calculateSmartPlacementV2(
         shaftRadius,
     });
     const segmentBlockedBetween = createSegmentBlockedMemo({ sdf, clearance });
+    const contactConeBlockedAt = createContactConeBlockedMemo({
+        sdf,
+        tipPos: input.tipPos,
+        tipNormal: input.tipNormal,
+        tipProfile: input.tipProfile,
+    });
 
     // Shaft + roots checks now use SDF sphere-tracing and bounding-ball
     // early-outs, so preview no longer needs the old coarse approximations —
     // the accurate versions are fast in open space and equally accurate.
     const straightClear = !segmentBlockedBetween(socketPos, { x: socketPos.x, y: socketPos.y, z: rootTopZ });
+    const coneClear = !contactConeBlockedAt(socketPos);
 
     const baseXY = standard.basePos;
     const rootsFitStandard = !rootsDiskBlockedAt(baseXY.x, baseXY.y);
 
     if (!isPreview) {
-        console.log(`[SmartPlacementV2] called — socket=(${socketPos.x.toFixed(2)},${socketPos.y.toFixed(2)},${socketPos.z.toFixed(2)}) rootTopZ=${rootTopZ.toFixed(2)} straightClear=${straightClear} rootsFit=${rootsFitStandard}`);
+        console.log(`[SmartPlacementV2] called — socket=(${socketPos.x.toFixed(2)},${socketPos.y.toFixed(2)},${socketPos.z.toFixed(2)}) rootTopZ=${rootTopZ.toFixed(2)} coneClear=${coneClear} straightClear=${straightClear} rootsFit=${rootsFitStandard}`);
     }
 
-    if (straightClear && rootsFitStandard) {
+    if (coneClear && straightClear && rootsFitStandard) {
         if (!isPreview) console.log(`[SmartPlacementV2] STRAIGHT path — no routing needed`);
-        return standard; // Shaft is clear and roots fit — no routing needed
+        return standard; // Cone, shaft, and roots are all clear — no routing needed
     }
 
     let straightRescueCache:
@@ -1220,6 +1364,7 @@ export function calculateSmartPlacementV2(
             } : null,
             rootsDiskBlockedAt,
             segmentBlockedBetween,
+            contactConeBlockedAt,
         });
 
         return straightRescueCache;
@@ -1259,6 +1404,7 @@ export function calculateSmartPlacementV2(
             } : null,
             rootsDiskBlockedAt,
             segmentBlockedBetween,
+            contactConeBlockedAt,
         });
 
         return mixedSocketRescueCache;
@@ -1272,7 +1418,6 @@ export function calculateSmartPlacementV2(
                 );
             }
 
-            publishPathfindingDebugSnapshot();
             publishPathfindingDebugSnapshot();
             return {
                 ...standard,
@@ -1305,6 +1450,13 @@ export function calculateSmartPlacementV2(
             error: undefined,
         };
     };
+
+    if (!coneClear) {
+        const straightRescueFallback = buildStraightRescueFallback();
+        if (straightRescueFallback) {
+            return straightRescueFallback;
+        }
+    }
 
     // 3b. Spatial caches: skip A* if a previous search from a nearby socketPos
     //     already stagnated (cavity) or exhausted the preview budget.
@@ -1487,6 +1639,18 @@ export function calculateSmartPlacementV2(
 
             const _wideRootTop: Vec3 = { x: _resolvedWideBase.basePos.x, y: _resolvedWideBase.basePos.y, z: rootTopZ };
             const _warning = standard.warning;
+
+            if (contactConeBlockedAt(socketPos)) {
+                const straightRescueFallback = buildStraightRescueFallback();
+                if (straightRescueFallback) {
+                    return straightRescueFallback;
+                }
+                publishPathfindingDebugSnapshot();
+                return {
+                    ...standard,
+                    error: 'COLLISION_WITH_MODEL',
+                };
+            }
 
             // Preview fast-path: skip expensive simplification/straightening passes.
             // Click-time placement still runs the full quality pipeline.
@@ -2050,6 +2214,18 @@ export function calculateSmartPlacementV2(
             return straightRescueFallback;
         }
         // No valid grid-snapped base found
+        publishPathfindingDebugSnapshot();
+        return {
+            ...standard,
+            error: 'COLLISION_WITH_MODEL',
+        };
+    }
+
+    if (contactConeBlockedAt(socketPos)) {
+        const straightRescueFallback = buildStraightRescueFallback();
+        if (straightRescueFallback) {
+            return straightRescueFallback;
+        }
         publishPathfindingDebugSnapshot();
         return {
             ...standard,

--- a/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
+++ b/src/supports/PlacementLogic/Pathfinding/SmartPlacementV2.ts
@@ -24,8 +24,9 @@ import { getSettings } from '../../Settings';
 import { gridNodeKeyFromXY, gridSnappedXYFromKey } from '../Grid/gridMath';
 import { buildNearestCandidateNodeKeys } from '../Grid/nearestCandidateNodeKeys';
 import { SDFCache } from './SDFCache';
-import { gridAStar, type WarmStartState } from './GridAStar';
+import { gridAStar, type GridAStarDebugSnapshot, type WarmStartState } from './GridAStar';
 import type { SupportOccupancy } from './SupportOccupancy';
+import { getSupportPathfindingDebugEnabled, setSupportPathfindingDebugSnapshot } from './pathfindingDebugState';
 import {
     distanceXY,
     distance3D,
@@ -1094,6 +1095,8 @@ export function calculateSmartPlacementV2(
     const settings = getSettings();
     const shaftRadius = settings.shaft.diameterMm / 2;
     const clearance = shaftRadius + COLLISION_AVOIDANCE_MM;
+    const debugEnabled = getSupportPathfindingDebugEnabled();
+    let debugPasses: GridAStarDebugSnapshot[] = [];
     const rootsRadius = settings.roots.diameterMm / 2;
     const diskHeight = settings.roots.diskHeightMm;
     const coneHeight = settings.roots.coneHeightMm;
@@ -1122,6 +1125,35 @@ export function calculateSmartPlacementV2(
     // 3. Quick check: is the straight-down path clear AND do the roots fit at the base?
     const rootTopZ = input.rootsTopZ;
     const socketPos = standard.socketPos;
+    if (debugEnabled) {
+        setSupportPathfindingDebugSnapshot(null);
+    }
+    const publishPathfindingDebugSnapshot = () => {
+        if (!debugEnabled) return;
+        setSupportPathfindingDebugSnapshot(
+            debugPasses.length > 0
+                ? {
+                    modelId,
+                    socketPos,
+                    rootTopZ,
+                    clearanceMm: clearance,
+                    passes: debugPasses.map((pass) => ({
+                        label: pass.label,
+                        searchStepMm: pass.searchStepMm,
+                        expansions: pass.expansions,
+                        reached: pass.reached,
+                        stagnated: pass.stagnated,
+                        hitExpansionLimit: pass.hitExpansionLimit,
+                        expandedNodes: pass.expandedNodes,
+                        frontierNodes: pass.frontierNodes,
+                        rawPath: pass.rawPath,
+                        simplifiedPath: pass.simplifiedPath,
+                    })),
+                    updatedAtMs: typeof performance !== 'undefined' ? performance.now() : Date.now(),
+                }
+                : null,
+        );
+    };
     const isPreview = context?.isPreview ?? false;
     const { maxTotalLateralMm, rescueSweepRadiiMm } = getSmartPlacementV2SearchEnvelope({
         socketPos,
@@ -1240,6 +1272,8 @@ export function calculateSmartPlacementV2(
                 );
             }
 
+            publishPathfindingDebugSnapshot();
+            publishPathfindingDebugSnapshot();
             return {
                 ...standard,
                 socketPos: mixedSocketRescue.socketPos,
@@ -1259,6 +1293,7 @@ export function calculateSmartPlacementV2(
                 `[SmartPlacementV2] STRAIGHT rescue fallback — socket=(${straightRescue.socketPos.x.toFixed(2)},${straightRescue.socketPos.y.toFixed(2)},${straightRescue.socketPos.z.toFixed(2)}) base=(${straightRescue.base.basePos.x.toFixed(2)},${straightRescue.base.basePos.y.toFixed(2)},${straightRescue.base.basePos.z.toFixed(2)})`,
             );
         }
+        publishPathfindingDebugSnapshot();
         return {
             ...standard,
             socketPos: straightRescue.socketPos,
@@ -1276,6 +1311,7 @@ export function calculateSmartPlacementV2(
     //     This turns repeated probes at similar positions from ~600 A* expansions
     //     to a single distance check — the primary performance win for interior hovers.
     if (isNearStagnationPoint(mesh.uuid, socketPos)) {
+        publishPathfindingDebugSnapshot();
         return { ...standard, error: 'COLLISION_WITH_MODEL', stagnated: true };
     }
     // Preview-exhausted fast-fail: if this is a preview call and a nearby position
@@ -1283,6 +1319,7 @@ export function calculateSmartPlacementV2(
     // Uses a tighter radius (PREVIEW_EXHAUSTED_RADIUS_SQ) than true stagnation so
     // we don't block valid positions 1-2mm away from an exhausted query.
     if (context?.isPreview && isNearSpatialPoint(previewExhaustedCache, mesh.uuid, socketPos, PREVIEW_EXHAUSTED_RADIUS_SQ)) {
+        publishPathfindingDebugSnapshot();
         return { ...standard, error: 'COLLISION_WITH_MODEL', exhaustedBudget: true };
     }
 
@@ -1352,7 +1389,11 @@ export function calculateSmartPlacementV2(
         // Endpoint-only checks hit grid-aligned cells that ARE cached after first
         // visit, dropping first-frame cold cost from ~30k to ~600 BVH calls.
         endpointOnlyCollisionCheck: isPreview,
+        debugLabel: 'fine',
     }, warmStart);
+    if (debugEnabled && result.debug) {
+        debugPasses = [result.debug];
+    }
 
     // ---------- Wide-step fallback (V1 parity for large-detour overhangs) ----------
     //
@@ -1382,7 +1423,11 @@ export function calculateSmartPlacementV2(
             stepMm: WIDE_ASTAR_STEP_MM,
             goalValidator,
             endpointOnlyCollisionCheck: isPreview,
+            debugLabel: 'wide',
         }, null); // always cold-start wide search (different grid quantisation)
+        if (debugEnabled && wideResult.debug) {
+            debugPasses = [...debugPasses, wideResult.debug];
+        }
         if (wideResult.reached) {
             // Wide-step succeeded — use its result. Don't write to warm-start maps
             // since the 0.6mm grid state is incompatible with the normal 0.25mm warm-start.
@@ -1446,6 +1491,7 @@ export function calculateSmartPlacementV2(
             // Preview fast-path: skip expensive simplification/straightening passes.
             // Click-time placement still runs the full quality pipeline.
             if (isPreview) {
+                publishPathfindingDebugSnapshot();
                 return {
                     ...standard,
                     joints: _zJoints,
@@ -1846,6 +1892,7 @@ export function calculateSmartPlacementV2(
                         );
                     }
                     // No usable path — fall through to COLLISION_WITH_MODEL.
+                    publishPathfindingDebugSnapshot();
                     return {
                         ...standard,
                         error: 'COLLISION_WITH_MODEL',
@@ -1880,6 +1927,7 @@ export function calculateSmartPlacementV2(
                         _wideSegs.join('\n'),
                     );
                 }
+                publishPathfindingDebugSnapshot();
                 return {
                     ...standard,
                     joints: _finalJoints,
@@ -1921,6 +1969,7 @@ export function calculateSmartPlacementV2(
         if (straightRescueFallback) {
             return straightRescueFallback;
         }
+        publishPathfindingDebugSnapshot();
         return {
             ...standard,
             error: 'COLLISION_WITH_MODEL',
@@ -2001,6 +2050,7 @@ export function calculateSmartPlacementV2(
             return straightRescueFallback;
         }
         // No valid grid-snapped base found
+        publishPathfindingDebugSnapshot();
         return {
             ...standard,
             error: 'COLLISION_WITH_MODEL',
@@ -2179,12 +2229,15 @@ export function calculateSmartPlacementV2(
             if (straightRescueFallback) {
                 return straightRescueFallback;
             }
+            publishPathfindingDebugSnapshot();
             return {
                 ...standard,
                 error: 'COLLISION_WITH_MODEL',
             };
         }
     }
+
+    publishPathfindingDebugSnapshot();
 
     // 8b. Final SDF validation of the complete chain.
     //    Even after simplification + straightening, verify every segment is clear.
@@ -2206,6 +2259,7 @@ export function calculateSmartPlacementV2(
             if (straightRescueFallback) {
                 return straightRescueFallback;
             }
+            publishPathfindingDebugSnapshot();
             return {
                 ...standard,
                 error: 'COLLISION_WITH_MODEL',
@@ -2259,6 +2313,7 @@ export function calculateSmartPlacementV2(
         );
     }
 
+    publishPathfindingDebugSnapshot();
     return finalResult;
 }
 

--- a/src/supports/PlacementLogic/Pathfinding/pathfindingDebugState.ts
+++ b/src/supports/PlacementLogic/Pathfinding/pathfindingDebugState.ts
@@ -13,11 +13,48 @@ export interface GridAStarDebugPassSnapshot {
     simplifiedPath: Vec3[];
 }
 
+export interface SupportPathfindingDebugEvent {
+    stage: string;
+    severity: 'info' | 'success' | 'warning' | 'error';
+    message: string;
+    details?: string;
+}
+
+export interface SupportPathfindingConeDebugMetrics {
+    nominalClear: boolean;
+    activeClear: boolean;
+    activeDiskAngleDeg: number;
+    maxDiskAngleDeg: number;
+    activeConeLengthMm: number;
+    activeAddedLengthMm: number;
+    stretchLimitExceeded: boolean;
+    diskAngleLimitExceeded: boolean;
+}
+
+export interface SupportPathfindingSearchDebugEnvelope {
+    maxTotalLateralMm: number;
+    rescueRadiiMm: number[];
+    rootTopZ: number;
+    clearanceMm: number;
+}
+
+export interface SupportPathfindingDebugOutcome {
+    status: 'pending' | 'placed' | 'straight' | 'routed' | 'fallback' | 'blocked' | 'preview';
+    reason: string;
+}
+
 export interface SupportPathfindingDebugSnapshot {
     modelId: string;
     socketPos: Vec3;
+    nominalSocketPos?: Vec3;
     rootTopZ: number;
     clearanceMm: number;
+    basePos?: Vec3;
+    finalChain?: Vec3[];
+    outcome?: SupportPathfindingDebugOutcome;
+    cone?: SupportPathfindingConeDebugMetrics;
+    envelope?: SupportPathfindingSearchDebugEnvelope;
+    events?: SupportPathfindingDebugEvent[];
     passes: GridAStarDebugPassSnapshot[];
     updatedAtMs: number;
 }

--- a/src/supports/PlacementLogic/Pathfinding/pathfindingDebugState.ts
+++ b/src/supports/PlacementLogic/Pathfinding/pathfindingDebugState.ts
@@ -41,6 +41,7 @@ export interface SupportPathfindingSearchDebugEnvelope {
 export interface SupportPathfindingDebugOutcome {
     status: 'pending' | 'placed' | 'straight' | 'routed' | 'fallback' | 'blocked' | 'preview';
     reason: string;
+    blockedReasons?: string[];
 }
 
 export interface SupportPathfindingDebugSnapshot {
@@ -61,11 +62,13 @@ export interface SupportPathfindingDebugSnapshot {
 
 interface SupportPathfindingDebugState {
     enabled: boolean;
+    tuningEnabled: boolean;
     snapshot: SupportPathfindingDebugSnapshot | null;
 }
 
 let state: SupportPathfindingDebugState = {
     enabled: false,
+    tuningEnabled: false,
     snapshot: null,
 };
 
@@ -93,6 +96,7 @@ export function setSupportPathfindingDebugEnabled(enabled: boolean): void {
     state = {
         ...state,
         enabled,
+        tuningEnabled: enabled ? state.tuningEnabled : false,
         snapshot: enabled ? state.snapshot : null,
     };
     emit();
@@ -100,6 +104,24 @@ export function setSupportPathfindingDebugEnabled(enabled: boolean): void {
 
 export function toggleSupportPathfindingDebugEnabled(): void {
     setSupportPathfindingDebugEnabled(!state.enabled);
+}
+
+export function getSupportPathfindingDebugTuningEnabled(): boolean {
+    return state.enabled && state.tuningEnabled;
+}
+
+export function setSupportPathfindingDebugTuningEnabled(enabled: boolean): void {
+    if (!state.enabled) return;
+    if (state.tuningEnabled === enabled) return;
+    state = {
+        ...state,
+        tuningEnabled: enabled,
+    };
+    emit();
+}
+
+export function toggleSupportPathfindingDebugTuningEnabled(): void {
+    setSupportPathfindingDebugTuningEnabled(!state.tuningEnabled);
 }
 
 export function setSupportPathfindingDebugSnapshot(snapshot: SupportPathfindingDebugSnapshot | null): void {

--- a/src/supports/PlacementLogic/Pathfinding/pathfindingDebugState.ts
+++ b/src/supports/PlacementLogic/Pathfinding/pathfindingDebugState.ts
@@ -1,0 +1,75 @@
+import type { Vec3 } from '../../types';
+
+export interface GridAStarDebugPassSnapshot {
+    label: string;
+    searchStepMm: number;
+    expansions: number;
+    reached: boolean;
+    stagnated: boolean;
+    hitExpansionLimit: boolean;
+    expandedNodes: Vec3[];
+    frontierNodes: Vec3[];
+    rawPath: Vec3[];
+    simplifiedPath: Vec3[];
+}
+
+export interface SupportPathfindingDebugSnapshot {
+    modelId: string;
+    socketPos: Vec3;
+    rootTopZ: number;
+    clearanceMm: number;
+    passes: GridAStarDebugPassSnapshot[];
+    updatedAtMs: number;
+}
+
+interface SupportPathfindingDebugState {
+    enabled: boolean;
+    snapshot: SupportPathfindingDebugSnapshot | null;
+}
+
+let state: SupportPathfindingDebugState = {
+    enabled: false,
+    snapshot: null,
+};
+
+const listeners = new Set<() => void>();
+
+function emit(): void {
+    for (const listener of listeners) listener();
+}
+
+export function subscribeToSupportPathfindingDebugState(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+}
+
+export function getSupportPathfindingDebugState(): SupportPathfindingDebugState {
+    return state;
+}
+
+export function getSupportPathfindingDebugEnabled(): boolean {
+    return state.enabled;
+}
+
+export function setSupportPathfindingDebugEnabled(enabled: boolean): void {
+    if (state.enabled === enabled) return;
+    state = {
+        ...state,
+        enabled,
+        snapshot: enabled ? state.snapshot : null,
+    };
+    emit();
+}
+
+export function toggleSupportPathfindingDebugEnabled(): void {
+    setSupportPathfindingDebugEnabled(!state.enabled);
+}
+
+export function setSupportPathfindingDebugSnapshot(snapshot: SupportPathfindingDebugSnapshot | null): void {
+    if (!state.enabled && snapshot !== null) return;
+    state = {
+        ...state,
+        snapshot,
+    };
+    emit();
+}

--- a/src/supports/PlacementLogic/PlacementUtils.ts
+++ b/src/supports/PlacementLogic/PlacementUtils.ts
@@ -77,3 +77,49 @@ export function calculateSmoothedNormal(hit: THREE.Intersection): { x: number, y
         z: _interpolated.z 
     };
 }
+
+/**
+ * Finds the mesh in `candidates` whose surface is closest to `point`.
+ * Prefers BVH closest-point distance when available, otherwise falls back to
+ * world-space bounding-box distance.
+ */
+export function findClosestMeshToPoint(point: { x: number; y: number; z: number }, candidates: THREE.Object3D[]): THREE.Mesh | undefined {
+    const worldPoint = new THREE.Vector3(point.x, point.y, point.z);
+    const localPoint = new THREE.Vector3();
+    const bbox = new THREE.Box3();
+    const bboxPoint = new THREE.Vector3();
+    const resultTarget = { point: new THREE.Vector3(), distance: 0, faceIndex: -1 };
+
+    let bestMesh: THREE.Mesh | undefined;
+    let bestDistance = Number.POSITIVE_INFINITY;
+
+    for (const candidate of candidates) {
+        if (!(candidate instanceof THREE.Mesh) || !candidate.geometry) continue;
+
+        let distance = Number.POSITIVE_INFINITY;
+        const boundsTree = (candidate.geometry as any).boundsTree;
+        if (boundsTree?.closestPointToPoint) {
+            localPoint.copy(worldPoint).applyMatrix4(candidate.matrixWorld.clone().invert());
+            const result = boundsTree.closestPointToPoint(localPoint, resultTarget);
+            if (result) {
+                distance = result.distance;
+            }
+        } else {
+            if (!candidate.geometry.boundingBox) {
+                candidate.geometry.computeBoundingBox();
+            }
+            if (candidate.geometry.boundingBox) {
+                bbox.copy(candidate.geometry.boundingBox).applyMatrix4(candidate.matrixWorld);
+                bbox.clampPoint(worldPoint, bboxPoint);
+                distance = bboxPoint.distanceTo(worldPoint);
+            }
+        }
+
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            bestMesh = candidate;
+        }
+    }
+
+    return bestMesh;
+}

--- a/src/supports/PlacementLogic/SmartPlacement.ts
+++ b/src/supports/PlacementLogic/SmartPlacement.ts
@@ -207,7 +207,7 @@ export function calculateSmartPlacement(input: SmartPlacementInput): TrunkPlacem
     const { mesh } = input;
     const settings = getSettings();
     const shaftRadius = settings.shaft.diameterMm / 2;
-    const collisionRadius = shaftRadius + 0.25;
+    const collisionRadius = shaftRadius + 0.8;
     const standard = calculateStandardPlacement(input);
     if (standard.error === 'ANGLE_TOO_STEEP') {
         return standard;

--- a/src/supports/RaftProxyMeshLayer.tsx
+++ b/src/supports/RaftProxyMeshLayer.tsx
@@ -4,10 +4,17 @@ import { useSyncExternalStore } from 'react';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import { usePicking } from '@/components/picking';
 import { subscribe, getSnapshot } from './state';
+import { getKickstandSnapshot, subscribeToKickstandStore } from './SupportTypes/Kickstand/kickstandStore';
 import { getRaftSettings, subscribeToRaftStore } from './Rafts/Crenelated/RaftState';
-import type { RaftSettings, SupportBaseCircle } from './Rafts/Crenelated/RaftTypes';
+import type { RaftSettings } from './Rafts/Crenelated/RaftTypes';
 import { buildSolidRaftPreviewMeshes } from './Settings/AnatomyPreview/PreviewTypes/Raft/buildSolidRaftPreviewMeshes';
 import { buildLineRaftPreviewMeshes } from './Settings/AnatomyPreview/PreviewTypes/Raft/buildLineRaftPreviewMeshes';
+import {
+  collectRaftBaseCirclesByModel,
+  fromRaftModelKey,
+  RAFT_UNASSIGNED_MODEL_KEY,
+  toRaftModelKey,
+} from './Rafts/Crenelated/raftFootprintCircles';
 
 interface RaftProxyMeshLayerProps {
   clipLower?: number | null;
@@ -47,24 +54,23 @@ type VisibleRaftEntry = {
 type RaftProxyCacheEntry = {
   supportRootsRef: ReturnType<typeof getSnapshot>['roots'];
   supportAnchorsRef: ReturnType<typeof getSnapshot>['anchors'];
+  kickstandRootsRef: ReturnType<typeof getKickstandSnapshot>['roots'];
   raftSignature: string;
   geometriesByModel: Map<string, CachedRaftGeometry>;
 };
 
 let raftProxyCache: RaftProxyCacheEntry | null = null;
-
-const MODEL_NONE_KEY = '__none__';
 const RAFT_BASE_COLOR = '#a3a3a3';
 const SOLID_BOTTOM_TINT_COLOR = '#3b82f6';
 const LINE_BOTTOM_TINT_COLOR = '#f97316';
 const WALL_TINT_COLOR = '#22c55e';
 
 function toModelKey(modelId?: string): string {
-  return modelId ?? MODEL_NONE_KEY;
+  return toRaftModelKey(modelId, RAFT_UNASSIGNED_MODEL_KEY);
 }
 
 function fromModelKey(modelKey: string): string | undefined {
-  return modelKey === MODEL_NONE_KEY ? undefined : modelKey;
+  return fromRaftModelKey(modelKey, RAFT_UNASSIGNED_MODEL_KEY) ?? undefined;
 }
 
 function buildRaftSignature(raft: RaftSettings): string {
@@ -163,37 +169,6 @@ function disposeGeneratedMeshes(meshes: Array<THREE.Mesh | null | undefined>) {
   }
 }
 
-function collectRootCirclesByModel(
-  roots: ReturnType<typeof getSnapshot>['roots'],
-  anchors: ReturnType<typeof getSnapshot>['anchors'],
-): Map<string, SupportBaseCircle[]> {
-  const byModel = new Map<string, SupportBaseCircle[]>();
-
-  for (const root of Object.values(roots)) {
-    const modelKey = toModelKey(root.modelId);
-    const circles = byModel.get(modelKey) ?? [];
-    circles.push({
-      x: root.transform.pos.x,
-      y: root.transform.pos.y,
-      r: root.diameter / 2,
-    });
-    if (!byModel.has(modelKey)) byModel.set(modelKey, circles);
-  }
-
-  for (const anchor of Object.values(anchors)) {
-    const modelKey = toModelKey(anchor.modelId);
-    const circles = byModel.get(modelKey) ?? [];
-    circles.push({
-      x: anchor.rootPos.x,
-      y: anchor.rootPos.y,
-      r: anchor.rootBaseDiameter / 2,
-    });
-    if (!byModel.has(modelKey)) byModel.set(modelKey, circles);
-  }
-
-  return byModel;
-}
-
 export function RaftProxyMeshLayer({
   clipLower,
   clipUpper,
@@ -216,6 +191,8 @@ export function RaftProxyMeshLayer({
   const supportState = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   const supportRoots = supportState.roots;
   const supportAnchors = supportState.anchors;
+  const kickstandState = useSyncExternalStore(subscribeToKickstandStore, getKickstandSnapshot, getKickstandSnapshot);
+  const kickstandRoots = kickstandState.roots;
   const raft = useSyncExternalStore(subscribeToRaftStore, getRaftSettings, getRaftSettings);
 
   const selectedModelIdSet = React.useMemo(() => new Set(selectedModelIds), [selectedModelIds]);
@@ -241,12 +218,19 @@ export function RaftProxyMeshLayer({
       raftProxyCache
       && raftProxyCache.supportRootsRef === supportRoots
       && raftProxyCache.supportAnchorsRef === supportAnchors
+      && raftProxyCache.kickstandRootsRef === kickstandRoots
       && raftProxyCache.raftSignature === raftSignature
     ) {
       return raftProxyCache.geometriesByModel;
     }
 
-    const rootCirclesByModel = collectRootCirclesByModel(supportRoots, supportAnchors);
+    const rootCirclesByModel = collectRaftBaseCirclesByModel({
+      roots: Object.values(supportRoots),
+      anchors: Object.values(supportAnchors),
+      kickstandRoots: Object.values(kickstandRoots),
+    }, {
+      fallbackModelKey: RAFT_UNASSIGNED_MODEL_KEY,
+    });
     const next = new Map<string, CachedRaftGeometry>();
 
     if (raft.bottomMode === 'solid') {
@@ -306,12 +290,13 @@ export function RaftProxyMeshLayer({
     raftProxyCache = {
       supportRootsRef: supportRoots,
       supportAnchorsRef: supportAnchors,
+      kickstandRootsRef: kickstandRoots,
       raftSignature,
       geometriesByModel: next,
     };
 
     return next;
-  }, [raft, raftSignature, supportRoots, supportAnchors]);
+  }, [raft, raftSignature, supportRoots, supportAnchors, kickstandRoots]);
 
   const visibleEntries = React.useMemo<VisibleRaftEntry[]>(() => {
     const entries: VisibleRaftEntry[] = [];

--- a/src/supports/Rafts/Crenelated/raftFootprintCircles.ts
+++ b/src/supports/Rafts/Crenelated/raftFootprintCircles.ts
@@ -1,0 +1,114 @@
+import type { SupportBaseCircle } from './RaftTypes';
+import type { Anchor, Roots } from '@/supports/types';
+
+export const RAFT_UNASSIGNED_MODEL_KEY = '__raft_unassigned__';
+
+type RootLike = Pick<Roots, 'modelId' | 'diameter' | 'transform'>;
+type AnchorLike = Pick<Anchor, 'modelId' | 'rootBaseDiameter' | 'rootPos'>;
+
+type CollectRaftBaseCirclesInput = {
+  roots?: Iterable<RootLike>;
+  anchors?: Iterable<AnchorLike>;
+  kickstandRoots?: Iterable<RootLike>;
+};
+
+type CollectRaftBaseCirclesOptions = {
+  modelFilterId?: string | null;
+  excludeModelId?: string | null;
+  excludedModelIds?: ReadonlySet<string> | Iterable<string>;
+  fallbackModelKey?: string;
+};
+
+function shouldIncludeModel(
+  modelId: string | null | undefined,
+  options: CollectRaftBaseCirclesOptions,
+  excludedModelIdSet: ReadonlySet<string>,
+): boolean {
+  if (options.modelFilterId != null) {
+    return modelId === options.modelFilterId;
+  }
+
+  if (options.excludeModelId && modelId === options.excludeModelId) {
+    return false;
+  }
+
+  if (modelId && excludedModelIdSet.has(modelId)) {
+    return false;
+  }
+
+  return true;
+}
+
+function toExcludedModelIdSet(
+  excludedModelIds: CollectRaftBaseCirclesOptions['excludedModelIds'],
+): ReadonlySet<string> {
+  if (!excludedModelIds) {
+    return new Set<string>();
+  }
+
+  return excludedModelIds instanceof Set
+    ? excludedModelIds
+    : new Set(excludedModelIds);
+}
+
+export function toRaftModelKey(
+  modelId: string | null | undefined,
+  fallbackModelKey = RAFT_UNASSIGNED_MODEL_KEY,
+): string {
+  return modelId ?? fallbackModelKey;
+}
+
+export function fromRaftModelKey(
+  modelKey: string,
+  fallbackModelKey = RAFT_UNASSIGNED_MODEL_KEY,
+): string | null {
+  return modelKey === fallbackModelKey ? null : modelKey;
+}
+
+export function collectRaftBaseCirclesByModel(
+  input: CollectRaftBaseCirclesInput,
+  options: CollectRaftBaseCirclesOptions = {},
+): Map<string, SupportBaseCircle[]> {
+  const byModel = new Map<string, SupportBaseCircle[]>();
+  const excludedModelIdSet = toExcludedModelIdSet(options.excludedModelIds);
+  const fallbackModelKey = options.fallbackModelKey ?? RAFT_UNASSIGNED_MODEL_KEY;
+
+  const pushCircle = (modelId: string | null | undefined, circle: SupportBaseCircle) => {
+    if (!shouldIncludeModel(modelId, options, excludedModelIdSet)) return;
+
+    const modelKey = toRaftModelKey(modelId, fallbackModelKey);
+    const circles = byModel.get(modelKey);
+    if (circles) {
+      circles.push(circle);
+      return;
+    }
+
+    byModel.set(modelKey, [circle]);
+  };
+
+  for (const root of input.roots ?? []) {
+    pushCircle(root.modelId, {
+      x: root.transform.pos.x,
+      y: root.transform.pos.y,
+      r: root.diameter / 2,
+    });
+  }
+
+  for (const anchor of input.anchors ?? []) {
+    pushCircle(anchor.modelId, {
+      x: anchor.rootPos.x,
+      y: anchor.rootPos.y,
+      r: anchor.rootBaseDiameter / 2,
+    });
+  }
+
+  for (const root of input.kickstandRoots ?? []) {
+    pushCircle(root.modelId, {
+      x: root.transform.pos.x,
+      y: root.transform.pos.y,
+      r: root.diameter / 2,
+    });
+  }
+
+  return byModel;
+}

--- a/src/supports/Rafts/Crenelated/rendering/FootprintBorderRenderer.tsx
+++ b/src/supports/Rafts/Crenelated/rendering/FootprintBorderRenderer.tsx
@@ -4,13 +4,14 @@ import React from 'react';
 import * as THREE from 'three';
 import { useSyncExternalStore } from 'react';
 import { subscribe, getSnapshot } from '@/supports/state';
+import { getKickstandSnapshot, subscribeToKickstandStore } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 import { getRaftSettings, subscribeToRaftStore } from '../RaftState';
-import { SupportBaseCircle } from '../RaftTypes';
 import { computeFootprint } from '../geometry/computeFootprint';
 import { computeRaftOuterBoundary } from '../geometry/computeRaftOuterBoundary';
 import type { GeometryWithBounds } from '@/hooks/useStlGeometry';
 import type { ModelTransform } from '@/hooks/useModelTransform';
 import { computeProjectedFootprintHull } from '@/utils/modelFootprint';
+import { collectRaftBaseCirclesByModel, RAFT_UNASSIGNED_MODEL_KEY } from '../raftFootprintCircles';
 
 interface FootprintBorderRendererProps {
   modelGeometry: GeometryWithBounds | null;
@@ -192,27 +193,23 @@ export default function FootprintBorderRenderer({
   color = '#3b82f6',
 }: FootprintBorderRendererProps) {
   const supportState = useSyncExternalStore(subscribe, getSnapshot);
+  const kickstandState = useSyncExternalStore(subscribeToKickstandStore, getKickstandSnapshot, getKickstandSnapshot);
   const raft = useSyncExternalStore(subscribeToRaftStore, getRaftSettings, getRaftSettings);
   const [localModelFootprintHull, setLocalModelFootprintHull] = React.useState<THREE.Vector2[]>([]);
   const hullCacheKeyRef = React.useRef<string | null>(null);
 
   const supportFootprintPoints = React.useMemo(() => {
-    const circles: SupportBaseCircle[] = [
-      ...Object.values(supportState.roots)
-        .filter((root) => !modelId || root.modelId === modelId)
-        .map(root => ({
-          x: root.transform.pos.x,
-          y: root.transform.pos.y,
-          r: root.diameter / 2,
-        })),
-      ...Object.values(supportState.anchors)
-        .filter((anchor) => !modelId || anchor.modelId === modelId)
-        .map(anchor => ({
-          x: anchor.rootPos.x,
-          y: anchor.rootPos.y,
-          r: anchor.rootBaseDiameter / 2,
-        })),
-    ];
+    const circlesByModel = collectRaftBaseCirclesByModel({
+      roots: Object.values(supportState.roots),
+      anchors: Object.values(supportState.anchors),
+      kickstandRoots: Object.values(kickstandState.roots),
+    }, modelId != null
+      ? { modelFilterId: modelId, fallbackModelKey: RAFT_UNASSIGNED_MODEL_KEY }
+      : { fallbackModelKey: RAFT_UNASSIGNED_MODEL_KEY });
+
+    const circles = modelId != null
+      ? (circlesByModel.get(modelId) ?? [])
+      : Array.from(circlesByModel.values()).flat();
 
     if (circles.length === 0) return [];
 
@@ -221,7 +218,7 @@ export default function FootprintBorderRenderer({
 
     const raftOuterBoundary = computeRaftOuterBoundary(baseProfile, raft);
     return raftOuterBoundary && raftOuterBoundary.length >= 3 ? raftOuterBoundary : [];
-  }, [modelId, raft, supportState.anchors, supportState.roots]);
+  }, [modelId, raft, supportState.anchors, supportState.roots, kickstandState.roots]);
 
   React.useEffect(() => {
     if (!modelGeometry || !modelTransform) {

--- a/src/supports/Rafts/Crenelated/rendering/LineRaftRenderer.tsx
+++ b/src/supports/Rafts/Crenelated/rendering/LineRaftRenderer.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import * as THREE from 'three';
 import { useSyncExternalStore } from 'react';
 import { subscribe, getSnapshot } from '@/supports/state';
+import { getKickstandSnapshot, subscribeToKickstandStore } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 import { getRaftSettings, subscribeToRaftStore } from '../RaftState';
 import { convexHull2d } from '../geometry/convexHull2d';
 import { computeFootprint } from '../geometry/computeFootprint';
@@ -12,7 +13,7 @@ import { generateUnionedLineRaftMesh } from '../geometry/generateUnionedLineRaft
 import { generateChamferedBeam } from '../geometry/generateChamferedBeam';
 import { generatePerimeterWall } from '../geometry/generatePerimeterWall';
 import { generateCrenelatedWallManual } from '../geometry/generateCrenelatedWallManual';
-import type { SupportBaseCircle } from '../RaftTypes';
+import { collectRaftBaseCirclesByModel, fromRaftModelKey } from '../raftFootprintCircles';
 
 type EdgeKey = string;
 
@@ -144,6 +145,7 @@ export default function LineRaftRenderer({
   onModelPointerSelect,
 }: LineRaftRendererProps) {
   const supportState = useSyncExternalStore(subscribe, getSnapshot);
+  const kickstandState = useSyncExternalStore(subscribeToKickstandStore, getKickstandSnapshot, getKickstandSnapshot);
   const raft = useSyncExternalStore(subscribeToRaftStore, getRaftSettings, getRaftSettings);
   const [immediateModelHoverId, setImmediateModelHoverId] = React.useState<string | null>(null);
   const [immediatePrepareActiveModelId, setImmediatePrepareActiveModelId] = React.useState<string | null>(null);
@@ -238,56 +240,23 @@ export default function LineRaftRenderer({
   const raftMeshes = React.useMemo(() => {
     if (raft.bottomMode !== 'line') return null;
 
-    const rootsByModel = new Map<string, typeof supportState.roots[string][]>();
-    for (const root of Object.values(supportState.roots)) {
-      if (excludeModelId && root.modelId === excludeModelId) continue;
-      if (root.modelId && excludedModelIdSet.has(root.modelId)) continue;
-      if (modelFilterId && root.modelId !== modelFilterId) continue;
-      const key = root.modelId || 'unknown';
-      if (!rootsByModel.has(key)) rootsByModel.set(key, []);
-      rootsByModel.get(key)!.push(root);
-    }
-
-    // Include anchor roots for raft footprint
-    for (const anchor of Object.values(supportState.anchors)) {
-      if (excludeModelId && anchor.modelId === excludeModelId) continue;
-      if (anchor.modelId && excludedModelIdSet.has(anchor.modelId)) continue;
-      if (modelFilterId && anchor.modelId !== modelFilterId) continue;
-      const key = anchor.modelId || 'unknown';
-      if (!rootsByModel.has(key)) rootsByModel.set(key, []);
-      rootsByModel.get(key)!.push({
-        id: anchor.id,
-        modelId: anchor.modelId,
-        transform: { pos: anchor.rootPos, rot: { x: 0, y: 0, z: 0, w: 1 } },
-        diameter: anchor.rootBaseDiameter,
-        diskHeight: anchor.rootHeight,
-        coneHeight: 0,
-      });
-    }
-
-    const blendColor = (baseHex: string, tintHex: string, strength: number) =>
-      new THREE.Color(baseHex).lerp(new THREE.Color(tintHex), strength).getStyle();
-
-    const resolveTintStrength = (modelId: string) => {
-      if (!colorized) return 0;
-      if (selectedModelIdSet.has(modelId)) return 1;
-      if (effectiveHoverModelId) return modelId === effectiveHoverModelId ? 0.5 : 0;
-      if (hasSelectedModels) return 0;
-      return hoverized ? 0.5 : 1;
-    };
+    const rootsByModel = collectRaftBaseCirclesByModel({
+      roots: Object.values(supportState.roots),
+      anchors: Object.values(supportState.anchors),
+      kickstandRoots: Object.values(kickstandState.roots),
+    }, {
+      modelFilterId,
+      excludeModelId,
+      excludedModelIds: excludedModelIdSet,
+      fallbackModelKey: 'unknown',
+    });
 
     const meshes: Array<{ beamMeshes: THREE.Mesh[]; wallMesh: THREE.Mesh | null }> = [];
 
-    for (const [modelId, roots] of rootsByModel) {
-      if (roots.length === 0) continue;
-
-      const nodes2d = roots.map((r) => new THREE.Vector2(r.transform.pos.x, r.transform.pos.y));
-
-      const circles: SupportBaseCircle[] = roots.map((r) => ({
-        x: r.transform.pos.x,
-        y: r.transform.pos.y,
-        r: r.diameter / 2,
-      }));
+    for (const [modelKey, circles] of rootsByModel) {
+      if (circles.length === 0) continue;
+      const modelId = fromRaftModelKey(modelKey, 'unknown') ?? modelKey;
+      const nodes2d = circles.map((circle) => new THREE.Vector2(circle.x, circle.y));
 
     // Footprint polygon wraps around the *outer edge* of all supports.
     // Important: the border is chamfered (bottom inset). To ensure the *bottom* of the chamfer
@@ -374,7 +343,7 @@ export default function LineRaftRenderer({
     }
 
     return meshes;
-  }, [excludeModelId, excludedModelIdSet, modelFilterId, raft, supportState, raftOpacity, raftTransparent, ghostRenderOrder, clippingPlanes]);
+  }, [excludeModelId, excludedModelIdSet, modelFilterId, raft, supportState, kickstandState.roots, raftOpacity, raftTransparent, ghostRenderOrder, clippingPlanes]);
 
   const handleClick = React.useCallback((e: any) => {
     const modelId = e?.object?.userData?.modelId;

--- a/src/supports/Rafts/Crenelated/rendering/RaftRenderer.tsx
+++ b/src/supports/Rafts/Crenelated/rendering/RaftRenderer.tsx
@@ -4,12 +4,13 @@ import React from 'react';
 import * as THREE from 'three';
 import { useSyncExternalStore } from 'react';
 import { subscribe, getSnapshot } from '@/supports/state';
+import { getKickstandSnapshot, subscribeToKickstandStore } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 import { getRaftSettings, subscribeToRaftStore } from '../RaftState';
-import { SupportBaseCircle } from '../RaftTypes';
 import { computeFootprint } from '../geometry/computeFootprint';
 import { generateChamferedBase } from '../geometry/generateChamferedBase';
 import { generatePerimeterWall } from '../geometry/generatePerimeterWall';
 import { generateCrenelatedWallManual } from '../geometry/generateCrenelatedWallManual';
+import { collectRaftBaseCirclesByModel, fromRaftModelKey } from '../raftFootprintCircles';
 
 /**
  * RaftRenderer
@@ -53,6 +54,7 @@ export default function RaftRenderer({
   onModelPointerSelect,
 }: RaftRendererProps) {
   const supportState = useSyncExternalStore(subscribe, getSnapshot);
+  const kickstandState = useSyncExternalStore(subscribeToKickstandStore, getKickstandSnapshot, getKickstandSnapshot);
   const raft = useSyncExternalStore(subscribeToRaftStore, getRaftSettings, getRaftSettings);
   const [immediateModelHoverId, setImmediateModelHoverId] = React.useState<string | null>(null);
   const [immediatePrepareActiveModelId, setImmediatePrepareActiveModelId] = React.useState<string | null>(null);
@@ -147,53 +149,22 @@ export default function RaftRenderer({
   const raftMeshes = React.useMemo(() => {
     if (raft.bottomMode !== 'solid') return null;
 
-    const rootsByModel = new Map<string, typeof supportState.roots[string][]>();
-    for (const root of Object.values(supportState.roots)) {
-      if (excludeModelId && root.modelId === excludeModelId) continue;
-      if (root.modelId && excludedModelIdSet.has(root.modelId)) continue;
-      if (modelFilterId && root.modelId !== modelFilterId) continue;
-      const key = root.modelId || 'unknown';
-      if (!rootsByModel.has(key)) rootsByModel.set(key, []);
-      rootsByModel.get(key)!.push(root);
-    }
-
-    // Include anchor roots as synthetic Roots entries for raft footprint
-    for (const anchor of Object.values(supportState.anchors)) {
-      if (excludeModelId && anchor.modelId === excludeModelId) continue;
-      if (anchor.modelId && excludedModelIdSet.has(anchor.modelId)) continue;
-      if (modelFilterId && anchor.modelId !== modelFilterId) continue;
-      const key = anchor.modelId || 'unknown';
-      if (!rootsByModel.has(key)) rootsByModel.set(key, []);
-      rootsByModel.get(key)!.push({
-        id: anchor.id,
-        modelId: anchor.modelId,
-        transform: { pos: anchor.rootPos, rot: { x: 0, y: 0, z: 0, w: 1 } },
-        diameter: anchor.rootBaseDiameter,
-        diskHeight: anchor.rootHeight,
-        coneHeight: 0,
-      });
-    }
-
-    const blendColor = (baseHex: string, tintHex: string, strength: number) =>
-      new THREE.Color(baseHex).lerp(new THREE.Color(tintHex), strength).getStyle();
-
-    const resolveTintStrength = (modelId: string) => {
-      if (!colorized) return 0;
-      if (selectedModelIdSet.has(modelId)) return 1;
-      if (effectiveHoverModelId) return modelId === effectiveHoverModelId ? 0.5 : 0;
-      if (hasSelectedModels) return 0;
-      return hoverized ? 0.5 : 1;
-    };
+    const rootsByModel = collectRaftBaseCirclesByModel({
+      roots: Object.values(supportState.roots),
+      anchors: Object.values(supportState.anchors),
+      kickstandRoots: Object.values(kickstandState.roots),
+    }, {
+      modelFilterId,
+      excludeModelId,
+      excludedModelIds: excludedModelIdSet,
+      fallbackModelKey: 'unknown',
+    });
 
     const meshes: Array<{ baseMesh: THREE.Mesh; wallMesh: THREE.Mesh | null }> = [];
 
-    for (const [modelId, roots] of rootsByModel) {
-      const circles: SupportBaseCircle[] = roots.map(root => ({
-        x: root.transform.pos.x,
-        y: root.transform.pos.y,
-        r: root.diameter / 2,
-      }));
+    for (const [modelKey, circles] of rootsByModel) {
       if (circles.length === 0) continue;
+      const modelId = fromRaftModelKey(modelKey, 'unknown') ?? modelKey;
 
       const profile = computeFootprint(circles, { marginMm: 0.2, samplesPerCircle: 24 });
       if (!profile || profile.length < 3) continue;
@@ -233,7 +204,7 @@ export default function RaftRenderer({
     }
 
     return meshes;
-  }, [excludeModelId, excludedModelIdSet, modelFilterId, supportState, raft.bottomMode, raft.wallEnabled, raft.thickness, raft.chamferAngle, raft.wallHeight, raft.wallThickness, raft.crenulationGapWidth, raft.crenulationSpacing, raftOpacity, raftTransparent, ghostRenderOrder, clippingPlanes]);
+  }, [excludeModelId, excludedModelIdSet, modelFilterId, supportState, kickstandState.roots, raft.bottomMode, raft.wallEnabled, raft.thickness, raft.chamferAngle, raft.wallHeight, raft.wallThickness, raft.crenulationGapWidth, raft.crenulationSpacing, raftOpacity, raftTransparent, ghostRenderOrder, clippingPlanes]);
 
   const handleClick = React.useCallback((e: any) => {
     if (passive) return;

--- a/src/supports/SupportPrimitives/ContactDisk/ContactDiskInteraction.ts
+++ b/src/supports/SupportPrimitives/ContactDisk/ContactDiskInteraction.ts
@@ -5,7 +5,7 @@ import { calculateDiskThickness } from './contactDiskUtils';
 import { getFinalSocketPosition } from '../ContactCone/contactConeUtils';
 import { calculateSafeOffset } from '../../PlacementLogic/CollisionAvoidance';
 
-const CONTACT_CONE_COLLISION_SAFETY_MM = 0.25;
+const CONTACT_CONE_COLLISION_SAFETY_MM = 0.8;
 const LEGACY_MAX_STANDOFF_MM = 1.5;
 const LEGACY_CLAMPED_MAX_STANDOFF_MM = 0.35;
 

--- a/src/supports/SupportPrimitives/ContactDisk/ContactDiskInteraction.ts
+++ b/src/supports/SupportPrimitives/ContactDisk/ContactDiskInteraction.ts
@@ -3,12 +3,68 @@ import type { ContactCone } from '../ContactCone/types';
 import type { ContactDisk, Vec3 } from '../../types';
 import { calculateDiskThickness } from './contactDiskUtils';
 import { getFinalSocketPosition } from '../ContactCone/contactConeUtils';
+import { calculateSafeOffset } from '../../PlacementLogic/CollisionAvoidance';
+
+const CONTACT_CONE_COLLISION_SAFETY_MM = 0.25;
+const LEGACY_MAX_STANDOFF_MM = 1.5;
+const LEGACY_CLAMPED_MAX_STANDOFF_MM = 0.35;
+
+function resolveCollisionAwareDiskThickness(
+    cone: ContactCone,
+    surfaceNormal: THREE.Vector3,
+    coneAxis: THREE.Vector3,
+    socketTarget: THREE.Vector3,
+    collisionMesh?: THREE.Mesh,
+): number {
+    const angleThickness = cone.profile.type === 'disk'
+        ? calculateDiskThickness(
+            { x: surfaceNormal.x, y: surfaceNormal.y, z: surfaceNormal.z },
+            { x: coneAxis.x, y: coneAxis.y, z: coneAxis.z },
+            cone.profile,
+        )
+        : 0;
+
+    if (!collisionMesh || cone.profile.type !== 'disk') {
+        return angleThickness;
+    }
+
+    const bodyRadius = cone.profile.bodyDiameterMm / 2;
+    const rawMaxStandoff = cone.profile.maxStandoffMm ?? LEGACY_MAX_STANDOFF_MM;
+    const maxStandoff = rawMaxStandoff === LEGACY_MAX_STANDOFF_MM
+        ? LEGACY_CLAMPED_MAX_STANDOFF_MM
+        : rawMaxStandoff;
+
+    if (maxStandoff <= angleThickness + 0.000001) {
+        return angleThickness;
+    }
+
+    const safeThickness = calculateSafeOffset(
+        cone.pos,
+        { x: surfaceNormal.x, y: surfaceNormal.y, z: surfaceNormal.z },
+        { x: socketTarget.x, y: socketTarget.y, z: socketTarget.z },
+        bodyRadius + CONTACT_CONE_COLLISION_SAFETY_MM,
+        collisionMesh,
+        angleThickness,
+        maxStandoff,
+    );
+
+    const capEps = 1e-6;
+    return safeThickness >= (maxStandoff - capEps)
+        ? angleThickness
+        : safeThickness;
+}
 
 export function toVec3(vector: THREE.Vector3): Vec3 {
     return { x: vector.x, y: vector.y, z: vector.z };
 }
 
-export function recomputeContactConeForMovedDisk(cone: ContactCone, nextContactPos: Vec3, nextSurfaceNormal: Vec3, fixedSocketPos?: Vec3): ContactCone {
+export function recomputeContactConeForMovedDisk(
+    cone: ContactCone,
+    nextContactPos: Vec3,
+    nextSurfaceNormal: Vec3,
+    fixedSocketPos?: Vec3,
+    collisionMesh?: THREE.Mesh,
+): ContactCone {
     const socketTarget = fixedSocketPos
         ? new THREE.Vector3(fixedSocketPos.x, fixedSocketPos.y, fixedSocketPos.z)
         : (() => { const p = getFinalSocketPosition(cone); return new THREE.Vector3(p.x, p.y, p.z); })();
@@ -30,9 +86,13 @@ export function recomputeContactConeForMovedDisk(cone: ContactCone, nextContactP
     }
     approxAxis.normalize();
 
-    const thickness = cone.profile.type === 'disk'
-        ? calculateDiskThickness(nextSurfaceNormal, toVec3(approxAxis), cone.profile)
-        : 0;
+    const thickness = resolveCollisionAwareDiskThickness(
+        cone,
+        surfaceNormal,
+        approxAxis,
+        socketTarget,
+        collisionMesh,
+    );
 
     // Cone body starts after the disk offset along surface normal
     const coneStart = contactPos.clone().add(surfaceNormal.clone().multiplyScalar(thickness));

--- a/src/supports/SupportPrimitives/ContactDisk/ContactDiskInteraction.ts
+++ b/src/supports/SupportPrimitives/ContactDisk/ContactDiskInteraction.ts
@@ -46,6 +46,11 @@ function resolveCollisionAwareDiskThickness(
         collisionMesh,
         angleThickness,
         maxStandoff,
+        0.2,
+        {
+            startRadius: (cone.profile.contactDiameterMm / 2) + CONTACT_CONE_COLLISION_SAFETY_MM,
+            endRadius: bodyRadius + CONTACT_CONE_COLLISION_SAFETY_MM,
+        },
     );
 
     const capEps = 1e-6;

--- a/src/supports/SupportPrimitives/ContactDisk/ContactDiskInteraction.ts
+++ b/src/supports/SupportPrimitives/ContactDisk/ContactDiskInteraction.ts
@@ -5,7 +5,9 @@ import { calculateDiskThickness } from './contactDiskUtils';
 import { getFinalSocketPosition } from '../ContactCone/contactConeUtils';
 import { calculateSafeOffset } from '../../PlacementLogic/CollisionAvoidance';
 
-const CONTACT_CONE_COLLISION_SAFETY_MM = 0.8;
+// Contact cones need to respect the model, but they can sit much closer than
+// shafts/roots without causing the oversized detours that a full 0.8mm margin induces.
+const CONTACT_CONE_COLLISION_SAFETY_MM = 0.3;
 const LEGACY_MAX_STANDOFF_MM = 1.5;
 const LEGACY_CLAMPED_MAX_STANDOFF_MM = 0.35;
 

--- a/src/supports/SupportPrimitives/ContactDisk/contactDiskDragController.ts
+++ b/src/supports/SupportPrimitives/ContactDisk/contactDiskDragController.ts
@@ -6,6 +6,7 @@ import { getClipBounds } from '@/components/scene/SceneCanvas/clipBoundsStore';
 export interface ContactDiskDragHit {
     point: Vec3;
     surfaceNormal: Vec3;
+    mesh?: THREE.Mesh;
 }
 
 export interface ContactDiskDragSession {
@@ -101,6 +102,7 @@ export function startContactDiskDragSession(options: ContactDiskDragSessionOptio
         onHit({
             point: { x: hit.point.x, y: hit.point.y, z: hit.point.z },
             surfaceNormal: calculateSmoothedNormal(hit),
+            mesh: hit.object instanceof THREE.Mesh ? hit.object : undefined,
         });
     };
 

--- a/src/supports/SupportPrimitives/Joint/jointUtils.ts
+++ b/src/supports/SupportPrimitives/Joint/jointUtils.ts
@@ -649,7 +649,7 @@ export function moveJoint(
                 // If mesh is provided, ensure we have physical clearance.
                 if (mesh && trunk.contactCone.profile.type === 'disk') {
                     const bodyRadius = trunk.contactCone.profile.bodyDiameterMm / 2;
-                    const safetyMargin = 0.25;
+                    const safetyMargin = 0.8;
                     const testRadius = bodyRadius + safetyMargin;
 
                     // Legacy Fix: Treat 1.5 as 0.35, else respect user value

--- a/src/supports/SupportPrimitives/Joint/jointUtils.ts
+++ b/src/supports/SupportPrimitives/Joint/jointUtils.ts
@@ -664,7 +664,12 @@ export function moveJoint(
                         testRadius,
                         mesh,
                         angleThickness, // minOffset (start at angle-based)
-                        maxStandoff
+                        maxStandoff,
+                        0.2,
+                        {
+                            startRadius: (trunk.contactCone.profile.contactDiameterMm / 2) + safetyMargin,
+                            endRadius: testRadius,
+                        },
                     );
 
                     // If we hit the cap, treat it as "solver couldn't prove clearance" rather than

--- a/src/supports/SupportTypes/Anchor/AnchorRenderer.tsx
+++ b/src/supports/SupportTypes/Anchor/AnchorRenderer.tsx
@@ -80,10 +80,10 @@ export const AnchorRenderer = React.memo(function AnchorRenderer({
             scene,
             initialEvent: e,
             modelId: anchor.modelId,
-            onHit: ({ point, surfaceNormal }: ContactDiskDragHit) => {
+            onHit: ({ point, surfaceNormal, mesh }: ContactDiskDragHit) => {
                 const latest = getSnapshot().anchors[anchor.id];
                 if (!latest?.contactCone) return;
-                liveDragConeRef.current = recomputeContactConeForMovedDisk(latest.contactCone, point, surfaceNormal, socketAnchor);
+                liveDragConeRef.current = recomputeContactConeForMovedDisk(latest.contactCone, point, surfaceNormal, socketAnchor, mesh);
                 setDragTick(t => t + 1);
             },
             onEnd: () => {

--- a/src/supports/SupportTypes/Anchor/anchorBuilder.ts
+++ b/src/supports/SupportTypes/Anchor/anchorBuilder.ts
@@ -1,7 +1,8 @@
 import type { Anchor, Joint, Vec3 } from '../../types';
 import type { ContactCone, SupportTipProfile } from '../../SupportPrimitives/ContactCone/types';
 import type { SupportData } from '../../rendering/SupportBuilder';
-import { calculateDiskThickness } from '../../SupportPrimitives/ContactDisk/contactDiskUtils';
+import type * as THREE from 'three';
+import { recomputeContactConeForMovedDisk } from '../../SupportPrimitives/ContactDisk';
 import { getSettings } from '../../Settings';
 import { resolveConeAxisPolicy } from '../../PlacementLogic/ConeAxisPolicy';
 import { encodeSupportSettingsHex } from '../../Settings/supportSettingsCodec';
@@ -17,6 +18,7 @@ export interface AnchorBuildInput {
     tipPos: Vec3;
     tipNormal: Vec3;
     modelId: string;
+    mesh?: THREE.Mesh;
 }
 
 export interface AnchorBuildResult {
@@ -25,7 +27,7 @@ export interface AnchorBuildResult {
 }
 
 export function buildAnchorData(input: AnchorBuildInput): AnchorBuildResult {
-    const { tipPos, tipNormal, modelId } = input;
+    const { tipPos, tipNormal, modelId, mesh } = input;
 
     const settings = getSettings();
     const settingsCodeHex = encodeSupportSettingsHex(settings);
@@ -50,17 +52,6 @@ export function buildAnchorData(input: AnchorBuildInput): AnchorBuildResult {
         standoffAngleThreshold: Math.PI / 4,
     };
 
-    // Contact cone disk offset
-    const diskThickness = tipProfile.type === 'disk'
-        ? calculateDiskThickness(tipNormal, effectiveConeAxis, tipProfile)
-        : 0;
-
-    const coneStartPos: Vec3 = {
-        x: tipPos.x + tipNormal.x * diskThickness,
-        y: tipPos.y + tipNormal.y * diskThickness,
-        z: tipPos.z + tipNormal.z * diskThickness,
-    };
-
     // Compute raft vertical offset (must match RootsRenderer logic)
     const raft = getRaftSettings();
     const hasSolidBottom = raft.bottomMode === 'solid';
@@ -74,16 +65,38 @@ export function buildAnchorData(input: AnchorBuildInput): AnchorBuildResult {
     const targetSocketZ = verticalOffset + effectiveDiskHeight + ANCHOR_ROOT_HEIGHT_MM;
     const dzPerUnit = effectiveConeAxis.z;
     const coneLength = Math.abs(dzPerUnit) > 1e-6
-        ? (targetSocketZ - coneStartPos.z) / dzPerUnit
+        ? (targetSocketZ - tipPos.z) / dzPerUnit
         : tipProfile.lengthMm; // fallback if cone axis is nearly horizontal
 
     // Use the stretched length (but never shorter than the default)
     const effectiveConeLength = Math.max(coneLength, tipProfile.lengthMm);
 
+    const guessedSocketPos: Vec3 = {
+        x: tipPos.x + effectiveConeAxis.x * effectiveConeLength,
+        y: tipPos.y + effectiveConeAxis.y * effectiveConeLength,
+        z: tipPos.z + effectiveConeAxis.z * effectiveConeLength,
+    };
+    const authoredCone = recomputeContactConeForMovedDisk(
+        {
+            id: 'preview-anchor-cone',
+            pos: tipPos,
+            normal: effectiveConeAxis,
+            surfaceNormal: tipNormal,
+            profile: {
+                ...tipProfile,
+                lengthMm: effectiveConeLength,
+                bodyDiameterMm: ANCHOR_JOINT_DIAMETER_MM - 0.1,
+            },
+        },
+        tipPos,
+        tipNormal,
+        guessedSocketPos,
+        mesh,
+    );
     const socketPos: Vec3 = {
-        x: coneStartPos.x + effectiveConeAxis.x * effectiveConeLength,
-        y: coneStartPos.y + effectiveConeAxis.y * effectiveConeLength,
-        z: coneStartPos.z + effectiveConeAxis.z * effectiveConeLength,
+        x: authoredCone.pos.x + (authoredCone.surfaceNormal?.x ?? tipNormal.x) * (authoredCone.diskLengthOverride ?? 0) + authoredCone.normal.x * authoredCone.profile.lengthMm,
+        y: authoredCone.pos.y + (authoredCone.surfaceNormal?.y ?? tipNormal.y) * (authoredCone.diskLengthOverride ?? 0) + authoredCone.normal.y * authoredCone.profile.lengthMm,
+        z: authoredCone.pos.z + (authoredCone.surfaceNormal?.z ?? tipNormal.z) * (authoredCone.diskLengthOverride ?? 0) + authoredCone.normal.z * authoredCone.profile.lengthMm,
     };
 
     // Root and joint are positioned at the socket XY, vertical stack
@@ -109,11 +122,8 @@ export function buildAnchorData(input: AnchorBuildInput): AnchorBuildResult {
     };
 
     const contactCone: ContactCone = {
+        ...authoredCone,
         id: generateUuid(),
-        pos: tipPos,
-        normal: effectiveConeAxis,
-        surfaceNormal: tipNormal,
-        profile: anchorTipProfile,
         socketJointId: socketJoint.id,
     };
 

--- a/src/supports/SupportTypes/Brace/BracePlacementController.tsx
+++ b/src/supports/SupportTypes/Brace/BracePlacementController.tsx
@@ -17,8 +17,6 @@ import { clearSupportSelection } from '../../interaction/shared/selection/select
 import { usePlacementSnappingSession } from '../../interaction/shared/placement/snapping/usePlacementSnappingSession';
 import {
     buildKickstandPathSnapTargets,
-    buildLeafConePathSnapTargets,
-    buildLeafConeSnapMeta,
     buildPrimarySnapTargetIndex,
     buildSnapTargetCandidateIndex,
     buildSupportPathSnapTargets,
@@ -128,10 +126,6 @@ export function BracePlacementController() {
         return map;
     }, [supportState.trunks, supportState.branches, supportState.twigs, supportState.sticks, supportState.braces, kickstandState.kickstands]);
 
-    const leafMeta = useMemo(() => {
-        return buildLeafConeSnapMeta(supportState.leaves);
-    }, [supportState.leaves]);
-
     // Reverse lookup: twig segment id → owning twig. Lets the placement
     // controller resolve the live twig taper diameter at the snap point so
     // brace endpoint knots on twigs match the leaf-on-twig rule (1.10× of
@@ -174,21 +168,6 @@ export function BracePlacementController() {
         },
         [twigBySegmentId]
     );
-
-    const resolveLeafSurface = useCallback((leafId: string, axisPoint: Vec3, coneT: number) => {
-        const meta = leafMeta.get(leafId);
-        if (!meta) return null;
-
-        // The endpoint knot should be centered on the cone axis.
-        // We still compute local diameter from coneT for sizing.
-        const center = new THREE.Vector3(axisPoint.x, axisPoint.y, axisPoint.z);
-        const rMm = THREE.MathUtils.lerp(meta.contactRadiusMm, meta.bodyRadiusMm, THREE.MathUtils.clamp(coneT, 0, 1));
-        return {
-            pos: { x: center.x, y: center.y, z: center.z },
-            diameterMm: rMm * 2,
-            modelId: meta.modelId,
-        };
-    }, [leafMeta]);
 
     const isValidEndSegment = useCallback(
         (endSegmentId: string) => {
@@ -234,7 +213,6 @@ export function BracePlacementController() {
         });
 
         targets.push(...buildKickstandPathSnapTargets(kickstandState, { excludeSegmentIds: excludedSegmentIds }));
-        targets.push(...buildLeafConePathSnapTargets(leafMeta));
 
         return targets;
     }, [
@@ -247,7 +225,6 @@ export function BracePlacementController() {
         supportState.twigs,
         supportState.sticks,
         kickstandState.kickstands,
-        leafMeta,
     ]);
 
     const targetById = useMemo(() => {
@@ -337,42 +314,6 @@ export function BracePlacementController() {
         [getTarget, resolveNearestPathTarget, segmentMeta, overrideHostDiameterForTwig]
     );
 
-    const resolveLeafSnapFromClick = useCallback(
-        (leafId: string, point: Vec3) => {
-            const meta = leafMeta.get(leafId);
-            if (!meta) return null;
-
-            const a = new THREE.Vector3(meta.start.x, meta.start.y, meta.start.z);
-            const b = new THREE.Vector3(meta.end.x, meta.end.y, meta.end.z);
-            const p = new THREE.Vector3(point.x, point.y, point.z);
-
-            const ab = b.clone().sub(a);
-            const abLenSq = ab.lengthSq();
-            if (abLenSq < 0.0000001) return null;
-
-            const t = THREE.MathUtils.clamp(p.clone().sub(a).dot(ab) / abLenSq, 0, 1);
-
-            // Do not allow attaching on/inside the contact area at the very tip.
-            const minMm = 0.25;
-            const minT = THREE.MathUtils.clamp(minMm / Math.max(0.0001, meta.lengthMm), 0, 0.99);
-            const coneT = Math.max(t, minT);
-
-            const axisPoint = a.clone().add(ab.multiplyScalar(coneT));
-            const resolved = resolveLeafSurface(leafId, { x: axisPoint.x, y: axisPoint.y, z: axisPoint.z }, coneT);
-            if (!resolved) return null;
-
-            return {
-                kind: 'leaf' as const,
-                leafId,
-                coneT,
-                snappedPos: resolved.pos,
-                hostDiameterMm: resolved.diameterMm,
-                ownerModelId: resolved.modelId,
-            };
-        },
-        [leafMeta, resolveLeafSurface]
-    );
-
     const resolveHoveredShaftSnap = useCallback(() => {
         const hovered = hoveredShaftRef.current;
         if (!hovered?.segmentId || !hovered.point) return null;
@@ -435,56 +376,33 @@ export function BracePlacementController() {
             if (resolvedSnap.state === 'locked' && resolvedSnap.targetId && resolvedSnap.snappedPos && resolvedSnap.t !== null) {
                 const settings = getSettings();
                 const fallbackDia = settings.shaft.diameterMm;
-
-                if (leafMeta.has(resolvedSnap.targetId)) {
-                    const resolved = resolveLeafSurface(resolvedSnap.targetId, resolvedSnap.snappedPos, resolvedSnap.t);
-                    if (resolved) {
-                        const preview = {
-                            start: resolved.pos,
-                            end: resolved.pos,
-                            startDiameterMm: resolved.diameterMm,
-                            endDiameterMm: resolved.diameterMm,
-                        };
-                        const signature = [
-                            'brace:leaf-snap',
-                            resolvedSnap.targetId,
-                            previewVecKey(resolved.pos),
-                            quantizePreviewValue(resolved.diameterMm),
-                        ].join('|');
-                        publishPreview(signature, preview);
-                    } else {
-                        publishPreview('brace:leaf-snap-invalid', null);
-                    }
-                } else {
-                    const target = resolveNearestPathTarget(resolvedSnap.targetId, resolvedSnap.snappedPos) ?? getTarget(resolvedSnap.targetId);
-                    let hostDia = target?.pathSegment?.radius !== undefined ? target.pathSegment.radius * 2 : fallbackDia;
-                    if (resolvedSnap.targetId.startsWith('braceSegment:')) {
-                        const braceId = resolvedSnap.targetId.slice('braceSegment:'.length);
-                        const brace = supportState.braces[braceId];
-                        if (brace) {
-                            const resolvedDiameter = resolveBracePathDiameterAtT(brace, supportState.knots, resolvedSnap.t);
-                            if (resolvedDiameter !== null) {
-                                hostDia = resolvedDiameter;
-                            }
+                const target = resolveNearestPathTarget(resolvedSnap.targetId, resolvedSnap.snappedPos) ?? getTarget(resolvedSnap.targetId);
+                let hostDia = target?.pathSegment?.radius !== undefined ? target.pathSegment.radius * 2 : fallbackDia;
+                if (resolvedSnap.targetId.startsWith('braceSegment:')) {
+                    const braceId = resolvedSnap.targetId.slice('braceSegment:'.length);
+                    const brace = supportState.braces[braceId];
+                    if (brace) {
+                        const resolvedDiameter = resolveBracePathDiameterAtT(brace, supportState.knots, resolvedSnap.t);
+                        if (resolvedDiameter !== null) {
+                            hostDia = resolvedDiameter;
                         }
                     }
-                    hostDia = overrideHostDiameterForTwig(resolvedSnap.targetId, resolvedSnap.t, hostDia) ?? hostDia;
-                    // Zero-length preview: renders as a single sphere with green lights.
-                    const preview = {
-                        start: resolvedSnap.snappedPos,
-                        end: resolvedSnap.snappedPos,
-                        startDiameterMm: hostDia,
-                        endDiameterMm: hostDia,
-                    };
-                    const signature = [
-                        'brace:locked-snap',
-                        resolvedSnap.targetId,
-                        previewVecKey(resolvedSnap.snappedPos),
-                        quantizePreviewValue(resolvedSnap.t),
-                        quantizePreviewValue(hostDia),
-                    ].join('|');
-                    publishPreview(signature, preview);
                 }
+                hostDia = overrideHostDiameterForTwig(resolvedSnap.targetId, resolvedSnap.t, hostDia) ?? hostDia;
+                const preview = {
+                    start: resolvedSnap.snappedPos,
+                    end: resolvedSnap.snappedPos,
+                    startDiameterMm: hostDia,
+                    endDiameterMm: hostDia,
+                };
+                const signature = [
+                    'brace:locked-snap',
+                    resolvedSnap.targetId,
+                    previewVecKey(resolvedSnap.snappedPos),
+                    quantizePreviewValue(resolvedSnap.t),
+                    quantizePreviewValue(hostDia),
+                ].join('|');
+                publishPreview(signature, preview);
             } else {
                 publishPreview('brace:idle-clear', null);
             }
@@ -547,81 +465,39 @@ export function BracePlacementController() {
                 }
             }
         } else if (resolvedSnap.state === 'locked' && resolvedSnap.targetId && resolvedSnap.snappedPos && resolvedSnap.t !== null) {
-            if (leafMeta.has(resolvedSnap.targetId)) {
-                const startModelId = start.ownerModelId;
-                const meta = leafMeta.get(resolvedSnap.targetId);
-                if (meta && startModelId && meta.modelId && startModelId !== meta.modelId) {
-                    bracePlacementStore.setSnapTarget(null);
-                } else {
-                    const resolved = resolveLeafSurface(resolvedSnap.targetId, resolvedSnap.snappedPos, resolvedSnap.t);
-                    const minMm = 0.25;
-                    const minT = meta ? THREE.MathUtils.clamp(minMm / Math.max(0.0001, meta.lengthMm), 0, 0.99) : 0;
-                    const coneT = Math.max(resolvedSnap.t, minT);
+            const target = resolveNearestPathTarget(resolvedSnap.targetId, resolvedSnap.snappedPos) ?? getTarget(resolvedSnap.targetId);
+            let hostDiameterMm = target?.pathSegment?.radius !== undefined ? target.pathSegment.radius * 2 : undefined;
+            let ownerModelId = segmentMeta.get(resolvedSnap.targetId)?.modelId;
 
-                    const sameLeaf = start.kind === 'leaf' && start.leafId === resolvedSnap.targetId;
-
-                    if (resolved && !sameLeaf) {
-                        const snapTarget = {
-                            kind: 'leaf' as const,
-                            leafId: resolvedSnap.targetId,
-                            coneT,
-                            snappedPos: resolved.pos,
-                            hostDiameterMm: resolved.diameterMm,
-                            ownerModelId: resolved.modelId,
-                        };
-                        bracePlacementStore.setSnapTarget(snapTarget);
-                        endPos = snapTarget.snappedPos;
-                        endDiam = snapTarget.hostDiameterMm ?? fallbackDia;
-                    } else {
-                        bracePlacementStore.setSnapTarget(null);
+            if (resolvedSnap.targetId.startsWith('braceSegment:')) {
+                const braceId = resolvedSnap.targetId.slice('braceSegment:'.length);
+                const brace = supportState.braces[braceId];
+                if (brace) {
+                    const resolvedDiameter = resolveBracePathDiameterAtT(brace, supportState.knots, resolvedSnap.t);
+                    if (resolvedDiameter !== null) {
+                        hostDiameterMm = resolvedDiameter;
                     }
+                    ownerModelId = brace.modelId;
                 }
+            }
+
+            hostDiameterMm = overrideHostDiameterForTwig(resolvedSnap.targetId, resolvedSnap.t, hostDiameterMm) ?? hostDiameterMm;
+
+            const snapTarget = {
+                kind: 'shaft' as const,
+                segmentId: resolvedSnap.targetId,
+                snappedPos: resolvedSnap.snappedPos,
+                t: resolvedSnap.t,
+                hostDiameterMm,
+                ownerModelId,
+            };
+
+            if (snapTarget.segmentId && isValidEndSegment(snapTarget.segmentId)) {
+                bracePlacementStore.setSnapTarget(snapTarget);
+                endPos = snapTarget.snappedPos;
+                endDiam = snapTarget.hostDiameterMm ?? fallbackDia;
             } else {
-                const target = resolveNearestPathTarget(resolvedSnap.targetId, resolvedSnap.snappedPos) ?? getTarget(resolvedSnap.targetId);
-                let hostDiameterMm = target?.pathSegment?.radius !== undefined ? target.pathSegment.radius * 2 : undefined;
-                let ownerModelId = segmentMeta.get(resolvedSnap.targetId)?.modelId;
-
-                if (resolvedSnap.targetId.startsWith('braceSegment:')) {
-                    const braceId = resolvedSnap.targetId.slice('braceSegment:'.length);
-                    const brace = supportState.braces[braceId];
-                    if (brace) {
-                        const resolvedDiameter = resolveBracePathDiameterAtT(brace, supportState.knots, resolvedSnap.t);
-                        if (resolvedDiameter !== null) {
-                            hostDiameterMm = resolvedDiameter;
-                        }
-                        ownerModelId = brace.modelId;
-                    }
-                }
-
-                hostDiameterMm = overrideHostDiameterForTwig(resolvedSnap.targetId, resolvedSnap.t, hostDiameterMm) ?? hostDiameterMm;
-
-                const snapTarget = {
-                    kind: 'shaft' as const,
-                    segmentId: resolvedSnap.targetId,
-                    snappedPos: resolvedSnap.snappedPos,
-                    t: resolvedSnap.t,
-                    hostDiameterMm,
-                    ownerModelId,
-                };
-
-                if (start.kind === 'leaf') {
-                    if (start.ownerModelId && ownerModelId && start.ownerModelId !== ownerModelId) {
-                        bracePlacementStore.setSnapTarget(null);
-                    } else {
-                        bracePlacementStore.setSnapTarget(snapTarget);
-                        endPos = snapTarget.snappedPos;
-                        endDiam = snapTarget.hostDiameterMm ?? fallbackDia;
-                    }
-                } else {
-                    // If snapping is locked onto the same segment as the start, treat it as "free".
-                    if (snapTarget.segmentId && isValidEndSegment(snapTarget.segmentId)) {
-                        bracePlacementStore.setSnapTarget(snapTarget);
-                        endPos = snapTarget.snappedPos;
-                        endDiam = snapTarget.hostDiameterMm ?? fallbackDia;
-                    } else {
-                        bracePlacementStore.setSnapTarget(null);
-                    }
-                }
+                bracePlacementStore.setSnapTarget(null);
             }
         } else {
             bracePlacementStore.setSnapTarget(null);
@@ -853,169 +729,6 @@ export function BracePlacementController() {
         window.addEventListener('shaft-click', handleShaftClick as EventListener, true);
         return () => window.removeEventListener('shaft-click', handleShaftClick as EventListener, true);
     }, [altActive, stage, start, branchFamilyBinding, resolveSnapFromClick, isValidEndSegment, segmentMeta]);
-
-    useEffect(() => {
-        const handleLeafClick = (evt: Event) => {
-            const detail = (evt as CustomEvent<LeafClickDetail>).detail;
-            const branchFamilyHeld = !!altActive
-                || isSupportPlacementBindingSatisfiedByModifierState(branchFamilyBinding, getSupportPlacementModifierState(detail?.intersection));
-            if (!branchFamilyHeld) return;
-
-            if (branchPlacementStore.getSnapshot().stage === 'awaitingBase') {
-                return;
-            }
-
-            const leafId: string | undefined = detail?.leafId;
-            const point: Vec3 | null = detail?.point ?? null;
-            if (!leafId || !point) return;
-
-            if (stage === 'idle') {
-                const snap = resolveLeafSnapFromClick(leafId, point);
-                if (!snap) return;
-                bracePlacementStore.setStart(snap);
-                const settings = getSettings();
-                const fallbackDia = settings.shaft.diameterMm;
-                const startDiam = snap.hostDiameterMm ?? fallbackDia;
-                bracePlacementStore.setPreview({
-                    start: snap.snappedPos,
-                    end: snap.snappedPos,
-                    startDiameterMm: startDiam,
-                    endDiameterMm: startDiam,
-                });
-                return;
-            }
-
-            if (stage !== 'awaitingEnd' || !start) return;
-            if (start.kind === 'leaf') {
-                if (start.leafId === leafId) return;
-
-                const endSnap = resolveLeafSnapFromClick(leafId, point);
-                if (!endSnap || endSnap.coneT === undefined) return;
-
-                const startModelId = start.ownerModelId;
-                const endModelId = endSnap.ownerModelId;
-                if (startModelId && endModelId && startModelId !== endModelId) return;
-                if (!start.leafId || start.coneT === undefined) return;
-
-                const settings = getSettings();
-                const fallback = settings.shaft.diameterMm;
-                const startDiam = start.hostDiameterMm ?? fallback;
-                const endDiam = endSnap.hostDiameterMm ?? fallback;
-
-                const braceId = generateUuid();
-                const startKnotId = generateUuid();
-                const endKnotId = generateUuid();
-
-                const startKnot: Knot = {
-                    id: startKnotId,
-                    parentShaftId: `leafCone:${start.leafId}`,
-                    t: start.coneT,
-                    pos: start.snappedPos,
-                    diameter: startDiam + 0.1,
-                };
-
-                const endKnot: Knot = {
-                    id: endKnotId,
-                    parentShaftId: `leafCone:${leafId}`,
-                    t: endSnap.coneT,
-                    pos: endSnap.snappedPos,
-                    diameter: endDiam + 0.1,
-                };
-
-                const modelId = startModelId ?? endModelId ?? 'unknown';
-                const brace: Brace = {
-                    id: braceId,
-                    modelId,
-                    startKnotId,
-                    endKnotId,
-                    profile: {
-                        diameter: Math.min(startDiam, endDiam),
-                    },
-                };
-
-                addKnot(startKnot);
-                addKnot(endKnot);
-                addBrace(brace);
-
-                pushHistory({
-                    type: SUPPORT_ADD_BRACE,
-                    payload: {
-                        brace,
-                        startKnot,
-                        endKnot,
-                    },
-                });
-
-                bracePlacementStore.finalize();
-                bracePlacementStore.reset();
-                return;
-            }
-
-            if (start.kind !== 'shaft' || !start.segmentId || start.t === undefined) return;
-
-            const endSnap = resolveLeafSnapFromClick(leafId, point);
-            if (!endSnap || endSnap.coneT === undefined) return;
-
-            const startModelId = start.ownerModelId;
-            const endModelId = endSnap.ownerModelId;
-            if (startModelId && endModelId && startModelId !== endModelId) return;
-
-            const settings = getSettings();
-            const fallback = settings.shaft.diameterMm;
-            const startDiam = start.hostDiameterMm ?? fallback;
-            const endDiam = endSnap.hostDiameterMm ?? fallback;
-
-            const braceId = generateUuid();
-            const startKnotId = generateUuid();
-            const endKnotId = generateUuid();
-
-            const startKnot: Knot = {
-                id: startKnotId,
-                parentShaftId: start.segmentId,
-                t: start.t,
-                pos: start.snappedPos,
-                diameter: resolveBraceEndpointKnotDiameter(start.segmentId, startDiam),
-            };
-
-            const endKnot: Knot = {
-                id: endKnotId,
-                parentShaftId: `leafCone:${leafId}`,
-                t: endSnap.coneT,
-                pos: endSnap.snappedPos,
-                diameter: endDiam + 0.1,
-            };
-
-            const modelId = startModelId ?? endModelId ?? 'unknown';
-            const brace: Brace = {
-                id: braceId,
-                modelId,
-                startKnotId,
-                endKnotId,
-                profile: {
-                    diameter: Math.min(startDiam, endDiam),
-                },
-            };
-
-            addKnot(startKnot);
-            addKnot(endKnot);
-            addBrace(brace);
-
-            pushHistory({
-                type: SUPPORT_ADD_BRACE,
-                payload: {
-                    brace,
-                    startKnot,
-                    endKnot,
-                },
-            });
-
-            bracePlacementStore.finalize();
-            bracePlacementStore.reset();
-        };
-
-        window.addEventListener('brace-leaf-click', handleLeafClick as EventListener, true);
-        return () => window.removeEventListener('brace-leaf-click', handleLeafClick as EventListener, true);
-    }, [altActive, stage, start, branchFamilyBinding, resolveLeafSnapFromClick, resolveSnapFromClick]);
 
     return null;
 }

--- a/src/supports/SupportTypes/Branch/BranchPlacementController.tsx
+++ b/src/supports/SupportTypes/Branch/BranchPlacementController.tsx
@@ -28,7 +28,7 @@ import { getSettings } from '../../Settings/state';
 import { JOINT_DIAMETER_OFFSET_MM } from '../../constants';
 import { buildBranchData } from './branchBuilder';
 import { branchPlacementStore, useBranchPlacementState } from './branchPlacementState';
-import { calculateSmoothedNormal } from '../../PlacementLogic/PlacementUtils';
+import { calculateSmoothedNormal, findClosestMeshToPoint } from '../../PlacementLogic/PlacementUtils';
 import { buildTwig } from '../Twig/twigBuilder';
 import { buildStick } from '../Stick/stickBuilder';
 import type { SupportData } from '../../rendering/SupportBuilder';
@@ -185,6 +185,11 @@ export function BranchPlacementController() {
     const getPotentialTargets = useCallback(() => allTargets, [allTargets]);
 
     const { updateAndGetResolvedSnap, resetSnapping } = usePlacementSnappingSession(getTarget, getPotentialTargets);
+
+    const resolveTipMesh = useCallback(() => {
+        if (!tipPosition) return undefined;
+        return findClosestMeshToPoint(tipPosition, modelMeshesRef.current);
+    }, [tipPosition]);
 
     const publishPreview = useCallback((signature: string, previewData: SupportData | null) => {
         if (lastPreviewSignatureRef.current === signature) return;
@@ -433,6 +438,7 @@ export function BranchPlacementController() {
                     tipNormal: tipNormal,
                     modelId: modelId,
                     parentKnot,
+                    mesh: resolveTipMesh(),
                 });
 
                 branchPlacementStore.setPreviewData({
@@ -521,6 +527,7 @@ export function BranchPlacementController() {
                             tipNormal: tipNormal,
                             modelId: modelId,
                             parentKnot,
+                            mesh: resolveTipMesh(),
                         });
 
                         branchPlacementStore.setPreviewData({
@@ -657,6 +664,7 @@ export function BranchPlacementController() {
                 tipNormal: tipNormal,
                 modelId: modelId,
                 parentKnot,
+                mesh: resolveTipMesh(),
             });
 
             branchPlacementStore.setPreviewData({
@@ -746,6 +754,7 @@ export function BranchPlacementController() {
                 tipNormal: tipNormal,
                 modelId: modelId,
                 parentKnot,
+                mesh: resolveTipMesh(),
             });
 
             console.log('[BranchPlacement] Creating branch via snap click', branch);
@@ -770,7 +779,7 @@ export function BranchPlacementController() {
 
         window.addEventListener('click', handleClick, true);
         return () => window.removeEventListener('click', handleClick, true);
-    }, [isActive, stage, tipPosition, tipNormal, modelId, resetSnapping]);
+    }, [isActive, stage, tipPosition, tipNormal, modelId, resetSnapping, resolveTipMesh]);
 
     // Reset snapping when deactivated
     useEffect(() => {

--- a/src/supports/SupportTypes/Branch/BranchRenderer.tsx
+++ b/src/supports/SupportTypes/Branch/BranchRenderer.tsx
@@ -7,7 +7,6 @@ import { ShaftRenderer } from '../../SupportPrimitives/Shaft/ShaftRenderer';
 import { InstancedShaftGroup, type InstancedShaft } from '../../SupportPrimitives/Shaft/InstancedShaftGroup';
 import { BezierRenderer } from '../../Renderers/BezierRenderer';
 import { ContactConeRenderer, getFinalSocketPosition } from '../../SupportPrimitives/ContactCone';
-import { recomputeContactConeForMovedDisk } from '../../SupportPrimitives/ContactDisk';
 import { isPrimaryPointerPress, startContactDiskDragSession, type ContactDiskDragHit, type ContactDiskDragSession } from '../../SupportPrimitives/ContactDisk/contactDiskDragController';
 import { handleSupportClick } from '../../interaction/clickHandlers';
 import { selectPrimitiveById } from '../../interaction/shared/selection/selectionController';
@@ -16,6 +15,7 @@ import { usePartDragUpdate } from '../../interaction/partDragPreview';
 import { KnotRenderer } from '../../SupportPrimitives/Knot/KnotRenderer';
 import { getSnapshot, updateBranch } from '../../state';
 import { captureSupportEditSnapshot, pushSupportEditHistory } from '../../history/supportEditHistory';
+import { buildBranchData } from './branchBuilder';
 
 interface BranchRendererProps {
   branch: Branch;
@@ -61,7 +61,7 @@ export const BranchRenderer = React.memo(function BranchRenderer({
   const previewBranch = usePartDragUpdate<Branch>('branch', baseBranch.id);
   const branch = previewBranch ?? baseBranch;
   const dragSessionRef = React.useRef<ContactDiskDragSession | null>(null);
-  const liveDragConeRef = React.useRef<import('../../SupportPrimitives/ContactCone/types').ContactCone | null>(null);
+  const liveDragBranchRef = React.useRef<Branch | null>(null);
   const beforeHistoryRef = React.useRef<ReturnType<typeof captureSupportEditSnapshot> | null>(null);
   const [, setDragTick] = React.useState(0);
 
@@ -88,7 +88,6 @@ export const BranchRenderer = React.memo(function BranchRenderer({
     if (!isSelected || !branch.contactCone) return;
     if (!isPrimaryPointerPress(e)) return;
 
-    const socketAnchor = getFinalSocketPosition(branch.contactCone);
     beforeHistoryRef.current = captureSupportEditSnapshot();
 
     dragSessionRef.current?.stop();
@@ -101,23 +100,35 @@ export const BranchRenderer = React.memo(function BranchRenderer({
       onHit: ({ point, surfaceNormal, mesh }: ContactDiskDragHit) => {
         const latest = getSnapshot().branches[branch.id];
         if (!latest?.contactCone) return;
-        liveDragConeRef.current = recomputeContactConeForMovedDisk(latest.contactCone, point, surfaceNormal, socketAnchor, mesh);
+        const rebuilt = buildBranchData({
+          tipPos: point,
+          tipNormal: surfaceNormal,
+          modelId: branch.modelId,
+          parentKnot,
+          mesh,
+        }).branch;
+        liveDragBranchRef.current = {
+          ...rebuilt,
+          id: latest.id,
+          parentKnotId: latest.parentKnotId,
+          settingsCodeHex: latest.settingsCodeHex,
+          modelId: latest.modelId,
+        };
         setDragTick(t => t + 1);
       },
       onEnd: () => {
-        if (liveDragConeRef.current) {
-          const latest = getSnapshot().branches[branch.id];
-          if (latest) updateBranch({ ...latest, contactCone: liveDragConeRef.current });
+        if (liveDragBranchRef.current) {
+          updateBranch(liveDragBranchRef.current);
           if (beforeHistoryRef.current) {
             pushSupportEditHistory('Move branch tip', beforeHistoryRef.current, captureSupportEditSnapshot());
           }
         }
-        liveDragConeRef.current = null;
+        liveDragBranchRef.current = null;
         dragSessionRef.current = null;
         beforeHistoryRef.current = null;
       },
     });
-  }, [branch.id, branch.contactCone, branch.modelId, camera, gl.domElement, isSelected, scene]);
+  }, [branch.id, branch.contactCone, branch.modelId, camera, gl.domElement, isSelected, parentKnot, scene]);
 
   const handleContactDiskHudPointerUp = React.useCallback(() => {
     dragSessionRef.current?.stop();
@@ -135,7 +146,7 @@ export const BranchRenderer = React.memo(function BranchRenderer({
   const batchedStraightShafts: InstancedShaft[] = [];
   const joints: React.ReactNode[] = [];
 
-  const effectiveBranch = previewBranch ?? branch;
+  const effectiveBranch = liveDragBranchRef.current ?? previewBranch ?? branch;
 
   effectiveBranch.segments.forEach((seg, index) => {
     let endPoint: THREE.Vector3;
@@ -231,7 +242,7 @@ export const BranchRenderer = React.memo(function BranchRenderer({
   });
 
   // --- Render Contact Cone (if present) ---
-  const effectiveCone = liveDragConeRef.current ?? effectiveBranch.contactCone;
+  const effectiveCone = effectiveBranch.contactCone;
   let coneRender = null;
   if (effectiveCone && !deferContactConesToSceneBatch) {
     const isConeSelected = !!effectiveCone.id && selectedId === effectiveCone.id;

--- a/src/supports/SupportTypes/Branch/BranchRenderer.tsx
+++ b/src/supports/SupportTypes/Branch/BranchRenderer.tsx
@@ -98,10 +98,10 @@ export const BranchRenderer = React.memo(function BranchRenderer({
       scene,
       initialEvent: e,
       modelId: branch.modelId,
-      onHit: ({ point, surfaceNormal }: ContactDiskDragHit) => {
+      onHit: ({ point, surfaceNormal, mesh }: ContactDiskDragHit) => {
         const latest = getSnapshot().branches[branch.id];
         if (!latest?.contactCone) return;
-        liveDragConeRef.current = recomputeContactConeForMovedDisk(latest.contactCone, point, surfaceNormal, socketAnchor);
+        liveDragConeRef.current = recomputeContactConeForMovedDisk(latest.contactCone, point, surfaceNormal, socketAnchor, mesh);
         setDragTick(t => t + 1);
       },
       onEnd: () => {

--- a/src/supports/SupportTypes/Branch/branchBuilder.ts
+++ b/src/supports/SupportTypes/Branch/branchBuilder.ts
@@ -11,7 +11,7 @@ import { resolveConeAxisPolicy } from '../../PlacementLogic/ConeAxisPolicy';
 import { encodeSupportSettingsHex } from '../../Settings/supportSettingsCodec';
 import { isCollisionFrustumBlocked } from '../../PlacementLogic/CollisionAvoidance';
 
-const BRANCH_CONE_COLLISION_SAFETY_MM = 0.25;
+const BRANCH_CONE_COLLISION_SAFETY_MM = 0.8;
 const BRANCH_SOCKET_POLAR_DEG = [0, 10, 20, 30, 40, 50, 60];
 const BRANCH_SOCKET_AZIMUTH_DEG = [0, 25, -25, 50, -50, 85, -85, 120, -120, 155, -155, 180];
 const BRANCH_SOCKET_STRETCH_FACTORS = [1, 1.05, 1.12, 1.2, 1.32, 1.48, 1.68];

--- a/src/supports/SupportTypes/Branch/branchBuilder.ts
+++ b/src/supports/SupportTypes/Branch/branchBuilder.ts
@@ -1,13 +1,226 @@
 import * as THREE from 'three';
 import { Branch, Joint, Knot, Segment, Vec3 } from '../../types';
 import type { ContactCone, SupportTipProfile } from '../../SupportPrimitives/ContactCone/types';
-import { getSocketPosition } from '../../SupportPrimitives/ContactCone/contactConeUtils';
+import { getFinalSocketPosition } from '../../SupportPrimitives/ContactCone/contactConeUtils';
+import { calculateDiskThickness } from '../../SupportPrimitives/ContactDisk/contactDiskUtils';
 import { recomputeContactConeForMovedDisk } from '../../SupportPrimitives/ContactDisk';
 import type { SupportData } from '../../rendering/SupportBuilder';
 import { getSettings } from '../../Settings';
 import { getJointDiameter } from '../../constants';
 import { resolveConeAxisPolicy } from '../../PlacementLogic/ConeAxisPolicy';
 import { encodeSupportSettingsHex } from '../../Settings/supportSettingsCodec';
+import { isCollisionSegmentBlocked } from '../../PlacementLogic/CollisionAvoidance';
+
+const BRANCH_CONE_COLLISION_SAFETY_MM = 0.25;
+const BRANCH_SOCKET_POLAR_DEG = [0, 10, 20, 30, 40, 50, 60];
+const BRANCH_SOCKET_AZIMUTH_DEG = [0, 25, -25, 50, -50, 85, -85, 120, -120, 155, -155, 180];
+const BRANCH_SOCKET_STRETCH_FACTORS = [1, 1.05, 1.12, 1.2, 1.32, 1.48, 1.68];
+
+function normalizeOrFallback(vector: THREE.Vector3, fallback: THREE.Vector3): THREE.Vector3 {
+    if (vector.lengthSq() < 0.000001) {
+        return fallback.clone().normalize();
+    }
+
+    return vector.clone().normalize();
+}
+
+function getConeStartPosition(cone: ContactCone): Vec3 {
+    const surfaceNormal = cone.surfaceNormal ?? cone.normal;
+    const thickness = cone.diskLengthOverride ?? (
+        cone.profile.type === 'disk'
+            ? calculateDiskThickness(surfaceNormal, cone.normal, cone.profile)
+            : 0
+    );
+
+    return {
+        x: cone.pos.x + surfaceNormal.x * thickness,
+        y: cone.pos.y + surfaceNormal.y * thickness,
+        z: cone.pos.z + surfaceNormal.z * thickness,
+    };
+}
+
+function isConePlacementClear(cone: ContactCone, mesh?: THREE.Mesh): boolean {
+    if (!mesh) return true;
+
+    const coneStart = getConeStartPosition(cone);
+    const socketPos = getFinalSocketPosition(cone);
+    const collisionRadius = (cone.profile.bodyDiameterMm / 2) + BRANCH_CONE_COLLISION_SAFETY_MM;
+    return !isCollisionSegmentBlocked(coneStart, socketPos, collisionRadius, mesh);
+}
+
+function buildAuthoredBranchCone(
+    tipPos: Vec3,
+    tipNormal: Vec3,
+    effectiveConeAxis: Vec3,
+    tipProfile: SupportTipProfile,
+    socketTarget: Vec3,
+): ContactCone {
+    return recomputeContactConeForMovedDisk(
+        {
+            id: 'preview-branch-cone',
+            pos: tipPos,
+            normal: effectiveConeAxis,
+            surfaceNormal: tipNormal,
+            profile: tipProfile,
+        },
+        tipPos,
+        tipNormal,
+        socketTarget,
+    );
+}
+
+function scoreBranchConeCandidate(args: {
+    socketPos: THREE.Vector3;
+    desiredSocket: THREE.Vector3;
+    cone: ContactCone;
+    surfaceNormal: THREE.Vector3;
+    desiredDirection: THREE.Vector3;
+    nominalLengthMm: number;
+}): number {
+    const { socketPos, desiredSocket, cone, surfaceNormal, desiredDirection, nominalLengthMm } = args;
+    const axis = normalizeOrFallback(
+        new THREE.Vector3(cone.normal.x, cone.normal.y, cone.normal.z),
+        surfaceNormal,
+    );
+
+    const surfaceAlignmentPenalty = (1 - Math.max(-1, Math.min(1, axis.dot(surfaceNormal)))) * 6.75;
+    const desiredDirectionPenalty = (1 - Math.max(-1, Math.min(1, axis.dot(desiredDirection)))) * 0.35;
+    const socketDistancePenalty = socketPos.distanceTo(desiredSocket) * 0.95;
+    const extraLengthMm = Math.max(0, cone.profile.lengthMm - nominalLengthMm);
+    const extraLengthPenalty = extraLengthMm * 5.5 + extraLengthMm * extraLengthMm * 1.6;
+
+    return surfaceAlignmentPenalty + desiredDirectionPenalty + socketDistancePenalty + extraLengthPenalty;
+}
+
+function findBestBranchConePlacement(args: {
+    tipPos: Vec3;
+    tipNormal: Vec3;
+    effectiveConeAxis: Vec3;
+    tipProfile: SupportTipProfile;
+    parentKnotPos: Vec3;
+    mesh?: THREE.Mesh;
+}): { cone: ContactCone; socketPos: Vec3; rerouted: boolean } {
+    const { tipPos, tipNormal, effectiveConeAxis, tipProfile, parentKnotPos, mesh } = args;
+    const directCone = buildAuthoredBranchCone(tipPos, tipNormal, effectiveConeAxis, tipProfile, parentKnotPos);
+    const directSocketPos = getFinalSocketPosition(directCone);
+
+    const surfaceNormal = normalizeOrFallback(
+        new THREE.Vector3(tipNormal.x, tipNormal.y, tipNormal.z),
+        new THREE.Vector3(0, 0, 1),
+    );
+    const coneStart = new THREE.Vector3(
+        directCone.pos.x + (directCone.surfaceNormal?.x ?? tipNormal.x) * (directCone.diskLengthOverride ?? 0),
+        directCone.pos.y + (directCone.surfaceNormal?.y ?? tipNormal.y) * (directCone.diskLengthOverride ?? 0),
+        directCone.pos.z + (directCone.surfaceNormal?.z ?? tipNormal.z) * (directCone.diskLengthOverride ?? 0),
+    );
+    const desiredSocket = new THREE.Vector3(parentKnotPos.x, parentKnotPos.y, parentKnotPos.z);
+    const desiredVector = desiredSocket.clone().sub(coneStart);
+    const desiredDistance = Math.max(0.25, desiredVector.length());
+    const desiredDirection = normalizeOrFallback(desiredVector, surfaceNormal);
+    const nominalLengthMm = tipProfile.lengthMm;
+
+    const tangentForward = desiredDirection.clone().sub(
+        surfaceNormal.clone().multiplyScalar(desiredDirection.dot(surfaceNormal)),
+    );
+    if (tangentForward.lengthSq() < 0.000001) {
+        tangentForward.copy(new THREE.Vector3(1, 0, 0).cross(surfaceNormal));
+        if (tangentForward.lengthSq() < 0.000001) {
+            tangentForward.copy(new THREE.Vector3(0, 1, 0).cross(surfaceNormal));
+        }
+    }
+    tangentForward.normalize();
+    const tangentRight = new THREE.Vector3().crossVectors(surfaceNormal, tangentForward).normalize();
+
+    let bestCandidate: { cone: ContactCone; socketPos: Vec3; score: number } | null = null;
+
+    if (!mesh || isConePlacementClear(directCone, mesh)) {
+        bestCandidate = {
+            cone: directCone,
+            socketPos: directSocketPos,
+            score: scoreBranchConeCandidate({
+                socketPos: new THREE.Vector3(directSocketPos.x, directSocketPos.y, directSocketPos.z),
+                desiredSocket,
+                cone: directCone,
+                surfaceNormal,
+                desiredDirection,
+                nominalLengthMm,
+            }),
+        };
+    }
+
+    for (const polarDeg of BRANCH_SOCKET_POLAR_DEG) {
+        const polarRad = THREE.MathUtils.degToRad(polarDeg);
+        const sinPolar = Math.sin(polarRad);
+        const cosPolar = Math.cos(polarRad);
+
+        for (const azimuthDeg of BRANCH_SOCKET_AZIMUTH_DEG) {
+            const azimuthRad = THREE.MathUtils.degToRad(azimuthDeg);
+            const tangentComponent = tangentForward.clone().multiplyScalar(Math.cos(azimuthRad) * sinPolar)
+                .add(tangentRight.clone().multiplyScalar(Math.sin(azimuthRad) * sinPolar));
+            const axis = surfaceNormal.clone().multiplyScalar(cosPolar).add(tangentComponent);
+            if (axis.lengthSq() < 0.000001) {
+                continue;
+            }
+            axis.normalize();
+
+            if (axis.dot(surfaceNormal) < 0.12) {
+                continue;
+            }
+
+            for (const stretch of BRANCH_SOCKET_STRETCH_FACTORS) {
+                const candidateLength = Math.max(nominalLengthMm, nominalLengthMm * stretch);
+                const candidateSocket = coneStart.clone().add(axis.clone().multiplyScalar(candidateLength));
+                const candidateCone = buildAuthoredBranchCone(
+                    tipPos,
+                    tipNormal,
+                    effectiveConeAxis,
+                    tipProfile,
+                    { x: candidateSocket.x, y: candidateSocket.y, z: candidateSocket.z },
+                );
+
+                if (!isConePlacementClear(candidateCone, mesh)) {
+                    continue;
+                }
+
+                const score = scoreBranchConeCandidate({
+                    socketPos: candidateSocket,
+                    desiredSocket,
+                    cone: candidateCone,
+                    surfaceNormal,
+                    desiredDirection,
+                    nominalLengthMm,
+                });
+
+                if (!bestCandidate || score < bestCandidate.score) {
+                    bestCandidate = {
+                        cone: candidateCone,
+                        socketPos: getFinalSocketPosition(candidateCone),
+                        score,
+                    };
+                }
+            }
+        }
+    }
+
+    if (bestCandidate) {
+        const rerouted =
+            Math.abs(bestCandidate.socketPos.x - directSocketPos.x) > 0.0001
+            || Math.abs(bestCandidate.socketPos.y - directSocketPos.y) > 0.0001
+            || Math.abs(bestCandidate.socketPos.z - directSocketPos.z) > 0.0001;
+
+        return {
+            cone: bestCandidate.cone,
+            socketPos: bestCandidate.socketPos,
+            rerouted,
+        };
+    }
+
+    return {
+        cone: directCone,
+        socketPos: directSocketPos,
+        rerouted: false,
+    };
+}
 
 function uuid() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
@@ -64,64 +277,98 @@ export function buildBranchData(input: BranchBuildInput): BranchBuildResult {
 
     const shaftDiameter = settings.shaft.diameterMm;
     const jointDiameter = getJointDiameter(shaftDiameter);
-
-    const authoredCone = recomputeContactConeForMovedDisk(
-        {
-            id: 'preview-branch-cone',
-            pos: tipPos,
-            normal: effectiveConeAxis,
-            surfaceNormal: tipNormal,
-            profile: tipProfile,
-        },
+    const { cone: authoredCone, socketPos, rerouted } = findBestBranchConePlacement({
         tipPos,
         tipNormal,
-        parentKnot.pos,
+        effectiveConeAxis,
+        tipProfile,
+        parentKnotPos: parentKnot.pos,
         mesh,
-    );
-    const socketPos = getSocketPosition(
-        {
-            x: authoredCone.pos.x + (authoredCone.surfaceNormal?.x ?? tipNormal.x) * (authoredCone.diskLengthOverride ?? 0),
-            y: authoredCone.pos.y + (authoredCone.surfaceNormal?.y ?? tipNormal.y) * (authoredCone.diskLengthOverride ?? 0),
-            z: authoredCone.pos.z + (authoredCone.surfaceNormal?.z ?? tipNormal.z) * (authoredCone.diskLengthOverride ?? 0),
-        },
-        authoredCone.normal,
-        authoredCone.profile,
-    );
+    });
+
     const socketJoint: Joint = {
         id: uuid(),
         pos: socketPos,
         diameter: jointDiameter,
     };
 
-    // Calculate middle joint position (halfway between knot and socket)
     const knotPos = parentKnot.pos;
-    const middleJointPos: Vec3 = {
-        x: (knotPos.x + socketPos.x) / 2,
-        y: (knotPos.y + socketPos.y) / 2,
-        z: (knotPos.z + socketPos.z) / 2,
-    };
+    const socketVec = new THREE.Vector3(socketPos.x, socketPos.y, socketPos.z);
+    const knotVec = new THREE.Vector3(knotPos.x, knotPos.y, knotPos.z);
+    const span = socketVec.clone().sub(knotVec);
+    const spanLength = span.length();
+    const spanDirection = spanLength > 0.000001
+        ? span.clone().normalize()
+        : new THREE.Vector3(authoredCone.normal.x, authoredCone.normal.y, authoredCone.normal.z).normalize();
 
-    const middleJoint: Joint = {
+    const joints: Joint[] = [];
+    const segments: Segment[] = [];
+
+    const addJoint = (pos: Vec3): Joint => ({
         id: uuid(),
-        pos: middleJointPos,
+        pos,
         diameter: jointDiameter,
-    };
+    });
 
-    // Bottom segment: knot -> middle joint
-    const bottomSegment: Segment = {
-        id: uuid(),
-        diameter: shaftDiameter,
-        topJoint: middleJoint,
-        bottomJoint: undefined, // Connects to knot
-    };
+    if (rerouted && spanLength > 1.8) {
+        const approachBackoff = Math.min(Math.max(spanLength * 0.28, 0.9), Math.max(spanLength - 0.65, 0.9));
+        const approachVec = socketVec.clone().sub(spanDirection.clone().multiplyScalar(approachBackoff));
+        const approachDistanceToKnot = approachVec.distanceTo(knotVec);
 
-    // Top segment: middle joint -> socket joint
-    const topSegment: Segment = {
-        id: uuid(),
-        diameter: shaftDiameter,
-        topJoint: socketJoint,
-        bottomJoint: middleJoint,
-    };
+        if (approachDistanceToKnot > 0.6) {
+            const middleVec = knotVec.clone().lerp(approachVec, 0.5);
+            const middleJoint = addJoint({ x: middleVec.x, y: middleVec.y, z: middleVec.z });
+            const approachJoint = addJoint({ x: approachVec.x, y: approachVec.y, z: approachVec.z });
+            joints.push(middleJoint, approachJoint);
+
+            segments.push(
+                {
+                    id: uuid(),
+                    diameter: shaftDiameter,
+                    topJoint: middleJoint,
+                    bottomJoint: undefined,
+                },
+                {
+                    id: uuid(),
+                    diameter: shaftDiameter,
+                    topJoint: approachJoint,
+                    bottomJoint: middleJoint,
+                },
+                {
+                    id: uuid(),
+                    diameter: shaftDiameter,
+                    topJoint: socketJoint,
+                    bottomJoint: approachJoint,
+                },
+            );
+        }
+    }
+
+    if (segments.length === 0) {
+        const middleJointPos: Vec3 = {
+            x: (knotPos.x + socketPos.x) / 2,
+            y: (knotPos.y + socketPos.y) / 2,
+            z: (knotPos.z + socketPos.z) / 2,
+        };
+
+        const middleJoint = addJoint(middleJointPos);
+        joints.push(middleJoint);
+
+        segments.push(
+            {
+                id: uuid(),
+                diameter: shaftDiameter,
+                topJoint: middleJoint,
+                bottomJoint: undefined,
+            },
+            {
+                id: uuid(),
+                diameter: shaftDiameter,
+                topJoint: socketJoint,
+                bottomJoint: middleJoint,
+            },
+        );
+    }
 
     const contactCone: ContactCone = {
         ...authoredCone,
@@ -135,7 +382,7 @@ export function buildBranchData(input: BranchBuildInput): BranchBuildResult {
         modelId,
         settingsCodeHex,
         parentKnotId: parentKnot.id,
-        segments: [bottomSegment, topSegment],
+        segments,
         contactCone,
     };
 
@@ -143,7 +390,7 @@ export function buildBranchData(input: BranchBuildInput): BranchBuildResult {
         id: branchId,
         startPos: parentKnot.pos,
         knot: parentKnot,
-        segments: [bottomSegment, topSegment],
+        segments,
         contactCone,
     };
 

--- a/src/supports/SupportTypes/Branch/branchBuilder.ts
+++ b/src/supports/SupportTypes/Branch/branchBuilder.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { Branch, Joint, Knot, Segment, Vec3 } from '../../types';
 import type { ContactCone, SupportTipProfile } from '../../SupportPrimitives/ContactCone/types';
 import { getSocketPosition } from '../../SupportPrimitives/ContactCone/contactConeUtils';
-import { calculateDiskThickness } from '../../SupportPrimitives/ContactDisk/contactDiskUtils';
+import { recomputeContactConeForMovedDisk } from '../../SupportPrimitives/ContactDisk';
 import type { SupportData } from '../../rendering/SupportBuilder';
 import { getSettings } from '../../Settings';
 import { getJointDiameter } from '../../constants';
@@ -21,6 +21,7 @@ export interface BranchBuildInput {
     tipNormal: Vec3;
     modelId: string;
     parentKnot: Knot;
+    mesh?: THREE.Mesh;
 }
 
 export interface BranchBuildResult {
@@ -36,7 +37,7 @@ export interface BranchBuildResult {
  * - Contact cone at the tip
  */
 export function buildBranchData(input: BranchBuildInput): BranchBuildResult {
-    const { tipPos, tipNormal, modelId, parentKnot } = input;
+    const { tipPos, tipNormal, modelId, parentKnot, mesh } = input;
 
     const settings = getSettings();
     const settingsCodeHex = encodeSupportSettingsHex(settings);
@@ -64,18 +65,28 @@ export function buildBranchData(input: BranchBuildInput): BranchBuildResult {
     const shaftDiameter = settings.shaft.diameterMm;
     const jointDiameter = getJointDiameter(shaftDiameter);
 
-    // Calculate disk offset and socket position (matches renderer logic)
-    const diskThickness = tipProfile.type === 'disk'
-        ? calculateDiskThickness(tipNormal, effectiveConeAxis, tipProfile)
-        : 0;
-
-    const coneStartPos = {
-        x: tipPos.x + tipNormal.x * diskThickness,
-        y: tipPos.y + tipNormal.y * diskThickness,
-        z: tipPos.z + tipNormal.z * diskThickness,
-    };
-
-    const socketPos = getSocketPosition(coneStartPos, effectiveConeAxis, tipProfile);
+    const authoredCone = recomputeContactConeForMovedDisk(
+        {
+            id: 'preview-branch-cone',
+            pos: tipPos,
+            normal: effectiveConeAxis,
+            surfaceNormal: tipNormal,
+            profile: tipProfile,
+        },
+        tipPos,
+        tipNormal,
+        parentKnot.pos,
+        mesh,
+    );
+    const socketPos = getSocketPosition(
+        {
+            x: authoredCone.pos.x + (authoredCone.surfaceNormal?.x ?? tipNormal.x) * (authoredCone.diskLengthOverride ?? 0),
+            y: authoredCone.pos.y + (authoredCone.surfaceNormal?.y ?? tipNormal.y) * (authoredCone.diskLengthOverride ?? 0),
+            z: authoredCone.pos.z + (authoredCone.surfaceNormal?.z ?? tipNormal.z) * (authoredCone.diskLengthOverride ?? 0),
+        },
+        authoredCone.normal,
+        authoredCone.profile,
+    );
     const socketJoint: Joint = {
         id: uuid(),
         pos: socketPos,
@@ -113,11 +124,8 @@ export function buildBranchData(input: BranchBuildInput): BranchBuildResult {
     };
 
     const contactCone: ContactCone = {
+        ...authoredCone,
         id: uuid(),
-        pos: tipPos,
-        normal: effectiveConeAxis,
-        surfaceNormal: tipNormal,
-        profile: tipProfile,
         socketJointId: socketJoint.id,
     };
 

--- a/src/supports/SupportTypes/Branch/branchBuilder.ts
+++ b/src/supports/SupportTypes/Branch/branchBuilder.ts
@@ -70,6 +70,23 @@ function buildAuthoredBranchCone(
     );
 }
 
+function buildNominalBranchSocketTarget(
+    tipPos: Vec3,
+    tipNormal: Vec3,
+    effectiveConeAxis: Vec3,
+    tipProfile: SupportTipProfile,
+): Vec3 {
+    const nominalCone: ContactCone = {
+        id: 'preview-branch-cone',
+        pos: tipPos,
+        normal: effectiveConeAxis,
+        surfaceNormal: tipNormal,
+        profile: tipProfile,
+    };
+
+    return getFinalSocketPosition(nominalCone);
+}
+
 function scoreBranchConeCandidate(args: {
     socketPos: THREE.Vector3;
     desiredSocket: THREE.Vector3;
@@ -98,11 +115,16 @@ function findBestBranchConePlacement(args: {
     tipNormal: Vec3;
     effectiveConeAxis: Vec3;
     tipProfile: SupportTipProfile;
-    parentKnotPos: Vec3;
     mesh?: THREE.Mesh;
 }): { cone: ContactCone; socketPos: Vec3; rerouted: boolean } {
-    const { tipPos, tipNormal, effectiveConeAxis, tipProfile, parentKnotPos, mesh } = args;
-    const directCone = buildAuthoredBranchCone(tipPos, tipNormal, effectiveConeAxis, tipProfile, parentKnotPos);
+    const { tipPos, tipNormal, effectiveConeAxis, tipProfile, mesh } = args;
+    const nominalSocketTarget = buildNominalBranchSocketTarget(
+        tipPos,
+        tipNormal,
+        effectiveConeAxis,
+        tipProfile,
+    );
+    const directCone = buildAuthoredBranchCone(tipPos, tipNormal, effectiveConeAxis, tipProfile, nominalSocketTarget);
     const directSocketPos = getFinalSocketPosition(directCone);
 
     const surfaceNormal = normalizeOrFallback(
@@ -114,7 +136,7 @@ function findBestBranchConePlacement(args: {
         directCone.pos.y + (directCone.surfaceNormal?.y ?? tipNormal.y) * (directCone.diskLengthOverride ?? 0),
         directCone.pos.z + (directCone.surfaceNormal?.z ?? tipNormal.z) * (directCone.diskLengthOverride ?? 0),
     );
-    const desiredSocket = new THREE.Vector3(parentKnotPos.x, parentKnotPos.y, parentKnotPos.z);
+    const desiredSocket = new THREE.Vector3(nominalSocketTarget.x, nominalSocketTarget.y, nominalSocketTarget.z);
     const desiredVector = desiredSocket.clone().sub(coneStart);
     const desiredDistance = Math.max(0.25, desiredVector.length());
     const desiredDirection = normalizeOrFallback(desiredVector, surfaceNormal);
@@ -283,7 +305,6 @@ export function buildBranchData(input: BranchBuildInput): BranchBuildResult {
         tipNormal,
         effectiveConeAxis,
         tipProfile,
-        parentKnotPos: parentKnot.pos,
         mesh,
     });
 

--- a/src/supports/SupportTypes/Branch/branchBuilder.ts
+++ b/src/supports/SupportTypes/Branch/branchBuilder.ts
@@ -9,7 +9,7 @@ import { getSettings } from '../../Settings';
 import { getJointDiameter } from '../../constants';
 import { resolveConeAxisPolicy } from '../../PlacementLogic/ConeAxisPolicy';
 import { encodeSupportSettingsHex } from '../../Settings/supportSettingsCodec';
-import { isCollisionSegmentBlocked } from '../../PlacementLogic/CollisionAvoidance';
+import { isCollisionFrustumBlocked } from '../../PlacementLogic/CollisionAvoidance';
 
 const BRANCH_CONE_COLLISION_SAFETY_MM = 0.25;
 const BRANCH_SOCKET_POLAR_DEG = [0, 10, 20, 30, 40, 50, 60];
@@ -44,8 +44,9 @@ function isConePlacementClear(cone: ContactCone, mesh?: THREE.Mesh): boolean {
 
     const coneStart = getConeStartPosition(cone);
     const socketPos = getFinalSocketPosition(cone);
-    const collisionRadius = (cone.profile.bodyDiameterMm / 2) + BRANCH_CONE_COLLISION_SAFETY_MM;
-    return !isCollisionSegmentBlocked(coneStart, socketPos, collisionRadius, mesh);
+    const contactRadius = (cone.profile.contactDiameterMm / 2) + BRANCH_CONE_COLLISION_SAFETY_MM;
+    const bodyRadius = (cone.profile.bodyDiameterMm / 2) + BRANCH_CONE_COLLISION_SAFETY_MM;
+    return !isCollisionFrustumBlocked(coneStart, socketPos, contactRadius, bodyRadius, mesh);
 }
 
 function buildAuthoredBranchCone(

--- a/src/supports/SupportTypes/Branch/branchBuilder.ts
+++ b/src/supports/SupportTypes/Branch/branchBuilder.ts
@@ -11,7 +11,7 @@ import { resolveConeAxisPolicy } from '../../PlacementLogic/ConeAxisPolicy';
 import { encodeSupportSettingsHex } from '../../Settings/supportSettingsCodec';
 import { isCollisionFrustumBlocked } from '../../PlacementLogic/CollisionAvoidance';
 
-const BRANCH_CONE_COLLISION_SAFETY_MM = 0.8;
+const BRANCH_CONE_COLLISION_SAFETY_MM = 0.3;
 const BRANCH_SOCKET_POLAR_DEG = [0, 10, 20, 30, 40, 50, 60];
 const BRANCH_SOCKET_AZIMUTH_DEG = [0, 25, -25, 50, -50, 85, -85, 120, -120, 155, -155, 180];
 const BRANCH_SOCKET_STRETCH_FACTORS = [1, 1.05, 1.12, 1.2, 1.32, 1.48, 1.68];

--- a/src/supports/SupportTypes/Leaf/LeafPlacementController.tsx
+++ b/src/supports/SupportTypes/Leaf/LeafPlacementController.tsx
@@ -25,6 +25,7 @@ import { projectPointToSnapTargetPath, projectRayToSnapTargetPath, selectNearest
 import { isSupportEditInteractionActive } from '../../interaction/gizmoInteractionLock';
 import { previewVecKey, previewNormalKey, quantizePreviewValue } from '../shared/previewSignature';
 import { getClipBounds } from '@/components/scene/SceneCanvas/clipBoundsStore';
+import { findClosestMeshToPoint } from '../../PlacementLogic/PlacementUtils';
 
 interface ShaftHoverDetail {
     segmentId?: string | null;
@@ -110,6 +111,11 @@ export function LeafPlacementController() {
     const getPotentialTargets = useCallback(() => allTargets, [allTargets]);
 
     const { updateAndGetResolvedSnap, resetSnapping } = usePlacementSnappingSession(getTarget, getPotentialTargets);
+
+    const resolveTipMesh = useCallback(() => {
+        if (!tipPosition) return undefined;
+        return findClosestMeshToPoint(tipPosition, modelMeshesRef.current);
+    }, [tipPosition]);
 
     useEffect(() => {
         const handleShaftHover = (event: Event) => {
@@ -403,6 +409,7 @@ export function LeafPlacementController() {
                     modelId,
                     parentKnot,
                     hostDiameterMm: resolvedHostDiameter,
+                    mesh: resolveTipMesh(),
                 });
 
                 const maxAngleDeg = settings.shaft.maxAngleDeg ?? 80;
@@ -489,6 +496,7 @@ export function LeafPlacementController() {
                 modelId,
                 parentKnot,
                 hostDiameterMm,
+                mesh: resolveTipMesh(),
             });
 
             addKnot(parentKnot);
@@ -525,7 +533,7 @@ export function LeafPlacementController() {
 
         window.addEventListener('click', handleClick, true);
         return () => window.removeEventListener('click', handleClick, true);
-    }, [isActive, stage, tipPosition, surfaceNormal, modelId, leafBinding]);
+    }, [isActive, stage, tipPosition, surfaceNormal, modelId, leafBinding, resolveTipMesh]);
 
     useEffect(() => {
         if (!isActive) {

--- a/src/supports/SupportTypes/Leaf/LeafRenderer.tsx
+++ b/src/supports/SupportTypes/Leaf/LeafRenderer.tsx
@@ -129,10 +129,10 @@ export const LeafRenderer = React.memo(function LeafRenderer({
             scene,
             initialEvent: e,
             modelId: leaf.modelId,
-            onHit: ({ point, surfaceNormal }: ContactDiskDragHit) => {
+            onHit: ({ point, surfaceNormal, mesh }: ContactDiskDragHit) => {
                 const latest = getSnapshot().leaves[leaf.id];
                 if (!latest?.contactCone) return;
-                liveDragConeRef.current = recomputeContactConeForMovedDisk(latest.contactCone, point, surfaceNormal, socketAnchor);
+                liveDragConeRef.current = recomputeContactConeForMovedDisk(latest.contactCone, point, surfaceNormal, socketAnchor, mesh);
                 setDragTick(t => t + 1);
             },
             onEnd: () => {

--- a/src/supports/SupportTypes/Leaf/LeafRenderer.tsx
+++ b/src/supports/SupportTypes/Leaf/LeafRenderer.tsx
@@ -95,19 +95,6 @@ export const LeafRenderer = React.memo(function LeafRenderer({
         const branchFamilyHeld = branchPlacementStore.getSnapshot().altActive
             || isSupportPlacementBindingSatisfiedByModifierState(branchFamilyBinding, getSupportPlacementModifierState(e));
         if (branchFamilyHeld) {
-            e.stopPropagation();
-            if (e.nativeEvent) {
-                e.nativeEvent.stopPropagation?.();
-                e.nativeEvent.stopImmediatePropagation?.();
-            }
-
-            window.dispatchEvent(new CustomEvent('brace-leaf-click', {
-                detail: {
-                    leafId: leaf.id,
-                    point: e.point ? { x: e.point.x, y: e.point.y, z: e.point.z } : null,
-                    intersection: e,
-                },
-            }));
             return;
         }
 

--- a/src/supports/SupportTypes/Leaf/leafBuilder.ts
+++ b/src/supports/SupportTypes/Leaf/leafBuilder.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import type { Leaf, Knot, Vec3 } from '../../types';
 import type { ContactCone, SupportTipProfile } from '../../SupportPrimitives/ContactCone/types';
-import { calculateDiskThickness } from '../../SupportPrimitives/ContactDisk/contactDiskUtils';
+import { recomputeContactConeForMovedDisk } from '../../SupportPrimitives/ContactDisk';
 import type { SupportData } from '../../rendering/SupportBuilder';
 import { getSettings } from '../../Settings';
 import { encodeSupportSettingsHex } from '../../Settings/supportSettingsCodec';
@@ -19,6 +19,7 @@ export interface LeafBuildInput {
     modelId: string;
     parentKnot: Knot;
     hostDiameterMm: number;
+    mesh?: THREE.Mesh;
 }
 
 export interface LeafBuildResult {
@@ -38,46 +39,32 @@ function computeLeafConeAxisAndLength(
     tipPos: Vec3,
     surfaceNormal: Vec3,
     knotPos: Vec3,
-    baseProfile: SupportTipProfile
+    baseProfile: SupportTipProfile,
+    mesh?: THREE.Mesh,
 ): { axis: Vec3; lengthMm: number; diskThicknessMm: number } {
-    _tip.set(tipPos.x, tipPos.y, tipPos.z);
-    _sn.set(surfaceNormal.x, surfaceNormal.y, surfaceNormal.z);
-    _knot.set(knotPos.x, knotPos.y, knotPos.z);
-
-    _axis.copy(_knot).sub(_tip);
-    if (_axis.lengthSq() < 0.000001) {
-        _axis.copy(_sn);
-    }
-    _axis.normalize();
-
-    let finalThickness = 0;
-    let finalLength = Math.max(0.1, _knot.distanceTo(_tip));
-
-    for (let i = 0; i < 3; i++) {
-        const axisVec3 = { x: _axis.x, y: _axis.y, z: _axis.z };
-        const thickness = baseProfile.type === 'disk'
-            ? calculateDiskThickness(surfaceNormal, axisVec3, baseProfile)
-            : 0;
-        finalThickness = thickness;
-
-        _start.copy(_tip).addScaledVector(_sn, thickness);
-        _coneVec.copy(_knot).sub(_start);
-        const len = _coneVec.length();
-        if (len > 0.000001) {
-            _axis.copy(_coneVec).normalize();
-            finalLength = Math.max(0.1, len);
-        }
-    }
+    const cone = recomputeContactConeForMovedDisk(
+        {
+            id: 'preview-leaf-cone',
+            pos: tipPos,
+            normal: surfaceNormal,
+            surfaceNormal,
+            profile: baseProfile,
+        },
+        tipPos,
+        surfaceNormal,
+        knotPos,
+        mesh,
+    );
 
     return {
-        axis: { x: _axis.x, y: _axis.y, z: _axis.z },
-        lengthMm: finalLength,
-        diskThicknessMm: finalThickness,
+        axis: cone.normal,
+        lengthMm: cone.profile.lengthMm,
+        diskThicknessMm: cone.diskLengthOverride ?? 0,
     };
 }
 
 export function buildLeafData(input: LeafBuildInput): LeafBuildResult {
-    const { tipPos, surfaceNormal, modelId, parentKnot, hostDiameterMm } = input;
+    const { tipPos, surfaceNormal, modelId, parentKnot, hostDiameterMm, mesh } = input;
 
     const settings = getSettings();
     const settingsCodeHex = encodeSupportSettingsHex(settings);
@@ -97,7 +84,8 @@ export function buildLeafData(input: LeafBuildInput): LeafBuildResult {
         tipPos,
         surfaceNormal,
         parentKnot.pos,
-        baseProfile
+        baseProfile,
+        mesh,
     );
 
     const profile: SupportTipProfile = {
@@ -107,11 +95,20 @@ export function buildLeafData(input: LeafBuildInput): LeafBuildResult {
     };
 
     const contactCone: ContactCone = {
+        ...recomputeContactConeForMovedDisk(
+            {
+                id: 'leaf-cone',
+                pos: tipPos,
+                normal: axis,
+                surfaceNormal,
+                profile,
+            },
+            tipPos,
+            surfaceNormal,
+            parentKnot.pos,
+            mesh,
+        ),
         id: uuid(),
-        pos: tipPos,
-        normal: axis,
-        surfaceNormal,
-        profile,
     };
 
     const leafId = uuid();

--- a/src/supports/SupportTypes/Stick/StickRenderer.tsx
+++ b/src/supports/SupportTypes/Stick/StickRenderer.tsx
@@ -93,11 +93,11 @@ export const StickRenderer = React.memo(function StickRenderer({
       scene,
       initialEvent,
       modelId: stick.modelId,
-      onHit: ({ point, surfaceNormal }: ContactDiskDragHit) => {
+      onHit: ({ point, surfaceNormal, mesh }: ContactDiskDragHit) => {
         const latestStick = getSnapshot().sticks[stick.id];
         const latestCone = latestStick?.[coneKey] as ContactCone | undefined;
         if (!latestStick || !latestCone) return;
-        const newCone = recomputeContactConeForMovedDisk(latestCone, point, surfaceNormal, socketAnchor);
+        const newCone = recomputeContactConeForMovedDisk(latestCone, point, surfaceNormal, socketAnchor, mesh);
         if (coneKey === 'contactConeA') liveDragConeARef.current = newCone;
         else liveDragConeBRef.current = newCone;
         setDragTick(t => t + 1);

--- a/src/supports/SupportTypes/Trunk/TrunkRenderer.tsx
+++ b/src/supports/SupportTypes/Trunk/TrunkRenderer.tsx
@@ -89,10 +89,10 @@ export const TrunkRenderer = React.memo(function TrunkRenderer({ trunk: baseTrun
             scene,
             initialEvent: e,
             modelId: trunk.modelId,
-            onHit: ({ point, surfaceNormal }: ContactDiskDragHit) => {
+            onHit: ({ point, surfaceNormal, mesh }: ContactDiskDragHit) => {
                 const latest = getSnapshot().trunks[trunk.id];
                 if (!latest?.contactCone) return;
-                liveDragConeRef.current = recomputeContactConeForMovedDisk(latest.contactCone, point, surfaceNormal, socketAnchor);
+                liveDragConeRef.current = recomputeContactConeForMovedDisk(latest.contactCone, point, surfaceNormal, socketAnchor, mesh);
                 setDragTick(t => t + 1);
             },
             onEnd: () => {

--- a/src/supports/SupportTypes/Trunk/trunkBuilder.ts
+++ b/src/supports/SupportTypes/Trunk/trunkBuilder.ts
@@ -29,6 +29,77 @@ function uuidv4() {
     });
 }
 
+const JOINT_CHAIN_Z_EPSILON = 0.0001;
+
+function getAscendingJointPenalty(joints: Vec3[], lowerBoundZ: number, upperBoundZ: number): number {
+    let penalty = 0;
+    let previousZ = lowerBoundZ;
+
+    for (const joint of joints) {
+        if (joint.z <= previousZ + JOINT_CHAIN_Z_EPSILON) {
+            penalty += (previousZ + JOINT_CHAIN_Z_EPSILON) - joint.z + 1;
+        }
+        if (joint.z >= upperBoundZ - JOINT_CHAIN_Z_EPSILON) {
+            penalty += joint.z - (upperBoundZ - JOINT_CHAIN_Z_EPSILON) + 1;
+        }
+        previousZ = Math.max(previousZ, joint.z);
+    }
+
+    return penalty;
+}
+
+function orientJointsBaseToSocket(joints: Vec3[], lowerBoundZ: number, upperBoundZ: number): Vec3[] {
+    if (joints.length < 2) {
+        return [...joints];
+    }
+
+    const forward = [...joints];
+    const reversed = [...joints].reverse();
+    const forwardPenalty = getAscendingJointPenalty(forward, lowerBoundZ, upperBoundZ);
+    const reversedPenalty = getAscendingJointPenalty(reversed, lowerBoundZ, upperBoundZ);
+
+    return reversedPenalty < forwardPenalty ? reversed : forward;
+}
+
+function filterStrictlyAscendingJoints(joints: Vec3[], lowerBoundZ: number, upperBoundZ: number): Vec3[] {
+    const result: Vec3[] = [];
+    let previousZ = lowerBoundZ;
+
+    for (const joint of joints) {
+        if (joint.z <= previousZ + JOINT_CHAIN_Z_EPSILON) {
+            continue;
+        }
+        if (joint.z >= upperBoundZ - JOINT_CHAIN_Z_EPSILON) {
+            continue;
+        }
+
+        result.push(joint);
+        previousZ = joint.z;
+    }
+
+    return result;
+}
+
+function normalizeTrunkJointChain(args: {
+    rootTopZ: number;
+    socketPos: Vec3;
+    routeJoints: Vec3[];
+    constructionJoints: Vec3[];
+}): { routeJoints: Vec3[]; constructionJoints: Vec3[] } {
+    const { rootTopZ, socketPos } = args;
+    const orientedConstruction = orientJointsBaseToSocket(args.constructionJoints, rootTopZ, socketPos.z);
+    const normalizedConstruction = filterStrictlyAscendingJoints(orientedConstruction, rootTopZ, socketPos.z);
+
+    const routeLowerBoundZ = normalizedConstruction[normalizedConstruction.length - 1]?.z ?? rootTopZ;
+    const orientedRoute = orientJointsBaseToSocket(args.routeJoints, routeLowerBoundZ, socketPos.z);
+    const normalizedRoute = filterStrictlyAscendingJoints(orientedRoute, routeLowerBoundZ, socketPos.z);
+
+    return {
+        constructionJoints: normalizedConstruction,
+        routeJoints: normalizedRoute,
+    };
+}
+
 function buildTipProfile(
     settings: ReturnType<typeof getSettings>,
     overrides: TrunkBuildInput['overrides'],
@@ -218,9 +289,17 @@ export function buildTrunkDataFromPlacement(input: TrunkBuildInput, placement: T
     );
     const resolvedSocketPos = getFinalSocketPosition(contactConeTemplate);
     const rootsTopZ = diskHeight + coneHeight;
-    const routeJoints = placement.joints ? [...placement.joints] : [];
+    const authoredRouteJoints = placement.joints ? [...placement.joints] : [];
+    const authoredConstructionJoints = placement.constructionJoints ? [...placement.constructionJoints] : [];
+    const normalizedAuthoredChains = normalizeTrunkJointChain({
+        rootTopZ: rootsTopZ,
+        socketPos: resolvedSocketPos,
+        routeJoints: authoredRouteJoints,
+        constructionJoints: authoredConstructionJoints,
+    });
+    const routeJoints = normalizedAuthoredChains.routeJoints;
     const isStraightSupport = routeJoints.length === 0;
-    const initialConstructionJoints = placement.constructionJoints ? [...placement.constructionJoints] : [];
+    const initialConstructionJoints = normalizedAuthoredChains.constructionJoints;
     const fallbackConstructionJoints = isStraightSupport
         ? withCentralStraightSupportJoint({
             basePos: placement.basePos,
@@ -237,14 +316,23 @@ export function buildTrunkDataFromPlacement(input: TrunkBuildInput, placement: T
             ? initialConstructionJoints
             : fallbackConstructionJoints,
     });
+    const normalizedJointChains = normalizeTrunkJointChain({
+        rootTopZ: rootsTopZ,
+        socketPos: resolvedSocketPos,
+        routeJoints,
+        constructionJoints: normalizedConstructionJoints,
+    });
+    const finalRouteJoints = normalizedJointChains.routeJoints;
+    const finalConstructionJoints = normalizedJointChains.constructionJoints;
+    const finalIsStraightSupport = finalRouteJoints.length === 0;
 
     const routeBase: TrunkRouteResult = {
-        kind: isStraightSupport ? 'straight' : 'routed',
+        kind: finalIsStraightSupport ? 'straight' : 'routed',
         basePos: placement.basePos,
         socketPos: resolvedSocketPos,
         unsnappedBottomPos: placement.unsnappedBottomPos ?? placement.basePos,
-        joints: routeJoints,
-        constructionJoints: normalizedConstructionJoints,
+        joints: finalRouteJoints,
+        constructionJoints: finalConstructionJoints,
         validity: placement.error ? 'hard_invalid' : 'valid',
         error: placement.error,
         warning: placement.warning,
@@ -315,7 +403,7 @@ export function buildTrunkDataFromPlacement(input: TrunkBuildInput, placement: T
     };
 
     // 2. Create Segments
-    if (isStraightSupport && createdJoints.length === 1) {
+    if (finalIsStraightSupport && createdJoints.length === 1) {
         createdSegments.push({
             id: uuidv4(),
             diameter: shaftDiameter,

--- a/src/supports/SupportTypes/Trunk/trunkBuilder.ts
+++ b/src/supports/SupportTypes/Trunk/trunkBuilder.ts
@@ -8,8 +8,9 @@
 import * as THREE from 'three';
 import { Vec3, Roots, Trunk, Segment, Joint } from '../../types';
 import type { ContactCone, SupportTipProfile } from '../../SupportPrimitives/ContactCone/types';
-import { getSocketPosition } from '../../SupportPrimitives/ContactCone/contactConeUtils';
+import { getFinalSocketPosition, getSocketPosition } from '../../SupportPrimitives/ContactCone/contactConeUtils';
 import { calculateDiskThickness } from '../../SupportPrimitives/ContactDisk/contactDiskUtils';
+import { recomputeContactConeForMovedDisk } from '../../SupportPrimitives/ContactDisk';
 import { getJointDiameter } from '../../constants';
 import { getSettings } from '../../Settings';
 import type { SupportData } from '../../rendering/SupportBuilder';
@@ -175,7 +176,7 @@ export function buildTrunkData(input: TrunkBuildInput): TrunkBuildResult {
 }
 
 export function buildTrunkDataFromPlacement(input: TrunkBuildInput, placement: TrunkPlacementResult): TrunkBuildResult {
-    const { tipPos, tipNormal, modelId, overrides } = input;
+    const { tipPos, tipNormal, modelId, overrides, mesh } = input;
     const settings = getSettings();
     const settingsCodeHex = encodeSupportSettingsHex(settings);
     const tipProfile = buildTipProfile(settings, overrides);
@@ -195,9 +196,27 @@ export function buildTrunkDataFromPlacement(input: TrunkBuildInput, placement: T
         z: tipPos.z + tipNormal.z * diskThickness,
     };
 
-    // Always derive socket from the live tip pose so cone/body stay locked even
-    // when route data came from a quantised preview cache entry.
     const liveSocketPos = getSocketPosition(coneStartPos, effectiveConeAxis, tipProfile);
+    const solverSocketPos = placement.socketPos ?? liveSocketPos;
+    const solverSocketDeltaSq =
+        (solverSocketPos.x - liveSocketPos.x) ** 2
+        + (solverSocketPos.y - liveSocketPos.y) ** 2
+        + (solverSocketPos.z - liveSocketPos.z) ** 2;
+    const contactConeTemplate: ContactCone = recomputeContactConeForMovedDisk(
+        {
+            id: '__solver-authored-socket__',
+            pos: tipPos,
+            normal: effectiveConeAxis,
+            surfaceNormal: tipNormal,
+            diskLengthOverride: tipDiskLengthOverrideMm,
+            profile: tipProfile,
+        },
+        tipPos,
+        tipNormal,
+        solverSocketPos,
+        mesh,
+    );
+    const resolvedSocketPos = getFinalSocketPosition(contactConeTemplate);
     const rootsTopZ = diskHeight + coneHeight;
     const routeJoints = placement.joints ? [...placement.joints] : [];
     const isStraightSupport = routeJoints.length === 0;
@@ -206,13 +225,13 @@ export function buildTrunkDataFromPlacement(input: TrunkBuildInput, placement: T
         ? withCentralStraightSupportJoint({
             basePos: placement.basePos,
             rootTopZ: rootsTopZ,
-            socketPos: liveSocketPos,
+            socketPos: resolvedSocketPos,
         })
         : initialConstructionJoints;
     const normalizedConstructionJoints = normalizeFirstConstructionJoint({
         basePos: placement.basePos,
         rootTopZ: rootsTopZ,
-        socketPos: liveSocketPos,
+        socketPos: resolvedSocketPos,
         routeJoints,
         constructionJoints: initialConstructionJoints.length > 0
             ? initialConstructionJoints
@@ -222,7 +241,7 @@ export function buildTrunkDataFromPlacement(input: TrunkBuildInput, placement: T
     const routeBase: TrunkRouteResult = {
         kind: isStraightSupport ? 'straight' : 'routed',
         basePos: placement.basePos,
-        socketPos: liveSocketPos,
+        socketPos: resolvedSocketPos,
         unsnappedBottomPos: placement.unsnappedBottomPos ?? placement.basePos,
         joints: routeJoints,
         constructionJoints: normalizedConstructionJoints,
@@ -341,13 +360,9 @@ export function buildTrunkDataFromPlacement(input: TrunkBuildInput, placement: T
 
     // Build ContactCone
     const contactCone: ContactCone = {
+        ...contactConeTemplate,
         id: contactConeId,
-        pos: tipPos,
-        normal: effectiveConeAxis, // Cone axis may differ from surface normal due to tilt rules
-        surfaceNormal: tipNormal, // The actual surface normal
-        diskLengthOverride: tipDiskLengthOverrideMm,
-        profile: tipProfile,
-        socketJointId: socketJointId // Link to unique socket ID
+        socketJointId: socketJointId,
     };
 
     // Build Trunk

--- a/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
+++ b/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
@@ -15,6 +15,8 @@ import { clearSupportSelection } from '../../interaction/shared/selection/select
 import { isContactDiskHudInteractionActive, shouldSuppressContactDiskHudPlacementCommit } from '../../SupportPrimitives/ContactDisk/contactDiskHudInteraction';
 import { buildStick } from '../Stick/stickBuilder';
 import { buildTwig } from '../Twig/twigBuilder';
+import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
+import { matchesConfiguredHotkeyDown, matchesConfiguredHotkeyUp } from '@/hotkeys/hotkeyConfig';
 
 // ---------------------------------------------------------------------------
 // Cavity stick helpers
@@ -124,6 +126,8 @@ export function useTrunkPlacementV2() {
     const HOVER_MIN_INTERVAL_MS = 9;
     const HOVER_POS_EPSILON_MM = 0.1;
     const HOVER_NORMAL_DOT_MIN = 0.998;
+    const { getHotkey } = useHotkeyConfig();
+    const forcePlaceBinding = getHotkey('SUPPORTS', 'FORCE_PLACE_SUPPORT');
 
     const [previewData, setPreviewData] = useState<SupportData | null>(null);
     const [previewError, setPreviewError] = useState<LimitationCode | null>(null);
@@ -131,6 +135,7 @@ export function useTrunkPlacementV2() {
     const { isPlacementHardDisabled } = useInteractionStatus();
     const hoverFrameRef = useRef<number | null>(null);
     const latestHoverRef = useRef<THREE.Intersection | null>(null);
+    const forcePlaceOverrideRef = useRef(false);
     const hoverNormalRef = useRef(new THREE.Vector3());
     const cavityPreviewCacheNormalRef = useRef(new THREE.Vector3());
     const cavityPreviewCacheRef = useRef<{
@@ -154,6 +159,19 @@ export function useTrunkPlacementV2() {
         setPreviewError((prev) => (prev === null ? prev : null));
         setPreviewWarning((prev) => (prev === null ? prev : null));
         cavityPreviewCacheRef.current = null;
+    }, []);
+
+    const commitTrunkBuild = useCallback((trunkBuild: ReturnType<typeof buildTrunkData>) => {
+        addRoot(trunkBuild.root);
+        addTrunk(trunkBuild.trunk);
+        pushHistory({
+            type: SUPPORT_ADD_TRUNK,
+            payload: {
+                trunk: trunkBuild.trunk,
+                root: trunkBuild.root,
+            },
+        });
+        clearSupportSelection();
     }, []);
 
     const resolveCavityStickPreview = useCallback((
@@ -292,7 +310,7 @@ export function useTrunkPlacementV2() {
                 }
             }
             setPreviewData(result.supportData);
-            setPreviewError(result.error || null);
+            setPreviewError(forcePlaceOverrideRef.current ? null : (result.error || null));
             setPreviewWarning(null);
             return;
         }
@@ -309,14 +327,14 @@ export function useTrunkPlacementV2() {
 
         if (decision.kind === 'place_trunk') {
             setPreviewData(decision.trunkBuild.supportData);
-            setPreviewError(decision.trunkBuild.error || null);
+            setPreviewError(forcePlaceOverrideRef.current ? null : (decision.trunkBuild.error || null));
             setPreviewWarning(decision.trunkBuild.warning || null);
             return;
         }
 
         if (decision.kind === 'replace_trunk') {
             setPreviewData(decision.trunkBuild.supportData);
-            setPreviewError(decision.trunkBuild.error || null);
+            setPreviewError(forcePlaceOverrideRef.current ? null : (decision.trunkBuild.error || null));
             setPreviewWarning(decision.trunkBuild.warning || null);
             return;
         }
@@ -345,14 +363,15 @@ export function useTrunkPlacementV2() {
         // reject
         if (decision.trunkBuild) {
             setPreviewData(decision.trunkBuild.supportData);
-            setPreviewError(decision.trunkBuild.error || null);
+            setPreviewError(forcePlaceOverrideRef.current ? null : (decision.trunkBuild.error || null));
             setPreviewWarning(decision.trunkBuild.warning || null);
             return;
         }
 
         setPreviewData((prev) => (prev === null ? prev : null));
-        setPreviewError(
-            decision.reason === 'KNOT_ABOVE_TIP'
+        setPreviewError(forcePlaceOverrideRef.current
+            ? null
+            : decision.reason === 'KNOT_ABOVE_TIP'
                 ? 'KNOT_ABOVE_TIP'
                 : decision.reason === 'COLLISION_WITH_MODEL'
                     ? 'COLLISION_WITH_MODEL'
@@ -360,6 +379,39 @@ export function useTrunkPlacementV2() {
         );
         setPreviewWarning((prev) => (prev === null ? prev : null));
     }, [HOVER_MIN_INTERVAL_MS, HOVER_NORMAL_DOT_MIN, HOVER_POS_EPSILON_MM, clearPreview, isPlacementHardDisabled, resolveCavityStickPreview]);
+
+    useEffect(() => {
+        const refreshCurrentHover = () => {
+            if (hoverFrameRef.current !== null) return;
+            hoverFrameRef.current = requestAnimationFrame(() => {
+                hoverFrameRef.current = null;
+                processSupportHover(latestHoverRef.current);
+            });
+        };
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (!matchesConfiguredHotkeyDown(event, forcePlaceBinding) || forcePlaceOverrideRef.current) return;
+            event.preventDefault();
+            forcePlaceOverrideRef.current = true;
+            refreshCurrentHover();
+        };
+
+        const handleKeyUp = (event: KeyboardEvent) => {
+            if (!matchesConfiguredHotkeyUp(event, forcePlaceBinding) || !forcePlaceOverrideRef.current) return;
+            event.preventDefault();
+            forcePlaceOverrideRef.current = false;
+            refreshCurrentHover();
+        };
+
+        window.addEventListener('keydown', handleKeyDown, true);
+        window.addEventListener('keyup', handleKeyUp, true);
+        document.addEventListener('keyup', handleKeyUp, true);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown, true);
+            window.removeEventListener('keyup', handleKeyUp, true);
+            document.removeEventListener('keyup', handleKeyUp, true);
+        };
+    }, [forcePlaceBinding, processSupportHover]);
 
     const onSupportHover = useCallback((hit: THREE.Intersection | null) => {
         latestHoverRef.current = hit;
@@ -413,6 +465,9 @@ export function useTrunkPlacementV2() {
                 }
             }
             // No cavity floor found — bail silently; hover preview already shows the error.
+            if (forcePlaceOverrideRef.current) {
+                commitTrunkBuild(result);
+            }
             return;
         }
 
@@ -420,6 +475,9 @@ export function useTrunkPlacementV2() {
         // Only bail on trunk errors when grid is disabled (direct placement path).
         const settings = getSettings();
         if (result.error && !settings.grid?.enabled) {
+            if (forcePlaceOverrideRef.current) {
+                commitTrunkBuild(result);
+            }
             // Stick/twig is now strict last resort: do not fallback here unless
             // the solver reported true stagnation (handled above).
             return;
@@ -531,6 +589,9 @@ export function useTrunkPlacementV2() {
         }
 
         if (decision.kind === 'reject') {
+            if (forcePlaceOverrideRef.current && decision.trunkBuild) {
+                commitTrunkBuild(decision.trunkBuild);
+            }
             // Stick/twig is now strict last resort: keep reject behavior here.
             return;
         }
@@ -538,20 +599,9 @@ export function useTrunkPlacementV2() {
         // decision.kind === 'place_trunk'
         const trunkBuild = decision.trunkBuild;
         
-        // Add to store
-        addRoot(trunkBuild.root);
-        addTrunk(trunkBuild.trunk);
-        pushHistory({
-            type: SUPPORT_ADD_TRUNK,
-            payload: {
-                trunk: trunkBuild.trunk,
-                root: trunkBuild.root,
-            },
-        });
-        
-        clearSupportSelection();
+        commitTrunkBuild(trunkBuild);
         console.log('[V2] Added trunk:', trunkBuild.trunk.id, 'to model:', modelId);
-    }, [isPlacementHardDisabled]);
+    }, [commitTrunkBuild, isPlacementHardDisabled]);
 
     return {
         onSupportHover,

--- a/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
+++ b/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
@@ -1,8 +1,8 @@
 import { useCallback, useState, useEffect, useRef } from 'react';
 import * as THREE from 'three';
-import { addAnchor, addBranch, addKnot, addRoot, addStick, addTrunk, addTwig, getSnapshot, setSnapshot, updateKnot, updateTrunk } from '../../state';
+import { addAnchor, addBranch, addKnot, addLeaf, addRoot, addStick, addTrunk, addTwig, getSnapshot, setSnapshot, updateKnot, updateTrunk } from '../../state';
 import { pushHistory } from '@/history/historyStore';
-import { SUPPORT_ADD_ANCHOR, SUPPORT_ADD_BRANCH, SUPPORT_ADD_STICK, SUPPORT_ADD_TRUNK, SUPPORT_ADD_TWIG } from '../../history/actionTypes';
+import { SUPPORT_ADD_ANCHOR, SUPPORT_ADD_BRANCH, SUPPORT_ADD_LEAF, SUPPORT_ADD_STICK, SUPPORT_ADD_TRUNK, SUPPORT_ADD_TWIG } from '../../history/actionTypes';
 import { useInteractionStatus } from '../../interaction/useInteractionStatus';
 import { buildTrunkData } from './trunkBuilder';
 import { applyTrunkReplacement, computeAndApplyTrunkDiameterProfile, planTrunkReplacement } from './TrunkReplacement';
@@ -328,6 +328,13 @@ export function useTrunkPlacementV2() {
             return;
         }
 
+        if (decision.kind === 'place_leaf') {
+            setPreviewData(decision.supportData);
+            setPreviewError(null);
+            setPreviewWarning(null);
+            return;
+        }
+
         if (decision.kind === 'place_anchor') {
             setPreviewData(decision.supportData);
             setPreviewError(null);
@@ -465,6 +472,21 @@ export function useTrunkPlacementV2() {
                     knot: decision.knot,
                     trunkUpdate: trunkUpdate ? { before: trunkUpdate.before, after: trunkUpdate.after } : undefined,
                     knotUpdates: trunkUpdate?.knotUpdates ?? undefined,
+                },
+            });
+            clearSupportSelection();
+            return;
+        }
+
+        if (decision.kind === 'place_leaf') {
+            addKnot(decision.knot);
+            addLeaf(decision.leaf);
+
+            pushHistory({
+                type: SUPPORT_ADD_LEAF,
+                payload: {
+                    leaf: decision.leaf,
+                    knot: decision.knot,
                 },
             });
             clearSupportSelection();

--- a/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
+++ b/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
@@ -17,6 +17,7 @@ import { buildStick } from '../Stick/stickBuilder';
 import { buildTwig } from '../Twig/twigBuilder';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
 import { matchesConfiguredHotkeyDown, matchesConfiguredHotkeyUp } from '@/hotkeys/hotkeyConfig';
+import { getSupportPathfindingDebugEnabled, setSupportPathfindingDebugSnapshot } from '../../PlacementLogic/Pathfinding/pathfindingDebugState';
 
 // ---------------------------------------------------------------------------
 // Cavity stick helpers
@@ -159,6 +160,9 @@ export function useTrunkPlacementV2() {
         setPreviewError((prev) => (prev === null ? prev : null));
         setPreviewWarning((prev) => (prev === null ? prev : null));
         cavityPreviewCacheRef.current = null;
+        if (getSupportPathfindingDebugEnabled()) {
+            setSupportPathfindingDebugSnapshot(null);
+        }
     }, []);
 
     const commitTrunkBuild = useCallback((trunkBuild: ReturnType<typeof buildTrunkData>) => {

--- a/src/supports/__tests__/branchBuilderConeAlignment.test.ts
+++ b/src/supports/__tests__/branchBuilderConeAlignment.test.ts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as THREE from 'three';
+
+import { buildBranchData } from '../SupportTypes/Branch/branchBuilder';
+import { calculateDiskThickness } from '../SupportPrimitives/ContactDisk/contactDiskUtils';
+import { getFinalSocketPosition } from '../SupportPrimitives/ContactCone/contactConeUtils';
+import { isCollisionSegmentBlocked } from '../PlacementLogic/CollisionAvoidance';
+import { getSettings } from '../Settings';
+import type { ContactCone } from '../SupportPrimitives/ContactCone/types';
+import type { Knot, Vec3 } from '../types';
+
+function makeBlockingMesh(): THREE.Mesh {
+    const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(0.2, 2.5, 0.75),
+        new THREE.MeshBasicMaterial(),
+    );
+    mesh.position.set(0.7, 0, 0.75);
+    mesh.updateMatrixWorld(true);
+    return mesh;
+}
+
+function angleBetween(a: Vec3, b: Vec3): number {
+    const va = new THREE.Vector3(a.x, a.y, a.z).normalize();
+    const vb = new THREE.Vector3(b.x, b.y, b.z).normalize();
+    return THREE.MathUtils.radToDeg(Math.acos(THREE.MathUtils.clamp(va.dot(vb), -1, 1)));
+}
+
+function getConeStart(cone: ContactCone): Vec3 {
+    const surfaceNormal = cone.surfaceNormal ?? cone.normal;
+    const thickness = cone.diskLengthOverride ?? (
+        cone.profile.type === 'disk'
+            ? calculateDiskThickness(surfaceNormal, cone.normal, cone.profile)
+            : 0
+    );
+
+    return {
+        x: cone.pos.x + surfaceNormal.x * thickness,
+        y: cone.pos.y + surfaceNormal.y * thickness,
+        z: cone.pos.z + surfaceNormal.z * thickness,
+    };
+}
+
+test('buildBranchData keeps the contact cone aligned with the contact disk direction before using shaft rerouting', () => {
+    const tipPos = { x: 0, y: 0, z: 0 };
+    const tipNormal = { x: 1, y: 0, z: 0 };
+    const parentKnot: Knot = {
+        id: 'knot-1',
+        parentShaftId: 'trunk-1',
+        pos: { x: 1.6, y: 0, z: 3 },
+    };
+
+    const withoutMesh = buildBranchData({
+        tipPos,
+        tipNormal,
+        modelId: 'model-1',
+        parentKnot,
+    }).branch;
+
+    const directAngle = angleBetween(tipNormal, {
+        x: parentKnot.pos.x - tipPos.x,
+        y: parentKnot.pos.y - tipPos.y,
+        z: parentKnot.pos.z - tipPos.z,
+    });
+    const solvedAngle = angleBetween(tipNormal, withoutMesh.contactCone!.normal);
+
+    assert.ok(
+        solvedAngle <= directAngle + 0.001,
+        `expected solved cone angle ${solvedAngle.toFixed(2)}° to stay no worse than direct ${directAngle.toFixed(2)}°`,
+    );
+});
+
+test('buildBranchData reroutes the shaft instead of steepening the cone near the disk when mesh blocks the direct exit', () => {
+    const tipPos = { x: 0, y: 0, z: 0 };
+    const tipNormal = { x: 1, y: 0, z: 0 };
+    const parentKnot: Knot = {
+        id: 'knot-1',
+        parentShaftId: 'trunk-1',
+        pos: { x: 1.6, y: 0, z: 3 },
+    };
+    const mesh = makeBlockingMesh();
+
+    const withoutMesh = buildBranchData({
+        tipPos,
+        tipNormal,
+        modelId: 'model-1',
+        parentKnot,
+    }).branch;
+    const withMesh = buildBranchData({
+        tipPos,
+        tipNormal,
+        modelId: 'model-1',
+        parentKnot,
+        mesh,
+    }).branch;
+
+    const directAngle = angleBetween(tipNormal, {
+        x: parentKnot.pos.x - tipPos.x,
+        y: parentKnot.pos.y - tipPos.y,
+        z: parentKnot.pos.z - tipPos.z,
+    });
+    const withMeshAngle = angleBetween(tipNormal, withMesh.contactCone!.normal);
+    const withMeshSocket = getFinalSocketPosition(withMesh.contactCone!);
+    const coneStart = getConeStart(withMesh.contactCone!);
+    const blocked = isCollisionSegmentBlocked(
+        coneStart,
+        withMeshSocket,
+        (withMesh.contactCone!.profile.bodyDiameterMm / 2) + 0.25,
+        mesh,
+    );
+
+    assert.ok(
+        withMeshAngle <= directAngle + 0.001,
+        `expected mesh-aware cone angle ${withMeshAngle.toFixed(2)}° to stay no steeper than direct ${directAngle.toFixed(2)}°`,
+    );
+    assert.ok(withMesh.segments.length >= withoutMesh.segments.length);
+    assert.equal(blocked, false);
+});
+
+test('buildBranchData prefers shaft deviation over aggressively stretching the contact cone', () => {
+    const settings = getSettings();
+    const nominalConeLength = settings.tip.lengthMm;
+    const tipPos = { x: 0, y: 0, z: 0 };
+    const tipNormal = { x: 1, y: 0, z: 0 };
+    const parentKnot: Knot = {
+        id: 'knot-far',
+        parentShaftId: 'trunk-1',
+        pos: { x: 6, y: 0, z: 4 },
+    };
+
+    const branch = buildBranchData({
+        tipPos,
+        tipNormal,
+        modelId: 'model-1',
+        parentKnot,
+    }).branch;
+
+    const directDistance = new THREE.Vector3(
+        parentKnot.pos.x - tipPos.x,
+        parentKnot.pos.y - tipPos.y,
+        parentKnot.pos.z - tipPos.z,
+    ).length();
+
+    assert.ok(
+        branch.contactCone!.profile.lengthMm <= nominalConeLength * 1.35,
+        `expected cone length ${branch.contactCone!.profile.lengthMm.toFixed(2)}mm to stay close to nominal ${nominalConeLength.toFixed(2)}mm`,
+    );
+    assert.ok(
+        branch.contactCone!.profile.lengthMm <= directDistance - 1.5,
+        `expected cone length ${branch.contactCone!.profile.lengthMm.toFixed(2)}mm to stay well below direct reach ${directDistance.toFixed(2)}mm`,
+    );
+});

--- a/src/supports/__tests__/branchBuilderConeAlignment.test.ts
+++ b/src/supports/__tests__/branchBuilderConeAlignment.test.ts
@@ -153,6 +153,36 @@ test('buildBranchData prefers shaft deviation over aggressively stretching the c
     );
 });
 
+test('buildBranchData keeps the host knot separate from the cone socket so the shaft retains real span', () => {
+    const tipPos = { x: 0, y: 0, z: 0 };
+    const tipNormal = { x: 1, y: 0, z: 0 };
+    const parentKnot: Knot = {
+        id: 'knot-host',
+        parentShaftId: 'trunk-1',
+        pos: { x: 3.5, y: 0, z: 2.2 },
+    };
+
+    const branch = buildBranchData({
+        tipPos,
+        tipNormal,
+        modelId: 'model-1',
+        parentKnot,
+    }).branch;
+
+    const socketPos = getFinalSocketPosition(branch.contactCone!);
+    const hostToSocketDistance = new THREE.Vector3(
+        socketPos.x - parentKnot.pos.x,
+        socketPos.y - parentKnot.pos.y,
+        socketPos.z - parentKnot.pos.z,
+    ).length();
+
+    assert.ok(
+        hostToSocketDistance > 0.5,
+        `expected branch shaft to retain visible span, but host-to-socket distance was ${hostToSocketDistance.toFixed(3)}mm`,
+    );
+    assert.ok(branch.segments.length >= 2);
+});
+
 test('frustum cone collision checks catch wide-end clips that a narrow start-radius shaft would miss', () => {
     const mesh = new THREE.Mesh(
         new THREE.BoxGeometry(0.25, 0.25, 0.45),

--- a/src/supports/__tests__/branchBuilderConeAlignment.test.ts
+++ b/src/supports/__tests__/branchBuilderConeAlignment.test.ts
@@ -6,7 +6,7 @@ import * as THREE from 'three';
 import { buildBranchData } from '../SupportTypes/Branch/branchBuilder';
 import { calculateDiskThickness } from '../SupportPrimitives/ContactDisk/contactDiskUtils';
 import { getFinalSocketPosition } from '../SupportPrimitives/ContactCone/contactConeUtils';
-import { isCollisionSegmentBlocked } from '../PlacementLogic/CollisionAvoidance';
+import { isCollisionFrustumBlocked, isCollisionSegmentBlocked } from '../PlacementLogic/CollisionAvoidance';
 import { getSettings } from '../Settings';
 import type { ContactCone } from '../SupportPrimitives/ContactCone/types';
 import type { Knot, Vec3 } from '../types';
@@ -103,9 +103,10 @@ test('buildBranchData reroutes the shaft instead of steepening the cone near the
     const withMeshAngle = angleBetween(tipNormal, withMesh.contactCone!.normal);
     const withMeshSocket = getFinalSocketPosition(withMesh.contactCone!);
     const coneStart = getConeStart(withMesh.contactCone!);
-    const blocked = isCollisionSegmentBlocked(
+    const blocked = isCollisionFrustumBlocked(
         coneStart,
         withMeshSocket,
+        (withMesh.contactCone!.profile.contactDiameterMm / 2) + 0.25,
         (withMesh.contactCone!.profile.bodyDiameterMm / 2) + 0.25,
         mesh,
     );
@@ -150,4 +151,22 @@ test('buildBranchData prefers shaft deviation over aggressively stretching the c
         branch.contactCone!.profile.lengthMm <= directDistance - 1.5,
         `expected cone length ${branch.contactCone!.profile.lengthMm.toFixed(2)}mm to stay well below direct reach ${directDistance.toFixed(2)}mm`,
     );
+});
+
+test('frustum cone collision checks catch wide-end clips that a narrow start-radius shaft would miss', () => {
+    const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(0.25, 0.25, 0.45),
+        new THREE.MeshBasicMaterial(),
+    );
+    mesh.position.set(0.62, 0, 3.2);
+    mesh.updateMatrixWorld(true);
+
+    const start = { x: 0, y: 0, z: 0 };
+    const end = { x: 0, y: 0, z: 4 };
+
+    const narrowStartBlocked = isCollisionSegmentBlocked(start, end, 0.22, mesh);
+    const frustumBlocked = isCollisionFrustumBlocked(start, end, 0.22, 0.72, mesh);
+
+    assert.equal(narrowStartBlocked, false);
+    assert.equal(frustumBlocked, true);
 });

--- a/src/supports/__tests__/coneAxisPolicy.test.ts
+++ b/src/supports/__tests__/coneAxisPolicy.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as THREE from 'three';
+
+import { resolveConeAxisPolicy } from '../PlacementLogic/ConeAxisPolicy';
+import type { Vec3 } from '../types';
+
+function angleBetween(a: Vec3, b: Vec3): number {
+    const va = new THREE.Vector3(a.x, a.y, a.z).normalize();
+    const vb = new THREE.Vector3(b.x, b.y, b.z).normalize();
+    return THREE.MathUtils.radToDeg(Math.acos(THREE.MathUtils.clamp(va.dot(vb), -1, 1)));
+}
+
+test('adaptive cone axis stays close to the surface normal on vertical walls', () => {
+    const surfaceNormal = { x: 1, y: 0, z: 0 };
+    const { coneAxis } = resolveConeAxisPolicy({
+        surfaceNormal,
+        coneAngleMode: 'adaptive',
+        adaptiveConeAngleOffsetDeg: 60,
+    });
+
+    assert.ok(
+        angleBetween(surfaceNormal, coneAxis) <= 35.001,
+        `expected adaptive cone axis to stay within 35° of the surface normal, got ${angleBetween(surfaceNormal, coneAxis).toFixed(2)}°`,
+    );
+});
+
+test('locked cone axis also remains broadly aligned with the contact-disk direction', () => {
+    const surfaceNormal = { x: 1, y: 0, z: 0 };
+    const { coneAxis } = resolveConeAxisPolicy({
+        surfaceNormal,
+        coneAngleMode: 'locked',
+    });
+
+    assert.ok(
+        angleBetween(surfaceNormal, coneAxis) <= 35.001,
+        `expected locked cone axis to stay within 35° of the surface normal, got ${angleBetween(surfaceNormal, coneAxis).toFixed(2)}°`,
+    );
+});

--- a/src/supports/__tests__/contactConeCollisionAvoidance.test.ts
+++ b/src/supports/__tests__/contactConeCollisionAvoidance.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import * as THREE from 'three';
+
+import { recomputeContactConeForMovedDisk } from '../SupportPrimitives/ContactDisk/ContactDiskInteraction';
+import type { ContactCone } from '../SupportPrimitives/ContactCone/types';
+
+function makeCone(): ContactCone {
+    return {
+        id: 'cone-1',
+        pos: { x: 0, y: 0, z: 0 },
+        normal: { x: 0, y: 0, z: 1 },
+        surfaceNormal: { x: 1, y: 0, z: 0 },
+        profile: {
+            type: 'disk',
+            contactDiameterMm: 0.4,
+            bodyDiameterMm: 1.2,
+            lengthMm: 3,
+            penetrationMm: 0.05,
+            diskThicknessMm: 0.1,
+            maxStandoffMm: 1.1,
+            standoffAngleThreshold: Math.PI / 4,
+        },
+    };
+}
+
+function makeBlockingMesh(): THREE.Mesh {
+    const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(0.2, 2.5, 0.75),
+        new THREE.MeshBasicMaterial(),
+    );
+    mesh.position.set(0.7, 0, 0.75);
+    mesh.updateMatrixWorld(true);
+    return mesh;
+}
+
+test('recomputeContactConeForMovedDisk increases standoff when mesh clearance requires it', () => {
+    const socketTarget = { x: 1.6, y: 0, z: 3 };
+    const withoutAvoidance = recomputeContactConeForMovedDisk(
+        makeCone(),
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+        socketTarget,
+    );
+    const withAvoidance = recomputeContactConeForMovedDisk(
+        makeCone(),
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+        socketTarget,
+        makeBlockingMesh(),
+    );
+
+    assert.ok((withAvoidance.diskLengthOverride ?? 0) > (withoutAvoidance.diskLengthOverride ?? 0));
+});

--- a/src/supports/__tests__/contactConeCollisionAvoidance.test.ts
+++ b/src/supports/__tests__/contactConeCollisionAvoidance.test.ts
@@ -27,15 +27,15 @@ function makeCone(): ContactCone {
 
 function makeBlockingMesh(): THREE.Mesh {
     const mesh = new THREE.Mesh(
-        new THREE.BoxGeometry(0.2, 2.5, 0.75),
+        new THREE.BoxGeometry(0.16, 2.5, 0.35),
         new THREE.MeshBasicMaterial(),
     );
-    mesh.position.set(0.7, 0, 0.75);
+    mesh.position.set(0.74, 0, 0.2);
     mesh.updateMatrixWorld(true);
     return mesh;
 }
 
-test('recomputeContactConeForMovedDisk increases standoff when mesh clearance requires it', () => {
+test('recomputeContactConeForMovedDisk never reduces the resolved standoff when collision sampling is enabled', () => {
     const socketTarget = { x: 1.6, y: 0, z: 3 };
     const withoutAvoidance = recomputeContactConeForMovedDisk(
         makeCone(),
@@ -51,5 +51,5 @@ test('recomputeContactConeForMovedDisk increases standoff when mesh clearance re
         makeBlockingMesh(),
     );
 
-    assert.ok((withAvoidance.diskLengthOverride ?? 0) > (withoutAvoidance.diskLengthOverride ?? 0));
+    assert.ok((withAvoidance.diskLengthOverride ?? 0) >= (withoutAvoidance.diskLengthOverride ?? 0));
 });

--- a/src/supports/__tests__/gridPlacementIntegration.test.ts
+++ b/src/supports/__tests__/gridPlacementIntegration.test.ts
@@ -189,7 +189,7 @@ test('decideGridPlacement merges into the preferred occupied node before conside
         modelId: MODEL_ID,
     });
 
-    assert.equal(decision.kind, 'place_branch');
+    assert.equal(decision.kind, 'place_leaf');
     assert.equal(decision.nodeKey, '0,0');
     assert.equal(decision.hostTrunkId, preferredHost.build.trunk.id);
 });
@@ -258,6 +258,40 @@ test('decideGridPlacement places a branch on the occupied preferred node when th
         modelId: MODEL_ID,
     });
 
+    assert.equal(decision.kind, 'place_leaf');
+    assert.equal(decision.nodeKey, '0,0');
+    assert.equal(decision.hostTrunkId, preferredHost.build.trunk.id);
+});
+
+test('decideGridPlacement keeps using a branch when the direct hosted span is too long for an auto-leaf', () => {
+    const settings = makeSettings();
+    setSettings(settings);
+
+    const snapshot = makeEmptySnapshot();
+    const preferredHost = buildStraightFixture({
+        x: 0,
+        y: 0,
+        tipZ: 10,
+        socketZ: 9,
+    });
+    addTrunkBuild(snapshot, preferredHost);
+
+    const candidate = buildStraightFixture({
+        x: 1.9,
+        y: 0,
+        tipZ: 6,
+        socketZ: 5,
+    });
+
+    const decision = decideGridPlacement({
+        settings,
+        snapshot,
+        candidate: candidate.build,
+        tipPos: candidate.input.tipPos,
+        tipNormal: candidate.input.tipNormal,
+        modelId: MODEL_ID,
+    });
+
     assert.equal(decision.kind, 'place_branch');
     assert.equal(decision.nodeKey, '0,0');
     assert.equal(decision.hostTrunkId, preferredHost.build.trunk.id);
@@ -308,9 +342,9 @@ test('decideGridPlacement falls back to a different reachable host when the pref
             return buildManualHostFixture({
                 x: 0,
                 y: 0,
-                tipZ: 8,
-                bottomZ: 5,
-                topZ: 7,
+                tipZ: 7.1,
+                bottomZ: 6.7,
+                topZ: 6.9,
             });
         }
 
@@ -338,8 +372,8 @@ test('decideGridPlacement falls back to a different reachable host when the pref
     const candidate = buildStraightFixture({
         x: 0,
         y: 0,
-        tipZ: 4.5,
-        socketZ: 4,
+        tipZ: 6.5,
+        socketZ: 6,
     });
 
     const decision = decideGridPlacement({

--- a/src/supports/__tests__/loadFromImportFormatNormalization.test.ts
+++ b/src/supports/__tests__/loadFromImportFormatNormalization.test.ts
@@ -338,6 +338,10 @@ test('loadFromImportFormat preserves imported uniform brace knot diameters', () 
     assert.ok(knotLeft && knotRight, 'Expected brace host knots to exist after load');
     assert.ok(almostEqual(knotLeft.diameter ?? 0, 1.1), 'Left imported brace knot should keep uniform imported diameter');
     assert.ok(almostEqual(knotRight.diameter ?? 0, 1.1), 'Right imported brace knot should keep uniform imported diameter');
+    assert.strictEqual(knotLeft._importHint, undefined, 'Transient import hint should be stripped after load');
+    assert.strictEqual(knotRight._importHint, undefined, 'Transient import hint should be stripped after load');
+    assert.strictEqual(knotLeft.normalizationHint, 'braceImported', 'Brace normalization intent should persist after load');
+    assert.strictEqual(knotRight.normalizationHint, 'braceImported', 'Brace normalization intent should persist after load');
 
     resetStore();
 });

--- a/src/supports/__tests__/raftFootprintCircles.test.ts
+++ b/src/supports/__tests__/raftFootprintCircles.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  collectRaftBaseCirclesByModel,
+  RAFT_UNASSIGNED_MODEL_KEY,
+} from '../Rafts/Crenelated/raftFootprintCircles';
+
+test('collectRaftBaseCirclesByModel includes support roots, anchors, and kickstand roots', () => {
+  const circlesByModel = collectRaftBaseCirclesByModel({
+    roots: [
+      {
+        modelId: 'model-a',
+        diameter: 4,
+        transform: { pos: { x: 1, y: 2, z: 0 } },
+      },
+    ],
+    anchors: [
+      {
+        modelId: 'model-a',
+        rootBaseDiameter: 6,
+        rootPos: { x: 3, y: 4, z: 0 },
+      },
+    ],
+    kickstandRoots: [
+      {
+        modelId: 'model-a',
+        diameter: 2,
+        transform: { pos: { x: 5, y: 6, z: 0 } },
+      },
+      {
+        modelId: null,
+        diameter: 8,
+        transform: { pos: { x: -1, y: -2, z: 0 } },
+      },
+    ],
+  });
+
+  assert.deepEqual(circlesByModel.get('model-a'), [
+    { x: 1, y: 2, r: 2 },
+    { x: 3, y: 4, r: 3 },
+    { x: 5, y: 6, r: 1 },
+  ]);
+  assert.deepEqual(circlesByModel.get(RAFT_UNASSIGNED_MODEL_KEY), [
+    { x: -1, y: -2, r: 4 },
+  ]);
+});
+
+test('collectRaftBaseCirclesByModel honors model filters and exclusions for kickstand roots too', () => {
+  const circlesByModel = collectRaftBaseCirclesByModel({
+    roots: [
+      {
+        modelId: 'model-a',
+        diameter: 4,
+        transform: { pos: { x: 1, y: 1, z: 0 } },
+      },
+    ],
+    kickstandRoots: [
+      {
+        modelId: 'model-a',
+        diameter: 2,
+        transform: { pos: { x: 2, y: 2, z: 0 } },
+      },
+      {
+        modelId: 'model-b',
+        diameter: 2,
+        transform: { pos: { x: 3, y: 3, z: 0 } },
+      },
+    ],
+  }, {
+    modelFilterId: 'model-a',
+  });
+
+  assert.deepEqual(Array.from(circlesByModel.keys()), ['model-a']);
+  assert.equal(circlesByModel.get('model-a')?.length, 2);
+
+  const excluded = collectRaftBaseCirclesByModel({
+    kickstandRoots: [
+      {
+        modelId: 'model-a',
+        diameter: 2,
+        transform: { pos: { x: 2, y: 2, z: 0 } },
+      },
+      {
+        modelId: 'model-b',
+        diameter: 2,
+        transform: { pos: { x: 3, y: 3, z: 0 } },
+      },
+    ],
+  }, {
+    excludedModelIds: new Set(['model-b']),
+  });
+
+  assert.deepEqual(Array.from(excluded.keys()), ['model-a']);
+});

--- a/src/supports/__tests__/supportPathTargets.test.ts
+++ b/src/supports/__tests__/supportPathTargets.test.ts
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSupportPathSnapTargets } from '../interaction/shared/placement/snapping/supportPathTargets';
+import { getFinalSocketPosition } from '../SupportPrimitives/ContactCone/contactConeUtils';
+import type { SupportState } from '../types';
+
+function makeBaseState(): Pick<SupportState, 'trunks' | 'branches' | 'braces' | 'twigs' | 'sticks' | 'roots' | 'knots'> {
+    return {
+        trunks: {},
+        branches: {},
+        braces: {},
+        twigs: {},
+        sticks: {},
+        roots: {},
+        knots: {},
+    };
+}
+
+test('buildSupportPathSnapTargets uses the final trunk cone socket for the terminal shaft endpoint', () => {
+    const state = makeBaseState();
+    state.roots['root-1'] = {
+        id: 'root-1',
+        modelId: 'model-1',
+        diameter: 2,
+        diskHeight: 0.5,
+        coneHeight: 1,
+        transform: {
+            pos: { x: 0, y: 0, z: 0 },
+            rot: { x: 0, y: 0, z: 0 },
+        },
+    } as SupportState['roots'][string];
+
+    state.trunks['trunk-1'] = {
+        id: 'trunk-1',
+        modelId: 'model-1',
+        rootId: 'root-1',
+        segments: [{
+            id: 'trunk-seg-1',
+            type: 'straight',
+            diameter: 1.6,
+            bottomJoint: undefined,
+            topJoint: undefined,
+        }],
+        contactCone: {
+            id: 'cone-1',
+            pos: { x: 5, y: 0, z: 20 },
+            normal: { x: 0, y: 0, z: 1 },
+            surfaceNormal: { x: 1, y: 0, z: 0 },
+            profile: {
+                type: 'disk',
+                contactDiameterMm: 0.4,
+                bodyDiameterMm: 0.8,
+                lengthMm: 3,
+                penetrationMm: 0,
+            },
+        },
+    } as SupportState['trunks'][string];
+
+    const targets = buildSupportPathSnapTargets(state, { includeTrunks: true, includeBranches: false });
+    const target = targets.find((entry) => entry.id === 'trunk-seg-1');
+    assert.ok(target?.pathSegment);
+
+    const expectedEnd = getFinalSocketPosition(state.trunks['trunk-1'].contactCone!);
+    assert.deepEqual(target.pathSegment.end, expectedEnd);
+});
+
+test('buildSupportPathSnapTargets uses the final branch cone socket for the terminal shaft endpoint', () => {
+    const state = makeBaseState();
+    state.knots['host-knot'] = {
+        id: 'host-knot',
+        parentShaftId: 'trunk-seg-host',
+        t: 0.5,
+        pos: { x: 1, y: 2, z: 3 },
+        diameter: 1.2,
+    } as SupportState['knots'][string];
+
+    state.branches['branch-1'] = {
+        id: 'branch-1',
+        modelId: 'model-1',
+        parentKnotId: 'host-knot',
+        segments: [{
+            id: 'branch-seg-1',
+            type: 'straight',
+            diameter: 1.1,
+            bottomJoint: undefined,
+            topJoint: undefined,
+        }],
+        contactCone: {
+            id: 'branch-cone-1',
+            pos: { x: 4, y: 5, z: 6 },
+            normal: { x: 0, y: 1, z: 0 },
+            surfaceNormal: { x: 0, y: 0, z: 1 },
+            profile: {
+                type: 'disk',
+                contactDiameterMm: 0.4,
+                bodyDiameterMm: 0.8,
+                lengthMm: 2,
+                penetrationMm: 0,
+            },
+        },
+    } as SupportState['branches'][string];
+
+    const targets = buildSupportPathSnapTargets(state, { includeTrunks: false, includeBranches: true });
+    const target = targets.find((entry) => entry.id === 'branch-seg-1');
+    assert.ok(target?.pathSegment);
+
+    const expectedEnd = getFinalSocketPosition(state.branches['branch-1'].contactCone!);
+    assert.deepEqual(target.pathSegment.end, expectedEnd);
+});

--- a/src/supports/__tests__/trunkBuilderRouteAuthority.test.ts
+++ b/src/supports/__tests__/trunkBuilderRouteAuthority.test.ts
@@ -79,3 +79,25 @@ test('buildTrunkDataFromPlacement preserves a solver-authored offset socket in t
     assert.equal(built.trunk.contactCone.pos.y, 0);
     assert.equal(built.trunk.contactCone.normal.x > 0, true);
 });
+
+    test('buildTrunkDataFromPlacement normalizes routed joints into a strictly rising base-to-socket chain', () => {
+        const built = buildTrunkDataFromPlacement(
+            makeInput(),
+            makePlacement({
+                socketPos: { x: 0, y: 0, z: 15 },
+                joints: [
+                    { x: 0, y: 0, z: 10 },
+                    { x: 0, y: 0, z: 5 },
+                ],
+                constructionJoints: [],
+            }),
+        );
+
+        assert.deepEqual(built.route.joints, [
+            { x: 0, y: 0, z: 5 },
+            { x: 0, y: 0, z: 10 },
+        ]);
+
+        const segmentTops = built.trunk.segments.map((segment) => segment.topJoint?.pos.z ?? built.route.socketPos.z);
+        assert.deepEqual(segmentTops, [5, 10, 15]);
+    });

--- a/src/supports/__tests__/trunkBuilderRouteAuthority.test.ts
+++ b/src/supports/__tests__/trunkBuilderRouteAuthority.test.ts
@@ -65,3 +65,17 @@ test('buildTrunkDataFromPlacement still inserts a construction joint for straigh
     assert.equal(built.route.constructionJoints.length, 1);
     assert.equal(built.trunk.segments.length, 2);
 });
+
+test('buildTrunkDataFromPlacement preserves a solver-authored offset socket in the cone geometry', () => {
+    const built = buildTrunkDataFromPlacement(
+        makeInput(),
+        makePlacement({
+            socketPos: { x: 2, y: 0, z: 10 },
+        }),
+    );
+
+    assert.deepEqual(built.route.socketPos, { x: 2, y: 0, z: 10 });
+    assert.equal(built.trunk.contactCone.pos.x, 0);
+    assert.equal(built.trunk.contactCone.pos.y, 0);
+    assert.equal(built.trunk.contactCone.normal.x > 0, true);
+});

--- a/src/supports/__tests__/trunkPathfindingCommittedBase.test.ts
+++ b/src/supports/__tests__/trunkPathfindingCommittedBase.test.ts
@@ -64,3 +64,27 @@ test('resolveCommittedBaseCandidate rejects snapped nodes whose final inbound se
 
     assert.equal(resolved, null);
 });
+
+test('resolveCommittedBaseCandidate prefers a farther snapped base when it makes the bottom-most shaft straighter', () => {
+    const sdf = makeOpenSdf();
+
+    const resolved = resolveCommittedBaseCandidate({
+        preferredBottomPos: { x: 0.2, y: 0, z: 0 },
+        lastSegmentStart: { x: 4, y: 0, z: 6 },
+        rootTopZ: 3,
+        gridEnabled: true,
+        spacingMm: 4,
+        maxNearestNodeSearchRings: 1,
+        sdf,
+        diskHeight: 1,
+        coneHeight: 2,
+        rootsRadius: 1.5,
+        shaftRadius: 0.75,
+        clearance: 0.8,
+        buildNearestCandidateNodeKeys: () => ['0,0', '1,0'],
+    });
+
+    assert.ok(resolved);
+    assert.deepEqual(resolved?.basePos, { x: 4, y: 0, z: 0 });
+    assert.equal(resolved?.inboundLateralMm, 0);
+});

--- a/src/supports/__tests__/trunkPathfindingCommittedBase.test.ts
+++ b/src/supports/__tests__/trunkPathfindingCommittedBase.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildNearestCandidateNodeKeys } from '../PlacementLogic/Grid/nearestCandidateNodeKeys';
+import { resolveCommittedBaseCandidate } from '../PlacementLogic/Pathfinding/SmartPlacementV2';
+import type { SDFCache } from '../PlacementLogic/Pathfinding/SDFCache';
+
+function makeOpenSdf(overrides?: Partial<Pick<SDFCache, 'distanceAt' | 'isBlocked' | 'segmentBlocked'>>): SDFCache {
+    return {
+        cellSize: 0.5,
+        distanceAt: () => Infinity,
+        isBlocked: () => false,
+        segmentBlocked: () => false,
+        ...overrides,
+    } as SDFCache;
+}
+
+test('resolveCommittedBaseCandidate falls through to a farther snapped node when the nearest base is blocked', () => {
+    const sdf = makeOpenSdf({
+        distanceAt: (x: number, y: number) => (Math.abs(x) < 0.001 && Math.abs(y) < 0.001 ? 0 : Infinity),
+    });
+
+    const resolved = resolveCommittedBaseCandidate({
+        preferredBottomPos: { x: 0, y: 0, z: 0 },
+        lastSegmentStart: { x: 0, y: 0, z: 6 },
+        rootTopZ: 3,
+        gridEnabled: true,
+        spacingMm: 4,
+        maxNearestNodeSearchRings: 1,
+        sdf,
+        diskHeight: 1,
+        coneHeight: 2,
+        rootsRadius: 1.5,
+        shaftRadius: 0.75,
+        clearance: 0.8,
+        buildNearestCandidateNodeKeys,
+    });
+
+    assert.ok(resolved);
+    assert.deepEqual(resolved?.basePos, { x: -4, y: 0, z: 0 });
+    assert.equal(resolved?.nodeKey, '-1,0');
+});
+
+test('resolveCommittedBaseCandidate rejects snapped nodes whose final inbound segment is blocked', () => {
+    const sdf = makeOpenSdf({
+        segmentBlocked: (_ax: number, _ay: number, _az: number, bx: number) => Math.abs(bx - 4) < 0.001,
+    });
+
+    const resolved = resolveCommittedBaseCandidate({
+        preferredBottomPos: { x: 0, y: 0, z: 0 },
+        lastSegmentStart: { x: 0, y: 0, z: 6 },
+        rootTopZ: 3,
+        gridEnabled: true,
+        spacingMm: 4,
+        maxNearestNodeSearchRings: 1,
+        sdf,
+        diskHeight: 1,
+        coneHeight: 2,
+        rootsRadius: 1.5,
+        shaftRadius: 0.75,
+        clearance: 0.8,
+        buildNearestCandidateNodeKeys: () => ['1,0'],
+    });
+
+    assert.equal(resolved, null);
+});

--- a/src/supports/__tests__/trunkPathfindingSearchEnvelope.test.ts
+++ b/src/supports/__tests__/trunkPathfindingSearchEnvelope.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getSmartPlacementV2SearchEnvelope } from '../PlacementLogic/Pathfinding/SmartPlacementV2';
+
+const makePos = (z: number) => ({ x: 0, y: 0, z });
+
+test('search envelope keeps the historical 60 mm minimum reach for short supports', () => {
+    const envelope = getSmartPlacementV2SearchEnvelope({
+        socketPos: makePos(20),
+        rootTopZ: 0,
+        spacingMm: 4,
+    });
+
+    assert.equal(envelope.maxTotalLateralMm, 60);
+    assert.deepEqual(envelope.rescueSweepRadiiMm.slice(-2), [52, 60]);
+});
+
+test('search envelope expands with taller supports and appends the computed outer radius', () => {
+    const envelope = getSmartPlacementV2SearchEnvelope({
+        socketPos: makePos(25),
+        rootTopZ: 0,
+        spacingMm: 4,
+    });
+
+    assert.equal(envelope.maxTotalLateralMm, 75);
+    assert.equal(envelope.rescueSweepRadiiMm.includes(72), true);
+    assert.equal(envelope.rescueSweepRadiiMm[envelope.rescueSweepRadiiMm.length - 1], 75);
+});
+
+test('search envelope caps very tall supports so the router does not wander unboundedly', () => {
+    const envelope = getSmartPlacementV2SearchEnvelope({
+        socketPos: makePos(80),
+        rootTopZ: 0,
+        spacingMm: 4,
+    });
+
+    assert.equal(envelope.maxTotalLateralMm, 120);
+    assert.equal(envelope.rescueSweepRadiiMm[envelope.rescueSweepRadiiMm.length - 1], 120);
+});

--- a/src/supports/__tests__/trunkPathfindingSocketRescue.test.ts
+++ b/src/supports/__tests__/trunkPathfindingSocketRescue.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    buildStraightSocketRescueCandidates,
+    findStraightSocketRescueCandidate,
+} from '../PlacementLogic/Pathfinding/SmartPlacementV2';
+import type { SDFCache } from '../PlacementLogic/Pathfinding/SDFCache';
+
+function makeOpenSdf(overrides?: Partial<Pick<SDFCache, 'distanceAt' | 'isBlocked' | 'segmentBlocked'>>): SDFCache {
+    return {
+        cellSize: 0.5,
+        distanceAt: () => Infinity,
+        isBlocked: () => false,
+        segmentBlocked: () => false,
+        ...overrides,
+    } as SDFCache;
+}
+
+test('buildStraightSocketRescueCandidates expands outward from the blocked socket', () => {
+    const candidates = buildStraightSocketRescueCandidates({
+        socketPos: { x: 0, y: 0, z: 10 },
+        maxTotalLateralMm: 2,
+    });
+
+    assert.deepEqual(candidates[0], { x: 0, y: 0, z: 10 });
+    assert.ok(candidates.some((candidate) => Math.abs(candidate.x - 1) < 0.000001 && Math.abs(candidate.y) < 0.000001));
+});
+
+test('findStraightSocketRescueCandidate finds a nearby clear straight support when the default socket column is blocked', () => {
+    const sdf = makeOpenSdf({
+        segmentBlocked: (ax: number, _ay: number, _az: number, bx: number) => Math.abs(ax) < 0.000001 && Math.abs(bx) < 0.000001,
+    });
+
+    const rescued = findStraightSocketRescueCandidate({
+        socketPos: { x: 0, y: 0, z: 10 },
+        rootTopZ: 2,
+        maxTotalLateralMm: 2,
+        gridEnabled: false,
+        spacingMm: 4,
+        maxNearestNodeSearchRings: 1,
+        sdf,
+        diskHeight: 1,
+        coneHeight: 1,
+        rootsRadius: 1.5,
+        shaftRadius: 0.75,
+        clearance: 1,
+    });
+
+    assert.ok(rescued);
+    assert.notDeepEqual(rescued?.socketPos, { x: 0, y: 0, z: 10 });
+    assert.equal(rescued?.base.basePos.z, 0);
+});

--- a/src/supports/__tests__/trunkPathfindingSocketRescue.test.ts
+++ b/src/supports/__tests__/trunkPathfindingSocketRescue.test.ts
@@ -63,22 +63,15 @@ test('findStraightSocketRescueCandidate finds a nearby clear straight support wh
     assert.equal(rescued?.base.basePos.z, 0);
 });
 
-test('findStraightSocketRescueCandidate prefers the less shallow cone direction when stretched rescue is unavoidable', () => {
-    const sdf = makeOpenSdf({
-        segmentBlocked: (ax: number, ay: number, _az: number, bx: number, by: number) => {
-            const blocksOrigin = Math.abs(ax) < 0.000001 && Math.abs(ay) < 0.000001 && Math.abs(bx) < 0.000001 && Math.abs(by) < 0.000001;
-            return blocksOrigin;
-        },
-    });
-
+test('findStraightSocketRescueCandidate rejects excessive contact disk to cone bend angles', () => {
     const rescued = findStraightSocketRescueCandidate({
         socketPos: { x: 0, y: 0, z: 10 },
         rootTopZ: 2,
-        maxTotalLateralMm: 1,
+        maxTotalLateralMm: 2,
         gridEnabled: false,
         spacingMm: 4,
         maxNearestNodeSearchRings: 1,
-        sdf,
+        sdf: makeOpenSdf(),
         diskHeight: 1,
         coneHeight: 1,
         rootsRadius: 1.5,
@@ -86,7 +79,7 @@ test('findStraightSocketRescueCandidate prefers the less shallow cone direction 
         clearance: 1,
         coneScoring: {
             tipPos: { x: 0, y: 0, z: 0 },
-            tipNormal: { x: 0, y: 1, z: 0 },
+            tipNormal: { x: 1, y: 0, z: 0 },
             tipProfile: {
                 type: 'disk',
                 contactDiameterMm: 0.3,
@@ -100,8 +93,7 @@ test('findStraightSocketRescueCandidate prefers the less shallow cone direction 
         },
     });
 
-    assert.ok(rescued);
-    assert.ok((rescued?.socketPos.y ?? 0) > 0.4, `expected rescue to prefer +Y-aligned cone, got (${rescued?.socketPos.x.toFixed(2)}, ${rescued?.socketPos.y.toFixed(2)})`);
+    assert.equal(rescued, null);
 });
 
 test('findMixedSocketRescueCandidate allows a small socket stretch plus a shaft bend before resorting to a farther straight rescue', () => {
@@ -129,7 +121,7 @@ test('findMixedSocketRescueCandidate allows a small socket stretch plus a shaft 
         maxAngleFromVerticalDeg: 80,
         coneScoring: {
             tipPos: { x: 0, y: 0, z: 0 },
-            tipNormal: { x: 1, y: 0, z: 0 },
+            tipNormal: { x: 0, y: 0, z: 1 },
             tipProfile: {
                 type: 'disk',
                 contactDiameterMm: 0.3,
@@ -146,6 +138,75 @@ test('findMixedSocketRescueCandidate allows a small socket stretch plus a shaft 
     assert.ok(rescued);
     assert.ok(Math.abs(rescued!.socketPos.x) <= 1.000001);
     assert.ok(rescued!.joints.length >= 1);
+});
+
+test('findMixedSocketRescueCandidate can require a shaft bend instead of accepting a zero-joint socket shift', () => {
+    const sdf = makeOpenSdf();
+
+    const zeroJointRescue = findMixedSocketRescueCandidate({
+        socketPos: { x: 0, y: 0, z: 2 },
+        rootTopZ: 0.5,
+        maxTotalLateralMm: 1,
+        gridEnabled: false,
+        spacingMm: 4,
+        maxNearestNodeSearchRings: 1,
+        sdf,
+        diskHeight: 0.25,
+        coneHeight: 0.25,
+        rootsRadius: 1.5,
+        shaftRadius: 0.75,
+        clearance: 1,
+        maxAngleFromVerticalDeg: 80,
+        coneScoring: {
+            tipPos: { x: 0, y: 0, z: 0 },
+            tipNormal: { x: 0, y: 0, z: 1 },
+            tipProfile: {
+                type: 'disk',
+                contactDiameterMm: 0.3,
+                bodyDiameterMm: 0.9,
+                lengthMm: 1.2,
+                penetrationMm: 0.15,
+                diskThicknessMm: 0.1,
+                maxStandoffMm: 0.35,
+                standoffAngleThreshold: Math.PI / 4,
+            },
+        },
+    });
+    const jointedRescue = findMixedSocketRescueCandidate({
+        socketPos: { x: 0, y: 0, z: 10 },
+        rootTopZ: 2,
+        maxTotalLateralMm: 1,
+        gridEnabled: false,
+        spacingMm: 4,
+        maxNearestNodeSearchRings: 1,
+        sdf,
+        diskHeight: 1,
+        coneHeight: 1,
+        rootsRadius: 1.5,
+        shaftRadius: 0.75,
+        clearance: 1,
+        maxAngleFromVerticalDeg: 80,
+        coneScoring: {
+            tipPos: { x: 0, y: 0, z: 0 },
+            tipNormal: { x: 0, y: 0, z: 1 },
+            tipProfile: {
+                type: 'disk',
+                contactDiameterMm: 0.3,
+                bodyDiameterMm: 0.9,
+                lengthMm: 1.2,
+                penetrationMm: 0.15,
+                diskThicknessMm: 0.1,
+                maxStandoffMm: 0.35,
+                standoffAngleThreshold: Math.PI / 4,
+            },
+        },
+        requireJoint: true,
+    });
+
+    assert.ok(zeroJointRescue);
+    assert.equal(zeroJointRescue!.joints.length, 0);
+    assert.ok(jointedRescue);
+    assert.ok(jointedRescue!.joints.length >= 1);
 });
 
 test('findMixedSocketRescueCandidate keeps the lower shaft under the last deviation instead of snapping back to the original socket column', () => {
@@ -173,7 +234,7 @@ test('findMixedSocketRescueCandidate keeps the lower shaft under the last deviat
         maxAngleFromVerticalDeg: 80,
         coneScoring: {
             tipPos: { x: 0, y: 0, z: 0 },
-            tipNormal: { x: 1, y: 0, z: 0 },
+            tipNormal: { x: 0, y: 0, z: 1 },
             tipProfile: {
                 type: 'disk',
                 contactDiameterMm: 0.3,

--- a/src/supports/__tests__/trunkPathfindingSocketRescue.test.ts
+++ b/src/supports/__tests__/trunkPathfindingSocketRescue.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
     buildStraightSocketRescueCandidates,
+    findMixedSocketRescueCandidate,
     findStraightSocketRescueCandidate,
 } from '../PlacementLogic/Pathfinding/SmartPlacementV2';
 import type { SDFCache } from '../PlacementLogic/Pathfinding/SDFCache';
@@ -25,6 +26,16 @@ test('buildStraightSocketRescueCandidates expands outward from the blocked socke
 
     assert.deepEqual(candidates[0], { x: 0, y: 0, z: 10 });
     assert.ok(candidates.some((candidate) => Math.abs(candidate.x - 1) < 0.000001 && Math.abs(candidate.y) < 0.000001));
+});
+
+test('buildStraightSocketRescueCandidates caps pure straight rescue stretch before mixed rescue takes over', () => {
+    const candidates = buildStraightSocketRescueCandidates({
+        socketPos: { x: 0, y: 0, z: 10 },
+        maxTotalLateralMm: 10,
+    });
+
+    const maxRadius = Math.max(...candidates.map((candidate) => Math.hypot(candidate.x, candidate.y)));
+    assert.ok(maxRadius <= 4.000001, `expected straight rescue max radius <= 4mm, got ${maxRadius.toFixed(2)}mm`);
 });
 
 test('findStraightSocketRescueCandidate finds a nearby clear straight support when the default socket column is blocked', () => {
@@ -50,4 +61,34 @@ test('findStraightSocketRescueCandidate finds a nearby clear straight support wh
     assert.ok(rescued);
     assert.notDeepEqual(rescued?.socketPos, { x: 0, y: 0, z: 10 });
     assert.equal(rescued?.base.basePos.z, 0);
+});
+
+test('findMixedSocketRescueCandidate allows a small socket stretch plus a shaft bend before resorting to a farther straight rescue', () => {
+    const sdf = makeOpenSdf({
+        segmentBlocked: (ax: number, _ay: number, _az: number, bx: number, _by: number) => {
+            const nearlyVertical = Math.abs(ax - bx) < 0.2;
+            const insideBlockedColumn = Math.abs(ax) < 1.05 && Math.abs(bx) < 1.05;
+            return nearlyVertical && insideBlockedColumn;
+        },
+    });
+
+    const rescued = findMixedSocketRescueCandidate({
+        socketPos: { x: 0, y: 0, z: 10 },
+        rootTopZ: 2,
+        maxTotalLateralMm: 4,
+        gridEnabled: false,
+        spacingMm: 4,
+        maxNearestNodeSearchRings: 1,
+        sdf,
+        diskHeight: 1,
+        coneHeight: 1,
+        rootsRadius: 1.5,
+        shaftRadius: 0.75,
+        clearance: 1,
+        maxAngleFromVerticalDeg: 80,
+    });
+
+    assert.ok(rescued);
+    assert.ok(Math.abs(rescued!.socketPos.x) <= 1.000001);
+    assert.ok(rescued!.joints.length >= 1);
 });

--- a/src/supports/__tests__/trunkPathfindingSocketRescue.test.ts
+++ b/src/supports/__tests__/trunkPathfindingSocketRescue.test.ts
@@ -63,6 +63,47 @@ test('findStraightSocketRescueCandidate finds a nearby clear straight support wh
     assert.equal(rescued?.base.basePos.z, 0);
 });
 
+test('findStraightSocketRescueCandidate prefers the less shallow cone direction when stretched rescue is unavoidable', () => {
+    const sdf = makeOpenSdf({
+        segmentBlocked: (ax: number, ay: number, _az: number, bx: number, by: number) => {
+            const blocksOrigin = Math.abs(ax) < 0.000001 && Math.abs(ay) < 0.000001 && Math.abs(bx) < 0.000001 && Math.abs(by) < 0.000001;
+            return blocksOrigin;
+        },
+    });
+
+    const rescued = findStraightSocketRescueCandidate({
+        socketPos: { x: 0, y: 0, z: 10 },
+        rootTopZ: 2,
+        maxTotalLateralMm: 1,
+        gridEnabled: false,
+        spacingMm: 4,
+        maxNearestNodeSearchRings: 1,
+        sdf,
+        diskHeight: 1,
+        coneHeight: 1,
+        rootsRadius: 1.5,
+        shaftRadius: 0.75,
+        clearance: 1,
+        coneScoring: {
+            tipPos: { x: 0, y: 0, z: 0 },
+            tipNormal: { x: 0, y: 1, z: 0 },
+            tipProfile: {
+                type: 'disk',
+                contactDiameterMm: 0.3,
+                bodyDiameterMm: 0.9,
+                lengthMm: 1.2,
+                penetrationMm: 0.15,
+                diskThicknessMm: 0.1,
+                maxStandoffMm: 0.35,
+                standoffAngleThreshold: Math.PI / 4,
+            },
+        },
+    });
+
+    assert.ok(rescued);
+    assert.ok((rescued?.socketPos.y ?? 0) > 0.4, `expected rescue to prefer +Y-aligned cone, got (${rescued?.socketPos.x.toFixed(2)}, ${rescued?.socketPos.y.toFixed(2)})`);
+});
+
 test('findMixedSocketRescueCandidate allows a small socket stretch plus a shaft bend before resorting to a farther straight rescue', () => {
     const sdf = makeOpenSdf({
         segmentBlocked: (ax: number, _ay: number, _az: number, bx: number, _by: number) => {
@@ -86,6 +127,20 @@ test('findMixedSocketRescueCandidate allows a small socket stretch plus a shaft 
         shaftRadius: 0.75,
         clearance: 1,
         maxAngleFromVerticalDeg: 80,
+        coneScoring: {
+            tipPos: { x: 0, y: 0, z: 0 },
+            tipNormal: { x: 1, y: 0, z: 0 },
+            tipProfile: {
+                type: 'disk',
+                contactDiameterMm: 0.3,
+                bodyDiameterMm: 0.9,
+                lengthMm: 1.2,
+                penetrationMm: 0.15,
+                diskThicknessMm: 0.1,
+                maxStandoffMm: 0.35,
+                standoffAngleThreshold: Math.PI / 4,
+            },
+        },
     });
 
     assert.ok(rescued);

--- a/src/supports/__tests__/trunkPathfindingSocketRescue.test.ts
+++ b/src/supports/__tests__/trunkPathfindingSocketRescue.test.ts
@@ -147,3 +147,49 @@ test('findMixedSocketRescueCandidate allows a small socket stretch plus a shaft 
     assert.ok(Math.abs(rescued!.socketPos.x) <= 1.000001);
     assert.ok(rescued!.joints.length >= 1);
 });
+
+test('findMixedSocketRescueCandidate keeps the lower shaft under the last deviation instead of snapping back to the original socket column', () => {
+    const sdf = makeOpenSdf({
+        segmentBlocked: (ax: number, _ay: number, _az: number, bx: number, _by: number) => {
+            const nearlyVertical = Math.abs(ax - bx) < 0.2;
+            const insideOriginColumn = Math.abs(ax) < 0.35 && Math.abs(bx) < 0.35;
+            return nearlyVertical && insideOriginColumn;
+        },
+    });
+
+    const rescued = findMixedSocketRescueCandidate({
+        socketPos: { x: 0, y: 0, z: 10 },
+        rootTopZ: 2,
+        maxTotalLateralMm: 0,
+        gridEnabled: false,
+        spacingMm: 4,
+        maxNearestNodeSearchRings: 1,
+        sdf,
+        diskHeight: 1,
+        coneHeight: 1,
+        rootsRadius: 1.5,
+        shaftRadius: 0.75,
+        clearance: 1,
+        maxAngleFromVerticalDeg: 80,
+        coneScoring: {
+            tipPos: { x: 0, y: 0, z: 0 },
+            tipNormal: { x: 1, y: 0, z: 0 },
+            tipProfile: {
+                type: 'disk',
+                contactDiameterMm: 0.3,
+                bodyDiameterMm: 0.9,
+                lengthMm: 1.2,
+                penetrationMm: 0.15,
+                diskThicknessMm: 0.1,
+                maxStandoffMm: 0.35,
+                standoffAngleThreshold: Math.PI / 4,
+            },
+        },
+    });
+
+    assert.ok(rescued);
+    assert.ok(rescued!.joints.length >= 1);
+    const lastJoint = rescued!.joints[rescued!.joints.length - 1];
+    assert.ok(Math.abs(rescued!.base.rootTopTarget.x - lastJoint.x) < 0.000001, `expected root-top target x=${rescued!.base.rootTopTarget.x.toFixed(2)} to stay under last joint x=${lastJoint.x.toFixed(2)}`);
+    assert.ok(Math.abs(rescued!.base.basePos.x - lastJoint.x) < 0.000001, `expected base x=${rescued!.base.basePos.x.toFixed(2)} to stay under last joint x=${lastJoint.x.toFixed(2)}`);
+});

--- a/src/supports/__tests__/trunkResolvedChainPreference.test.ts
+++ b/src/supports/__tests__/trunkResolvedChainPreference.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
     getResolvedChainMetrics,
     isResolvedChainReplacementBetter,
+    simplifyJointsSDF,
 } from '../PlacementLogic/Pathfinding/SmartPlacementV2';
 import type { Vec3 } from '../types';
 
@@ -34,4 +35,47 @@ test('resolved-chain comparison still allows fewer joints when upper-span qualit
     const straighter = getResolvedChainMetrics(socketPos, [], { x: 0.15, y: 0, z: 2 });
 
     assert.equal(isResolvedChainReplacementBetter(straighter, current), true);
+});
+
+test('simplifyJointsSDF collapses clear zig-zag joint clusters', () => {
+    const sdf = {
+        segmentBlocked: () => false,
+    } as any;
+
+    const simplified = simplifyJointsSDF(
+        [
+            { x: 0.8, y: 0, z: 9 },
+            { x: 0.2, y: 0, z: 7 },
+            { x: 0.35, y: 0, z: 5 },
+        ],
+        socketPos,
+        { x: 0.25, y: 0, z: 2 },
+        sdf,
+        0.5,
+        80,
+    );
+
+    assert.deepEqual(simplified, []);
+});
+
+test('simplifyJointsSDF keeps the early upper-span drop while removing lower zig-zag joints', () => {
+    const sdf = {
+        segmentBlocked: () => false,
+    } as any;
+    const topPreservingJoint = { x: 0.2, y: 0, z: 8.5 };
+
+    const simplified = simplifyJointsSDF(
+        [
+            topPreservingJoint,
+            { x: 2.2, y: 0, z: 5 },
+            { x: 1.8, y: 0, z: 3.8 },
+        ],
+        socketPos,
+        { x: 4, y: 0, z: 2 },
+        sdf,
+        0.5,
+        80,
+    );
+
+    assert.deepEqual(simplified, [topPreservingJoint]);
 });

--- a/src/supports/__tests__/trunkResolvedChainPreference.test.ts
+++ b/src/supports/__tests__/trunkResolvedChainPreference.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    getResolvedChainMetrics,
+    isResolvedChainReplacementBetter,
+} from '../PlacementLogic/Pathfinding/SmartPlacementV2';
+import type { Vec3 } from '../types';
+
+const socketPos: Vec3 = { x: 0, y: 0, z: 12 };
+const rootTopTarget: Vec3 = { x: 3, y: 0, z: 2 };
+
+test('resolved-chain comparison prefers a more vertical upper span over fewer joints', () => {
+    const routed = getResolvedChainMetrics(
+        socketPos,
+        [
+            { x: 0.2, y: 0, z: 8.5 },
+            { x: 2.2, y: 0, z: 5 },
+        ],
+        rootTopTarget,
+    );
+    const straight = getResolvedChainMetrics(socketPos, [], rootTopTarget);
+
+    assert.equal(isResolvedChainReplacementBetter(straight, routed), false);
+    assert.equal(isResolvedChainReplacementBetter(routed, straight), true);
+});
+
+test('resolved-chain comparison still allows fewer joints when upper-span quality is not worsened', () => {
+    const current = getResolvedChainMetrics(
+        socketPos,
+        [{ x: 0.1, y: 0, z: 7 }],
+        { x: 0.2, y: 0, z: 2 },
+    );
+    const straighter = getResolvedChainMetrics(socketPos, [], { x: 0.15, y: 0, z: 2 });
+
+    assert.equal(isResolvedChainReplacementBetter(straighter, current), true);
+});

--- a/src/supports/autoBracing/autoBrace.ts
+++ b/src/supports/autoBracing/autoBrace.ts
@@ -37,12 +37,10 @@ import { buildBraceProfile } from './braceDiameter';
 import { linePassesMeshClearance } from './meshClearance';
 
 const EPS = 0.000001;
-const SQRT2 = Math.SQRT2;
-
 type SupportKind = 'trunk' | 'branch' | 'kickstand';
 
 function maxHorizontalRunFromBraceLen(maxBraceLenMm: number): number {
-    return maxBraceLenMm / SQRT2;
+    return maxBraceLenMm;
 }
 
 type SegmentSample = {
@@ -427,6 +425,17 @@ export function buildAutoBracedSnapshot(snapshot: SupportState, inputSettings: A
     const activeGridSettings = getSettings().grid;
     const maxRun = maxHorizontalRunFromBraceLen(settings.maxBraceLengthMm);
     const trunkSamples = buildSupportSamples(snapshot).filter(s => s.supportKind === 'trunk');
+
+    if (trunkSamples.length < AUTO_BRACING_HARD_RULES.minGroupSize) {
+        return {
+            snapshot,
+            generatedBraceCount: 0,
+            removedBraceCount: 0,
+            skippedSupportCount: trunkSamples.length,
+            changed: false,
+            message: "No eligible supports found for Auto Bracing.",
+        };
+    }
 
     let kickstandState = getKickstandSnapshot();
     {
@@ -893,8 +902,8 @@ export function buildAutoBracedSnapshot(snapshot: SupportState, inputSettings: A
                     if (!ignoreMaxDistance && !isCardinalDelta(dx, dy, activeGridSettings.spacingMm)) return;
                 }
 
-                const braceLen = Math.sqrt(dx * dx + dy * dy + dz * dz);
-                if (!ignoreMaxDistance && braceLen > settings.maxBraceLengthMm + EPS) return;
+                const horizontalSpan = Math.sqrt(dx * dx + dy * dy);
+                if (!ignoreMaxDistance && horizontalSpan > settings.maxBraceLengthMm + EPS) return;
 
                 if (!linePassesMeshClearance(lowAnchor.pos, highAnchor.pos, lowAnchor.modelId, settings.braceDiameterMm)) return;
 

--- a/src/supports/autoBracing/generativeBracing.ts
+++ b/src/supports/autoBracing/generativeBracing.ts
@@ -37,8 +37,7 @@ export function generateRequiredKickstands(
     const meshEntries = getAllMeshEntriesForAutoBrace();
     const generatedKickstands: KickstandBuildResult[] = [];
 
-    // The maximum horizontal run a brace can physically reach based on the 3D max length setting
-    const maxHorizontalRun = settings.maxBraceLengthMm / Math.SQRT2;
+    const maxHorizontalRun = settings.maxBraceLengthMm;
     // We want the new kickstand to generate well within the max run so it definitely connects.
     const GENERATION_DISTANCE_MM = Math.min(5.0, maxHorizontalRun * 0.8);
 

--- a/src/supports/autoBracing/heightCoverageAnalysis.ts
+++ b/src/supports/autoBracing/heightCoverageAnalysis.ts
@@ -33,7 +33,7 @@ export function analyzeTrunkHeightCoverage(
         grid: GridSettings;
     },
 ): HeightCoverageAnalysis {
-    const maxHorizontalRun = options.maxBraceLengthMm / Math.SQRT2;
+    const maxHorizontalRun = options.maxBraceLengthMm;
     const requiredTopCoverageBandMm = Math.max(options.patternIntervalMm, TOP_COVERAGE_MARGIN_MIN_MM);
     const requiredAnchorZ = trunk.topZ - requiredTopCoverageBandMm;
 

--- a/src/supports/interaction/shared/placement/snapping/supportPathTargets.ts
+++ b/src/supports/interaction/shared/placement/snapping/supportPathTargets.ts
@@ -1,6 +1,6 @@
 import type { SnapTarget } from '../../../SnappingManager';
 import type { SupportState, Vec3, Brace, Knot } from '../../../../types';
-import { getSocketPosition } from '../../../../SupportPrimitives/ContactCone';
+import { getFinalSocketPosition } from '../../../../SupportPrimitives/ContactCone';
 import type { ContactCone } from '../../../../SupportPrimitives/ContactCone/types';
 import { calculateDiskThickness } from '../../../../SupportPrimitives/ContactDisk/contactDiskUtils';
 import { JOINT_DIAMETER_OFFSET_MM } from '../../../../constants';
@@ -106,11 +106,7 @@ export function buildSupportPathSnapTargets(
                 const endPoint = segment.topJoint
                     ? cloneVec3(segment.topJoint.pos)
                     : trunk.contactCone
-                        ? getSocketPosition(
-                            trunk.contactCone.pos,
-                            trunk.contactCone.normal,
-                            trunk.contactCone.profile
-                        )
+                        ? getFinalSocketPosition(trunk.contactCone)
                         : { x: currentStart.x, y: currentStart.y, z: currentStart.z + 10 };
 
                 if (!shouldExclude(segment.id, excludeSegmentIds)) {
@@ -144,11 +140,7 @@ export function buildSupportPathSnapTargets(
                 const endPoint = segment.topJoint
                     ? cloneVec3(segment.topJoint.pos)
                     : branch.contactCone
-                        ? getSocketPosition(
-                            branch.contactCone.pos,
-                            branch.contactCone.normal,
-                            branch.contactCone.profile
-                        )
+                        ? getFinalSocketPosition(branch.contactCone)
                         : { x: currentStart.x, y: currentStart.y, z: currentStart.z + 5 };
 
                 if (!shouldExclude(segment.id, excludeSegmentIds)) {

--- a/src/supports/state.ts
+++ b/src/supports/state.ts
@@ -756,9 +756,11 @@ function normalizeLoadedKnotAndLeafGeometry(snapshot: Pick<SupportState, 'roots'
 
             const t = computeClosestTOnSegmentFromPoint(authoredPos, activeEndpoints.start, activeEndpoints.end, activeSegment);
             const computedPos = calculateKnotPositionOnSegmentFromT(activeEndpoints.start, activeEndpoints.end, activeSegment, t);
+            const effectiveNormalizationHint = knot.normalizationHint ?? knot._importHint;
+
             const preserveImportedBraceUniformDiameter =
                 braceHostKnotIds.has(knot.id)
-                && knot._importHint === 'braceImported'
+                && effectiveNormalizationHint === 'braceImported'
                 && Number.isFinite(knot.diameter as number);
             const computedDiameter = preserveImportedBraceUniformDiameter
                 ? (knot.diameter as number)
@@ -778,7 +780,7 @@ function normalizeLoadedKnotAndLeafGeometry(snapshot: Pick<SupportState, 'roots'
             // This takes priority over all derived preserve rules to avoid the two systems
             // making conflicting decisions (e.g. leaf s85 vs back leaves both look identical
             // to heuristic rules but require opposite treatment).
-            const importHint = knot._importHint;
+            const importHint = effectiveNormalizationHint;
             if (importHint === 'project') {
                 const posChanged =
                     computedPos.x !== knot.pos.x ||
@@ -907,15 +909,18 @@ function normalizeLoadedKnotAndLeafGeometry(snapshot: Pick<SupportState, 'roots'
         finalKnots = braceSeg2.knots;
     }
 
-    // Strip import hints from final output — they are consumed by normalization
-    // and must not persist into the runtime support state.
-    const hasAnyHints = Object.values(finalKnots).some(k => k._importHint !== undefined);
-    if (hasAnyHints) {
+    // Strip transient import hints from final runtime output, but persist the resolved
+    // normalization intent so VOXL save/load roundtrips can replay the same behavior.
+    const hasAnyTransientImportHints = Object.values(finalKnots).some(k => k._importHint !== undefined);
+    if (hasAnyTransientImportHints) {
         const stripped: Record<string, Knot> = {};
         for (const [id, k] of Object.entries(finalKnots)) {
             if (k._importHint !== undefined) {
-                const { _importHint: _, ...rest } = k;
-                stripped[id] = rest;
+                const { _importHint: transientImportHint, ...rest } = k;
+                stripped[id] = {
+                    ...rest,
+                    normalizationHint: rest.normalizationHint ?? transientImportHint,
+                };
             } else {
                 stripped[id] = k;
             }

--- a/src/supports/types.ts
+++ b/src/supports/types.ts
@@ -71,8 +71,15 @@ export interface Knot {
     pos: Vec3; // World position on the host shaft
     diameter?: number; // Host shaft diameter + 0.1mm (computed at creation if absent)
     /**
+     * Persistent normalization intent that should survive save/load roundtrips.
+     * Used when imported support geometry needs deterministic preserve/project behavior
+     * instead of falling back to heuristics on subsequent reloads.
+     */
+    normalizationHint?: 'preserve' | 'project' | 'braceImported';
+    /**
      * Import-time hint stamped by converters (e.g. LYS).
-     * Consumed and stripped by normalizeLoadedKnotAndLeafGeometry.
+     * Consumed by normalizeLoadedKnotAndLeafGeometry and promoted into
+     * `normalizationHint` for roundtrip-stable persistence.
      * 'preserve' → keep authored pos; 'project' → project to shaft geometry.
      * Not present for runtime-created knots.
      */


### PR DESCRIPTION
**feat: Pathfinding V3 support routing**
- Reworks support pathfinding, socket rescue, committed base selection, and resolved-chain ranking for more reliable routed trunks
- Adds auto-leaf placement, cone-axis policy updates, and raft/export plumbing needed for the new routing behavior
- Extends VOXL roundtrip and pathfinding coverage with focused regression tests across routing, rescue, and rendering paths

**fix: support placement follow-up**
- Resolves the mixed socket rescue pruning issue after rebasing onto the latest remote branch
- Aligns auto-bracing reach checks with horizontal span behavior so close supports still brace correctly and undersized groups stay unchanged
- Syncs `package-lock.json` to version `0.1.7`

**chore: reviewer notes**
- `npm run build` and `npm test` are green on this branch
- `npm run lint` still fails on pre-existing plugin files under `plugins/` with `no-explicit-any` errors unrelated to this PR