### PR TITLE
feat: Add independent wait times for bottom layers + fixes in CTB

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -16,6 +16,10 @@ on:
         description: PR number (for fork PR checkout)
         required: false
         type: string
+      release_name:
+        description: Override release name (e.g. "Feature: Test"). Inferred from branch if empty.
+        required: false
+        type: string
   issue_comment:
     types:
       - created
@@ -120,6 +124,26 @@ jobs:
               core.info(`PR is from a fork (${pr.head.repo.full_name}) — will dispatch on base ref.`);
             }
 
+      - name: Extract custom release name from comment
+        id: extract_name
+        if: steps.check_access.outputs.result == 'granted'
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const body = context.payload.comment.body;
+            // Everything after "/nightly " (with trailing space) is the custom name
+            const prefix = '/nightly';
+            if (body.startsWith(prefix)) {
+              const rest = body.slice(prefix.length).trim();
+              if (rest) {
+                core.info(`Custom release name detected: "${rest}"`);
+                return rest;
+              }
+            }
+            core.info('No custom release name in comment.');
+            return '';
+
       - name: Add nightly-build label
         if: steps.check_access.outputs.result == 'granted'
         env:
@@ -134,12 +158,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HEAD_BRANCH: ${{ steps.pr_info.outputs.head_ref }}
           BASE_BRANCH: ${{ steps.pr_info.outputs.base_ref }}
+          RELEASE_NAME: ${{ steps.extract_name.outputs.result }}
         run: |
-          gh workflow run build-nightly.yml \
-            --repo "${{ github.repository }}" \
-            --ref "$BASE_BRANCH" \
-            -f branch="$HEAD_BRANCH" \
-            -f pr_number="${{ github.event.issue.number }}"
+          CMD="gh workflow run build-nightly.yml \
+            --repo \"${{ github.repository }}\" \
+            --ref \"$BASE_BRANCH\" \
+            -f branch=\"$HEAD_BRANCH\" \
+            -f pr_number=\"${{ github.event.issue.number }}\""
+
+          if [[ -n "$RELEASE_NAME" ]]; then
+            CMD="$CMD -f release_name=\"$RELEASE_NAME\""
+          fi
+
+          eval "$CMD"
 
       - name: Acknowledge activation
         if: steps.check_access.outputs.result == 'granted'
@@ -200,6 +231,8 @@ jobs:
       - name: Derive release metadata
         id: meta
         shell: bash
+        env:
+          RELEASE_NAME_OVERRIDE: ${{ inputs.release_name }}
         run: |
           version="$(node -p "require('./package.json').version")"
           commit_hash="$(git rev-parse --short HEAD)"
@@ -210,24 +243,34 @@ jobs:
           safe_branch="${branch_name//\//_}"
 
           # Human-readable release name
-          human_name="$branch_name"
-          case "$branch_name" in
-            feat/*) human_name="Feature: ${branch_name#feat/}" ;;
-            fix/*)  human_name="Fix: ${branch_name#fix/}" ;;
-            chore/*) human_name="Chore: ${branch_name#chore/}" ;;
-            refactor/*) human_name="Refactor: ${branch_name#refactor/}" ;;
-            docs/*) human_name="Docs: ${branch_name#docs/}" ;;
-            perf/*) human_name="Perf: ${branch_name#perf/}" ;;
-            ci/*)   human_name="CI: ${branch_name#ci/}" ;;
-            *)      human_name="Nightly: ${branch_name}" ;;
-          esac
+          if [[ -n "$RELEASE_NAME_OVERRIDE" ]]; then
+            human_name="$RELEASE_NAME_OVERRIDE"
+          else
+            human_name="$branch_name"
+            case "$branch_name" in
+              feat/*) human_name="Feature: ${branch_name#feat/}" ;;
+              fix/*)  human_name="Fix: ${branch_name#fix/}" ;;
+              chore/*) human_name="Chore: ${branch_name#chore/}" ;;
+              refactor/*) human_name="Refactor: ${branch_name#refactor/}" ;;
+              docs/*) human_name="Docs: ${branch_name#docs/}" ;;
+              perf/*) human_name="Perf: ${branch_name#perf/}" ;;
+              ci/*)   human_name="CI: ${branch_name#ci/}" ;;
+              *)      human_name="Nightly: ${branch_name}" ;;
+            esac
 
-          # Capitalize the descriptive part
-          rest="${human_name#*: }"
-          prefix="${human_name%%: *}"
-          first_char="$(printf '%s' "${rest:0:1}" | tr '[:lower:]' '[:upper:]')"
-          capitalized="${first_char}${rest:1}"
-          human_name="${prefix}: ${capitalized}"
+            # Replace underscores and hyphens with spaces, then title-case each word
+            rest="${human_name#*: }"
+            prefix="${human_name%%: *}"
+            rest="${rest//_/ }"
+            rest="${rest//-/ }"
+            capitalized=""
+            for word in $rest; do
+              first="$(printf '%s' "${word:0:1}" | tr '[:lower:]' '[:upper:]')"
+              capitalized="${capitalized}${first}${word:1} "
+            done
+            capitalized="${capitalized% }"
+            human_name="${prefix}: ${capitalized}"
+          fi
 
           release_tag="nightly_${safe_branch}"
 

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
       release_name:
-        description: Override release name (e.g. "Feature: Test"). Inferred from branch if empty.
+        description: 'Override release name (e.g. "Feature: Test"). Inferred from branch if empty.'
         required: false
         type: string
   issue_comment:

--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -1,7 +1,7 @@
 name: PR macOS Build Check
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize
@@ -23,6 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
 
       - name: Setup Node.js


### PR DESCRIPTION
Summary
This PR exposes independent PWM control for bottom and normal layers, adds configurable bottom layer wait times tracked against their own layer count (separate from burn-in layers), and introduces a new Advanced Single Step Motion mode that enables per-layer settings in the CTB output.
Changes
Advanced Single Step Motion mode (formerly "SimpleBeta")
Adds a new motion profile mode — Advanced Single Step Motion — that exposes per-layer settings in the CTB output. This mode is designed for testing against the Saturn 4 Ultra in CTB mode and roughly matches the layout produced by Satellite's .goo export. The mode was initially introduced as SimpleBeta and renamed to better reflect its function.
Independent bottom layer wait times
Bottom layer wait times are now tracked independently from normal layer wait times, using a separate layer count. Note: Lychee 6.2.0 appears to ignore the "bottom wait before cure" field entirely in its CTB output — this implementation preserves that value correctly.
Separate bottom and normal layer PWM
Bottom layer PWM and normal layer PWM are now written as independent values, allowing finer control over exposure settings per layer type.
Fix: projector PWM not being applied
Resolved a bug where the projector PWM value was not being applied to the output file.
Build fixes
Resolved compilation issues to restore a clean build.
Testing
Validated output against a Satellite .goo export and a Lychee 6.2.0 CTB export on the Saturn 4 Ultra. Screenshots of the comparison are included in the PR comments.

Dependency:
Merge the following PR: Open-Resin-Alliance/df-plugin-ctb#2 before this one.