### PR TITLE
feat: Responsive layout changed for TopBar and Transform bar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -184,7 +184,6 @@ body {
     ),
     var(--surface-0);
   border-bottom: 1px solid var(--border-strong);
-  padding: 0 var(--space-4);
   gap: var(--space-3);
 }
 

--- a/src/components/controls/TransformToolbar.tsx
+++ b/src/components/controls/TransformToolbar.tsx
@@ -31,70 +31,73 @@ export function TransformToolbar({ mode, onModeChange }: TransformToolbarProps) 
 
   return (
     <div
-      className="fixed top-16 left-1/2 z-30 -translate-x-1/2 flex items-center pointer-events-auto"
-    >
-    <div
-      className="rounded-full"
-      style={{
-        padding: '2px',
-        background: 'linear-gradient(135deg, color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 70%), var(--border-subtle), color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 70%))',
-        boxShadow: '0 4px 20px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(0, 0, 0, 0.2)',
-      }}
+      id="transform-toolbar"
+      className="fixed top-16 left-1/2 z-30 -translate-x-1/2 flex w-auto items-center pointer-events-auto"
     >
       <div
-        className={`relative grid items-center rounded-full px-1 py-1 ${
-          buttons.length === 6
-            ? 'grid-cols-6'
-            : buttons.length === 5
-              ? 'grid-cols-5'
-              : 'grid-cols-4'
-        }`}
+        className="rounded-full"
         style={{
-          background: 'color-mix(in srgb, var(--surface-0), var(--surface-1) 50%)',
-          backdropFilter: 'blur(12px)',
+          padding: '2px',
+          background: 'linear-gradient(135deg, color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 70%), var(--border-subtle), color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 70%))',
+          boxShadow: '0 4px 20px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(0, 0, 0, 0.2)',
         }}
       >
         <div
-          className="pointer-events-none absolute left-1 top-1 bottom-1 rounded-full transition-transform duration-300 ease-out"
+          className={`relative rounded-full px-1 py-1`}
           style={{
-            width: `calc((100% - 8px) / ${buttons.length})`,
-            transform: `translateX(${activeIndex * 100}%)`,
-            background: 'var(--accent-secondary)',
-            boxShadow: '0 2px 12px color-mix(in srgb, var(--accent-secondary), transparent 50%)',
+            background: 'color-mix(in srgb, var(--surface-0), var(--surface-1) 50%)',
+            backdropFilter: 'blur(12px)',
           }}
-        />
+        >
+          <div
+            className="pointer-events-none absolute left-1 top-1 bottom-1 rounded-full transition-transform duration-300 ease-out"
+            style={{
+              width: `calc((100% - 8px) / ${buttons.length})`,
+              transform: `translateX(${activeIndex * 100}%)`,
+              background: 'var(--accent-secondary)',
+              boxShadow: '0 2px 12px color-mix(in srgb, var(--accent-secondary), transparent 50%)',
+            }}
+          />
 
-        {buttons.map((btn) => {
-          const active = mode === btn.mode;
-          const hovered = hoveredMode === btn.mode;
+          <div className={`grid ${
+            buttons.length === 6
+              ? 'grid-cols-6'
+              : buttons.length === 5
+                ? 'grid-cols-5'
+                : 'grid-cols-4'
+          }`}>
+            {buttons.map((btn) => {
+              const active = mode === btn.mode;
+              const hovered = hoveredMode === btn.mode;
 
-          return (
-            <button
-              key={btn.mode}
-              onClick={() => handleModeClick(btn.mode)}
-              onMouseEnter={() => setHoveredMode(btn.mode)}
-              onMouseLeave={() => setHoveredMode((prev) => (prev === btn.mode ? null : prev))}
-              className={`relative z-[1] flex w-[112px] items-center justify-center gap-1.5 rounded-full px-3.5 py-2 text-[11px] font-semibold uppercase tracking-wider transition-all duration-200 active:scale-[0.98] ${
-                active
-                  ? 'scale-[1.01]'
-                  : 'hover:-translate-y-[1px] hover:shadow-[0_4px_14px_rgba(0,0,0,0.22)]'
-              }`}
-              style={active ? {
-                color: '#000000',
-              } : {
-                background: hovered
-                  ? 'color-mix(in srgb, var(--surface-2), transparent 18%)'
-                  : 'transparent',
-                color: hovered ? 'var(--text-strong)' : 'var(--text-muted)',
-              }}
-              title={`${btn.label} • ${btn.hint}`}
-            >
-              <span>{btn.icon}</span>
-              <span>{btn.label}</span>
-            </button>
-          );
-        })}
-      </div>
+              return (
+                <button
+                  key={btn.mode}
+                  onClick={() => handleModeClick(btn.mode)}
+                  onMouseEnter={() => setHoveredMode(btn.mode)}
+                  onMouseLeave={() => setHoveredMode((prev) => (prev === btn.mode ? null : prev))}
+                  className={`z-[1] flex items-center justify-center gap-0.5 lg:gap-1.5 rounded-full px-1 lg:px-3.5 py-2 text-[11px] font-semibold uppercase xl:tracking-wider transition-all duration-200 active:scale-[0.98] ${
+                    active
+                      ? 'scale-[1.01]'
+                      : 'hover:-translate-y-[1px] hover:shadow-[0_4px_14px_rgba(0,0,0,0.22)]'
+                  }`}
+                  style={active ? {
+                    color: '#000000',
+                  } : {
+                    background: hovered
+                      ? 'color-mix(in srgb, var(--surface-2), transparent 18%)'
+                      : 'transparent',
+                    color: hovered ? 'var(--text-strong)' : 'var(--text-muted)',
+                  }}
+                  title={`${btn.label} • ${btn.hint}`}
+                >
+                  <span>{btn.icon}</span>
+                  <span style={{whiteSpace:"nowrap"}}>{btn.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
       </div>
 
     </div>

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -626,7 +626,7 @@ export function TopBar({
 
   return (
     <div
-      className="ui-topbar fixed top-0 left-0 right-0 z-50 flex items-center relative"
+      className="ui-topbar px-2 xl:px-4 fixed top-0 left-0 right-0 z-50 flex items-center relative"
       onMouseDownCapture={handleTopBarPointerDown}
     >
       <div
@@ -665,7 +665,7 @@ export function TopBar({
         </button>
 
         <div
-          className="h-6 w-px mx-0.5 shrink-0"
+          className="h-6 w-px mx-0 shrink-0 hidden xl:block"
           style={{ background: 'color-mix(in srgb, var(--border-subtle), transparent 24%)' }}
           aria-hidden="true"
         />
@@ -685,7 +685,7 @@ export function TopBar({
             }
             requestOpenProfileSettings('printer');
           }}
-          className="group inline-flex h-10 max-w-[300px] items-center gap-2 rounded-md px-2 transition-colors"
+          className="group inline-flex h-10 max-w-[300px] items-center gap-2 rounded-md xl:px-2 transition-colors"
           style={{
             background: 'transparent',
           }}
@@ -925,7 +925,7 @@ export function TopBar({
 
       <div className="pointer-events-none absolute inset-x-0 flex justify-center px-2">
         <div
-          className={`relative w-full max-w-[760px] transition-opacity ${topbarActionsDisabled ? 'opacity-45' : ''}`}
+          className={`relative max-w-[760px] transition-opacity ${topbarActionsDisabled ? 'opacity-45' : ''}`}
           aria-disabled={topbarActionsDisabled}
         >
           <div
@@ -933,7 +933,7 @@ export function TopBar({
             style={{ background: 'color-mix(in srgb, var(--border-subtle), transparent 10%)' }}
           />
 
-          <div className={`relative grid grid-cols-5 gap-2 ${topbarActionsDisabled ? 'pointer-events-none' : 'pointer-events-auto'}`}>
+          <div className={`relative grid grid-cols-5 gap-1 xl:gap-2 ${topbarActionsDisabled ? 'pointer-events-none' : 'pointer-events-auto'}`}>
             {steps.map((item) => {
               const active = mode === item.mode;
               const locked = item.locked;
@@ -953,7 +953,7 @@ export function TopBar({
                   }}
                   disabled={nativeDisabled}
                   aria-disabled={disabled}
-                  className={`group relative flex cursor-pointer items-center gap-2 rounded-lg border px-2.5 py-2 transition-all duration-180 ${
+                  className={`group relative flex cursor-pointer items-center gap-2 rounded-lg border px-1 xl:px-2.5 py-2 transition-all duration-180 ${
                     active
                       ? 'shadow-[0_6px_16px_rgba(0,0,0,0.25)]'
                       : 'hover:-translate-y-[1px] hover:shadow-[0_6px_14px_rgba(0,0,0,0.18)]'
@@ -1037,7 +1037,7 @@ export function TopBar({
       </div>
 
       <div className="ml-auto flex w-[320px] items-center justify-end gap-2 pr-2">
-        <div className={`flex items-center gap-2 transition-opacity ${topbarActionsDisabled ? 'opacity-45 pointer-events-none' : ''}`}>
+        <div className={`flex items-center gap-1 xl:gap-2 transition-opacity ${topbarActionsDisabled ? 'opacity-45 pointer-events-none' : ''}`}>
           {showLayoutWarning && (
             <div className="relative group" data-no-window-drag="true">
               <Button


### PR DESCRIPTION
Added responsive hints and improved collapsing down to smaller screen widths for TopBar and Transform bar.

<img width="1033" height="301" alt="image" src="https://github.com/user-attachments/assets/eefd383c-c5a5-4c9a-b768-6cf363eec616" />
