### PR TITLE
chore: enhance nightly build workflow with access checks for collaborators

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -38,8 +38,50 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: read
     steps:
+      - name: Check commenter has write access
+        id: check_access
+        uses: actions/github-script@v7
+        env:
+          COMMENT_USER: ${{ github.event.comment.user.login }}
+        with:
+          result-encoding: string
+          script: |
+            const commentUser = process.env.COMMENT_USER;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username: commentUser,
+              });
+              const permission = data.permission;
+              const hasWrite = ['write', 'admin', 'maintain'].includes(permission);
+              core.info(`User ${commentUser} has ${permission} permission — ${hasWrite ? 'granted' : 'denied'}.`);
+              return hasWrite ? 'granted' : 'denied';
+            } catch (e) {
+              if (e.status === 404) {
+                core.warning(`User ${commentUser} is not a collaborator — denied.`);
+                return 'denied';
+              }
+              throw e;
+            }
+
+      - name: Abort if not authorized
+        if: steps.check_access.outputs.result != 'granted'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          gh issue comment "$PR" \
+            --repo "${{ github.repository }}" \
+            --body "❌ Sorry, only collaborators with write access can trigger nightly builds."
+
       - name: Add nightly-build label
+        if: steps.check_access.outputs.result == 'granted'
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.issue.number }}
@@ -47,6 +89,7 @@ jobs:
           gh issue edit "$PR" --add-label "${{ env.NIGHTLY_LABEL }}" --repo "${{ github.repository }}"
 
       - name: Acknowledge activation
+        if: steps.check_access.outputs.result == 'granted'
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.issue.number }}
@@ -60,7 +103,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
-       contains(github.event.pull_request.labels.*.name, env.NIGHTLY_LABEL))
+       contains(github.event.pull_request.labels.*.name, 'nightly-build'))
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.branch.outputs.branch }}


### PR DESCRIPTION
Implement access checks to ensure only collaborators with write permissions can trigger nightly builds, improving security and control over the workflow.