### PR TITLE
feat: Supports Presets & Various UI Improvements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -651,13 +651,13 @@ input[type="number"].no-spinners {
   }
 }
 
-/* One-shot 360° spin for the defaults icon button */
-@keyframes spinOnce {
+/* One-shot 360° counter-clockwise spin for the defaults icon button */
+@keyframes spinOnceCCW {
   0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  100% { transform: rotate(-360deg); }
 }
 .animate-spin-once {
-  animation: spinOnce 500ms ease-in-out;
+  animation: spinOnceCCW 500ms ease-in-out;
 }
 
 /* Themed custom scrollbar */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -651,6 +651,15 @@ input[type="number"].no-spinners {
   }
 }
 
+/* One-shot 360° spin for the defaults icon button */
+@keyframes spinOnce {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+.animate-spin-once {
+  animation: spinOnce 500ms ease-in-out;
+}
+
 /* Themed custom scrollbar */
 .custom-scrollbar {
   scrollbar-width: thin;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11826,7 +11826,61 @@ export default function Home() {
 
     const visibleModels = resolveArrangeVisibleModels(scope, explicitSelectedIds);
 
-    if (visibleModels.length <= 1) return;
+    if (visibleModels.length <= 1) {
+      if (visibleModels.length === 1) {
+        const model = visibleModels[0];
+        const t = getArrangeTransform(model);
+        const dims = getModelSupportAwareDimensionsMm(model, undefined, t);
+
+        const rawMinX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
+        const rawMaxX = rawMinX + scene.view3dSettings.widthMm;
+        const rawMinY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
+        const rawMaxY = rawMinY + scene.view3dSettings.depthMm;
+        const sm = scene.view3dSettings.safetyMarginMm;
+        const minX = rawMinX + Math.max(0, sm?.left ?? 0);
+        const maxX = rawMaxX - Math.max(0, sm?.right ?? 0);
+        const minY = rawMinY + Math.max(0, sm?.front ?? 0);
+        const maxY = rawMaxY - Math.max(0, sm?.back ?? 0);
+
+        let centerX: number;
+        let centerY: number;
+        if (arrangeAnchorMode === 'front_left') {
+          centerX = minX + dims.width * 0.5;
+          centerY = minY + dims.depth * 0.5;
+        } else if (arrangeAnchorMode === 'front_right') {
+          centerX = maxX - dims.width * 0.5;
+          centerY = minY + dims.depth * 0.5;
+        } else if (arrangeAnchorMode === 'back_left') {
+          centerX = minX + dims.width * 0.5;
+          centerY = maxY - dims.depth * 0.5;
+        } else if (arrangeAnchorMode === 'back_right') {
+          centerX = maxX - dims.width * 0.5;
+          centerY = maxY - dims.depth * 0.5;
+        } else {
+          centerX = (minX + maxX) * 0.5;
+          centerY = (minY + maxY) * 0.5;
+        }
+
+        // Arrange and Duplicate previews should never overlap.
+        setDuplicateApplySourceModel(null);
+        setDuplicateApplySourceTransform(null);
+        setDuplicateSourcePreviewTransform(null);
+        setDuplicatePreviewTransforms([]);
+        setDuplicateTotalCopies(1);
+
+        applyArrangeTransforms([{
+          id: model.id,
+          transform: {
+            position: new THREE.Vector3(centerX, centerY, t.position.z),
+            rotation: t.rotation.clone(),
+            scale: t.scale.clone(),
+          },
+        }]);
+
+        transformMgr.setTransformMode('select');
+      }
+      return;
+    }
 
     // Arrange and Duplicate previews should never overlap.
     setDuplicateApplySourceModel(null);
@@ -12290,7 +12344,61 @@ export default function Home() {
     if (isAutoArranging) return;
 
     const visibleModels = resolveArrangeVisibleModels(scope, explicitSelectedIds);
-    if (visibleModels.length <= 1) return;
+    if (visibleModels.length <= 1) {
+      if (visibleModels.length === 1) {
+        const model = visibleModels[0];
+        const t = getArrangeTransform(model);
+        const dims = getModelSupportAwareDimensionsMm(model, undefined, t);
+
+        const rawMinX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
+        const rawMaxX = rawMinX + scene.view3dSettings.widthMm;
+        const rawMinY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
+        const rawMaxY = rawMinY + scene.view3dSettings.depthMm;
+        const sm = scene.view3dSettings.safetyMarginMm;
+        const minX = rawMinX + Math.max(0, sm?.left ?? 0);
+        const maxX = rawMaxX - Math.max(0, sm?.right ?? 0);
+        const minY = rawMinY + Math.max(0, sm?.front ?? 0);
+        const maxY = rawMaxY - Math.max(0, sm?.back ?? 0);
+
+        let centerX: number;
+        let centerY: number;
+        if (arrangeAnchorMode === 'front_left') {
+          centerX = minX + dims.width * 0.5;
+          centerY = minY + dims.depth * 0.5;
+        } else if (arrangeAnchorMode === 'front_right') {
+          centerX = maxX - dims.width * 0.5;
+          centerY = minY + dims.depth * 0.5;
+        } else if (arrangeAnchorMode === 'back_left') {
+          centerX = minX + dims.width * 0.5;
+          centerY = maxY - dims.depth * 0.5;
+        } else if (arrangeAnchorMode === 'back_right') {
+          centerX = maxX - dims.width * 0.5;
+          centerY = maxY - dims.depth * 0.5;
+        } else {
+          centerX = (minX + maxX) * 0.5;
+          centerY = (minY + maxY) * 0.5;
+        }
+
+        // Arrange and Duplicate previews should never overlap.
+        setDuplicateApplySourceModel(null);
+        setDuplicateApplySourceTransform(null);
+        setDuplicateSourcePreviewTransform(null);
+        setDuplicatePreviewTransforms([]);
+        setDuplicateTotalCopies(1);
+
+        applyArrangeTransforms([{
+          id: model.id,
+          transform: {
+            position: new THREE.Vector3(centerX, centerY, t.position.z),
+            rotation: t.rotation.clone(),
+            scale: t.scale.clone(),
+          },
+        }]);
+
+        transformMgr.setTransformMode('select');
+      }
+      return;
+    }
 
     // Arrange and Duplicate previews should never overlap.
     setDuplicateApplySourceModel(null);
@@ -12472,7 +12580,68 @@ export default function Home() {
     if (isAutoArranging) return;
 
     const visibleModels = resolveArrangeVisibleModels(scope, explicitSelectedIds);
-    if (visibleModels.length <= 1) return;
+    if (visibleModels.length <= 1) {
+      if (visibleModels.length === 1) {
+        const model = visibleModels[0];
+        const t = getArrangeTransform(model);
+        const dims = getModelSupportAwareDimensionsMm(model, undefined, t);
+
+        const rawMinX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
+        const rawMaxX = rawMinX + scene.view3dSettings.widthMm;
+        const rawMinY = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.depthMm * 0.5;
+        const rawMaxY = rawMinY + scene.view3dSettings.depthMm;
+        const sm = scene.view3dSettings.safetyMarginMm;
+        const minX = rawMinX + Math.max(0, sm?.left ?? 0);
+        const maxX = rawMaxX - Math.max(0, sm?.right ?? 0);
+        const minY = rawMinY + Math.max(0, sm?.front ?? 0);
+        const maxY = rawMaxY - Math.max(0, sm?.back ?? 0);
+
+        let centerX: number;
+        let centerY: number;
+        if (arrangeAnchorMode === 'front_left') {
+          centerX = minX + dims.width * 0.5;
+          centerY = minY + dims.depth * 0.5;
+        } else if (arrangeAnchorMode === 'front_right') {
+          centerX = maxX - dims.width * 0.5;
+          centerY = minY + dims.depth * 0.5;
+        } else if (arrangeAnchorMode === 'back_left') {
+          centerX = minX + dims.width * 0.5;
+          centerY = maxY - dims.depth * 0.5;
+        } else if (arrangeAnchorMode === 'back_right') {
+          centerX = maxX - dims.width * 0.5;
+          centerY = maxY - dims.depth * 0.5;
+        } else {
+          centerX = (minX + maxX) * 0.5;
+          centerY = (minY + maxY) * 0.5;
+        }
+
+        // Arrange and Duplicate previews should never overlap.
+        setDuplicateApplySourceModel(null);
+        setDuplicateApplySourceTransform(null);
+        setDuplicateSourcePreviewTransform(null);
+        setDuplicatePreviewTransforms([]);
+        setDuplicateTotalCopies(1);
+
+        applyArrangeTransforms([{
+          id: model.id,
+          transform: {
+            position: new THREE.Vector3(centerX, centerY, t.position.z),
+            rotation: t.rotation.clone(),
+            scale: t.scale.clone(),
+          },
+        }]);
+
+        transformMgr.setTransformMode('select');
+      }
+      return;
+    }
+
+    // Arrange and Duplicate previews should never overlap.
+    setDuplicateApplySourceModel(null);
+    setDuplicateApplySourceTransform(null);
+    setDuplicateSourcePreviewTransform(null);
+    setDuplicatePreviewTransforms([]);
+    setDuplicateTotalCopies(1);
 
     const minSpinnerMs = 220;
     const startedAt = performance.now();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1122,7 +1122,6 @@ export default function Home() {
   const [isPrepareDragUnsupported, setIsPrepareDragUnsupported] = React.useState(false);
   const [isSupportSpotlightHoldActive, setIsSupportSpotlightHoldActive] = React.useState(false);
   const [allowPrepareWithoutPrinter, setAllowPrepareWithoutPrinter] = React.useState(false);
-  const [prepareSmoothingSettingsExpanded, setPrepareSmoothingSettingsExpanded] = React.useState(true);
   const [debugPrimitivesPanelVisible, setDebugPrimitivesPanelVisible] = React.useState<boolean>(false);
   const [editorContextMenuPos, setEditorContextMenuPos] = React.useState<{ x: number; y: number } | null>(null);
   const [editorContextMenuSupportTarget, setEditorContextMenuSupportTarget] = React.useState<{
@@ -14710,43 +14709,7 @@ export default function Home() {
             )}
 
             {scene.geom && transformMgr.transformMode === 'smoothing' && (
-              <div
-                key="prepare-smoothing-settings"
-                className="ui-panel rounded-lg border shadow-lg overflow-hidden"
-                style={{ borderColor: 'var(--border-subtle)' }}
-              >
-                <div
-                  className="px-2.5 py-2.5 flex items-center gap-2.5"
-                >
-                  <IconButton
-                    onClick={() => setPrepareSmoothingSettingsExpanded((prev) => !prev)}
-                    className="!p-0.5"
-                    title={prepareSmoothingSettingsExpanded ? 'Collapse card' : 'Expand card'}
-                  >
-                    <svg
-                      className="w-3 h-3 transform transition-transform"
-                      style={{ color: prepareSmoothingSettingsExpanded ? 'var(--accent)' : 'var(--text-muted)' }}
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      {prepareSmoothingSettingsExpanded ? (
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                      ) : (
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                      )}
-                    </svg>
-                  </IconButton>
-                  <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
-                    Mesh Smoothing
-                  </h3>
-                </div>
-                {prepareSmoothingSettingsExpanded && (
-                  <div className="max-h-[calc(100vh-var(--topbar-height)-88px)] overflow-hidden">
-                    <MeshSmoothingSettingsPanel />
-                  </div>
-                )}
-              </div>
+              <MeshSmoothingSettingsPanel key="prepare-smoothing-settings" />
             )}
 
             {scene.models.length > 0 && transformMgr.transformMode === 'arrange' && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16142,15 +16142,21 @@ export default function Home() {
           <>
             <button
               type="button"
-              className="ui-button ui-button-danger !h-9 px-3 text-xs"
+              className="ui-button !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
+              style={{
+                borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
+                color: 'var(--danger)',
+              }}
               disabled={closeUnsavedChangesBusy !== 'none'}
               onClick={handleDiscardAndCloseProgram}
             >
-              Close Without Saving
+              <Trash2 className="w-3.5 h-3.5" />
+              Discard Changes
             </button>
             <button
               type="button"
-              className="ui-button ui-button-accent !h-9 px-3 text-xs"
+              className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
               disabled={closeUnsavedChangesBusy !== 'none'}
               onClick={handleSaveAndCloseProgram}
             >
@@ -16165,7 +16171,7 @@ export default function Home() {
             : 'Close DragonFruit now?'}
         </p>
         <p className="text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
-          <strong>Save &amp; Close</strong> keeps your latest edits. <strong>Close Without Saving</strong> discards them.
+          <strong>Please ensure you have saved any important work.</strong>
         </p>
       </StructuredDialogModal>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15787,17 +15787,17 @@ export default function Home() {
                 </span>
               </p>
 
-              <div className="flex items-center justify-end gap-2 pt-1">
+              <div className="grid grid-cols-2 gap-2 pt-1">
                 <button
                   type="button"
-                  className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+                  className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
                   onClick={() => scene.resolveSceneImportPlacementPrompt('load_as_is')}
                 >
                   Load As-Is
                 </button>
                 <button
                   type="button"
-                  className="ui-button ui-button-accent !h-9 px-3 text-xs"
+                  className="ui-button ui-button-accent !h-9 w-full px-3 text-xs"
                   onClick={() => scene.resolveSceneImportPlacementPrompt('auto_arrange')}
                 >
                   Auto-Arrange
@@ -15914,10 +15914,10 @@ export default function Home() {
                   </div>
                 </div>
 
-                <div className="flex items-center justify-end gap-2 pt-1">
+                <div className="grid grid-cols-2 gap-2 pt-1">
                   <button
                     type="button"
-                    className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+                    className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
                     disabled={isManualRepairing}
                     onClick={() => setManualRepairModelId(null)}
                   >
@@ -15925,7 +15925,7 @@ export default function Home() {
                   </button>
                   <button
                     type="button"
-                    className="ui-button ui-button-accent !h-9 px-3 text-xs flex items-center gap-1.5 disabled:opacity-60"
+                    className="ui-button ui-button-accent !h-9 w-full px-3 text-xs flex items-center justify-center gap-1.5 disabled:opacity-60"
                     disabled={isManualRepairing}
                     onClick={() => {
                       const id = manualRepairModelId;
@@ -16339,17 +16339,17 @@ export default function Home() {
                   )}
               </p>
 
-              <div className="flex items-center justify-end gap-2 pt-1">
+              <div className="grid grid-cols-2 gap-2 pt-1">
                 <button
                   type="button"
-                  className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+                  className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
                   onClick={() => setPrintingMonitorPendingConfirmation(null)}
                 >
                   {printingMonitorPendingConfirmation.kind === 'plate' ? 'Keep File' : 'Keep Printing'}
                 </button>
                 <button
                   type="button"
-                  className="ui-button !h-9 px-3 text-xs"
+                  className="ui-button !h-9 w-full px-3 text-xs"
                   style={
                     printingMonitorPendingConfirmation.kind === 'plate'
                       ? (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14593,6 +14593,8 @@ export default function Home() {
         heatmapColors={scene.heatmapColors}
         onHeatmapColorChange={scene.onHeatmapColorChange}
         isSlicingBusy={isSlicingBusy}
+        onLoadMeshChange={handleLoadMeshChangeWithZip}
+        onImportSceneChange={handleImportSceneChangeWithZip}
         onSaveScene={() => { void handleTopBarSaveScene(); }}
         onOpenScene={handleTopBarOpenScene}
         onCloseProgram={handleRequestProgramClose}
@@ -14627,10 +14629,6 @@ export default function Home() {
               onOpenSupportsInfo={handleOpenModelSupportsInfo}
               onDelete={scene.deleteModel}
               onVisibilityChange={scene.setModelVisibility}
-              onLoadMeshClick={() => { void handleOpenMeshDialog(); }}
-              onLoadMeshChange={handleLoadMeshChangeWithZip}
-              onImportSceneClick={() => { void handleOpenSceneDialog(); }}
-              onImportSceneChange={handleImportSceneChangeWithZip}
               dimmed={showEmptySceneDialog || importOverlayState.active}
               bottomClearancePx={modelStatsBottomClearancePx}
             />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11876,8 +11876,6 @@ export default function Home() {
             scale: t.scale.clone(),
           },
         }]);
-
-        transformMgr.setTransformMode('select');
       }
       return;
     }
@@ -12327,8 +12325,6 @@ export default function Home() {
           }),
         ],
       );
-
-      transformMgr.setTransformMode('select');
     } finally {
       const elapsed = performance.now() - startedAt;
       if (elapsed < minSpinnerMs) {
@@ -12394,8 +12390,6 @@ export default function Home() {
             scale: t.scale.clone(),
           },
         }]);
-
-        transformMgr.setTransformMode('select');
       }
       return;
     }
@@ -12438,7 +12432,6 @@ export default function Home() {
 
       if (updates.length > 1) {
         applyArrangeTransforms(updates);
-        transformMgr.setTransformMode('select');
       }
     } finally {
       const elapsed = performance.now() - startedAt;
@@ -12630,8 +12623,6 @@ export default function Home() {
             scale: t.scale.clone(),
           },
         }]);
-
-        transformMgr.setTransformMode('select');
       }
       return;
     }
@@ -12655,7 +12646,6 @@ export default function Home() {
       if (updates.length <= 1) return;
 
       applyArrangeTransforms(updates);
-      transformMgr.setTransformMode('select');
     } finally {
       const elapsed = performance.now() - startedAt;
       if (elapsed < minSpinnerMs) {
@@ -14335,8 +14325,7 @@ export default function Home() {
   const handlePlaceOnFace = React.useCallback((modelId: string) => {
     if (scene.activeModelId !== modelId) return;
     handleTransformEnd('rotate');
-    transformMgr.setTransformMode('transform');
-  }, [handleTransformEnd, scene.activeModelId, transformMgr]);
+  }, [handleTransformEnd, scene.activeModelId]);
 
   const handlePlaceOnFaceBeforeApply = React.useCallback((_normal: THREE.Vector3, continueApply: () => void) => {
     return requestDestructiveTransformSupportDeletionWithContinuation('Place On Face', continueApply);

--- a/src/components/controls/ArrangePanel.tsx
+++ b/src/components/controls/ArrangePanel.tsx
@@ -108,7 +108,7 @@ export function ArrangePanel({
   disableArrangeActions = false,
 }: ArrangePanelProps) {
   const [expanded, setExpanded] = useFloatingPanelCollapse(true);
-  const isArrangeAllDisabled = modelCount <= 1 || isApplying || disableArrangeActions;
+  const isArrangeAllDisabled = modelCount <= 0 || isApplying || disableArrangeActions;
   const isArrangeSelectedDisabled = selectedModelCount === 0 || isApplying || disableArrangeActions;
   const panelCardStyle: React.CSSProperties = {
     borderColor: 'var(--border-subtle)',

--- a/src/components/controls/ArrangePanel.tsx
+++ b/src/components/controls/ArrangePanel.tsx
@@ -3,6 +3,7 @@ import { LayoutGrid, Loader2, RotateCw } from 'lucide-react';
 import { NumberInput } from '@/components/ui/NumberInput';
 import { Button, Card, CardHeader, IconButton, Select } from '@/components/ui/primitives';
 import { ScrollableNumberField } from '@/components/ui/scrollableNumberField';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 
 export type ArrangeAnchorMode = 'center' | 'front_left' | 'front_right' | 'back_left' | 'back_right';
 export type ArrangeLayoutMode = 'auto' | 'array';
@@ -106,7 +107,7 @@ export function ArrangePanel({
   isApplying = false,
   disableArrangeActions = false,
 }: ArrangePanelProps) {
-  const [expanded, setExpanded] = React.useState(true);
+  const [expanded, setExpanded] = useFloatingPanelCollapse(true);
   const isArrangeAllDisabled = modelCount <= 1 || isApplying || disableArrangeActions;
   const isArrangeSelectedDisabled = selectedModelCount === 0 || isApplying || disableArrangeActions;
   const panelCardStyle: React.CSSProperties = {

--- a/src/components/controls/DebugPrimitivesPanel.tsx
+++ b/src/components/controls/DebugPrimitivesPanel.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Trash2 } from 'lucide-react';
 import { Button, Card, CardHeader, IconButton } from '@/components/ui/primitives';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 
 export type DebugPrimitiveType =
   | 'pillar'
@@ -90,7 +91,7 @@ function PrimitiveIcon({ type }: { type: DebugPrimitiveType }) {
 }
 
 export function DebugPrimitivesPanel({ onAdd, onClear }: DebugPrimitivesPanelProps) {
-  const [expanded, setExpanded] = React.useState(true);
+  const [expanded, setExpanded] = useFloatingPanelCollapse(true);
   const [sizePreset, setSizePreset] = React.useState<DebugPrimitiveSizePreset>('medium');
 
   const buttons: Array<{ type: DebugPrimitiveType; label: string }> = [

--- a/src/components/controls/DuplicatePanel.tsx
+++ b/src/components/controls/DuplicatePanel.tsx
@@ -3,6 +3,7 @@ import { CopyPlus, Loader2 } from 'lucide-react';
 import { Button, Card, CardHeader, IconButton } from '@/components/ui/primitives';
 import { ScrollableNumberField } from '@/components/ui/scrollableNumberField';
 import type { ArrangePrecisionMode } from '@/components/controls/ArrangePanel';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 
 export type DuplicateLayoutMode = 'auto' | 'array';
 
@@ -61,7 +62,7 @@ export function DuplicatePanel({
   previewCount,
   isApplying = false,
 }: DuplicatePanelProps) {
-  const [expanded, setExpanded] = React.useState(true);
+  const [expanded, setExpanded] = useFloatingPanelCollapse(true);
   const hasSelection = !!activeModelName;
   const panelDisabled = !hasSelection || isApplying;
 

--- a/src/components/controls/IslandListCard.tsx
+++ b/src/components/controls/IslandListCard.tsx
@@ -4,6 +4,7 @@ import type { Island } from '@/volumeAnalysis/IslandScan/types';
 import { IslandHierarchyModal } from '@/components/modals/IslandHierarchyModal';
 import { ChevronRight, Network } from 'lucide-react';
 import { Button, Card, CardHeader, IconButton, Input } from '@/components/ui/primitives';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 
 type IslandListCardProps = {
   islands: Island[];
@@ -29,7 +30,7 @@ export function IslandListCard({
   zOffsetMm,
 }: IslandListCardProps) {
   const cardRef = React.useRef<HTMLDivElement | null>(null);
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useFloatingPanelCollapse(true);
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState<'id' | 'volume' | 'layers'>('id');
   const [showHierarchyModal, setShowHierarchyModal] = useState(false);

--- a/src/components/controls/IslandOverlayControls.tsx
+++ b/src/components/controls/IslandOverlayControls.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { NumberInput } from '@/components/ui/NumberInput';
 import { Card, CardHeader, IconButton, Input } from '@/components/ui/primitives';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 
 type IslandOverlayControlsProps = {
   enabled: boolean;
@@ -33,7 +34,7 @@ export function IslandOverlayControls({
   onTaperChange,
   islandCount
 }: IslandOverlayControlsProps) {
-  const [expanded, setExpanded] = useState(enabled);
+  const [expanded, setExpanded] = useFloatingPanelCollapse(enabled);
   const [editingColor, setEditingColor] = useState(color);
 
   // Sync editing values when props change

--- a/src/components/controls/IslandVoxelControls.tsx
+++ b/src/components/controls/IslandVoxelControls.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Card, CardHeader, IconButton, Select } from '@/components/ui/primitives';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 
 interface IslandVoxelControlsProps {
   enabled: boolean;
@@ -29,7 +30,7 @@ export function IslandVoxelControls({
   onShowMergedChange,
   islandCount = 0,
 }: IslandVoxelControlsProps) {
-  const [expanded, setExpanded] = React.useState(false);
+  const [expanded, setExpanded] = useFloatingPanelCollapse(false);
 
   return (
     <Card>

--- a/src/components/controls/ModelManagerPanel.tsx
+++ b/src/components/controls/ModelManagerPanel.tsx
@@ -5,8 +5,7 @@ import {
   Trash2,
   Box,
   AlertTriangle,
-  Upload,
-  FolderInput,
+
   Folder,
   FolderOpen,
   ChevronRight,
@@ -45,10 +44,7 @@ interface ModelManagerPanelProps {
   onOpenSupportsInfo?: (id: string) => void;
   onDelete: (id: string) => void;
   onVisibilityChange: (id: string, visible: boolean) => void;
-  onLoadMeshClick?: () => void;
-  onLoadMeshChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onImportSceneClick?: () => void;
-  onImportSceneChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+
   dimmed?: boolean;
   bottomClearancePx?: number;
 }
@@ -104,10 +100,6 @@ export function ModelManagerPanel({
   onOpenSupportsInfo,
   onDelete,
   onVisibilityChange,
-  onLoadMeshClick,
-  onLoadMeshChange,
-  onImportSceneClick,
-  onImportSceneChange,
   dimmed = false,
   bottomClearancePx = 220,
 }: ModelManagerPanelProps) {
@@ -119,8 +111,37 @@ export function ModelManagerPanel({
   const [renamingModelName, setRenamingModelName] = useState('');
   const [renamingModelSuffix, setRenamingModelSuffix] = useState('');
   const [contextMenu, setContextMenu] = useState<PanelContextMenuState | null>(null);
-  const [useCompactQuickActionLabels, setUseCompactQuickActionLabels] = useState(false);
-  const quickActionsGridRef = useRef<HTMLDivElement | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const resizeDragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  const getParentPanel = (el: HTMLElement): HTMLElement | null =>
+    el.closest('.absolute.pointer-events-auto') as HTMLElement | null;
+
+  const handleResizePointerDown = React.useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const handle = e.currentTarget as HTMLElement;
+    const parent = getParentPanel(handle);
+    if (!parent) return;
+    const rect = parent.getBoundingClientRect();
+    resizeDragRef.current = { startX: e.clientX, startWidth: rect.width };
+    handle.setPointerCapture(e.pointerId);
+  }, []);
+
+  const handleResizePointerMove = React.useCallback((e: React.PointerEvent) => {
+    const drag = resizeDragRef.current;
+    if (!drag) return;
+    const handle = e.currentTarget as HTMLElement;
+    const parent = getParentPanel(handle);
+    if (!parent) return;
+    const dx = e.clientX - drag.startX;
+    const newWidth = Math.max(280, Math.min(600, drag.startWidth + dx));
+    parent.style.width = `${newWidth}px`;
+  }, []);
+
+  const handleResizePointerUp = React.useCallback((e: React.PointerEvent) => {
+    resizeDragRef.current = null;
+  }, []);
 
   const selectedSet = useMemo(() => new Set(selectedModelIds), [selectedModelIds]);
 
@@ -198,8 +219,8 @@ export function ModelManagerPanel({
   const computedBottomClearance = Math.max(140, Math.round(bottomClearancePx));
   const panelMaxHeight = `calc(100vh - var(--topbar-height) - ${computedBottomClearance}px)`;
   const panelClassName = dimmed
-    ? 'opacity-60 pointer-events-none transition-opacity duration-150 flex flex-col'
-    : 'transition-opacity duration-150 flex flex-col';
+    ? 'opacity-60 pointer-events-none transition-opacity duration-150 flex flex-col relative'
+    : 'transition-opacity duration-150 flex flex-col relative';
   const panelStyle: React.CSSProperties = {
     ...(dimmed ? { filter: 'grayscale(0.25)' } : {}),
     ...(expanded ? { maxHeight: panelMaxHeight } : {}),
@@ -302,55 +323,6 @@ export function ModelManagerPanel({
     };
   }, [contextMenu]);
 
-  useEffect(() => {
-    const grid = quickActionsGridRef.current;
-    if (!grid) return;
-
-    const computeCompactMode = (width: number) => {
-      const compactThreshold = onImportSceneChange ? 312 : 184;
-      const nextCompact = width < compactThreshold;
-      setUseCompactQuickActionLabels((prev) => (prev === nextCompact ? prev : nextCompact));
-    };
-
-    computeCompactMode(grid.clientWidth);
-
-    if (typeof ResizeObserver === 'undefined') {
-      return;
-    }
-
-    const observer = new ResizeObserver((entries) => {
-      const width = entries[0]?.contentRect.width;
-      if (typeof width === 'number') {
-        computeCompactMode(width);
-      }
-    });
-
-    observer.observe(grid);
-    return () => observer.disconnect();
-  }, [onImportSceneChange]);
-
-  const triggerMeshPicker = React.useCallback(() => {
-    if (onLoadMeshClick) {
-      onLoadMeshClick();
-      return;
-    }
-
-    if (typeof document === 'undefined') return;
-    const input = document.getElementById('models-card-mesh-input') as HTMLInputElement | null;
-    input?.click();
-  }, [onLoadMeshClick]);
-
-  const triggerScenePicker = React.useCallback(() => {
-    if (onImportSceneClick) {
-      onImportSceneClick();
-      return;
-    }
-
-    if (typeof document === 'undefined') return;
-    const input = document.getElementById('models-card-scene-input') as HTMLInputElement | null;
-    input?.click();
-  }, [onImportSceneClick]);
-
   return (
     <Card
       className={panelClassName}
@@ -404,57 +376,7 @@ export function ModelManagerPanel({
 
       {expanded && (
         <div className="px-2.5 pt-1 pb-2.5 space-y-2 flex flex-col flex-1 min-h-0">
-          <div
-            className="rounded-md border p-2"
-            style={{ background: 'var(--surface-1)', borderColor: 'var(--border-subtle)' }}
-          >
-            <div
-              ref={quickActionsGridRef}
-              className={`grid gap-2 ${onImportSceneChange ? 'grid-cols-2' : 'grid-cols-1'}`}
-            >
-              <button
-                type="button"
-                onClick={triggerMeshPicker}
-                className="ui-button ui-button-primary inline-flex min-w-0 items-center justify-center gap-1.5 min-h-9 !px-2 text-[11px] leading-none"
-                title="Load Mesh"
-              >
-                <Upload className="w-3.5 h-3.5 shrink-0" />
-                <span className="whitespace-nowrap">{useCompactQuickActionLabels ? 'Mesh' : 'Load Mesh'}</span>
-              </button>
-              <input
-                id="models-card-mesh-input"
-                type="file"
-                accept=".stl,.obj,.3mf,.zip"
-                multiple
-                onChange={onLoadMeshChange}
-                className="hidden"
-              />
-
-              {onImportSceneChange && (
-                <>
-                  <button
-                    type="button"
-                    onClick={triggerScenePicker}
-                    className="ui-button ui-button-accent inline-flex min-w-0 items-center justify-center gap-1.5 min-h-9 !px-2 text-[11px] leading-none"
-                    title="Import Scene"
-                  >
-                    <FolderInput className="w-3.5 h-3.5 shrink-0" />
-                    <span className="whitespace-nowrap">{useCompactQuickActionLabels ? 'Scene' : 'Import Scene'}</span>
-                  </button>
-                  <input
-                    id="models-card-scene-input"
-                    type="file"
-                    accept=".voxl,.lys,.zip"
-                    onChange={onImportSceneChange}
-                    className="hidden"
-                  />
-                </>
-              )}
-            </div>
-
-          </div>
-
-          <div className="space-y-1 overflow-y-auto custom-scrollbar pr-0.5 flex-1 min-h-0">
+<div className="space-y-1 overflow-y-auto custom-scrollbar pr-0.5 flex-1 min-h-0">
             {models.length === 0 ? (
               <div className="text-xs text-center py-2 italic" style={{ color: 'var(--text-muted)' }}>
                 No models loaded
@@ -878,6 +800,24 @@ export function ModelManagerPanel({
           </div>
         </div>
       )}
+      {/* Horizontal resize handle on the right edge */}
+      <div
+        className="absolute right-0 top-0 bottom-0 w-1.5 cursor-col-resize hover:opacity-100 opacity-0 transition-opacity"
+        style={{
+          background: 'transparent',
+        }}
+        onPointerDown={handleResizePointerDown}
+        onPointerMove={handleResizePointerMove}
+        onPointerUp={handleResizePointerUp}
+        onPointerCancel={handleResizePointerUp}
+      >
+        <div
+          className="absolute right-0 top-0 bottom-0 w-[3px] rounded-full transition-colors"
+          style={{
+            background: 'color-mix(in srgb, var(--accent), transparent 60%)',
+          }}
+        />
+      </div>
     </Card>
   );
 }

--- a/src/components/controls/ModelManagerPanel.tsx
+++ b/src/components/controls/ModelManagerPanel.tsx
@@ -21,6 +21,7 @@ import {
 import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import { Card, CardHeader, IconButton } from '@/components/ui/primitives';
 import { formatMeshStatsForDisplay } from '@/utils/meshStatsFormatting';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 
 type SelectMode = 'single' | 'toggle' | 'add';
 
@@ -103,7 +104,7 @@ export function ModelManagerPanel({
   dimmed = false,
   bottomClearancePx = 220,
 }: ModelManagerPanelProps) {
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useFloatingPanelCollapse(true);
   const [collapsedGroupIds, setCollapsedGroupIds] = useState<Record<string, boolean>>({});
   const [renamingGroupId, setRenamingGroupId] = useState<string | null>(null);
   const [renamingGroupName, setRenamingGroupName] = useState('');
@@ -191,15 +192,18 @@ export function ModelManagerPanel({
         : []);
   }, [models, outsidePlateModelIds]);
 
+  const contextModelId = contextMenu?.modelId;
+  const contextGroupId = contextMenu?.groupId;
+
   const contextModel = useMemo(() => {
-    if (!contextMenu?.modelId) return null;
-    return models.find((m) => m.id === contextMenu.modelId) ?? null;
-  }, [contextMenu?.modelId, models]);
+    if (!contextModelId) return null;
+    return models.find((m) => m.id === contextModelId) ?? null;
+  }, [contextModelId, models]);
 
   const contextGroup = useMemo(() => {
-    if (!contextMenu?.groupId) return null;
-    return grouped.find((g) => g.id === contextMenu.groupId) ?? null;
-  }, [contextMenu?.groupId, grouped]);
+    if (!contextGroupId) return null;
+    return grouped.find((g) => g.id === contextGroupId) ?? null;
+  }, [contextGroupId, grouped]);
 
   const selectedGroupedCount = useMemo(() => {
     if (selectedModelIds.length === 0) return 0;

--- a/src/components/controls/ModelStatsCard.tsx
+++ b/src/components/controls/ModelStatsCard.tsx
@@ -39,6 +39,41 @@ export function ModelStatsCard({
   estimatedPrintTimeLabelOverride,
   estimatedResinLabelOverride,
 }: ModelStatsCardProps) {
+  // Match the same viewport-responsive width as floating panels
+  const panelWidth = React.useMemo(() => {
+    if (typeof window === 'undefined') return 320;
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    let scale = 1;
+    if (w >= 3200 && h >= 1100) scale = 1.14;
+    else if (w >= 2600 && h >= 980) scale = 1.08;
+    else if (w <= 1100 || h <= 700) scale = 0.72;
+    else if (w <= 1366 || h <= 820) scale = 0.82;
+    else if (w <= 1600 || h <= 900) scale = 0.9;
+    else if (w <= 1800 || h <= 980) scale = 0.95;
+    return Math.max(72, Math.round(320 * scale));
+  }, []);
+
+  // Recompute on window resize
+  const [resizedWidth, setResizedWidth] = React.useState(panelWidth);
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const compute = () => {
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      let scale = 1;
+      if (w >= 3200 && h >= 1100) scale = 1.14;
+      else if (w >= 2600 && h >= 980) scale = 1.08;
+      else if (w <= 1100 || h <= 700) scale = 0.72;
+      else if (w <= 1366 || h <= 820) scale = 0.82;
+      else if (w <= 1600 || h <= 900) scale = 0.9;
+      else if (w <= 1800 || h <= 980) scale = 0.95;
+      setResizedWidth(Math.max(72, Math.round(320 * scale)));
+    };
+    window.addEventListener('resize', compute);
+    return () => window.removeEventListener('resize', compute);
+  }, []);
+
   const [isFlipped, setIsFlipped] = React.useState(false);
   const baseResinMlCacheRef = React.useRef<Map<string, number | null>>(new Map());
   const inFlightBaseResinMlRef = React.useRef<Map<string, Promise<number | null>>>(new Map());
@@ -423,7 +458,7 @@ export function ModelStatsCard({
   };
 
   return (
-    <div className="pointer-events-auto select-none w-[320px] max-w-[320px]">
+    <div className="pointer-events-auto select-none" style={{ width: resizedWidth, maxWidth: resizedWidth }}>
       <div
         className="w-full [perspective:1200px]"
       >

--- a/src/components/controls/TerritoryVoxelControls.tsx
+++ b/src/components/controls/TerritoryVoxelControls.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Card, CardHeader, IconButton } from '@/components/ui/primitives';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 
 interface TerritoryVoxelControlsProps {
     enabled: boolean;
@@ -27,7 +28,7 @@ export function TerritoryVoxelControls({
     onUseSurfaceContiguityChange,
     onRescan,
 }: TerritoryVoxelControlsProps) {
-    const [expanded, setExpanded] = React.useState(false);
+    const [expanded, setExpanded] = useFloatingPanelCollapse(false);
 
     return (
         <Card>

--- a/src/components/controls/TransformControls.tsx
+++ b/src/components/controls/TransformControls.tsx
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import { NumberInput } from '@/components/ui/NumberInput';
 import { Card, CardHeader, IconButton } from '@/components/ui/primitives';
 import { SNAP_STORAGE_KEY } from '@/components/gizmo/rotate/snapRotation';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 
 interface SectionHeaderProps {
   title: string;
@@ -69,7 +70,7 @@ export function TransformControls({
   onDrop,
   onTransformCommit,
 }: TransformControlsProps) {
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useFloatingPanelCollapse(true);
   const [uniformScaling, setUniformScaling] = useState(true);
   const [snapEnabled, setSnapEnabled] = useState(() => {
     try { return localStorage.getItem(SNAP_STORAGE_KEY) === 'true'; } catch { return false; }

--- a/src/components/controls/TransformControls.tsx
+++ b/src/components/controls/TransformControls.tsx
@@ -83,7 +83,7 @@ export function TransformControls({
   };
 
   const compactButtonClass = 'ui-button ui-button-secondary !h-8 whitespace-nowrap px-1.5 text-[10px] sm:text-[11px]';
-  const valueInputClass = 'ui-input h-8 w-full px-1.5 text-xs sm:text-sm text-center tabular-nums no-spinners';
+  const valueInputClass = 'ui-input h-8 w-full px-1.5 text-xs sm:text-sm text-left tabular-nums no-spinners';
 
   const sectionCardStyle: React.CSSProperties = {
     borderColor: 'var(--border-subtle)',
@@ -193,30 +193,42 @@ export function TransformControls({
                 <div className="grid grid-cols-3 gap-1 min-w-0">
                   <div className="min-w-0">
                     <label className="ui-meta mb-1 block text-center" style={{ color: '#f87171' }}>X</label>
-                    <NumberInput
-                      value={parseFloat(position.x.toFixed(2))}
-                      onChange={(val) => handlePositionChange('x', val)}
-                      onBlur={() => onTransformCommit?.()}
-                      className={valueInputClass}
-                    />
+                    <div className="relative">
+                      <NumberInput
+                        value={parseFloat(position.x.toFixed(2))}
+                        onChange={(val) => handlePositionChange('x', val)}
+                        onBlur={() => onTransformCommit?.()}
+                        className={valueInputClass}
+                        showStepper={false}
+                      />
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[11px] font-semibold" style={{ color: 'var(--text-muted)' }}>mm</span>
+                    </div>
                   </div>
                   <div className="min-w-0">
                     <label className="ui-meta mb-1 block text-center" style={{ color: '#4ade80' }}>Y</label>
-                    <NumberInput
-                      value={parseFloat(position.y.toFixed(2))}
-                      onChange={(val) => handlePositionChange('y', val)}
-                      onBlur={() => onTransformCommit?.()}
-                      className={valueInputClass}
-                    />
+                    <div className="relative">
+                      <NumberInput
+                        value={parseFloat(position.y.toFixed(2))}
+                        onChange={(val) => handlePositionChange('y', val)}
+                        onBlur={() => onTransformCommit?.()}
+                        className={valueInputClass}
+                        showStepper={false}
+                      />
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[11px] font-semibold" style={{ color: 'var(--text-muted)' }}>mm</span>
+                    </div>
                   </div>
                   <div className="min-w-0">
                     <label className="ui-meta mb-1 block text-center" style={{ color: '#60a5fa' }}>Z</label>
-                    <NumberInput
-                      value={parseFloat(position.z.toFixed(2))}
-                      onChange={(val) => handlePositionChange('z', val)}
-                      onBlur={() => onTransformCommit?.()}
-                      className={valueInputClass}
-                    />
+                    <div className="relative">
+                      <NumberInput
+                        value={parseFloat(position.z.toFixed(2))}
+                        onChange={(val) => handlePositionChange('z', val)}
+                        onBlur={() => onTransformCommit?.()}
+                        className={valueInputClass}
+                        showStepper={false}
+                      />
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[11px] font-semibold" style={{ color: 'var(--text-muted)' }}>mm</span>
+                    </div>
                   </div>
                 </div>
 
@@ -326,39 +338,51 @@ export function TransformControls({
                 <div className="grid grid-cols-3 gap-1 min-w-0">
                   <div className="min-w-0">
                     <label className="ui-meta mb-1 block text-center" style={{ color: '#f87171' }}>X</label>
-                    <NumberInput
-                      value={parseFloat(wrapRotationDegrees(toDegrees(rotation.x)).toFixed(2))}
-                      onChange={(val) => handleRotationChange('x', val)}
-                      onBlur={() => {
-                        onRotationComplete?.();
-                        onTransformCommit?.();
-                      }}
-                      className={valueInputClass}
-                    />
+                    <div className="relative">
+                      <NumberInput
+                        value={parseFloat(wrapRotationDegrees(toDegrees(rotation.x)).toFixed(2))}
+                        onChange={(val) => handleRotationChange('x', val)}
+                        onBlur={() => {
+                          onRotationComplete?.();
+                          onTransformCommit?.();
+                        }}
+                        className={valueInputClass}
+                        showStepper={false}
+                      />
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[14px] font-semibold" style={{ color: 'var(--text-muted)' }}>°</span>
+                    </div>
                   </div>
                   <div className="min-w-0">
                     <label className="ui-meta mb-1 block text-center" style={{ color: '#4ade80' }}>Y</label>
-                    <NumberInput
-                      value={parseFloat(wrapRotationDegrees(toDegrees(rotation.y)).toFixed(2))}
-                      onChange={(val) => handleRotationChange('y', val)}
-                      onBlur={() => {
-                        onRotationComplete?.();
-                        onTransformCommit?.();
-                      }}
-                      className={valueInputClass}
-                    />
+                    <div className="relative">
+                      <NumberInput
+                        value={parseFloat(wrapRotationDegrees(toDegrees(rotation.y)).toFixed(2))}
+                        onChange={(val) => handleRotationChange('y', val)}
+                        onBlur={() => {
+                          onRotationComplete?.();
+                          onTransformCommit?.();
+                        }}
+                        className={valueInputClass}
+                        showStepper={false}
+                      />
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[14px] font-semibold" style={{ color: 'var(--text-muted)' }}>°</span>
+                    </div>
                   </div>
                   <div className="min-w-0">
                     <label className="ui-meta mb-1 block text-center" style={{ color: '#60a5fa' }}>Z</label>
-                    <NumberInput
-                      value={parseFloat(wrapRotationDegrees(toDegrees(rotation.z)).toFixed(2))}
-                      onChange={(val) => handleRotationChange('z', val)}
-                      onBlur={() => {
-                        onRotationComplete?.();
-                        onTransformCommit?.();
-                      }}
-                      className={valueInputClass}
-                    />
+                    <div className="relative">
+                      <NumberInput
+                        value={parseFloat(wrapRotationDegrees(toDegrees(rotation.z)).toFixed(2))}
+                        onChange={(val) => handleRotationChange('z', val)}
+                        onBlur={() => {
+                          onRotationComplete?.();
+                          onTransformCommit?.();
+                        }}
+                        className={valueInputClass}
+                        showStepper={false}
+                      />
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[14px] font-semibold" style={{ color: 'var(--text-muted)' }}>°</span>
+                    </div>
                   </div>
                 </div>
 

--- a/src/components/controls/TransformControls.tsx
+++ b/src/components/controls/TransformControls.tsx
@@ -1,37 +1,19 @@
 import React, { useState } from 'react';
 import * as THREE from 'three';
-import { ChevronDown, ChevronRight } from 'lucide-react';
 import { NumberInput } from '@/components/ui/NumberInput';
 import { Card, CardHeader, IconButton } from '@/components/ui/primitives';
 import { SNAP_STORAGE_KEY } from '@/components/gizmo/rotate/snapRotation';
 
 interface SectionHeaderProps {
   title: string;
-  expanded: boolean;
-  onToggle: () => void;
   accentColor?: string;
 }
 
-function SectionHeader({ title, expanded, onToggle, accentColor }: SectionHeaderProps) {
+function SectionHeader({ title }: { title: string }) {
   return (
-    <button
-      onClick={onToggle}
-      className="flex w-full items-center justify-between py-0.5 text-xs font-semibold uppercase tracking-wide transition-colors"
-      style={{ color: 'var(--text-strong)' }}
-    >
-      <span className="inline-flex items-center gap-1.5">
-        <span
-          className="inline-block h-1.5 w-1.5 rounded-full"
-          style={{ background: accentColor ?? 'var(--accent)' }}
-        />
-        {title}
-      </span>
-      {expanded ? (
-        <ChevronDown className="w-4 h-4" style={{ color: 'var(--text-muted)' }} />
-      ) : (
-        <ChevronRight className="w-4 h-4" style={{ color: 'var(--text-muted)' }} />
-      )}
-    </button>
+    <div className="py-0.5 text-center text-xs font-semibold uppercase tracking-wide" style={{ color: 'var(--text-strong)' }}>
+      {title}
+    </div>
   );
 }
 
@@ -88,11 +70,7 @@ export function TransformControls({
   onTransformCommit,
 }: TransformControlsProps) {
   const [expanded, setExpanded] = useState(true);
-  const [moveExpanded, setMoveExpanded] = useState(true);
-  const [rotateExpanded, setRotateExpanded] = useState(true);
-  const [scaleExpanded, setScaleExpanded] = useState(true);
   const [uniformScaling, setUniformScaling] = useState(true);
-  const [scaleUnit, setScaleUnit] = useState<'mm' | '%'>('%');
   const [snapEnabled, setSnapEnabled] = useState(() => {
     try { return localStorage.getItem(SNAP_STORAGE_KEY) === 'true'; } catch { return false; }
   });
@@ -125,6 +103,11 @@ export function TransformControls({
   const scaleCardStyle: React.CSSProperties = {
     borderColor: 'color-mix(in srgb, #2eb67d, var(--border-subtle) 80%)',
     background: 'color-mix(in srgb, #2eb67d, var(--surface-1) 95%)',
+  };
+
+  const liftCardStyle: React.CSSProperties = {
+    borderColor: 'color-mix(in srgb, #f59e0b, var(--border-subtle) 76%)',
+    background: 'color-mix(in srgb, #f59e0b, var(--surface-1) 93%)',
   };
 
   const outlinedConfigEmphasisStyle: React.CSSProperties = {
@@ -166,40 +149,6 @@ export function TransformControls({
     onRotationChange(newRot.x, newRot.y, newRot.z);
   };
 
-  // Scale handlers
-  const handleScaleChange = (axis: 'x' | 'y' | 'z', value: number) => {
-    let newScale: number;
-
-    if (scaleUnit === '%') {
-      newScale = value / 100;
-    } else {
-      newScale = value / originalSize[axis];
-    }
-
-    if (uniformScaling) {
-      onScaleChange(newScale, newScale, newScale);
-    } else {
-      const updated = scale.clone();
-      updated[axis] = newScale;
-      onScaleChange(updated.x, updated.y, updated.z);
-    }
-  };
-
-  const getScaleDisplayValue = (axis: 'x' | 'y' | 'z'): number => {
-    if (scaleUnit === '%') {
-      return (scale[axis] * 100);
-    } else {
-      return (scale[axis] * originalSize[axis]);
-    }
-  };
-
-  const handleArrangeAll = () => {
-    onCenter();
-    if (modelBBox) {
-      onPlatform(modelBBox);
-    }
-  };
-
   return (
     <Card
       className="w-full overflow-x-hidden shadow-xl"
@@ -239,8 +188,7 @@ export function TransformControls({
 
           {/* MOVE SECTION */}
           <div className="rounded-md border p-2" style={moveCardStyle}>
-            <SectionHeader title="Move" expanded={moveExpanded} onToggle={() => setMoveExpanded(!moveExpanded)} accentColor="#4f8cff" />
-            {moveExpanded && (
+            <SectionHeader title="Move" />
               <div className="pt-1.5 space-y-2">
                 <div className="grid grid-cols-3 gap-1 min-w-0">
                   <div className="min-w-0">
@@ -272,101 +220,109 @@ export function TransformControls({
                   </div>
                 </div>
 
-                <div className="grid grid-cols-3 gap-1 min-w-0">
-                  <button
-                    onClick={() => {
-                      onCenter();
-                      onTransformCommit?.();
-                    }}
-                    className={compactButtonClass}
-                  >
-                    Center
-                  </button>
-                  <button
-                    onClick={() => {
-                      if (!modelBBox) return;
-                      onPlatform(modelBBox);
-                      onTransformCommit?.();
-                    }}
-                    disabled={!modelBBox}
-                    className={`ui-button ui-button-accent !h-8 whitespace-nowrap px-1.5 text-[10px] sm:text-[11px] disabled:opacity-50 disabled:cursor-not-allowed`}
-                  >
-                    Platform
-                  </button>
-                  <button
-                    onClick={handleArrangeAll}
-                    disabled={!modelBBox}
-                    className={`ui-button ui-button-primary !h-8 whitespace-nowrap px-1.5 text-[10px] sm:text-[11px] disabled:opacity-50 disabled:cursor-not-allowed`}
-                  >
-                    Arrange
-                  </button>
-                </div>
-
-                <div className="rounded-md border p-2 space-y-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="ui-meta" style={{ color: 'var(--text-muted)' }}>Auto-Lift</span>
-                    <button
-                      type="button"
-                      onClick={() => onAutoLiftChange(!autoLift)}
-                      className="h-8 min-w-[72px] rounded-md border px-3 text-[11px] font-semibold uppercase tracking-wide transition-colors"
-                      style={autoLift
-                        ? {
-                            borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
-                            background: 'color-mix(in srgb, var(--accent), var(--surface-0) 76%)',
-                            color: 'var(--accent-contrast)',
-                          }
-                        : {
-                            borderColor: 'var(--border-subtle)',
-                            background: 'var(--surface-1)',
-                            color: 'var(--text-muted)',
-                          }}
-                    >
-                      {autoLift ? 'ON' : 'OFF'}
-                    </button>
-                  </div>
-
-                  <div className="grid grid-cols-[auto_1fr] items-center gap-2 min-w-0">
-                    <span className="ui-meta" style={{ color: 'var(--text-muted)' }}>Distance (mm)</span>
-                    <NumberInput
-                      value={liftDistance}
-                      onChange={(val) => onLiftDistanceChange(val)}
-                      onBlur={() => onTransformCommit?.()}
-                      className="ui-input h-8 w-full px-2 text-xs sm:text-sm no-spinners"
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-2 gap-1">
-                    <button
-                      onClick={() => {
-                        onLift();
-                        onTransformCommit?.();
-                      }}
-                      disabled={!modelBBox}
-                      className="ui-button ui-button-primary !h-8 px-1.5 text-[10px] sm:text-[11px] disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      Lift
-                    </button>
-                    <button
-                      onClick={() => {
-                        onDrop();
-                        onTransformCommit?.();
-                      }}
-                      disabled={!modelBBox}
-                      className="ui-button ui-button-accent !h-8 px-1.5 text-[10px] sm:text-[11px] disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      Drop
-                    </button>
-                  </div>
-                </div>
               </div>
-            )}
+          </div>
+
+          {/* LIFT SECTION */}
+          <div className="rounded-md border p-2" style={liftCardStyle}>
+            <div className="flex items-center">
+              <div className="flex-1" />
+              <SectionHeader title="Lift" />
+              <div className="flex-1 flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => onAutoLiftChange(!autoLift)}
+                  className="h-7 min-w-[64px] rounded-md border px-2 text-[10px] font-semibold uppercase tracking-wide transition-colors"
+                  style={autoLift
+                    ? {
+                        borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
+                        background: 'color-mix(in srgb, var(--accent), var(--surface-0) 76%)',
+                        color: 'var(--accent-contrast)',
+                      }
+                    : {
+                        borderColor: 'var(--border-subtle)',
+                        background: 'var(--surface-1)',
+                        color: 'var(--text-muted)',
+                      }}
+                >
+                  Auto
+                </button>
+              </div>
+            </div>
+            <div className="pt-1.5 space-y-2">
+              <div className="relative">
+                <NumberInput
+                  value={liftDistance}
+                  onChange={(val) => onLiftDistanceChange(val)}
+                  onBlur={() => onTransformCommit?.()}
+                  className="ui-input h-8 w-full px-2 text-xs sm:text-sm text-center no-spinners"
+                  showStepper={false}
+                />
+                <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>mm</span>
+              </div>
+
+              <div className="grid grid-cols-2 gap-1">
+                <button
+                  onClick={() => {
+                    onLift();
+                    onTransformCommit?.();
+                  }}
+                  disabled={!modelBBox}
+                  className="ui-button ui-button-secondary !h-8 px-1.5 text-[10px] sm:text-[11px] disabled:opacity-50 disabled:cursor-not-allowed"
+                  style={{
+                    borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 38%)',
+                    color: 'color-mix(in srgb, var(--accent), var(--text-strong) 30%)',
+                    background: 'color-mix(in srgb, var(--accent), var(--surface-1) 90%)',
+                  }}
+                >
+                  Lift
+                </button>
+                <button
+                  onClick={() => {
+                    onDrop();
+                    onTransformCommit?.();
+                  }}
+                  disabled={!modelBBox}
+                  className="ui-button ui-button-secondary !h-8 px-1.5 text-[10px] sm:text-[11px] disabled:opacity-50 disabled:cursor-not-allowed"
+                  style={{
+                    borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 42%)',
+                    color: 'color-mix(in srgb, var(--accent-secondary), var(--text-strong) 30%)',
+                    background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 92%)',
+                  }}
+                >
+                  Drop
+                </button>
+              </div>
+            </div>
           </div>
 
           {/* ROTATE SECTION */}
           <div className="rounded-md border p-2" style={rotateCardStyle}>
-            <SectionHeader title="Rotate" expanded={rotateExpanded} onToggle={() => setRotateExpanded(!rotateExpanded)} accentColor="#8f6cff" />
-            {rotateExpanded && (
-              <div className="pt-1.5 space-y-2">
+            <div className="flex items-center">
+              <div className="flex-1" />
+              <SectionHeader title="Rotate" />
+              <div className="flex-1 flex justify-end">
+                <button
+                  type="button"
+                  onClick={handleSnapToggle}
+                  className="h-7 min-w-[64px] rounded-md border px-2 text-[10px] font-semibold uppercase tracking-wide transition-colors"
+                  style={snapEnabled
+                    ? {
+                        borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
+                        background: 'color-mix(in srgb, var(--accent), var(--surface-0) 76%)',
+                        color: 'var(--accent-contrast)',
+                      }
+                    : {
+                        borderColor: 'var(--border-subtle)',
+                        background: 'var(--surface-1)',
+                        color: 'var(--text-muted)',
+                      }}
+                >
+                  Snap
+                </button>
+              </div>
+            </div>
+            <div className="pt-1.5 space-y-2">
                 <div className="grid grid-cols-3 gap-1 min-w-0">
                   <div className="min-w-0">
                     <label className="ui-meta mb-1 block text-center" style={{ color: '#f87171' }}>X</label>
@@ -406,28 +362,6 @@ export function TransformControls({
                   </div>
                 </div>
 
-                <div className="flex items-center justify-between gap-2">
-                  <span className="ui-meta" style={{ color: 'var(--text-muted)' }}>Angle-Snap</span>
-                  <button
-                    type="button"
-                    onClick={handleSnapToggle}
-                    className="h-8 min-w-[72px] rounded-md border px-3 text-[11px] font-semibold uppercase tracking-wide transition-colors"
-                    style={snapEnabled
-                      ? {
-                          borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
-                          background: 'color-mix(in srgb, var(--accent), var(--surface-0) 76%)',
-                          color: 'var(--accent-contrast)',
-                        }
-                      : {
-                          borderColor: 'var(--border-subtle)',
-                          background: 'var(--surface-1)',
-                          color: 'var(--text-muted)',
-                        }}
-                  >
-                    {snapEnabled ? 'ON' : 'OFF'}
-                  </button>
-                </div>
-
                 <button
                   onClick={() => {
                     onResetRotation();
@@ -438,75 +372,146 @@ export function TransformControls({
                   Reset Rotation
                 </button>
               </div>
-            )}
           </div>
 
           {/* SCALE SECTION */}
           <div className="rounded-md border p-2" style={scaleCardStyle}>
-            <SectionHeader title="Scale" expanded={scaleExpanded} onToggle={() => setScaleExpanded(!scaleExpanded)} accentColor="#2eb67d" />
-            {scaleExpanded && (
-              <div className="pt-1.5 space-y-2">
-                <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_44px] gap-1 min-w-0">
+            <div className="flex items-center justify-between">
+              <div className="flex-1" />
+              <SectionHeader title="Scale" />
+              <div className="flex-1 flex justify-end">
+                <button
+                type="button"
+                onClick={() => setUniformScaling(!uniformScaling)}
+                className="h-7 min-w-[64px] rounded-md border px-2 text-[10px] font-semibold uppercase tracking-wide transition-colors"
+                style={uniformScaling
+                  ? {
+                      borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
+                      background: 'color-mix(in srgb, var(--accent), var(--surface-0) 76%)',
+                      color: 'var(--accent-contrast)',
+                    }
+                  : {
+                      borderColor: 'var(--border-subtle)',
+                      background: 'var(--surface-1)',
+                      color: 'var(--text-muted)',
+                    }}
+              >
+                Uniform
+              </button>
+            </div>
+            </div>
+            <div className="pt-1.5 space-y-1.5">
+                {/* Percentage row */}
+                <div className="grid grid-cols-3 gap-1 min-w-0 items-start">
                   <div className="min-w-0">
-                    <label className="ui-meta mb-1 block text-center" style={{ color: '#f87171' }}>X</label>
-                    <NumberInput
-                      value={parseFloat(getScaleDisplayValue('x').toFixed(2))}
-                      onChange={(val) => handleScaleChange('x', val)}
-                      onBlur={() => onTransformCommit?.()}
-                      className={valueInputClass}
-                    />
+                    <label className="ui-meta mb-1 block text-center text-[10px]" style={{ color: '#f87171' }}>X</label>
+                    <div className="relative">
+                      <NumberInput
+                        value={parseFloat((scale.x * 100).toFixed(2))}
+                        onChange={(val) => {
+                          const newScale = val / 100;
+                          if (uniformScaling) onScaleChange(newScale, newScale, newScale);
+                          else onScaleChange(newScale, scale.y, scale.z);
+                        }}
+                        onBlur={() => onTransformCommit?.()}
+                        className={valueInputClass}
+                        showStepper={false}
+                      />
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>%</span>
+                    </div>
                   </div>
                   <div className="min-w-0">
-                    <label className="ui-meta mb-1 block text-center" style={{ color: '#4ade80' }}>Y</label>
-                    <NumberInput
-                      value={parseFloat(getScaleDisplayValue('y').toFixed(2))}
-                      onChange={(val) => handleScaleChange('y', val)}
-                      disabled={uniformScaling}
-                      onBlur={() => onTransformCommit?.()}
-                      className={`${valueInputClass} disabled:opacity-50`}
-                    />
+                    <label className="ui-meta mb-1 block text-center text-[10px]" style={{ color: '#4ade80' }}>Y</label>
+                    <div className="relative">
+                      <NumberInput
+                        value={parseFloat((scale.y * 100).toFixed(2))}
+                        onChange={(val) => {
+                          const newScale = val / 100;
+                          if (uniformScaling) onScaleChange(newScale, newScale, newScale);
+                          else onScaleChange(scale.x, newScale, scale.z);
+                        }}
+                        disabled={uniformScaling}
+                        onBlur={() => onTransformCommit?.()}
+                        className={`${valueInputClass} disabled:opacity-50`}
+                        showStepper={false}
+                      />
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>%</span>
+                    </div>
                   </div>
                   <div className="min-w-0">
-                    <label className="ui-meta mb-1 block text-center" style={{ color: '#60a5fa' }}>Z</label>
-                    <NumberInput
-                      value={parseFloat(getScaleDisplayValue('z').toFixed(2))}
-                      onChange={(val) => handleScaleChange('z', val)}
-                      disabled={uniformScaling}
-                      onBlur={() => onTransformCommit?.()}
-                      className={`${valueInputClass} disabled:opacity-50`}
-                    />
-                  </div>
-                  <div className="flex items-end min-w-0">
-                    <button
-                      onClick={() => setScaleUnit(scaleUnit === 'mm' ? '%' : 'mm')}
-                      className="ui-button ui-button-secondary !h-8 w-full !px-0 text-[10px] sm:text-[11px] tracking-normal inline-flex items-center justify-center leading-none"
-                      style={outlinedConfigEmphasisStyle}
-                    >
-                      {scaleUnit === 'mm' ? 'MM' : '%'}
-                    </button>
+                    <label className="ui-meta mb-1 block text-center text-[10px]" style={{ color: '#60a5fa' }}>Z</label>
+                    <div className="relative">
+                      <NumberInput
+                        value={parseFloat((scale.z * 100).toFixed(2))}
+                        onChange={(val) => {
+                          const newScale = val / 100;
+                          if (uniformScaling) onScaleChange(newScale, newScale, newScale);
+                          else onScaleChange(scale.x, scale.y, newScale);
+                        }}
+                        disabled={uniformScaling}
+                        onBlur={() => onTransformCommit?.()}
+                        className={`${valueInputClass} disabled:opacity-50`}
+                        showStepper={false}
+                      />
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>%</span>
+                    </div>
                   </div>
                 </div>
-
-                <div className="flex items-center justify-between gap-2">
-                  <span className="ui-meta" style={{ color: 'var(--text-muted)' }}>Uniform</span>
-                  <button
-                    type="button"
-                    onClick={() => setUniformScaling(!uniformScaling)}
-                    className="h-8 min-w-[72px] rounded-md border px-3 text-[11px] font-semibold uppercase tracking-wide transition-colors"
-                    style={uniformScaling
-                      ? {
-                          borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
-                          background: 'color-mix(in srgb, var(--accent), var(--surface-0) 76%)',
-                          color: 'var(--accent-contrast)',
-                        }
-                      : {
-                          borderColor: 'var(--border-subtle)',
-                          background: 'var(--surface-1)',
-                          color: 'var(--text-muted)',
+                {/* Millimeters row */}
+                <div className="grid grid-cols-3 gap-1 min-w-0 items-start">
+                  <div className="min-w-0">
+                    <div className="relative">
+                      <NumberInput
+                        value={originalSize ? parseFloat((scale.x * originalSize.x).toFixed(2)) : 0}
+                        onChange={(val) => {
+                          if (!originalSize) return;
+                          const newScale = val / originalSize.x;
+                          if (uniformScaling) onScaleChange(newScale, newScale, newScale);
+                          else onScaleChange(newScale, scale.y, scale.z);
                         }}
-                  >
-                    {uniformScaling ? 'ON' : 'OFF'}
-                  </button>
+                        onBlur={() => onTransformCommit?.()}
+                        className={valueInputClass}
+                        showStepper={false}
+                      />
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>mm</span>
+                    </div>
+                  </div>
+                  <div className="min-w-0">
+                    <div className="relative">
+                      <NumberInput
+                        value={originalSize ? parseFloat((scale.y * originalSize.y).toFixed(2)) : 0}
+                        onChange={(val) => {
+                          if (!originalSize) return;
+                          const newScale = val / originalSize.y;
+                          if (uniformScaling) onScaleChange(newScale, newScale, newScale);
+                          else onScaleChange(scale.x, newScale, scale.z);
+                        }}
+                        disabled={uniformScaling}
+                        onBlur={() => onTransformCommit?.()}
+                        className={`${valueInputClass} disabled:opacity-50`}
+                        showStepper={false}
+                      />
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>mm</span>
+                    </div>
+                  </div>
+                  <div className="min-w-0">
+                    <div className="relative">
+                      <NumberInput
+                        value={originalSize ? parseFloat((scale.z * originalSize.z).toFixed(2)) : 0}
+                        onChange={(val) => {
+                          if (!originalSize) return;
+                          const newScale = val / originalSize.z;
+                          if (uniformScaling) onScaleChange(newScale, newScale, newScale);
+                          else onScaleChange(scale.x, scale.y, newScale);
+                        }}
+                        disabled={uniformScaling}
+                        onBlur={() => onTransformCommit?.()}
+                        className={`${valueInputClass} disabled:opacity-50`}
+                        showStepper={false}
+                      />
+                      <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>mm</span>
+                    </div>
+                  </div>
                 </div>
 
                 <button
@@ -519,7 +524,6 @@ export function TransformControls({
                   Reset Scale
                 </button>
               </div>
-            )}
           </div>
         </div>
       ) : null}

--- a/src/components/layout/FloatingPanelStack.tsx
+++ b/src/components/layout/FloatingPanelStack.tsx
@@ -618,6 +618,7 @@ function FloatingPanelItem({
   return (
     <div
       ref={itemRef}
+      data-panel-id={id}
       className="absolute pointer-events-auto"
       style={{
         left: position.x,
@@ -1344,7 +1345,18 @@ export function FloatingPanelStack({ children }: { children: React.ReactNode }) 
 
       return next;
     });
-  }, [closeWindowContextMenu, seededPositions]);
+
+    // Reset any manual width set by a resize handle — directly set the correct default
+    if (typeof document !== 'undefined') {
+      const panelEl = document.querySelector(`[data-panel-id="${panelId}"]`) as HTMLElement | null;
+      if (panelEl) {
+        const base = PANEL_WIDTH_OVERRIDES[panelId] ?? DEFAULT_PANEL_WIDTH;
+        const scale = panelWidthScale;
+        const defaultWidth = Math.max(72, Math.round(base * scale));
+        panelEl.style.width = `${defaultWidth}px`;
+      }
+    }
+  }, [closeWindowContextMenu, seededPositions, panelWidthScale]);
 
   const resetAllWindows = React.useCallback(() => {
     closeWindowContextMenu();

--- a/src/components/layout/FloatingPanelStack.tsx
+++ b/src/components/layout/FloatingPanelStack.tsx
@@ -73,7 +73,6 @@ const DEFAULT_PANEL_WIDTH = 320;
 const DEFAULT_PANEL_HEIGHT = 150;
 const PANEL_WIDTH_OVERRIDES: Record<string, number> = {
   'visual-settings': 48,
-  'prepare-smoothing-settings': 340,
   'transform-debug-overlay': 420,
 };
 const PANEL_SCALE_EXEMPT_IDS = new Set<string>(['support-settings']);

--- a/src/components/layout/FloatingPanelStack.tsx
+++ b/src/components/layout/FloatingPanelStack.tsx
@@ -44,6 +44,20 @@ type PanelAttachment = {
 
 type AttachmentPanelRect = PanelRect & { id: string };
 
+type CollapsiblePanelRegistration = {
+  expanded: boolean;
+  setExpanded: React.Dispatch<React.SetStateAction<boolean>>;
+  autoCollapse: boolean;
+};
+
+type FloatingPanelStackContextValue = {
+  registerCollapsiblePanel: (panelId: string, registration: CollapsiblePanelRegistration) => () => void;
+  requestPanelExpand: (panelId: string) => void;
+};
+
+const FloatingPanelStackContext = React.createContext<FloatingPanelStackContextValue | null>(null);
+const FloatingPanelItemContext = React.createContext<string | null>(null);
+
 type FloatingPanelItemProps = {
   id: string;
   index: number;
@@ -56,6 +70,37 @@ type FloatingPanelItemProps = {
   onSizeChange: (id: string, size: PanelSize) => void;
   children: React.ReactNode;
 };
+
+export function useFloatingPanelCollapse(defaultExpanded = true, options?: { autoCollapse?: boolean }) {
+  const stack = React.useContext(FloatingPanelStackContext);
+  const panelId = React.useContext(FloatingPanelItemContext);
+  const [expanded, setExpandedState] = React.useState(defaultExpanded);
+  const autoCollapse = options?.autoCollapse ?? true;
+
+  React.useLayoutEffect(() => {
+    if (!stack || !panelId) return undefined;
+
+    return stack.registerCollapsiblePanel(panelId, {
+      expanded,
+      setExpanded: setExpandedState,
+      autoCollapse,
+    });
+  }, [autoCollapse, expanded, panelId, stack]);
+
+  const setExpanded = React.useCallback<React.Dispatch<React.SetStateAction<boolean>>>((next) => {
+    const resolved = typeof next === 'function'
+      ? (next as (value: boolean) => boolean)(expanded)
+      : next;
+
+    if (resolved && !expanded && stack && panelId) {
+      stack.requestPanelExpand(panelId);
+    }
+
+    setExpandedState(resolved);
+  }, [expanded, panelId, stack]);
+
+  return [expanded, setExpanded] as const;
+}
 
 type WindowContextMenuState = {
   panelId: string;
@@ -508,6 +553,39 @@ function getAttachmentDesiredPosition(
   };
 }
 
+function addAssociationEdge(edges: Map<string, Set<string>>, from: string, to: string) {
+  const fromEdges = edges.get(from) ?? new Set<string>();
+  fromEdges.add(to);
+  edges.set(from, fromEdges);
+
+  const toEdges = edges.get(to) ?? new Set<string>();
+  toEdges.add(from);
+  edges.set(to, toEdges);
+}
+
+function collectVerticalAssociationGroup(rootId: string, edges: Map<string, Set<string>>) {
+  const result = new Set<string>([rootId]);
+  const queue = [rootId];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) break;
+
+    for (const next of edges.get(current) ?? []) {
+      if (result.has(next)) continue;
+      result.add(next);
+      queue.push(next);
+    }
+  }
+
+  return result;
+}
+
+function estimateStackHeight(panelIds: string[], getSize: (panelId: string) => PanelSize, panelGap: number) {
+  if (panelIds.length === 0) return 0;
+  return panelIds.reduce((total, panelId) => total + getSize(panelId).height, 0) + panelGap * (panelIds.length - 1);
+}
+
 function buildSeededPositions(
   orderedPanelIds: string[],
   profile: LayoutProfile | null,
@@ -659,9 +737,11 @@ function FloatingPanelItem({
         rightClickGestureRef.current = null;
       }}
     >
-      <div className="w-full [&>*]:!w-full">
-        {children}
-      </div>
+      <FloatingPanelItemContext.Provider value={id}>
+        <div className="w-full [&>*]:!w-full">
+          {children}
+        </div>
+      </FloatingPanelItemContext.Provider>
     </div>
   );
 }
@@ -673,6 +753,9 @@ function FloatingPanelItem({
 export function FloatingPanelStack({ children }: { children: React.ReactNode }) {
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const panelSizesRef = React.useRef<Record<string, PanelSize>>({});
+  const expandedPanelSizesRef = React.useRef<Record<string, PanelSize>>({});
+  const collapsedPanelSizesRef = React.useRef<Record<string, PanelSize>>({});
+  const collapsiblePanelsRef = React.useRef<Record<string, CollapsiblePanelRegistration>>({});
   const dragRef = React.useRef<{ id: string; offsetX: number; offsetY: number } | null>(null);
 
   const [panelPositions, setPanelPositions] = React.useState<Record<string, PanelPosition>>({});
@@ -683,6 +766,7 @@ export function FloatingPanelStack({ children }: { children: React.ReactNode }) 
   const [dropPreview, setDropPreview] = React.useState<DropPreview | null>(null);
   const [windowContextMenu, setWindowContextMenu] = React.useState<WindowContextMenuState | null>(null);
   const [persistLayout, setPersistLayout] = React.useState<boolean>(() => isFloatingLayoutPersistenceEnabled());
+  const [collapsibleRegistryVersion, setCollapsibleRegistryVersion] = React.useState(0);
 
   const panelIdsRef = React.useRef<string[]>([]);
   const panelPositionsRef = React.useRef<Record<string, PanelPosition>>({});
@@ -695,7 +779,10 @@ export function FloatingPanelStack({ children }: { children: React.ReactNode }) 
   const panelEntries = React.useMemo(() => flattenPanelChildren(children), [children]);
   const panelIds = React.useMemo(() => panelEntries.map((entry) => entry.id), [panelEntries]);
   const panelIdsSignature = React.useMemo(() => panelIds.join('\u001f'), [panelIds]);
-  const stablePanelIds = React.useMemo(() => panelIds, [panelIdsSignature]);
+  const stablePanelIds = React.useMemo(
+    () => (panelIdsSignature.length > 0 ? panelIdsSignature.split('\u001f') : []),
+    [panelIdsSignature],
+  );
   const panelWidthScale = React.useMemo(() => {
     const width = containerSize.width;
     const height = containerSize.height;
@@ -751,25 +838,127 @@ export function FloatingPanelStack({ children }: { children: React.ReactNode }) 
     [containerSize, getPanelSize, layoutProfile, orderedPanelIds, panelGap],
   );
 
-  const collectProfileAnchorDescendants = React.useCallback((rootId: string) => {
-    const anchors = layoutProfile?.anchors ?? {};
-    const result = new Set<string>();
-    const queue: string[] = [rootId];
+  const buildVerticalAssociationEdges = React.useCallback(() => {
+    const validIds = new Set(panelIdsRef.current);
+    const edges = new Map<string, Set<string>>();
 
-    while (queue.length > 0) {
-      const current = queue.shift();
-      if (!current) break;
+    for (const [panelId, rule] of Object.entries(layoutProfile?.anchors ?? {})) {
+      if (rule.side !== 'below' && rule.side !== 'above') continue;
+      if (!validIds.has(panelId) || !validIds.has(rule.to)) continue;
+      if (manualOverrideRef.current[panelId]) continue;
+      addAssociationEdge(edges, panelId, rule.to);
+    }
 
-      for (const [panelId, rule] of Object.entries(anchors)) {
-        if (rule.to !== current) continue;
-        if (result.has(panelId) || panelId === rootId) continue;
-        result.add(panelId);
-        queue.push(panelId);
+    for (const [panelId, attachments] of Object.entries(attachmentMemoryRef.current)) {
+      if (!validIds.has(panelId)) continue;
+
+      for (const attachment of attachments) {
+        if (attachment.side !== 'below' && attachment.side !== 'above') continue;
+        if (!validIds.has(attachment.to)) continue;
+        addAssociationEdge(edges, panelId, attachment.to);
       }
     }
 
-    return result;
+    return edges;
   }, [layoutProfile]);
+
+  const getPredictedPanelSize = React.useCallback((panelId: string, expandedOverride?: boolean): PanelSize => {
+    const registration = collapsiblePanelsRef.current[panelId];
+    const isExpanded = expandedOverride ?? registration?.expanded;
+
+    if (registration) {
+      if (isExpanded) {
+        return expandedPanelSizesRef.current[panelId] ?? panelSizesRef.current[panelId] ?? { width: getPanelWidth(panelId), height: DEFAULT_PANEL_HEIGHT };
+      }
+
+      return collapsedPanelSizesRef.current[panelId] ?? panelSizesRef.current[panelId] ?? { width: getPanelWidth(panelId), height: 48 };
+    }
+
+    return panelSizesRef.current[panelId] ?? { width: getPanelWidth(panelId), height: DEFAULT_PANEL_HEIGHT };
+  }, [getPanelWidth]);
+
+  const getAssociatedPanelOrder = React.useCallback((panelIdsInGroup: Set<string>) => {
+    const orderIndexById = new Map(orderedPanelIds.map((panelId, index) => [panelId, index] as const));
+
+    return [...panelIdsInGroup].sort((a, b) => {
+      const aPos = panelPositionsRef.current[a];
+      const bPos = panelPositionsRef.current[b];
+      if (aPos && bPos && Math.abs(aPos.y - bPos.y) > 0.5) {
+        return aPos.y - bPos.y;
+      }
+
+      return (orderIndexById.get(a) ?? Number.MAX_SAFE_INTEGER)
+        - (orderIndexById.get(b) ?? Number.MAX_SAFE_INTEGER);
+    });
+  }, [orderedPanelIds]);
+
+  const requestPanelExpand = React.useCallback((panelId: string) => {
+    if (!panelId) return;
+
+    const edges = buildVerticalAssociationEdges();
+    const group = collectVerticalAssociationGroup(panelId, edges);
+    const associatedIds = getAssociatedPanelOrder(group)
+      .filter((id) => collapsiblePanelsRef.current[id]);
+
+    if (associatedIds.length <= 1) return;
+
+    const topY = associatedIds.reduce((minY, id) => {
+      const pos = panelPositionsRef.current[id];
+      return pos ? Math.min(minY, pos.y) : minY;
+    }, Number.POSITIVE_INFINITY);
+
+    const availableHeight = containerSize.height - (Number.isFinite(topY) ? topY : PANEL_MARGIN) - PANEL_MARGIN;
+    let predictedHeight = estimateStackHeight(
+      associatedIds,
+      (id) => getPredictedPanelSize(id, id === panelId ? true : undefined),
+      panelGap,
+    );
+
+    if (predictedHeight <= availableHeight) return;
+
+    const targetIndex = associatedIds.indexOf(panelId);
+    const candidates = associatedIds
+      .filter((id) => id !== panelId)
+      .filter((id) => {
+        const registration = collapsiblePanelsRef.current[id];
+        return registration?.expanded && registration.autoCollapse;
+      })
+      .sort((a, b) => Math.abs(associatedIds.indexOf(a) - targetIndex) - Math.abs(associatedIds.indexOf(b) - targetIndex));
+
+    for (const candidateId of candidates) {
+      const expandedSize = getPredictedPanelSize(candidateId, true);
+      const collapsedSize = getPredictedPanelSize(candidateId, false);
+      collapsiblePanelsRef.current[candidateId]?.setExpanded(false);
+      predictedHeight -= Math.max(0, expandedSize.height - collapsedSize.height);
+
+      if (predictedHeight <= availableHeight) break;
+    }
+  }, [buildVerticalAssociationEdges, containerSize.height, getAssociatedPanelOrder, getPredictedPanelSize, panelGap]);
+
+  const registerCollapsiblePanel = React.useCallback((
+    panelId: string,
+    registration: CollapsiblePanelRegistration,
+  ) => {
+    collapsiblePanelsRef.current = {
+      ...collapsiblePanelsRef.current,
+      [panelId]: registration,
+    };
+    setCollapsibleRegistryVersion((version) => version + 1);
+
+    return () => {
+      if (collapsiblePanelsRef.current[panelId] !== registration) return;
+
+      const next = { ...collapsiblePanelsRef.current };
+      delete next[panelId];
+      collapsiblePanelsRef.current = next;
+      setCollapsibleRegistryVersion((version) => version + 1);
+    };
+  }, []);
+
+  const floatingPanelStackContext = React.useMemo<FloatingPanelStackContextValue>(() => ({
+    registerCollapsiblePanel,
+    requestPanelExpand,
+  }), [registerCollapsiblePanel, requestPanelExpand]);
 
   React.useEffect(() => {
     panelIdsRef.current = stablePanelIds;
@@ -1029,6 +1218,21 @@ export function FloatingPanelStack({ children }: { children: React.ReactNode }) 
       [panelId]: size,
     };
 
+    const registration = collapsiblePanelsRef.current[panelId];
+    if (registration) {
+      if (registration.expanded) {
+        expandedPanelSizesRef.current = {
+          ...expandedPanelSizesRef.current,
+          [panelId]: size,
+        };
+      } else {
+        collapsedPanelSizesRef.current = {
+          ...collapsedPanelSizesRef.current,
+          [panelId]: size,
+        };
+      }
+    }
+
     setPanelSizeVersion((v) => v + 1);
 
     setPanelPositions((previous) => {
@@ -1106,6 +1310,92 @@ export function FloatingPanelStack({ children }: { children: React.ReactNode }) 
       return next;
     });
   }, [containerSize, getPanelSize, panelGap]);
+
+  React.useEffect(() => {
+    if (activeDragPanelId) return;
+
+    const edges = buildVerticalAssociationEdges();
+    const visited = new Set<string>();
+    const orderIndexById = new Map(orderedPanelIds.map((panelId, index) => [panelId, index] as const));
+
+    for (const rootId of panelIdsRef.current) {
+      if (visited.has(rootId)) continue;
+
+      const group = collectVerticalAssociationGroup(rootId, edges);
+      group.forEach((id) => visited.add(id));
+
+      const associatedIds = [...group]
+        .filter((id) => collapsiblePanelsRef.current[id]?.autoCollapse)
+        .sort((a, b) => {
+          const aPos = panelPositionsRef.current[a];
+          const bPos = panelPositionsRef.current[b];
+          if (aPos && bPos && Math.abs(aPos.y - bPos.y) > 0.5) {
+            return aPos.y - bPos.y;
+          }
+
+          return (orderIndexById.get(a) ?? Number.MAX_SAFE_INTEGER)
+            - (orderIndexById.get(b) ?? Number.MAX_SAFE_INTEGER);
+        });
+
+      if (associatedIds.length <= 1) continue;
+
+      const topY = associatedIds.reduce((minY, id) => {
+        const pos = panelPositionsRef.current[id];
+        return pos ? Math.min(minY, pos.y) : minY;
+      }, Number.POSITIVE_INFINITY);
+      const availableHeight = containerSize.height - (Number.isFinite(topY) ? topY : PANEL_MARGIN) - PANEL_MARGIN;
+
+      let predictedHeight = estimateStackHeight(associatedIds, getPredictedPanelSize, panelGap);
+      let hasColumnBreak = false;
+
+      for (const [from, targets] of edges) {
+        if (!group.has(from)) continue;
+        const fromRegistration = collapsiblePanelsRef.current[from];
+        const fromPos = panelPositionsRef.current[from];
+        if (!fromRegistration?.expanded || !fromPos) continue;
+
+        for (const to of targets) {
+          if (from > to || !group.has(to)) continue;
+          const toRegistration = collapsiblePanelsRef.current[to];
+          const toPos = panelPositionsRef.current[to];
+          if (!toRegistration?.expanded || !toPos) continue;
+
+          if (Math.abs(fromPos.x - toPos.x) > CHAIN_ATTACH_TOLERANCE * 2) {
+            hasColumnBreak = true;
+            break;
+          }
+        }
+
+        if (hasColumnBreak) break;
+      }
+
+      if (predictedHeight <= availableHeight && !hasColumnBreak) continue;
+
+      const candidates = associatedIds
+        .slice(1)
+        .reverse()
+        .filter((id) => collapsiblePanelsRef.current[id]?.expanded);
+
+      for (const candidateId of candidates) {
+        const expandedSize = getPredictedPanelSize(candidateId, true);
+        const collapsedSize = getPredictedPanelSize(candidateId, false);
+        collapsiblePanelsRef.current[candidateId]?.setExpanded(false);
+        predictedHeight -= Math.max(0, expandedSize.height - collapsedSize.height);
+
+        if (predictedHeight <= availableHeight) break;
+      }
+    }
+  }, [
+    activeDragPanelId,
+    buildVerticalAssociationEdges,
+    collapsibleRegistryVersion,
+    containerSize.height,
+    getPredictedPanelSize,
+    orderedPanelIds,
+    panelGap,
+    panelPositions,
+    panelSizeVersion,
+  ]);
 
   const snapPanelToNearestSpot = React.useCallback((panelId: string, position: PanelPosition) => {
     const size = getPanelSize(panelId);
@@ -1437,10 +1727,11 @@ export function FloatingPanelStack({ children }: { children: React.ReactNode }) 
   const viewportHeight = typeof window !== 'undefined' ? window.innerHeight : 1080;
 
   return (
-    <div
-      ref={containerRef}
-      className="absolute left-0 right-0 top-[var(--topbar-height)] bottom-0 z-10 pointer-events-none"
-    >
+    <FloatingPanelStackContext.Provider value={floatingPanelStackContext}>
+      <div
+        ref={containerRef}
+        className="absolute left-0 right-0 top-[var(--topbar-height)] bottom-0 z-10 pointer-events-none"
+      >
       {panelEntries.map((entry, index) => {
         const panelId = entry.id;
         const panelPosition = panelPositions[panelId] ?? seededPositions[panelId] ?? {
@@ -1527,6 +1818,7 @@ export function FloatingPanelStack({ children }: { children: React.ReactNode }) 
           </button>
         </div>
       ) : null}
-    </div>
+      </div>
+    </FloatingPanelStackContext.Provider>
   );
 }

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -28,7 +28,7 @@ import {
   selectPrinterNetworkDevice,
   subscribeToProfileStore,
 } from '@/features/profiles/profileStore';
-import { getInstalledProfilePlugins } from '@/features/plugins/pluginRegistry';
+
 import type { View3DSettings } from '@/components/settings/view3dPreferences';
 import type { SlicingThumbnailRenderSettings } from '@/components/settings/PerformanceSettingsTab';
 
@@ -485,17 +485,7 @@ export function TopBar({
 
   const profileState = React.useSyncExternalStore(subscribeToProfileStore, getProfileStoreSnapshot, getProfileStoreServerSnapshot);
   const activePrinterProfile = React.useMemo(() => getActivePrinterProfile(profileState), [profileState]);
-  const athenaPresetIds = React.useMemo(() => {
-    const athenaPlugin = getInstalledProfilePlugins().find(
-      (plugin) => plugin.enabled && plugin.manifest.id === 'athena-builtin',
-    );
-    return new Set((athenaPlugin?.manifest.printerPresets ?? []).map((preset) => preset.presetId));
-  }, []);
-  const isAthenaPublicBetaProfile = React.useMemo(() => {
-    const officialPresetId = activePrinterProfile?.officialPresetId?.trim();
-    if (!officialPresetId) return false;
-    return athenaPresetIds.has(officialPresetId);
-  }, [activePrinterProfile?.officialPresetId, athenaPresetIds]);
+
 
   React.useEffect(() => {
     setPrinterThumbnailFailed(false);
@@ -601,30 +591,23 @@ export function TopBar({
       locked: false,
     },
     {
-      mode: 'analysis',
-      label: 'Analysis',
-      step: 2,
-      hint: 'Inspect islands and diagnostics',
-      locked: !hasModels,
-    },
-    {
       mode: 'support',
       label: 'Support',
-      step: 3,
+      step: 2,
       hint: 'Build and tune supports',
       locked: !hasModels,
     },
     {
       mode: 'export',
       label: 'Export',
-      step: 4,
+      step: 3,
       hint: 'Finalize and export output',
       locked: !hasModels,
     },
     {
       mode: 'printing',
       label: 'Printing',
-      step: 5,
+      step: 4,
       hint: 'Inspect sliced layers before printing',
       locked: !hasModels || !hasPrintingData,
     },
@@ -939,14 +922,13 @@ export function TopBar({
             style={{ background: 'color-mix(in srgb, var(--border-subtle), transparent 10%)' }}
           />
 
-          <div className={`relative grid grid-cols-5 gap-2 ${topbarActionsDisabled ? 'pointer-events-none' : 'pointer-events-auto'}`}>
+          <div className={`relative grid grid-cols-4 gap-2 ${topbarActionsDisabled ? 'pointer-events-none' : 'pointer-events-auto'}`}>
             {steps.map((item) => {
               const active = mode === item.mode;
               const locked = item.locked;
-              const analysisComingSoon = item.mode === 'analysis' && isAthenaPublicBetaProfile;
-              const disabled = locked || topbarActionsDisabled || analysisComingSoon;
-              const nativeDisabled = disabled && !analysisComingSoon;
-              const visuallyDimmed = topbarActionsDisabled || (locked && !analysisComingSoon);
+              const disabled = locked || topbarActionsDisabled;
+              const nativeDisabled = disabled;
+              const visuallyDimmed = topbarActionsDisabled || locked;
               const printingLocked = item.mode === 'printing' && locked;
 
               return (
@@ -980,8 +962,6 @@ export function TopBar({
                   }
                   title={topbarActionsDisabled
                     ? 'Slicing in progress. Topbar actions are temporarily disabled.'
-                    : analysisComingSoon
-                    ? 'Coming Soon! Analysis workspace for Athena public beta is temporarily unavailable.'
                     : locked
                     ? (item.mode === 'printing'
                       ? 'Run slicing in Export to unlock Printing preview'
@@ -1015,26 +995,7 @@ export function TopBar({
                     <Lock className="h-3 w-3 ml-auto" style={{ color: 'var(--text-muted)' }} />
                   )}
 
-                  {analysisComingSoon && (
-                    <div
-                      className="pointer-events-none absolute right-0 top-full mt-2 z-[70] w-[190px] rounded-md border px-2.5 py-2 text-[12px] leading-tight opacity-0 -translate-y-1 transition-all duration-150 group-hover:opacity-100 group-hover:translate-y-0"
-                      style={{
-                        borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 35%)',
-                        background: 'color-mix(in srgb, var(--surface-0), black 10%)',
-                        color: 'var(--text-muted)',
-                        boxShadow: '0 10px 24px rgba(0,0,0,0.28)',
-                      }}
-                      role="tooltip"
-                      aria-hidden="true"
-                    >
-                      <div className="font-semibold mb-0.5" style={{ color: 'var(--text-strong)' }}>
-                        Coming Soon!
-                      </div>
-                      <div>
-                        Analysis Workspace is still under development! We appreciate your patience as we work to bring this feature to life in a future update.
-                      </div>
-                    </div>
-                  )}
+
                 </button>
               );
             })}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -8,7 +8,7 @@ import type { SupportMode } from '@/supports/types';
 import type { MatcapVariant, MeshShaderType } from '@/features/shaders/mesh';
 import type { SelectionHighlightMode } from '@/components/selection';
 import { Button } from '@/components/ui/primitives';
-import { Activity, AlertTriangle, ChevronDown, FolderOpen, Lock, Maximize2, Minimize2, Power, Printer, Save, Square, X } from 'lucide-react';
+import { Activity, AlertTriangle, ChevronDown, FolderInput, FolderOpen, Lock, Maximize2, Minimize2, Power, Printer, Save, Square, Upload, X } from 'lucide-react';
 import {
   applyThemeCustomColors,
   getSavedThemeCustomColors,
@@ -83,6 +83,8 @@ interface TopBarProps {
   isSlicingBusy?: boolean;
   onSaveScene?: () => void;
   onOpenScene?: () => void;
+  onLoadMeshChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onImportSceneChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onCloseProgram?: () => void;
   showMonitorButton?: boolean;
   monitorButtonActive?: boolean;
@@ -141,6 +143,8 @@ export function TopBar({
   heatmapColors,
   onHeatmapColorChange,
   isSlicingBusy = false,
+  onLoadMeshChange,
+  onImportSceneChange,
   onSaveScene,
   onOpenScene,
   onCloseProgram,
@@ -801,6 +805,50 @@ export function TopBar({
               type="button"
               onClick={() => {
                 closeAppMenu();
+                if (typeof document === 'undefined') return;
+                const input = document.getElementById('topbar-mesh-input') as HTMLInputElement | null;
+                input?.click();
+              }}
+              disabled={topbarActionsDisabled || !onLoadMeshChange}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium transition-colors"
+              style={{
+                color: (topbarActionsDisabled || !onLoadMeshChange) ? 'var(--text-muted)' : 'var(--text-strong)',
+                opacity: (topbarActionsDisabled || !onLoadMeshChange) ? 0.55 : 1,
+              }}
+              role="menuitem"
+            >
+              <span className="inline-flex h-5 w-5 items-center justify-center rounded border" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+                <Upload className="h-3.5 w-3.5" />
+              </span>
+              <span>Import Mesh…</span>
+            </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                closeAppMenu();
+                if (typeof document === 'undefined') return;
+                const input = document.getElementById('topbar-scene-input') as HTMLInputElement | null;
+                input?.click();
+              }}
+              disabled={topbarActionsDisabled || !onImportSceneChange}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium transition-colors"
+              style={{
+                color: (topbarActionsDisabled || !onImportSceneChange) ? 'var(--text-muted)' : 'var(--text-strong)',
+                opacity: (topbarActionsDisabled || !onImportSceneChange) ? 0.55 : 1,
+              }}
+              role="menuitem"
+            >
+              <span className="inline-flex h-5 w-5 items-center justify-center rounded border" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+                <FolderInput className="h-3.5 w-3.5" />
+              </span>
+              <span>Import Scene…</span>
+            </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                closeAppMenu();
                 void handleCloseProgram();
               }}
               className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium transition-colors"
@@ -815,6 +863,22 @@ export function TopBar({
           </div>
         </div>
       )}
+
+      <input
+        id="topbar-mesh-input"
+        type="file"
+        accept=".stl,.obj,.3mf,.zip"
+        multiple
+        onChange={onLoadMeshChange}
+        className="hidden"
+      />
+      <input
+        id="topbar-scene-input"
+        type="file"
+        accept=".voxl,.lys,.zip"
+        onChange={onImportSceneChange}
+        className="hidden"
+      />
 
       {isPrinterQuickMenuOpen && printerQuickMenuPosition && hasTopbarFleetUnits && activePrinterProfile && (
         <div

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -177,16 +177,6 @@ export function TopBar({
     innerWidth: 0,
     innerHeight: 0,
   }));
-  const MIN_GOOD_WIDTH = 1920;
-  const MIN_GOOD_HEIGHT = 1080;
-  const showLayoutWarning =
-    windowMetrics.innerWidth > 0
-    && (windowMetrics.innerWidth < MIN_GOOD_WIDTH || windowMetrics.innerHeight < MIN_GOOD_HEIGHT);
-  const layoutMetricsLabel =
-    windowMetrics.innerWidth > 0
-      ? `${windowMetrics.innerWidth}×${windowMetrics.innerHeight}`
-      : 'detecting…';
-  const layoutWarningTitle = `Layout tip: Current window ${layoutMetricsLabel}. For full panel comfort use ≥ ${MIN_GOOD_WIDTH}×${MIN_GOOD_HEIGHT} and maximize the app window.`;
   const topbarActionsDisabled = isSlicingBusy;
   const [isAppMenuOpen, setIsAppMenuOpen] = useState(false);
   const [appMenuPosition, setAppMenuPosition] = useState<{ x: number; y: number } | null>(null);
@@ -1069,41 +1059,6 @@ export function TopBar({
 
       <div className="ml-auto flex w-[320px] items-center justify-end gap-2 pr-2">
         <div className={`flex items-center gap-2 transition-opacity ${topbarActionsDisabled ? 'opacity-45 pointer-events-none' : ''}`}>
-          {showLayoutWarning && (
-            <div className="relative group" data-no-window-drag="true">
-              <Button
-                type="button"
-                variant="secondary"
-                className="!p-2"
-                aria-label="Layout tip"
-                data-no-window-drag="true"
-              >
-                <AlertTriangle
-                  className="w-4 h-4"
-                  style={{ color: 'color-mix(in srgb, #f59e0b, var(--text-strong) 20%)' }}
-                />
-              </Button>
-
-              <div
-                className="pointer-events-none absolute right-0 top-full mt-2 z-[70] w-[300px] rounded-md border px-2.5 py-2 text-[10px] leading-tight opacity-0 -translate-y-1 transition-all duration-150 group-hover:opacity-100 group-hover:translate-y-0"
-                style={{
-                  borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 35%)',
-                  background: 'color-mix(in srgb, var(--surface-0), black 10%)',
-                  color: 'var(--text-muted)',
-                  boxShadow: '0 10px 24px rgba(0,0,0,0.28)',
-                }}
-                role="tooltip"
-                aria-hidden="true"
-              >
-                <div className="font-semibold mb-0.5" style={{ color: 'var(--text-strong)' }}>
-                  Layout tip
-                </div>
-                <div>
-                  Current window: {layoutMetricsLabel}. For full panel comfort use ≥ {MIN_GOOD_WIDTH}×{MIN_GOOD_HEIGHT} and maximize the app window.
-                </div>
-              </div>
-            </div>
-          )}
           <ViewTypeDropdown
             value={viewTypeOverride}
             onChange={onViewTypeOverrideChange}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1251,17 +1251,17 @@ export function TopBar({
                 You can continue to adjust profiles, but you’ll be prompted to re-slice before printing with the updated settings.
               </p>
 
-              <div className="flex items-center justify-end gap-2 pt-1">
+              <div className="grid grid-cols-2 gap-2 pt-1">
                 <button
                   type="button"
-                  className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+                  className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
                   onClick={() => setShowProfileChangeWarning(false)}
                 >
                   Keep Current Profiles
                 </button>
                 <button
                   type="button"
-                  className="ui-button !h-9 px-3 text-xs"
+                  className="ui-button !h-9 w-full px-3 text-xs"
                   style={{
                     borderColor: 'color-mix(in srgb, #f59e0b, var(--border-subtle) 45%)',
                     background: 'color-mix(in srgb, #f59e0b, var(--surface-1) 86%)',

--- a/src/components/modals/DestructiveTransformModal.tsx
+++ b/src/components/modals/DestructiveTransformModal.tsx
@@ -112,20 +112,20 @@ export function DestructiveTransformModal({
             This transform invalidates existing supports. If you continue, all supports for this model will be deleted.
           </p>
 
-          <div className="flex items-center justify-end gap-2 pt-1">
+          <div className="grid grid-cols-2 gap-2 pt-1">
             <button
               type="button"
-              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+              className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
               onClick={onCancel}
             >
               Cancel
             </button>
             <button
               type="button"
-              className="ui-button ui-button-accent !h-9 px-3 text-xs"
+              className="ui-button ui-button-accent !h-9 w-full px-3 text-xs"
               onClick={onConfirm}
             >
-              Delete Supports & Continue
+              Delete & Continue
             </button>
           </div>
         </div>

--- a/src/components/modals/PrintingResliceModal.tsx
+++ b/src/components/modals/PrintingResliceModal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React from 'react';
-import { AlertTriangle, X } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
+import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
 
 type PrintingResliceModalProps = {
   isOpen: boolean;
@@ -14,99 +15,40 @@ export function PrintingResliceModal({
   onCancel,
   onResliceNow,
 }: PrintingResliceModalProps) {
-  React.useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onCancel();
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onCancel]);
-
-  if (!isOpen) return null;
-
   return (
-    <div
-      className="fixed inset-0 z-[130] flex items-center justify-center bg-black/55 backdrop-blur-sm px-3"
-      onMouseDown={(event) => {
-        if (event.target === event.currentTarget) onCancel();
-      }}
-    >
-      <div
-        className="w-full max-w-md overflow-hidden rounded-xl border shadow-2xl"
-        style={{
-          background: 'var(--surface-0)',
-          borderColor: 'var(--border-subtle)',
-          boxShadow: '0 24px 46px rgba(0,0,0,0.42)',
-        }}
-        role="dialog"
-        aria-modal="true"
-        aria-label="Re-slice required"
-      >
-        <div className="flex items-center justify-between border-b px-4 py-3" style={{ borderColor: 'var(--border-subtle)' }}>
-          <div className="flex items-center gap-2.5">
-            <span
-              className="inline-flex h-8 w-8 items-center justify-center rounded-md border"
-              style={{
-                borderColor: 'color-mix(in srgb, #d97706, var(--border-subtle) 50%)',
-                background: 'color-mix(in srgb, #d97706, var(--surface-1) 85%)',
-                color: '#d97706',
-              }}
-            >
-              <AlertTriangle className="h-4 w-4" />
-            </span>
-            <div>
-              <h2 className="text-base font-semibold" style={{ color: 'var(--text-strong)' }}>
-                Scene Modified
-              </h2>
-              <p className="mt-0.5 text-[11px]" style={{ color: 'var(--text-muted)' }}>
-                Please re-slice before printing
-              </p>
-            </div>
-          </div>
-
+    <StructuredDialogModal
+      open={isOpen}
+      ariaLabel="Re-slice required"
+      title="Scene Modified"
+      subtitle="Please re-slice before printing"
+      icon={<AlertTriangle className="h-4 w-4" />}
+      iconTone="warning"
+      zIndexClassName="z-[130]"
+      closeAriaLabel="Close modal"
+      onClose={onCancel}
+      onBackdropClick={onCancel}
+      actions={(
+        <>
           <button
             type="button"
-            className="h-8 w-8 inline-flex items-center justify-center rounded-md border transition-colors"
-            style={{
-              borderColor: 'var(--border-subtle)',
-              background: 'var(--surface-1)',
-              color: 'var(--text-muted)',
-            }}
-            aria-label="Close modal"
+            className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
             onClick={onCancel}
           >
-            <X className="w-4 h-4" />
+            Back
           </button>
-        </div>
-
-        <div className="p-4 space-y-3">
-          <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
-            Your model has been modified (geometry, position, rotation, scale, or supports changed). The current slice is no longer valid.
-          </p>
-
-          <div className="flex items-center justify-end gap-2 pt-1">
-            <button
-              type="button"
-              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
-              onClick={onCancel}
-            >
-              Back
-            </button>
-            <button
-              type="button"
-              className="ui-button ui-button-accent !h-9 px-3 text-xs"
-              onClick={onResliceNow}
-            >
-              Re-Slice Now
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+          <button
+            type="button"
+            className="ui-button ui-button-accent !h-9 w-full px-3 text-xs"
+            onClick={onResliceNow}
+          >
+            Re-Slice Now
+          </button>
+        </>
+      )}
+    >
+      <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+        Your model has been modified (geometry, position, rotation, scale, or supports changed). The current slice is no longer valid.
+      </p>
+    </StructuredDialogModal>
   );
 }

--- a/src/components/scene/MeshRepairConfirmModal.tsx
+++ b/src/components/scene/MeshRepairConfirmModal.tsx
@@ -121,17 +121,17 @@ export function MeshRepairConfirmModal({ prompt, onRepair, onLoadAsIs, onCancelI
           </div>
 
           {/* Actions */}
-          <div className="flex items-center justify-end gap-2 pt-1">
+          <div className="grid grid-cols-2 gap-2 pt-1">
             <button
               type="button"
-              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+              className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
               onClick={onLoadAsIs}
             >
               Load As-Is
             </button>
             <button
               type="button"
-              className="ui-button ui-button-accent !h-9 px-3 text-xs flex items-center gap-1.5"
+              className="ui-button ui-button-accent !h-9 w-full px-3 text-xs flex items-center justify-center gap-1.5"
               onClick={onRepair}
             >
               <Wrench className="h-3.5 w-3.5" />

--- a/src/components/settings/HotkeysSettingsTab.tsx
+++ b/src/components/settings/HotkeysSettingsTab.tsx
@@ -30,21 +30,27 @@ const SECTION_GROUPS: Array<{
   categories: string[];
 }> = [
   {
-    id: 'navigation',
-    title: 'Navigation & Workspace',
-    description: 'Focus, projection, and canvas tool switching.',
-    categories: ['CAMERA', 'CANVAS'],
+    id: 'global',
+    title: 'Global',
+    description: 'Camera, focus, and viewport shortcuts available across all workspaces.',
+    categories: ['CAMERA'],
+  },
+  {
+    id: 'scene',
+    title: 'Prepare',
+    description: 'Canvas tool switching and scene arrangement shortcuts.',
+    categories: ['CANVAS'],
   },
   {
     id: 'supports',
-    title: 'Support Authoring',
-    description: 'Placement modes and support workflow shortcuts.',
+    title: 'Supports',
+    description: 'Support authoring workflow shortcuts.',
     categories: ['SUPPORTS'],
   },
   {
     id: 'presets',
-    title: 'Preset Actions',
-    description: 'Quick-apply detail, structure, anchor, and custom presets.',
+    title: 'Support Presets',
+    description: 'Quick-apply support preset shortcuts.',
     categories: ['PRESETS'],
   },
   {
@@ -208,38 +214,16 @@ export function HotkeysSettingsTab() {
     [configurableSections],
   );
 
-  const navigationSection = useMemo(
-    () => nonRotationSections.find((section) => section.id === 'navigation') ?? null,
-    [nonRotationSections],
-  );
-
-  const supportSection = useMemo(
-    () => nonRotationSections.find((section) => section.id === 'supports') ?? null,
-    [nonRotationSections],
-  );
-
-  const presetSection = useMemo(
-    () => nonRotationSections.find((section) => section.id === 'presets') ?? null,
-    [nonRotationSections],
-  );
-
-  const extraNonRotationSections = useMemo(
-    () => nonRotationSections.filter((section) => !['navigation', 'supports', 'presets'].includes(section.id)),
-    [nonRotationSections],
-  );
-
-  const [firstExtraSection, ...remainingExtraSections] = extraNonRotationSections;
-
-  const remainingExtraRows = useMemo(() => {
-    const rows: Array<[typeof remainingExtraSections[number] | null, typeof remainingExtraSections[number] | null]> = [];
-    for (let index = 0; index < remainingExtraSections.length; index += 2) {
+  const sectionRows = useMemo(() => {
+    const rows: Array<[typeof nonRotationSections[number] | null, typeof nonRotationSections[number] | null]> = [];
+    for (let index = 0; index < nonRotationSections.length; index += 2) {
       rows.push([
-        remainingExtraSections[index] ?? null,
-        remainingExtraSections[index + 1] ?? null,
+        nonRotationSections[index] ?? null,
+        nonRotationSections[index + 1] ?? null,
       ]);
     }
     return rows;
-  }, [remainingExtraSections]);
+  }, [nonRotationSections]);
 
   const renderConfigSection = (section: {
     id: string;
@@ -317,28 +301,14 @@ export function HotkeysSettingsTab() {
 
       <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar pr-1">
         <div className="space-y-2.5">
-          {(navigationSection || supportSection) && (
-            <div className="grid gap-2.5 lg:grid-cols-2 lg:items-stretch">
-              {navigationSection ? renderConfigSection(navigationSection) : <div />}
-              {supportSection ? renderConfigSection(supportSection) : <div />}
-            </div>
-          )}
-
-          {(presetSection || firstExtraSection) && (
-            <div className="grid gap-2.5 lg:grid-cols-2 lg:items-stretch">
-              {presetSection ? renderConfigSection(presetSection) : <div />}
-              {firstExtraSection ? renderConfigSection(firstExtraSection) : <div />}
-            </div>
-          )}
-
-          {remainingExtraRows.map(([leftSection, rightSection], index) => (
-            <div key={`extra-row-${index}`} className="grid gap-2.5 lg:grid-cols-2 lg:items-stretch">
+          {sectionRows.map(([leftSection, rightSection], index) => (
+            <div key={`section-row-${index}`} className="grid gap-2.5 lg:grid-cols-2">
               {leftSection ? renderConfigSection(leftSection) : <div />}
               {rightSection ? renderConfigSection(rightSection) : <div />}
             </div>
           ))}
 
-          <div className="grid gap-2.5 lg:grid-cols-2 lg:items-stretch">
+          <div className="grid gap-2.5 lg:grid-cols-2">
             {rotationSection ? renderConfigSection(rotationSection) : <div />}
 
             <section

--- a/src/components/settings/HotkeysSettingsTab.tsx
+++ b/src/components/settings/HotkeysSettingsTab.tsx
@@ -4,15 +4,14 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { Keyboard, Lock, RotateCcw } from 'lucide-react';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
 import { HotkeyBinding, UNIVERSAL_HOTKEYS } from '@/hotkeys/hotkeyConfig';
-import { getPresetList, subscribeToPresets } from '@/supports/Settings/presets';
 
-const PRESET_ACTION_TO_ID: Record<string, string> = {
-  APPLY_DETAIL: 'detail',
-  APPLY_STRUCTURE: 'structure',
-  APPLY_ANCHOR: 'anchor',
-  APPLY_CUSTOM_1: 'custom1',
-  APPLY_CUSTOM_2: 'custom2',
-  APPLY_CUSTOM_3: 'custom3',
+const PINNED_SLOT_LABELS: Record<string, string> = {
+  SLOT_1: 'Slot 1',
+  SLOT_2: 'Slot 2',
+  SLOT_3: 'Slot 3',
+  SLOT_4: 'Slot 4',
+  SLOT_5: 'Slot 5',
+  SLOT_6: 'Slot 6',
 };
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -91,20 +90,6 @@ function getBindingTokens(binding: HotkeyBinding): string[] {
 export function HotkeysSettingsTab() {
   const { config, updateHotkey, resetToDefaults } = useHotkeyConfig();
   const [recordingKey, setRecordingKey] = useState<{ category: string, action: string } | null>(null);
-  const [presetNames, setPresetNames] = useState<Record<string, string>>({});
-
-  // Subscribe to preset changes to keep labels in sync
-  useEffect(() => {
-    const updateNames = () => {
-      const list = getPresetList();
-      const map: Record<string, string> = {};
-      list.forEach(p => map[p.id] = p.name);
-      setPresetNames(map);
-    };
-
-    updateNames();
-    return subscribeToPresets(updateNames);
-  }, []);
 
   // Effect to handle key recording
   useEffect(() => {
@@ -158,11 +143,10 @@ export function HotkeysSettingsTab() {
               return { action, label: binding.description, binding };
             }
 
-            const presetId = PRESET_ACTION_TO_ID[action];
-            const presetName = presetId ? presetNames[presetId] : null;
+            const slotLabel = PINNED_SLOT_LABELS[action] ?? action;
             return {
               action,
-              label: presetName ? `Apply \"${presetName}\" Preset` : binding.description,
+              label: slotLabel,
               binding,
             };
           });
@@ -180,7 +164,7 @@ export function HotkeysSettingsTab() {
         categories,
       };
     }).filter((section) => section.categories.some((category) => category.entries.length > 0));
-  }, [config, presetNames]);
+  }, [config]);
 
   const universalRows = useMemo(() => {
     return Object.entries(UNIVERSAL_HOTKEYS).map(([action, binding]) => {

--- a/src/components/settings/MeshSettingsTab.tsx
+++ b/src/components/settings/MeshSettingsTab.tsx
@@ -45,7 +45,9 @@ type MeshSettingsTabProps = {
   heatmapColors: string[];
   onHeatmapColorChange: (index: number, color: string) => void;
   selectionColor: string;
+  onSelectionColorChange: (color: string) => void;
   hoverColor: string;
+  onHoverColorChange: (color: string) => void;
   selectionHighlightMode: SelectionHighlightMode;
   onSelectionHighlightModeChange: (mode: SelectionHighlightMode) => void;
   hoverTintStrength: number;
@@ -80,7 +82,9 @@ export function MeshSettingsTab({
   heatmapColors,
   onHeatmapColorChange,
   selectionColor,
+  onSelectionColorChange,
   hoverColor,
+  onHoverColorChange,
   selectionHighlightMode,
   onSelectionHighlightModeChange,
   hoverTintStrength,
@@ -486,7 +490,7 @@ export function MeshSettingsTab({
           </span>
           <div className="flex-1 min-w-0">
             <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
-              Selection
+              Selection &amp; Hover
             </h3>
             <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
               How selected and hovered models are emphasized throughout the app.
@@ -514,49 +518,44 @@ export function MeshSettingsTab({
               <div className="text-xs font-semibold mb-2" style={{ color: 'var(--text-strong)' }}>Colors</div>
               <div className="grid gap-2 sm:grid-cols-2">
                 <div className="space-y-1">
-                  <div className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>Selection (Theme Accent)</div>
+                  <div className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>Selection Color</div>
                   <div className="flex items-center gap-2">
                     <input
                       type="color"
                       value={selectionColor}
-                      readOnly
-                      disabled
+                      onChange={(e) => onSelectionColorChange(e.target.value)}
                       className="h-8 w-10 shrink-0 rounded border"
-                      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)', opacity: 0.7 }}
+                      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
                     />
                     <input
                       type="text"
                       value={selectionColor}
-                      readOnly
+                      onChange={(e) => onSelectionColorChange(e.target.value)}
                       className="ui-input h-8 w-[7.5rem] min-w-0"
                       placeholder="#ec2a77"
                     />
                   </div>
                 </div>
                 <div className="space-y-1">
-                  <div className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>Hover (Theme Accent Hover)</div>
+                  <div className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>Hover Color</div>
                   <div className="flex items-center gap-2">
                     <input
                       type="color"
                       value={hoverColor}
-                      readOnly
-                      disabled
+                      onChange={(e) => onHoverColorChange(e.target.value)}
                       className="h-8 w-10 shrink-0 rounded border"
-                      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)', opacity: 0.7 }}
+                      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
                     />
                     <input
                       type="text"
                       value={hoverColor}
-                      readOnly
+                      onChange={(e) => onHoverColorChange(e.target.value)}
                       className="ui-input h-8 w-[7.5rem] min-w-0"
                       placeholder="#ec2a77"
                     />
                   </div>
                 </div>
               </div>
-              <p className="mt-2 text-[11px]" style={{ color: 'var(--text-muted)' }}>
-                Managed by <strong>UI &amp; Theme</strong> → <strong>Accent</strong> and <strong>Accent Hover</strong>.
-              </p>
             </div>
 
             <div className="rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>

--- a/src/components/settings/PerformanceSettingsTab.tsx
+++ b/src/components/settings/PerformanceSettingsTab.tsx
@@ -349,67 +349,6 @@ export function PerformanceSettingsTab({
         </div>
       </section>
 
-      {/* Experimental Slicing Toggles */}
-      <section
-        className="rounded-lg border p-3"
-        style={{
-          background: 'var(--surface-1)',
-          borderColor: 'var(--border-subtle)',
-        }}
-      >
-        <div className="flex items-start gap-2">
-          <span
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md border shrink-0"
-            style={{
-              borderColor: 'var(--border-subtle)',
-              background: 'color-mix(in srgb, var(--surface-2), transparent 8%)',
-            }}
-          >
-            <Sparkles className="h-4 w-4" style={{ color: 'var(--accent-secondary)' }} />
-          </span>
-          <div className="flex-1">
-            <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
-              Experimental
-            </h3>
-            <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
-              Advanced slicing toggles that are not recommended for most prints.
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-3 rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <div className="text-xs font-semibold" style={{ color: 'var(--text-strong)' }}>
-                AA on Supports
-              </div>
-              <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
-                Off by default. Keeps support/raft geometry crisp and avoids unnecessary anti-aliased halos.
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={() => patch({ aaOnSupportsExperimental: !settings.aaOnSupportsExperimental })}
-              className="h-10 min-w-[92px] rounded-md border px-3 text-[12px] font-semibold uppercase tracking-wide transition-colors"
-              style={settings.aaOnSupportsExperimental
-                ? {
-                    borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
-                    background: 'color-mix(in srgb, var(--accent), var(--surface-0) 76%)',
-                    color: 'var(--accent)',
-                  }
-                : {
-                    borderColor: 'var(--border-subtle)',
-                    background: 'var(--surface-1)',
-                    color: 'var(--text-muted)',
-                  }}
-            >
-              {settings.aaOnSupportsExperimental ? 'On' : 'Off'}
-            </button>
-          </div>
-
-        </div>
-      </section>
-
       {/* Temp File Cleanup Section */}
       <section
         className="rounded-lg border p-3"

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1346,7 +1346,9 @@ export function SettingsModal({
                   heatmapColors={draftHeatmapColors}
                   onHeatmapColorChange={handleDraftHeatmapColorChange}
                   selectionColor={draftSelectionColor}
+                  onSelectionColorChange={setDraftSelectionColor}
                   hoverColor={draftHoverColor}
+                  onHoverColorChange={setDraftHoverColor}
                   selectionHighlightMode={draftSelectionHighlightMode}
                   onSelectionHighlightModeChange={setDraftSelectionHighlightMode}
                   hoverTintStrength={draftHoverTintStrength}

--- a/src/components/ui/StructuredDialogModal.tsx
+++ b/src/components/ui/StructuredDialogModal.tsx
@@ -59,7 +59,7 @@ export function StructuredDialogModal({
   maxWidthClassName = 'max-w-lg',
   panelClassName = '',
   bodyClassName = 'space-y-4 p-5',
-  actionsClassName = 'grid grid-flow-col gap-2 pt-1',
+  actionsClassName = 'grid grid-flow-col auto-cols-fr gap-2 pt-1',
   closeAriaLabel = 'Close dialog',
   closeDisabled = false,
   onClose,

--- a/src/components/ui/StructuredDialogModal.tsx
+++ b/src/components/ui/StructuredDialogModal.tsx
@@ -59,7 +59,7 @@ export function StructuredDialogModal({
   maxWidthClassName = 'max-w-lg',
   panelClassName = '',
   bodyClassName = 'space-y-4 p-5',
-  actionsClassName = 'flex shrink-0 items-center justify-end gap-2 pt-1',
+  actionsClassName = 'grid grid-flow-col gap-2 pt-1',
   closeAriaLabel = 'Close dialog',
   closeDisabled = false,
   onClose,

--- a/src/features/export/components/ExportPanel.tsx
+++ b/src/features/export/components/ExportPanel.tsx
@@ -288,7 +288,7 @@ export function ExportPanel({
                   )}
                 </svg>
               </IconButton>
-              <h2 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Export</h2>
+              <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Export</h3>
             </>
           )}
           hideDivider={!isExpanded}
@@ -326,7 +326,7 @@ export function ExportPanel({
                 )}
               </svg>
             </IconButton>
-            <h2 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Export</h2>
+            <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Export</h3>
           </>
         )}
         hideDivider={!isExpanded}

--- a/src/features/export/components/ExportPanel.tsx
+++ b/src/features/export/components/ExportPanel.tsx
@@ -6,6 +6,7 @@ import { ExportManager, ExportOptions } from '../logic/ExportManager';
 import { normalizeExportBaseName, resolveEntirePlateExportBaseName } from '../logic/exportFileNaming';
 import { Button, Card, CardHeader, IconButton, Input, Select } from '@/components/ui/primitives';
 import { pickDirectoryWithNativeDialog } from '@/features/slicing/tauri/nativeSlicerBridge';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 
 interface ExportPanelProps {
   models: LoadedModel[];
@@ -38,7 +39,7 @@ export function ExportPanel({
   onExportSuccess,
   onExportError,
 }: ExportPanelProps) {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useFloatingPanelCollapse(true);
   const [exportScope, setExportScope] = useState<ExportScope>('entire_plate');
   const [filename, setFilename] = useState(() => normalizeExportBaseName(activeModel?.name));
   const [isExporting, setIsExporting] = useState(false);

--- a/src/features/mesh-smoothing/MeshSmoothingSettingsPanel.tsx
+++ b/src/features/mesh-smoothing/MeshSmoothingSettingsPanel.tsx
@@ -182,7 +182,7 @@ export function MeshSmoothingSettingsPanel() {
                   type="text"
                   value={clampedColorInput}
                   onChange={(e) => updateMeshSmoothingSettings({ highlightColor: e.target.value })}
-                  className="ui-input flex-1 h-8 text-xs uppercase"
+                  className="ui-input flex-1 min-w-0 h-8 text-xs uppercase"
                   placeholder="#269EFF"
                 />
               </div>

--- a/src/features/mesh-smoothing/MeshSmoothingSettingsPanel.tsx
+++ b/src/features/mesh-smoothing/MeshSmoothingSettingsPanel.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { HexColorPicker } from 'react-colorful';
 import { RotateCcw } from 'lucide-react';
 import { NumberInput } from '@/components/ui/NumberInput';
+import { Card, CardHeader, IconButton } from '@/components/ui/primitives';
 import {
   DEFAULT_MESH_SMOOTHING_SETTINGS,
   clampMeshSmoothingBrushSizeMm,
@@ -25,6 +26,7 @@ function SectionHeader({ title }: { title: string }) {
 }
 
 export function MeshSmoothingSettingsPanel() {
+  const [expanded, setExpanded] = React.useState(true);
   const [settings, setSettings] = React.useState(() => getMeshSmoothingSettings());
 
   React.useEffect(() => {
@@ -68,119 +70,149 @@ export function MeshSmoothingSettingsPanel() {
   const valueInputClass = 'ui-input h-8 w-full px-2 text-xs sm:text-sm text-center tabular-nums no-spinners';
 
   return (
-    <div className="h-full w-full flex flex-col">
-      <div className="flex-1 min-h-0 overflow-y-auto px-2.5 py-2 space-y-2">
-
-        {/* BRUSH SECTION */}
-        <div className="rounded-md border p-2" style={brushCardStyle}>
-          <SectionHeader title="Brush" />
-          <div className="pt-1.5 space-y-2">
-            <div className="relative">
-              <NumberInput
-                value={settings.brushSizeMm}
-                onChange={(val) => updateMeshSmoothingSettings({ brushSizeMm: clampMeshSmoothingBrushSizeMm(val) })}
-                className={valueInputClass}
-                showStepper={false}
-              />
-              <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>mm</span>
-            </div>
-
-            <div className="relative">
-              <NumberInput
-                value={settings.strength}
-                onChange={(val) => updateMeshSmoothingSettings({ strength: Math.min(1, Math.max(0, val)) })}
-                className={valueInputClass}
-                step={0.01}
-                showStepper={false}
-              />
-              <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>Strength</span>
-            </div>
-
-            <div className="relative">
-              <NumberInput
-                value={settings.iterations}
-                onChange={(val) => updateMeshSmoothingSettings({ iterations: Math.round(Math.min(20, Math.max(1, val))) })}
-                className={valueInputClass}
-                step={1}
-                showStepper={false}
-              />
-              <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>Iterations</span>
-            </div>
-
-            <div className="grid grid-cols-3 gap-1.5">
-              {(['linear', 'smooth', 'sharp'] as MeshSmoothingFalloff[]).map((falloff) => (
-                <button
-                  key={falloff}
-                  type="button"
-                  onClick={() => updateMeshSmoothingSettings({ falloff })}
-                  className="min-h-[36px] rounded-md border px-3 text-[12px] font-semibold uppercase tracking-wide transition-colors"
-                  style={
-                    settings.falloff === falloff
-                      ? {
-                          borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
-                          background: 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)',
-                          color: 'color-mix(in srgb, var(--accent), var(--text-strong) 25%)',
-                        }
-                      : {
-                          borderColor: 'var(--border-subtle)',
-                          background: 'var(--surface-1)',
-                          color: 'var(--text-muted)',
-                        }
-                  }
-                >
-                  {falloff}
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
-
-        {/* HIGHLIGHT SECTION */}
-        <div className="rounded-md border p-2" style={highlightCardStyle}>
-          <SectionHeader title="Highlight" />
-          <div className="pt-1.5 space-y-2">
-            <div className="flex items-center gap-2">
-              <div
-                className="h-8 w-8 shrink-0 rounded-md border"
-                style={{
-                  background: settings.highlightColor,
-                  borderColor: 'color-mix(in srgb, var(--border-subtle), white 8%)',
-                }}
-              />
-              <input
-                type="text"
-                value={clampedColorInput}
-                onChange={(e) => updateMeshSmoothingSettings({ highlightColor: e.target.value })}
-                className="ui-input flex-1 h-8 text-xs uppercase"
-                placeholder="#269EFF"
-              />
-            </div>
-
-            <div
-              className="h-28 rounded-md border p-1 overflow-hidden"
-              data-no-drag="true"
-              style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-0), transparent 6%)' }}
+    <Card className="w-full overflow-x-hidden shadow-xl">
+      <CardHeader
+        left={(
+          <>
+            <IconButton
+              onClick={() => setExpanded(!expanded)}
+              className="!p-0.5"
+              title={expanded ? 'Collapse card' : 'Expand card'}
             >
-              <HexColorPicker
-                data-no-drag="true"
-                color={settings.highlightColor}
-                onChange={(c) => updateMeshSmoothingSettings({ highlightColor: c })}
-                style={{ width: '100%', height: '100%' }}
-              />
+              <svg
+                className="w-3 h-3 transform transition-transform"
+                style={{ color: expanded ? 'var(--accent)' : 'var(--text-muted)' }}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                {expanded ? (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                ) : (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                )}
+              </svg>
+            </IconButton>
+            <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Mesh Smoothing</h3>
+          </>
+        )}
+        hideDivider={!expanded}
+      />
+
+      {expanded && (
+        <div className="px-2.5 pb-2.5 space-y-2 max-h-[calc(100vh-var(--topbar-height)-88px)] overflow-y-auto custom-scrollbar">
+
+          {/* BRUSH SECTION */}
+          <div className="rounded-md border p-2" style={brushCardStyle}>
+            <SectionHeader title="Brush" />
+            <div className="pt-1.5 space-y-2">
+              <div className="relative">
+                <NumberInput
+                  value={settings.brushSizeMm}
+                  onChange={(val) => updateMeshSmoothingSettings({ brushSizeMm: clampMeshSmoothingBrushSizeMm(val) })}
+                  className={valueInputClass}
+                  showStepper={false}
+                />
+                <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>mm</span>
+              </div>
+
+              <div className="relative">
+                <NumberInput
+                  value={settings.strength}
+                  onChange={(val) => updateMeshSmoothingSettings({ strength: Math.min(1, Math.max(0, val)) })}
+                  className={valueInputClass}
+                  step={0.01}
+                  showStepper={false}
+                />
+                <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>Strength</span>
+              </div>
+
+              <div className="relative">
+                <NumberInput
+                  value={settings.iterations}
+                  onChange={(val) => updateMeshSmoothingSettings({ iterations: Math.round(Math.min(20, Math.max(1, val))) })}
+                  className={valueInputClass}
+                  step={1}
+                  showStepper={false}
+                />
+                <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>Iterations</span>
+              </div>
+
+              <div className="grid grid-cols-3 gap-1.5">
+                {(['linear', 'smooth', 'sharp'] as MeshSmoothingFalloff[]).map((falloff) => (
+                  <button
+                    key={falloff}
+                    type="button"
+                    onClick={() => updateMeshSmoothingSettings({ falloff })}
+                    className="min-h-[36px] rounded-md border px-3 text-[12px] font-semibold uppercase tracking-wide transition-colors"
+                    style={
+                      settings.falloff === falloff
+                        ? {
+                            borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
+                            background: 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)',
+                            color: 'color-mix(in srgb, var(--accent), var(--text-strong) 25%)',
+                          }
+                        : {
+                            borderColor: 'var(--border-subtle)',
+                            background: 'var(--surface-1)',
+                            color: 'var(--text-muted)',
+                          }
+                    }
+                  >
+                    {falloff}
+                  </button>
+                ))}
+              </div>
             </div>
           </div>
+
+          {/* HIGHLIGHT SECTION */}
+          <div className="rounded-md border p-2" style={highlightCardStyle}>
+            <SectionHeader title="Highlight" />
+            <div className="pt-1.5 space-y-2">
+              <div className="flex items-center gap-2">
+                <div
+                  className="h-8 w-8 shrink-0 rounded-md border"
+                  style={{
+                    background: settings.highlightColor,
+                    borderColor: 'color-mix(in srgb, var(--border-subtle), white 8%)',
+                  }}
+                />
+                <input
+                  type="text"
+                  value={clampedColorInput}
+                  onChange={(e) => updateMeshSmoothingSettings({ highlightColor: e.target.value })}
+                  className="ui-input flex-1 h-8 text-xs uppercase"
+                  placeholder="#269EFF"
+                />
+              </div>
+
+              <div
+                className="h-28 rounded-md border p-1 overflow-hidden"
+                data-no-drag="true"
+                style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-0), transparent 6%)' }}
+              >
+                <HexColorPicker
+                  data-no-drag="true"
+                  color={settings.highlightColor}
+                  onChange={(c) => updateMeshSmoothingSettings({ highlightColor: c })}
+                  style={{ width: '100%', height: '100%' }}
+                />
+              </div>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            className="ui-button ui-button-secondary w-full !h-8 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+            onClick={() => setMeshSmoothingSettings({ ...DEFAULT_MESH_SMOOTHING_SETTINGS })}
+          >
+            <RotateCcw className="w-3 h-3" />
+            Reset Defaults
+          </button>
+
         </div>
-
-        <button
-          type="button"
-          className="ui-button ui-button-secondary w-full !h-8 px-3 text-xs inline-flex items-center justify-center gap-1.5"
-          onClick={() => setMeshSmoothingSettings({ ...DEFAULT_MESH_SMOOTHING_SETTINGS })}
-        >
-          <RotateCcw className="w-3 h-3" />
-          Reset Defaults
-        </button>
-
-      </div>
-    </div>
+      )}
+    </Card>
   );
 }

--- a/src/features/mesh-smoothing/MeshSmoothingSettingsPanel.tsx
+++ b/src/features/mesh-smoothing/MeshSmoothingSettingsPanel.tsx
@@ -3,9 +3,9 @@
 import React from 'react';
 import { HexColorPicker } from 'react-colorful';
 import { RotateCcw } from 'lucide-react';
+import { NumberInput } from '@/components/ui/NumberInput';
 import {
   DEFAULT_MESH_SMOOTHING_SETTINGS,
-  MESH_SMOOTHING_BRUSH_SIZE_MM,
   clampMeshSmoothingBrushSizeMm,
   getMeshSmoothingSettings,
   loadMeshSmoothingSettingsFromLocalStorage,
@@ -15,6 +15,14 @@ import {
   updateMeshSmoothingSettings,
   type MeshSmoothingFalloff,
 } from './settings';
+
+function SectionHeader({ title }: { title: string }) {
+  return (
+    <div className="py-0.5 text-center text-xs font-semibold uppercase tracking-wide" style={{ color: 'var(--text-strong)' }}>
+      {title}
+    </div>
+  );
+}
 
 export function MeshSmoothingSettingsPanel() {
   const [settings, setSettings] = React.useState(() => getMeshSmoothingSettings());
@@ -47,70 +55,77 @@ export function MeshSmoothingSettingsPanel() {
     return raw.startsWith('#') ? raw.toUpperCase() : `#${raw.toUpperCase()}`;
   }, [settings.highlightColor]);
 
+  const brushCardStyle: React.CSSProperties = {
+    borderColor: 'color-mix(in srgb, #4f8cff, var(--border-subtle) 78%)',
+    background: 'color-mix(in srgb, #4f8cff, var(--surface-1) 94%)',
+  };
+
+  const highlightCardStyle: React.CSSProperties = {
+    borderColor: 'color-mix(in srgb, #8f6cff, var(--border-subtle) 80%)',
+    background: 'color-mix(in srgb, #8f6cff, var(--surface-1) 95%)',
+  };
+
+  const valueInputClass = 'ui-input h-8 w-full px-2 text-xs sm:text-sm text-center tabular-nums no-spinners';
+
   return (
     <div className="h-full w-full flex flex-col">
       <div className="flex-1 min-h-0 overflow-y-auto px-2.5 py-2 space-y-2">
 
-        <div
-          className="rounded-md border p-2 space-y-2"
-          style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
-        >
-          <div className="text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-            Brush Dynamics
-          </div>
+        {/* BRUSH SECTION */}
+        <div className="rounded-md border p-2" style={brushCardStyle}>
+          <SectionHeader title="Brush" />
+          <div className="pt-1.5 space-y-2">
+            <div className="relative">
+              <NumberInput
+                value={settings.brushSizeMm}
+                onChange={(val) => updateMeshSmoothingSettings({ brushSizeMm: clampMeshSmoothingBrushSizeMm(val) })}
+                className={valueInputClass}
+                showStepper={false}
+              />
+              <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>mm</span>
+            </div>
 
-          <div className="space-y-0.5">
-            <label className="flex items-center justify-between text-[11px]" style={{ color: 'var(--text-muted)' }}>
-              <span>Brush Size</span>
-              <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold tabular-nums" style={{ color: 'var(--text-strong)', background: 'var(--surface-0)' }}>
-                {settings.brushSizeMm.toFixed(2)} mm
-              </span>
-            </label>
-            <input
-              type="range"
-              min={MESH_SMOOTHING_BRUSH_SIZE_MM.min}
-              max={MESH_SMOOTHING_BRUSH_SIZE_MM.max}
-              step={MESH_SMOOTHING_BRUSH_SIZE_MM.step}
-              value={settings.brushSizeMm}
-              onChange={(e) => updateMeshSmoothingSettings({ brushSizeMm: clampMeshSmoothingBrushSizeMm(parseFloat(e.target.value)) })}
-              className="ui-range"
-            />
-          </div>
+            <div className="relative">
+              <NumberInput
+                value={settings.strength}
+                onChange={(val) => updateMeshSmoothingSettings({ strength: Math.min(1, Math.max(0, val)) })}
+                className={valueInputClass}
+                step={0.01}
+                showStepper={false}
+              />
+              <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>Strength</span>
+            </div>
 
-          <div className="space-y-0.5">
-            <label className="flex items-center justify-between text-[11px]" style={{ color: 'var(--text-muted)' }}>
-              <span>Strength</span>
-              <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold tabular-nums" style={{ color: 'var(--text-strong)', background: 'var(--surface-0)' }}>
-                {settings.strength.toFixed(2)}
-              </span>
-            </label>
-            <input
-              type="range"
-              min="0"
-              max="1"
-              step="0.01"
-              value={settings.strength}
-              onChange={(e) => updateMeshSmoothingSettings({ strength: parseFloat(e.target.value) })}
-              className="ui-range"
-            />
-          </div>
+            <div className="relative">
+              <NumberInput
+                value={settings.iterations}
+                onChange={(val) => updateMeshSmoothingSettings({ iterations: Math.round(Math.min(20, Math.max(1, val))) })}
+                className={valueInputClass}
+                step={1}
+                showStepper={false}
+              />
+              <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] font-semibold" style={{ color: 'var(--text-muted)' }}>Iterations</span>
+            </div>
 
-          <div className="space-y-1">
-            <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>Falloff</div>
-            <div
-              className="flex rounded-md overflow-hidden border"
-              style={{ borderColor: 'var(--border-subtle)' }}
-            >
-              {(['linear', 'smooth', 'sharp'] as MeshSmoothingFalloff[]).map((falloff, i) => (
+            <div className="grid grid-cols-3 gap-1.5">
+              {(['linear', 'smooth', 'sharp'] as MeshSmoothingFalloff[]).map((falloff) => (
                 <button
                   key={falloff}
                   type="button"
                   onClick={() => updateMeshSmoothingSettings({ falloff })}
-                  className={`flex-1 py-1 text-[11px] font-medium capitalize transition-colors${i > 0 ? ' border-l' : ''}`}
+                  className="min-h-[36px] rounded-md border px-3 text-[12px] font-semibold uppercase tracking-wide transition-colors"
                   style={
                     settings.falloff === falloff
-                      ? { background: 'var(--accent)', color: 'var(--accent-fg)', borderColor: 'var(--border-subtle)' }
-                      : { background: 'var(--surface-1)', color: 'var(--text-muted)', borderColor: 'var(--border-subtle)' }
+                      ? {
+                          borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
+                          background: 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)',
+                          color: 'color-mix(in srgb, var(--accent), var(--text-strong) 25%)',
+                        }
+                      : {
+                          borderColor: 'var(--border-subtle)',
+                          background: 'var(--surface-1)',
+                          color: 'var(--text-muted)',
+                        }
                   }
                 >
                   {falloff}
@@ -118,62 +133,41 @@ export function MeshSmoothingSettingsPanel() {
               ))}
             </div>
           </div>
-
-          <div className="space-y-0.5">
-            <label className="flex items-center justify-between text-[11px]" style={{ color: 'var(--text-muted)' }}>
-              <span>Iterations</span>
-              <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold tabular-nums" style={{ color: 'var(--text-strong)', background: 'var(--surface-0)' }}>
-                {settings.iterations}
-              </span>
-            </label>
-            <input
-              type="range"
-              min="1"
-              max="20"
-              step="1"
-              value={settings.iterations}
-              onChange={(e) => updateMeshSmoothingSettings({ iterations: parseInt(e.target.value, 10) })}
-              className="ui-range"
-            />
-          </div>
         </div>
 
-        <div
-          className="rounded-md border p-2 space-y-2"
-          style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
-        >
-          <div className="text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-            Paint Highlight
-          </div>
+        {/* HIGHLIGHT SECTION */}
+        <div className="rounded-md border p-2" style={highlightCardStyle}>
+          <SectionHeader title="Highlight" />
+          <div className="pt-1.5 space-y-2">
+            <div className="flex items-center gap-2">
+              <div
+                className="h-8 w-8 shrink-0 rounded-md border"
+                style={{
+                  background: settings.highlightColor,
+                  borderColor: 'color-mix(in srgb, var(--border-subtle), white 8%)',
+                }}
+              />
+              <input
+                type="text"
+                value={clampedColorInput}
+                onChange={(e) => updateMeshSmoothingSettings({ highlightColor: e.target.value })}
+                className="ui-input flex-1 h-8 text-xs uppercase"
+                placeholder="#269EFF"
+              />
+            </div>
 
-          <div className="flex items-center gap-2">
             <div
-              className="h-8 w-8 shrink-0 rounded-md border"
-              style={{
-                background: settings.highlightColor,
-                borderColor: 'color-mix(in srgb, var(--border-subtle), white 8%)',
-              }}
-            />
-            <input
-              type="text"
-              value={clampedColorInput}
-              onChange={(e) => updateMeshSmoothingSettings({ highlightColor: e.target.value })}
-              className="ui-input flex-1 h-8 text-xs uppercase"
-              placeholder="#269EFF"
-            />
-          </div>
-
-          <div
-            className="h-36 rounded-md border p-1 overflow-hidden"
-            data-no-drag="true"
-            style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-0), transparent 6%)' }}
-          >
-            <HexColorPicker
+              className="h-28 rounded-md border p-1 overflow-hidden"
               data-no-drag="true"
-              color={settings.highlightColor}
-              onChange={(c) => updateMeshSmoothingSettings({ highlightColor: c })}
-              style={{ width: '100%', height: '100%' }}
-            />
+              style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-0), transparent 6%)' }}
+            >
+              <HexColorPicker
+                data-no-drag="true"
+                color={settings.highlightColor}
+                onChange={(c) => updateMeshSmoothingSettings({ highlightColor: c })}
+                style={{ width: '100%', height: '100%' }}
+              />
+            </div>
           </div>
         </div>
 

--- a/src/features/mesh-smoothing/MeshSmoothingSettingsPanel.tsx
+++ b/src/features/mesh-smoothing/MeshSmoothingSettingsPanel.tsx
@@ -5,6 +5,7 @@ import { HexColorPicker } from 'react-colorful';
 import { RotateCcw } from 'lucide-react';
 import { NumberInput } from '@/components/ui/NumberInput';
 import { Card, CardHeader, IconButton } from '@/components/ui/primitives';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 import {
   DEFAULT_MESH_SMOOTHING_SETTINGS,
   clampMeshSmoothingBrushSizeMm,
@@ -26,7 +27,7 @@ function SectionHeader({ title }: { title: string }) {
 }
 
 export function MeshSmoothingSettingsPanel() {
-  const [expanded, setExpanded] = React.useState(true);
+  const [expanded, setExpanded] = useFloatingPanelCollapse(true);
   const [settings, setSettings] = React.useState(() => getMeshSmoothingSettings());
 
   React.useEffect(() => {

--- a/src/features/printing/components/PrintingPanel.tsx
+++ b/src/features/printing/components/PrintingPanel.tsx
@@ -99,7 +99,7 @@ export function PrintingPanel({
                 )}
               </svg>
             </IconButton>
-            <h2 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Printing</h2>
+            <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Printing</h3>
           </>
         )}
       />

--- a/src/features/printing/components/PrintingPanel.tsx
+++ b/src/features/printing/components/PrintingPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ChevronDown, Download, FolderOpen, Loader2, Printer, RotateCcw, X } from 'lucide-react';
 import { Button, Card, CardHeader, IconButton } from '@/components/ui/primitives';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 
 type PrintingPanelProps = {
   outputName: string | null;
@@ -45,7 +46,7 @@ export function PrintingPanel({
   sliceIntent = null,
   savedFilePath = null,
 }: PrintingPanelProps) {
-  const [isExpanded, setIsExpanded] = React.useState(true);
+  const [isExpanded, setIsExpanded] = useFloatingPanelCollapse(true);
   const [revealingSavedPath, setRevealingSavedPath] = React.useState(false);
   const [revealSavedPathError, setRevealSavedPathError] = React.useState<string | null>(null);
 

--- a/src/features/slicing/components/SlicingPanel.tsx
+++ b/src/features/slicing/components/SlicingPanel.tsx
@@ -2492,7 +2492,7 @@ export function SlicingPanel({
                   )}
                 </svg>
               </IconButton>
-              <h2 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Slicing</h2>
+              <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Slicing</h3>
             </>
           )}
           hideDivider={!isExpanded}
@@ -2530,7 +2530,7 @@ export function SlicingPanel({
                 )}
               </svg>
             </IconButton>
-            <h2 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Slicing</h2>
+            <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>Slicing</h3>
           </>
         )}
         hideDivider={!isExpanded}

--- a/src/features/slicing/components/SlicingPanel.tsx
+++ b/src/features/slicing/components/SlicingPanel.tsx
@@ -6,6 +6,7 @@ import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import { KNOWN_SOURCE_EXTENSION_STRIP_RE } from '@/features/plugins/pluginFileTypeExtensions';
 import { Button, Card, CardHeader, IconButton } from '@/components/ui/primitives';
 import { ScrollableNumberField } from '@/components/ui/scrollableNumberField';
+import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 import { openProfileSettingsModal } from '@/components/settings/profileModalEvents';
 import { MaterialAntiAliasingSection, type MaterialDraft } from '@/components/settings/profileFormAtoms';
 import {
@@ -774,7 +775,7 @@ export function SlicingPanel({
   onBeforeSlicingRun,
   resolveOutputPathForIntent,
 }: SlicingPanelProps) {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useFloatingPanelCollapse(true);
   const [sliceIntent, setSliceIntent] = useState<SliceIntent>(() => {
     const id = (getActivePrinterProfile(getProfileStoreSnapshot())?.id ?? '').trim();
     if (!id) return 'file';

--- a/src/hotkeys/HotkeyContext.tsx
+++ b/src/hotkeys/HotkeyContext.tsx
@@ -24,8 +24,10 @@ export function HotkeyProvider({ children }: { children: React.ReactNode }) {
             const stored = localStorage.getItem(HOTKEY_STORAGE_KEY);
             if (stored) {
                 const parsed = JSON.parse(stored);
-                // Merge with defaults to ensure any new keys added to the app are present
-                setConfig(prev => deepMerge(prev, parsed));
+                // Merge with defaults to ensure any new keys added to the app are present,
+                // and strip any stored entries whose actions no longer exist in the defaults
+                const cleaned = stripStaleActions(DEFAULT_KEYBINDINGS, parsed);
+                setConfig(prev => deepMerge(prev, cleaned));
             }
         } catch (e) {
             console.error('Failed to load hotkeys', e);
@@ -74,6 +76,32 @@ export function useHotkeyConfig() {
         throw new Error('useHotkeyConfig must be used within a HotkeyProvider');
     }
     return context;
+}
+
+// Strip any stored category entries whose actions don't exist in the current defaults.
+// This automatically cleans up old hotkeys (e.g. APPLY_DETAIL) that have been removed.
+function stripStaleActions(defaults: HotkeyConfig, stored: any): any {
+    const result: any = {};
+    for (const category in stored) {
+        if (!stored.hasOwnProperty(category)) continue;
+        if (!defaults[category]) {
+            // Entire category no longer exists — drop it
+            continue;
+        }
+        const categoryDefaults = defaults[category];
+        const categoryStored = stored[category];
+        const cleanedCategory: any = {};
+        for (const action in categoryStored) {
+            if (!categoryStored.hasOwnProperty(action)) continue;
+            if (!categoryDefaults[action]) {
+                // Action no longer exists in defaults — drop it
+                continue;
+            }
+            cleanedCategory[action] = categoryStored[action];
+        }
+        result[category] = cleanedCategory;
+    }
+    return result;
 }
 
 // Helper to merge stored config with defaults (to pick up new default keys and keep user overrides)

--- a/src/hotkeys/hotkeyConfig.ts
+++ b/src/hotkeys/hotkeyConfig.ts
@@ -101,32 +101,29 @@ export const DEFAULT_KEYBINDINGS: HotkeyConfig = {
         }
     },
     PRESETS: {
-        APPLY_DETAIL: {
+        SLOT_1: {
             key: '1',
-            description: 'Apply Detail Preset'
+            description: 'Pinned Slot 1'
         },
-        APPLY_STRUCTURE: {
+        SLOT_2: {
             key: '2',
-            description: 'Apply Structure Preset'
+            description: 'Pinned Slot 2'
         },
-        APPLY_ANCHOR: {
+        SLOT_3: {
             key: '3',
-            description: 'Apply Anchor Preset'
+            description: 'Pinned Slot 3'
         },
-        APPLY_CUSTOM_1: {
-            key: '1',
-            modifier: 'ctrl',
-            description: 'Apply Custom 1 Preset'
+        SLOT_4: {
+            key: '4',
+            description: 'Pinned Slot 4'
         },
-        APPLY_CUSTOM_2: {
-            key: '2',
-            modifier: 'ctrl',
-            description: 'Apply Custom 2 Preset'
+        SLOT_5: {
+            key: '5',
+            description: 'Pinned Slot 5'
         },
-        APPLY_CUSTOM_3: {
-            key: '3',
-            modifier: 'ctrl',
-            description: 'Apply Custom 3 Preset'
+        SLOT_6: {
+            key: '6',
+            description: 'Pinned Slot 6'
         }
     },
     ROTATION: {

--- a/src/hotkeys/usePresetHotkeys.ts
+++ b/src/hotkeys/usePresetHotkeys.ts
@@ -1,15 +1,21 @@
-import { useEffect } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
 import { useHotkeyConfig } from './HotkeyContext';
 import { matchesConfiguredHotkeyDown } from './hotkeyConfig';
-import { setActivePreset } from '@/supports/Settings/presets';
+import { setActivePreset, getPresetForPinnedSlot, subscribeToPresets } from '@/supports/Settings/presets';
 
 export function usePresetHotkeys() {
     const { getHotkey } = useHotkeyConfig();
 
-    // Retrieve current bindings
-    const detailKey = getHotkey('PRESETS', 'APPLY_DETAIL');
-    const structureKey = getHotkey('PRESETS', 'APPLY_STRUCTURE');
-    const anchorKey = getHotkey('PRESETS', 'APPLY_ANCHOR');
+    // Subscribe to preset changes so pinned slots are always current
+    useSyncExternalStore(subscribeToPresets, () => null, () => null);
+
+    // Retrieve current bindings for 6 pinned slots
+    const slot1Key = getHotkey('PRESETS', 'SLOT_1');
+    const slot2Key = getHotkey('PRESETS', 'SLOT_2');
+    const slot3Key = getHotkey('PRESETS', 'SLOT_3');
+    const slot4Key = getHotkey('PRESETS', 'SLOT_4');
+    const slot5Key = getHotkey('PRESETS', 'SLOT_5');
+    const slot6Key = getHotkey('PRESETS', 'SLOT_6');
 
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
@@ -19,20 +25,28 @@ export function usePresetHotkeys() {
 
             if (e.repeat) return;
 
-            // Check bindings and apply corresponding preset
-            if (matchesConfiguredHotkeyDown(e, { key: detailKey.key, modifier: detailKey.modifier })) {
-                e.preventDefault();
-                setActivePreset('detail');
-            } else if (matchesConfiguredHotkeyDown(e, { key: structureKey.key, modifier: structureKey.modifier })) {
-                e.preventDefault();
-                setActivePreset('structure');
-            } else if (matchesConfiguredHotkeyDown(e, { key: anchorKey.key, modifier: anchorKey.modifier })) {
-                e.preventDefault();
-                setActivePreset('anchor');
+            const slots = [
+                { key: slot1Key, slot: 1 },
+                { key: slot2Key, slot: 2 },
+                { key: slot3Key, slot: 3 },
+                { key: slot4Key, slot: 4 },
+                { key: slot5Key, slot: 5 },
+                { key: slot6Key, slot: 6 },
+            ];
+
+            for (const { key, slot } of slots) {
+                if (matchesConfiguredHotkeyDown(e, { key: key.key, modifier: key.modifier })) {
+                    e.preventDefault();
+                    const preset = getPresetForPinnedSlot(slot);
+                    if (preset) {
+                        setActivePreset(preset.id);
+                    }
+                    break;
+                }
             }
         };
 
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [detailKey, structureKey, anchorKey]);
+    }, [slot1Key, slot2Key, slot3Key, slot4Key, slot5Key, slot6Key]);
 }

--- a/src/supports/Settings/AnatomyPreview/AnatomyPreviewCameraLogic.ts
+++ b/src/supports/Settings/AnatomyPreview/AnatomyPreviewCameraLogic.ts
@@ -5,7 +5,6 @@ import {
     LEAF_HOME_FOCUS_STATE,
     getBranchTargetFocusState,
     getLeafTargetFocusState,
-    getStickTargetFocusState,
     getSupportTargetFocusState,
     getTwigTargetFocusState,
     SUPPORT_HOME_FOCUS_STATE,
@@ -13,16 +12,18 @@ import {
 } from './PreviewTypes/Trunk/camera';
 import { getRaftTargetFocusState, RAFT_HOME_FOCUS_STATE } from './PreviewTypes/Raft/camera';
 import { getGridTargetFocusState } from './PreviewTypes/Grid/camera';
+import { getBraceTargetFocusState, BRACE_HOME_FOCUS_STATE } from './PreviewTypes/Brace/camera';
 
 export type { CameraFocusState };
 
 export const HOME_FOCUS_STATE: CameraFocusState = SUPPORT_HOME_FOCUS_STATE;
 export { RAFT_HOME_FOCUS_STATE };
+export { BRACE_HOME_FOCUS_STATE };
 
 export function getTargetFocusState(kind: SupportKind, key: string | null): CameraFocusState {
     if (kind === 'raft') return getRaftTargetFocusState(key);
     if (kind === 'grid') return getGridTargetFocusState(key);
-    if (kind === 'stick') return getStickTargetFocusState(key);
+    if (kind === 'stick') return getBraceTargetFocusState(key);
     if (kind === 'twig') return getTwigTargetFocusState(key);
     if (kind === 'branch' && !key) return BRANCH_HOME_FOCUS_STATE;
     if (kind === 'leaf' && !key) return LEAF_HOME_FOCUS_STATE;

--- a/src/supports/Settings/AnatomyPreview/PreviewTypes/Brace/BracePreview.tsx
+++ b/src/supports/Settings/AnatomyPreview/PreviewTypes/Brace/BracePreview.tsx
@@ -1,0 +1,297 @@
+import React from 'react';
+import * as THREE from 'three';
+import { SupportBuilder } from '@/supports/rendering/SupportBuilder';
+import { ANATOMY_CONFIG } from '../../AnatomyPreviewConfig';
+import type { SupportKind } from '../../../supportKindState';
+
+interface BracePreviewProps {
+    settings: any;
+    activeKind: SupportKind;
+    previewState: any;
+}
+
+const PREVIEW_HEIGHT_MM = 22.95; // 1.7× then −10%
+
+/**
+ * Build support data for a single vertical trunk at (posX, posY) using
+ * realistic settings (root cones, joint spheres, contact cones, etc.)
+ */
+function buildTrunkData(
+    posX: number,
+    posY: number,
+    index: number,
+    shaftDiameterMm: number,
+    rootsDiameterMm: number,
+    rootsDiskHeightMm: number,
+    rootsConeHeightMm: number,
+) {
+    const u = (s: string) => `brace-trunk-${index}-${s}`;
+
+    const rootPos = { x: posX, y: posY, z: 0 };
+
+    const root = {
+        id: u('root'),
+        modelId: `anatomy-preview-brace-trunk-${index}`,
+        transform: { pos: rootPos, rot: { x: 0, y: 0, z: 0, w: 1 } },
+        diameter: rootsDiameterMm,
+        diskHeight: rootsDiskHeightMm,
+        coneHeight: rootsConeHeightMm,
+    };
+
+    // Roots top-of-cone Z (where shaft starts)
+    const rootsTopZ = rootsDiskHeightMm + rootsConeHeightMm;
+
+    // Bottom joint at the top of the root cone
+    const bottomJointPos = { x: posX, y: posY, z: rootsTopZ };
+    const bottomJoint = {
+        id: u('bottomJoint'),
+        pos: bottomJointPos,
+        diameter: shaftDiameterMm + 0.2,
+    };
+
+    // Top joint at the top of the trunk
+    const topJointPos = { x: posX, y: posY, z: PREVIEW_HEIGHT_MM };
+    const topJoint = {
+        id: u('topJoint'),
+        pos: topJointPos,
+        diameter: shaftDiameterMm + 0.2,
+    };
+
+    // Two segments: root→bottomJoint→topJoint for a realistic look with a joint sphere
+    const seg1 = {
+        id: u('seg1'),
+        diameter: shaftDiameterMm,
+        topJoint: bottomJoint,
+    };
+
+    const seg2 = {
+        id: u('seg2'),
+        diameter: shaftDiameterMm,
+        topJoint,
+    };
+
+    // Contact cone pointing upward at the top
+    const contactCone = {
+        id: u('cone'),
+        pos: { x: posX, y: posY, z: PREVIEW_HEIGHT_MM + 2.0 },
+        normal: { x: 0, y: 0, z: -1 },
+        surfaceNormal: { x: 0, y: 0, z: -1 },
+        profile: {
+            type: 'disk' as const,
+            contactDiameterMm: 0.35,
+            bodyDiameterMm: shaftDiameterMm,
+            lengthMm: 2.0,
+            penetrationMm: 0.1,
+            diskThicknessMm: 0.1,
+            maxStandoffMm: 1.5,
+            standoffAngleThreshold: Math.PI / 4,
+        },
+        socketJointId: u('topJoint'),
+    };
+
+    return {
+        id: u('trunk'),
+        roots: root,
+        segments: [seg1, seg2],
+        contactCone,
+        angle: 0,
+    };
+}
+
+/**
+ * Real auto-bracing pattern for a single pair of trunks at a given rung Z.
+ * 
+ * Mirrors the production logic in autoBrace.ts:
+ * - The "low" end of each brace sits at `anchorZ` on the first trunk.
+ * - The "high" end sits at `anchorZ + horizontalDist` on the second trunk
+ *   (dzGuess ≈ horizontal distance between the two supports).
+ * - singleDiagonal → one brace (a → b)
+ * - crossDiagonal   → two braces (a → b and b → a)
+ */
+function applyPatternToPair(
+    result: { start: THREE.Vector3; end: THREE.Vector3; section: 'initial' | 'repeating' }[],
+    aX: number,
+    aY: number,
+    bX: number,
+    bY: number,
+    horizontalDist: number,
+    anchorZ: number,
+    pattern: string,
+    section: 'initial' | 'repeating',
+    trunkTopZ: number,
+) {
+    const dzGuess = horizontalDist;
+
+    // Real auto-bracing rule: skip if the high end would go past the top joint.
+    if (anchorZ + dzGuess >= trunkTopZ - 0.1) return;
+
+    const placeLowHigh = (lowX: number, lowY: number, highX: number, highY: number) => {
+        result.push({
+            start: new THREE.Vector3(lowX, lowY, anchorZ),
+            end: new THREE.Vector3(highX, highY, anchorZ + dzGuess),
+            section,
+        });
+    };
+
+    // singleDiagonal: place(a, b)
+    // crossDiagonal:  place(a, b) + place(b, a)
+    placeLowHigh(aX, aY, bX, bY);
+    if (pattern === 'crossDiagonal') {
+        placeLowHigh(bX, bY, aX, aY);
+    }
+}
+
+/**
+ * Brace anatomy preview: 3×3 grid of proper trunks (rendered through SupportBuilder
+ * like the Grid preview) with simulated braces between adjacent trunks using
+ * the real auto-bracing rules.
+ */
+export function BracePreview({
+    settings,
+    activeKind,
+    previewState,
+}: BracePreviewProps) {
+    if (activeKind !== 'stick') return null;
+
+    const autoBracing = settings.autoBracing ?? {};
+    const braceDiameter = autoBracing.braceDiameterMm ?? 0.7;
+    const initialPattern: string = autoBracing.initialPattern ?? 'singleDiagonal';
+    const initialDistance = autoBracing.initialDistanceMm ?? 2.0;
+    const repeatingPattern: string = autoBracing.repeatingPattern ?? 'singleDiagonal';
+    const patternInterval = autoBracing.patternIntervalMm ?? 10.0;
+    const shaftDiameterMm = Math.max(0.5, settings.shaft?.diameterMm ?? 1.0);
+    const rootsDiameterMm = settings.roots?.diameterMm ?? 2.0;
+    const rootsDiskHeightMm = settings.roots?.diskHeightMm ?? 0.2;
+    const rootsConeHeightMm = settings.roots?.coneHeightMm ?? 0.3;
+    const braceRadius = braceDiameter / 2;
+
+    const HIGHLIGHT_COLOR = ANATOMY_CONFIG.colors.highlight;
+    const DIM_COLOR = ANATOMY_CONFIG.colors.dim;
+    const NORMAL_COLOR = ANATOMY_CONFIG.colors.normal;
+    const focusKey = previewState.activeSettingKey;
+    const isBraceFocused = focusKey?.startsWith('brace') ?? false;
+    const isPatternFocused = focusKey === 'initialPattern' || focusKey === 'repeatingPattern';
+    const isDiameterFocused = focusKey === 'braceDiameterMm';
+
+    // Three trunks with varying spacing to show different brace distances
+    const maxBraceLength = autoBracing.maxBraceLengthMm ?? 10.0;
+    const rootsTopZ = rootsDiskHeightMm + rootsConeHeightMm;
+
+    // Positions: left gap 5mm (X only), right gap 10mm (X + Y offset for 3D scenario)
+    const trunkPositions: { x: number; y: number; index: number }[] = [
+        { x: -7.5, y: 0,  index: 0 },
+        { x: -2.5, y: 0,  index: 1 },
+        { x: 7.5,  y: 5,  index: 2 },
+    ];
+
+    // Build trunk support data (memoised)
+    const trunkSupports = React.useMemo(
+        () => trunkPositions.map(({ x, y, index }) =>
+            buildTrunkData(x, y, index, shaftDiameterMm, rootsDiameterMm, rootsDiskHeightMm, rootsConeHeightMm),
+        ),
+        [shaftDiameterMm, rootsDiameterMm, rootsDiskHeightMm, rootsConeHeightMm],
+    );
+
+    // Anatomy colour overrides for the trunks
+    const trunkOverrides = React.useMemo(() => {
+        if (isDiameterFocused || isBraceFocused) {
+            return {
+                roots: DIM_COLOR,
+                rootsDisk: DIM_COLOR,
+                rootsCone: DIM_COLOR,
+                shaft: DIM_COLOR,
+                joint: DIM_COLOR,
+                tipBody: DIM_COLOR,
+                tipDisk: DIM_COLOR,
+            };
+        }
+        return undefined; // default orange
+    }, [isDiameterFocused, isBraceFocused, DIM_COLOR]);
+
+    // Brace pairs: one at 5mm (flat X), one at ~11.18mm (3D — X + Y offset)
+    type GridPair = { aX: number; aY: number; bX: number; bY: number; dist: number };
+    const bracePairs: GridPair[] = [
+        { aX: -7.5, aY: 0, bX: -2.5, bY: 0, dist: 5 },
+        { aX: -2.5, aY: 0, bX: 7.5,  bY: 5, dist: Math.sqrt(10 * 10 + 5 * 5) },
+    ];
+
+    // Build brace geometry using the real auto-bracing ladder logic
+    const braces: { start: THREE.Vector3; end: THREE.Vector3; section: 'initial' | 'repeating' }[] = [];
+
+    const ladder: number[] = [rootsTopZ + initialDistance];
+    let curr = rootsTopZ + initialDistance + patternInterval;
+    const maxZ = PREVIEW_HEIGHT_MM - 1.0;
+    while (curr <= maxZ) { ladder.push(curr); curr += patternInterval; }
+
+    ladder.forEach((anchorZ, tierIndex) => {
+        const isInitial = tierIndex === 0;
+        const pattern = isInitial ? initialPattern : repeatingPattern;
+        const section: 'initial' | 'repeating' = isInitial ? 'initial' : 'repeating';
+
+        for (const pair of bracePairs) {
+            applyPatternToPair(
+                braces,
+                pair.aX, pair.aY,
+                pair.bX, pair.bY,
+                pair.dist,
+                anchorZ, pattern, section, PREVIEW_HEIGHT_MM,
+            );
+        }
+    });
+
+    // Colour per section
+    const getSectionColor = (s: 'initial' | 'repeating'): string => {
+        if (isPatternFocused) return HIGHLIGHT_COLOR;
+        if (isDiameterFocused || isBraceFocused) return s === 'initial' ? DIM_COLOR : '#666666';
+        return s === 'initial' ? '#00cc66' : '#33aaff';
+    };
+
+    return (
+        <group>
+            <directionalLight position={[0, 0, -20]} intensity={0.6} color="#ffffff" />
+
+            {/* Trunks rendered through SupportBuilder (same pattern as Grid) */}
+            {trunkSupports.map((data) => (
+                <SupportBuilder
+                    key={data.id}
+                    data={data}
+                    isPreview={ANATOMY_CONFIG.rendering.showAsGhostPreview}
+                    raftOverride={{ bottomMode: 'off', thickness: 0 }}
+                    anatomyOverrides={trunkOverrides}
+                />
+            ))}
+
+            {/* Braces simulated between the trunks */}
+            {braces.map((brace, i) => {
+                const dir = brace.end.clone().sub(brace.start);
+                const length = dir.length();
+                if (length < 0.001) return null;
+                const mid = brace.start.clone().add(dir.clone().multiplyScalar(0.5));
+                const quat = new THREE.Quaternion().setFromUnitVectors(
+                    new THREE.Vector3(0, 1, 0),
+                    dir.clone().normalize(),
+                );
+                const color = getSectionColor(brace.section);
+
+                return (
+                    <group key={`brace-${i}`}>
+                        <group position={[mid.x, mid.y, mid.z]} quaternion={quat}>
+                            <mesh>
+                                <cylinderGeometry args={[braceRadius, braceRadius, length, 8]} />
+                                <meshStandardMaterial color={color} roughness={0.5} metalness={0.1} transparent opacity={0.75} />
+                            </mesh>
+                        </group>
+                        <mesh position={[brace.start.x, brace.start.y, brace.start.z]}>
+                            <sphereGeometry args={[braceRadius * 1.8, 8, 8]} />
+                            <meshStandardMaterial color={color} roughness={0.5} metalness={0.1} transparent opacity={0.75} />
+                        </mesh>
+                        <mesh position={[brace.end.x, brace.end.y, brace.end.z]}>
+                            <sphereGeometry args={[braceRadius * 1.8, 8, 8]} />
+                            <meshStandardMaterial color={color} roughness={0.5} metalness={0.1} transparent opacity={0.75} />
+                        </mesh>
+                    </group>
+                );
+            })}
+        </group>
+    );
+}

--- a/src/supports/Settings/AnatomyPreview/PreviewTypes/Brace/camera.ts
+++ b/src/supports/Settings/AnatomyPreview/PreviewTypes/Brace/camera.ts
@@ -1,0 +1,16 @@
+import type { CameraFocusState } from '../../AnatomyPreviewCameraTypes';
+
+/**
+ * Home focus state for the Brace anatomy preview.
+ * Framed to show two vertical trunks with braces between them.
+ */
+export const BRACE_HOME_FOCUS_STATE: CameraFocusState = {
+    position: [27.3, -33.7, 32.4],
+    target: [1.33, 0.53, 7.72],
+    zoom: 8.16,
+};
+
+export function getBraceTargetFocusState(_key: string | null): CameraFocusState {
+    // Brace preview maintains a fixed camera; no parameter-specific zoom jumps.
+    return BRACE_HOME_FOCUS_STATE;
+}

--- a/src/supports/Settings/AnatomyPreview/PreviewTypes/Trunk/camera.ts
+++ b/src/supports/Settings/AnatomyPreview/PreviewTypes/Trunk/camera.ts
@@ -9,7 +9,7 @@ export const SUPPORT_HOME_FOCUS_STATE: CameraFocusState = {
 
 export const TRUNK_HOME_FOCUS_STATE: CameraFocusState = {
     position: [0, -49.53, 10],
-    target: [0, 0, 8],
+    target: [0, 0, 7.6],
     zoom: 27.00,
 };
 

--- a/src/supports/Settings/AnatomyPreview/SupportAnatomyPreviewCanvas.tsx
+++ b/src/supports/Settings/AnatomyPreview/SupportAnatomyPreviewCanvas.tsx
@@ -8,6 +8,7 @@ import { OrbitControls, TransformControls } from '@react-three/drei';
 import { RaftPreview } from './PreviewTypes/Raft/RaftPreview';
 import { GridPreview } from './PreviewTypes/Grid/GridPreview';
 import { TrunkPreview } from './PreviewTypes/Trunk/TrunkPreview';
+import { BracePreview } from './PreviewTypes/Brace/BracePreview';
 import { subscribeToSettings, getSettingsSnapshot } from '../state';
 import { subscribeToAnatomyPreviewState, getAnatomyPreviewState, setAnatomyPreviewActiveSettingKey } from './previewState';
 import { ANATOMY_CONFIG } from './AnatomyPreviewConfig';
@@ -770,7 +771,15 @@ function PreviewContent({
                     />
                 )}
 
-                {activeKind !== 'raft' && activeKind !== 'grid' && (
+                {activeKind === 'stick' && (
+                    <BracePreview
+                        settings={previewSettings}
+                        activeKind={activeKind}
+                        previewState={previewState}
+                    />
+                )}
+
+                {activeKind !== 'raft' && activeKind !== 'grid' && activeKind !== 'stick' && (
                     <TrunkPreview
                             settings={previewSettings}
                         liveConfig={liveConfig}

--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -624,7 +624,7 @@ export function SupportSidebar() {
         </div>
     );
 
-    const sectionScrollClass = 'flex-1 min-h-0 overflow-y-auto custom-scrollbar pr-1';
+    const sectionScrollClass = 'flex-1 min-h-0 overflow-y-auto custom-scrollbar';
     const shouldUseOverflowCompactMode = OVERFLOW_COMPACT_KIND_SET.has(activeKind) && trunkCompactByOverflow;
     const shouldUseCompactTrunkLayout = activeKind === 'trunk' && shouldUseOverflowCompactMode;
     const hasFloatingTrunkPreviewTrigger = POPUP_PREVIEW_KIND_SET.has(activeKind)
@@ -1221,11 +1221,11 @@ export function SupportSidebar() {
                                                 </div>
                                             ) : (
                                                 <div className="flex gap-2 items-stretch">
-                                                    <div className="flex-1 min-w-0 flex flex-col">
+                                                    <div className="w-1/2 min-w-0 flex flex-col">
                                                         {renderPreviewBox('flex-1 min-h-[340px]')}
                                                     </div>
 
-                                                    <div className="flex-1 min-w-0 rounded-md border p-2" style={SECTION_CARD_STYLE}>
+                                                    <div className="w-1/2 min-w-0 rounded-md border p-2" style={SECTION_CARD_STYLE}>
                                                         {supportGeometryFields}
                                                     </div>
                                                 </div>

--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -60,7 +60,7 @@ import {
 import { DEFAULT_RAFT_SETTINGS } from '../Rafts/Crenelated/RaftDefaults';
 import type { SupportKind } from './supportKindState';
 
-const INPUT_CLASS = 'ui-input h-8 w-full px-2.5 text-xs sm:text-sm no-spinners';
+const INPUT_CLASS = 'ui-input h-8 w-full px-2.5 text-xs sm:text-sm text-center no-spinners';
 const SECTION_CARD_STYLE: React.CSSProperties = {
     borderColor: 'var(--border-subtle)',
     background: 'var(--surface-1)',
@@ -786,27 +786,39 @@ export function SupportSidebar() {
         : 'text-[11px] font-medium leading-tight';
     const compactTrunkPairClass = 'grid grid-cols-2 gap-1.5 items-start';
 
+    const unitHint = (unit: string) => (
+        <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[11px] font-semibold" style={{ color: 'var(--text-muted)' }}>{unit}</span>
+    );
+
     const supportGeometryFieldsDefault = (
         <div className="space-y-2.5">
             <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('tip.contactDiameterMm')}>
-                <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Contact Diameter (mm)">Contact Diameter (mm)</div>
-                <NumberInput
-                    value={settings.tip.contactDiameterMm}
-                    onChange={(val) => updateTipProfile({ contactDiameterMm: val })}
-                    step={0.1}
-                    {...getInputProps('tip.contactDiameterMm', compactInputClass)}
-                />
+                <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Contact Diameter">Contact Diameter</div>
+                <div className="relative">
+                    <NumberInput
+                        value={settings.tip.contactDiameterMm}
+                        onChange={(val) => updateTipProfile({ contactDiameterMm: val })}
+                        step={0.1}
+                        showStepper={false}
+                        {...getInputProps('tip.contactDiameterMm', compactInputClass)}
+                    />
+                    {unitHint('mm')}
+                </div>
             </div>
 
             {(activeKind === 'trunk' || activeKind === 'branch' || activeKind === 'leaf') && (
                 <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('tip.lengthMm')}>
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Contact Cone Length (mm)">Contact Cone Length (mm)</div>
-                    <NumberInput
-                        value={settings.tip.lengthMm}
-                        onChange={(val) => updateTipProfile({ lengthMm: val })}
-                        step={0.1}
-                        {...getInputProps('tip.lengthMm', compactInputClass)}
-                    />
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Contact Cone Length">Contact Cone Length</div>
+                    <div className="relative">
+                        <NumberInput
+                            value={settings.tip.lengthMm}
+                            onChange={(val) => updateTipProfile({ lengthMm: val })}
+                            step={0.1}
+                            showStepper={false}
+                            {...getInputProps('tip.lengthMm', compactInputClass)}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </div>
             )}
 
@@ -817,15 +829,15 @@ export function SupportSidebar() {
                     setAnatomyPreviewActiveSettingKey(null);
                 })}>
                     <div
-                        className={isAdaptiveConeAngle ? 'grid grid-cols-[1fr_82px] gap-1 items-center' : 'flex items-center'}
+                        className={isAdaptiveConeAngle ? 'grid grid-cols-2 gap-1.5 items-center' : 'flex items-center'}
                     >
-                        <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Cone Angle">Cone Angle</div>
+                        <div className={`${compactFieldLabelClass} text-center`} style={{ color: 'var(--text-muted)' }} title="Cone Angle">Cone Angle</div>
                         {isAdaptiveConeAngle && (
-                            <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Offset">Offset</div>
+                            <div className={`${compactFieldLabelClass} text-center`} style={{ color: 'var(--text-muted)' }} title="Offset">Offset</div>
                         )}
                     </div>
                     <div
-                        className={isAdaptiveConeAngle ? 'grid grid-cols-[1fr_82px] gap-1 items-center' : 'flex items-center gap-1'}
+                        className={isAdaptiveConeAngle ? 'grid grid-cols-2 gap-1.5 items-center' : 'flex items-center gap-1'}
                     >
                         <SelectDropdown
                             value={settings.tip.coneAngleMode ?? 'normal'}
@@ -835,7 +847,7 @@ export function SupportSidebar() {
                                 { value: 'locked', label: 'Locked' },
                                 { value: 'adaptive', label: 'Adaptive' },
                             ]}
-                            className={`${isAdaptiveConeAngle ? 'w-full' : 'flex-1'} min-w-0 space-y-0`}
+                            className={`${isAdaptiveConeAngle ? 'w-full' : 'flex-1'} min-w-0 space-y-0 h-8`}
                             selectClassName={`${isAdaptiveConeAngle ? 'w-full' : 'flex-1'} min-w-0 h-8 px-2.5 pr-10 text-xs sm:text-sm truncate`}
                             menuClassName="!min-w-[9.5rem]"
                             selectedDisplay={useAdaptiveIconCompactDisplay ? <WandSparkles className="h-3.5 w-3.5" style={{ color: 'var(--text-muted)' }} aria-label="Adaptive mode" /> : undefined}
@@ -848,16 +860,21 @@ export function SupportSidebar() {
                                     boxShadow: '0 0 0 1px color-mix(in srgb, var(--accent), white 8%) inset, 0 0 0 2px color-mix(in srgb, var(--accent), transparent 72%)',
                                 }
                                 : undefined}
+
                         />
 
                         {isAdaptiveConeAngle && (
-                            <NumberInput
-                                value={settings.tip.adaptiveConeAngleOffsetDeg ?? 30}
-                                onChange={(val) => updateTipProfile({ adaptiveConeAngleOffsetDeg: val })}
-                                aria-label="Adaptive offset (deg)"
-                                title="Adaptive offset (deg)"
-                                {...getInputProps('tip.adaptiveConeAngleOffsetDeg', compactInputClass)}
-                            />
+                            <div className="relative h-8">
+                                <NumberInput
+                                    value={settings.tip.adaptiveConeAngleOffsetDeg ?? 30}
+                                    onChange={(val) => updateTipProfile({ adaptiveConeAngleOffsetDeg: val })}
+                                    aria-label="Adaptive offset"
+                                    title="Adaptive offset"
+                                    showStepper={false}
+                                    {...getInputProps('tip.adaptiveConeAngleOffsetDeg', compactInputClass)}
+                                />
+                                {unitHint('°')}
+                            </div>
                         )}
                     </div>
                 </div>
@@ -865,50 +882,65 @@ export function SupportSidebar() {
 
             {(activeKind === 'trunk' || activeKind === 'branch') && (
                 <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('shaft.diameterMm')}>
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Trunk Diameter (mm)">Trunk Diameter (mm)</div>
-                    <NumberInput
-                        value={settings.shaft.diameterMm}
-                        onChange={(val) => updateShaftProfile({ diameterMm: val })}
-                        step={0.1}
-                        {...getInputProps('shaft.diameterMm', compactInputClass)}
-                    />
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Trunk Diameter">Trunk Diameter</div>
+                    <div className="relative">
+                        <NumberInput
+                            value={settings.shaft.diameterMm}
+                            onChange={(val) => updateShaftProfile({ diameterMm: val })}
+                            step={0.1}
+                            showStepper={false}
+                            {...getInputProps('shaft.diameterMm', compactInputClass)}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </div>
             )}
 
             {activeKind === 'trunk' && (
                 <>
                     <div className="h-px" style={{ background: 'var(--border-subtle)' }} />
-                    <div className="text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>Roots</div>
 
                     <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('roots.diameterMm')}>
-                        <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Roots Diameter (mm)">Roots Diameter (mm)</div>
-                        <NumberInput
-                            value={settings.roots.diameterMm}
-                            onChange={(val) => updateRootsProfile({ diameterMm: val })}
-                            step={0.1}
-                            {...getInputProps('roots.diameterMm', compactInputClass)}
-                        />
+                        <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Roots Diameter">Roots Diameter</div>
+                        <div className="relative">
+                            <NumberInput
+                                value={settings.roots.diameterMm}
+                                onChange={(val) => updateRootsProfile({ diameterMm: val })}
+                                step={0.1}
+                                showStepper={false}
+                                {...getInputProps('roots.diameterMm', compactInputClass)}
+                            />
+                            {unitHint('mm')}
+                        </div>
                     </div>
 
                     <div className="space-y-2">
                         <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('roots.diskHeightMm')}>
-                            <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Disk Height (mm)</div>
-                            <NumberInput
-                                value={settings.roots.diskHeightMm}
-                                onChange={(val) => updateRootsProfile({ diskHeightMm: val })}
-                                step={0.1}
-                                {...getInputProps('roots.diskHeightMm', compactInputClass)}
-                            />
+                            <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Disk Height</div>
+                            <div className="relative">
+                                <NumberInput
+                                    value={settings.roots.diskHeightMm}
+                                    onChange={(val) => updateRootsProfile({ diskHeightMm: val })}
+                                    step={0.1}
+                                    showStepper={false}
+                                    {...getInputProps('roots.diskHeightMm', compactInputClass)}
+                                />
+                                {unitHint('mm')}
+                            </div>
                         </div>
 
                         <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('roots.coneHeightMm')}>
-                            <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Cone Height (mm)</div>
-                            <NumberInput
-                                value={settings.roots.coneHeightMm}
-                                onChange={(val) => updateRootsProfile({ coneHeightMm: val })}
-                                step={0.1}
-                                {...getInputProps('roots.coneHeightMm', compactInputClass)}
-                            />
+                            <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Cone Height</div>
+                            <div className="relative">
+                                <NumberInput
+                                    value={settings.roots.coneHeightMm}
+                                    onChange={(val) => updateRootsProfile({ coneHeightMm: val })}
+                                    step={0.1}
+                                    showStepper={false}
+                                    {...getInputProps('roots.coneHeightMm', compactInputClass)}
+                                />
+                                {unitHint('mm')}
+                            </div>
                         </div>
                     </div>
                 </>
@@ -920,23 +952,31 @@ export function SupportSidebar() {
         <div className="space-y-2.5">
             <div className={compactTrunkPairClass}>
                 <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('tip.contactDiameterMm')}>
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Contact Diameter (mm)">Contact Diameter (mm)</div>
-                    <NumberInput
-                        value={settings.tip.contactDiameterMm}
-                        onChange={(val) => updateTipProfile({ contactDiameterMm: val })}
-                        step={0.1}
-                        {...getInputProps('tip.contactDiameterMm', compactInputClass)}
-                    />
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Contact Diameter">Contact Diameter</div>
+                    <div className="relative">
+                        <NumberInput
+                            value={settings.tip.contactDiameterMm}
+                            onChange={(val) => updateTipProfile({ contactDiameterMm: val })}
+                            step={0.1}
+                            showStepper={false}
+                            {...getInputProps('tip.contactDiameterMm', compactInputClass)}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </div>
 
                 <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('tip.lengthMm')}>
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Contact Cone Length (mm)">Contact Cone Length (mm)</div>
-                    <NumberInput
-                        value={settings.tip.lengthMm}
-                        onChange={(val) => updateTipProfile({ lengthMm: val })}
-                        step={0.1}
-                        {...getInputProps('tip.lengthMm', compactInputClass)}
-                    />
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Contact Cone Length">Contact Cone Length</div>
+                    <div className="relative">
+                        <NumberInput
+                            value={settings.tip.lengthMm}
+                            onChange={(val) => updateTipProfile({ lengthMm: val })}
+                            step={0.1}
+                            showStepper={false}
+                            {...getInputProps('tip.lengthMm', compactInputClass)}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </div>
             </div>
 
@@ -948,9 +988,9 @@ export function SupportSidebar() {
                 <div
                     className={isAdaptiveConeAngle ? 'grid grid-cols-2 gap-1.5 items-center' : 'flex items-center'}
                 >
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Cone Angle">Cone Angle</div>
+                    <div className={`${compactFieldLabelClass} text-center`} style={{ color: 'var(--text-muted)' }} title="Cone Angle">Cone Angle</div>
                     {isAdaptiveConeAngle && (
-                        <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Offset">Offset</div>
+                        <div className={`${compactFieldLabelClass} text-center`} style={{ color: 'var(--text-muted)' }} title="Offset">Offset</div>
                     )}
                 </div>
                 <div
@@ -980,58 +1020,78 @@ export function SupportSidebar() {
                     />
 
                     {isAdaptiveConeAngle && (
-                        <NumberInput
-                            value={settings.tip.adaptiveConeAngleOffsetDeg ?? 30}
-                            onChange={(val) => updateTipProfile({ adaptiveConeAngleOffsetDeg: val })}
-                            aria-label="Adaptive offset (deg)"
-                            title="Adaptive offset (deg)"
-                            {...getInputProps('tip.adaptiveConeAngleOffsetDeg', compactInputClass)}
-                        />
+                        <div className="relative">
+                            <NumberInput
+                                value={settings.tip.adaptiveConeAngleOffsetDeg ?? 30}
+                                onChange={(val) => updateTipProfile({ adaptiveConeAngleOffsetDeg: val })}
+                                aria-label="Adaptive offset"
+                                title="Adaptive offset"
+                                showStepper={false}
+                                {...getInputProps('tip.adaptiveConeAngleOffsetDeg', compactInputClass)}
+                            />
+                            {unitHint('°')}
+                        </div>
                     )}
                 </div>
             </div>
 
             <div className={compactTrunkPairClass}>
                 <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('shaft.diameterMm')}>
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Trunk Diameter (mm)">Trunk Diameter (mm)</div>
-                    <NumberInput
-                        value={settings.shaft.diameterMm}
-                        onChange={(val) => updateShaftProfile({ diameterMm: val })}
-                        step={0.1}
-                        {...getInputProps('shaft.diameterMm', compactInputClass)}
-                    />
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Trunk Diameter">Trunk Diameter</div>
+                    <div className="relative">
+                        <NumberInput
+                            value={settings.shaft.diameterMm}
+                            onChange={(val) => updateShaftProfile({ diameterMm: val })}
+                            step={0.1}
+                            showStepper={false}
+                            {...getInputProps('shaft.diameterMm', compactInputClass)}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </div>
 
                 <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('roots.diameterMm')}>
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Roots Diameter (mm)">Roots Diameter (mm)</div>
-                    <NumberInput
-                        value={settings.roots.diameterMm}
-                        onChange={(val) => updateRootsProfile({ diameterMm: val })}
-                        step={0.1}
-                        {...getInputProps('roots.diameterMm', compactInputClass)}
-                    />
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Roots Diameter">Roots Diameter</div>
+                    <div className="relative">
+                        <NumberInput
+                            value={settings.roots.diameterMm}
+                            onChange={(val) => updateRootsProfile({ diameterMm: val })}
+                            step={0.1}
+                            showStepper={false}
+                            {...getInputProps('roots.diameterMm', compactInputClass)}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </div>
             </div>
 
             <div className={compactTrunkPairClass}>
                 <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('roots.diskHeightMm')}>
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Disk Height (mm)">Disk Height (mm)</div>
-                    <NumberInput
-                        value={settings.roots.diskHeightMm}
-                        onChange={(val) => updateRootsProfile({ diskHeightMm: val })}
-                        step={0.1}
-                        {...getInputProps('roots.diskHeightMm', compactInputClass)}
-                    />
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Disk Height">Disk Height</div>
+                    <div className="relative">
+                        <NumberInput
+                            value={settings.roots.diskHeightMm}
+                            onChange={(val) => updateRootsProfile({ diskHeightMm: val })}
+                            step={0.1}
+                            showStepper={false}
+                            {...getInputProps('roots.diskHeightMm', compactInputClass)}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </div>
 
                 <div className="space-y-1 min-w-0" {...makeRowFocusHandlers('roots.coneHeightMm')}>
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Cone Height (mm)">Cone Height (mm)</div>
-                    <NumberInput
-                        value={settings.roots.coneHeightMm}
-                        onChange={(val) => updateRootsProfile({ coneHeightMm: val })}
-                        step={0.1}
-                        {...getInputProps('roots.coneHeightMm', compactInputClass)}
-                    />
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }} title="Cone Height">Cone Height</div>
+                    <div className="relative">
+                        <NumberInput
+                            value={settings.roots.coneHeightMm}
+                            onChange={(val) => updateRootsProfile({ coneHeightMm: val })}
+                            step={0.1}
+                            showStepper={false}
+                            {...getInputProps('roots.coneHeightMm', compactInputClass)}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState, useEffect, useLayoutEffect, useSyncExternalStore } from 'react';
 import ReactDOM from 'react-dom';
-import { Save, RotateCcw, Sparkles, Wrench, WandSparkles, Sailboat, Grid3X3, Pickaxe } from 'lucide-react';
+import { Check, Save, RotateCcw, Sparkles, Wrench, WandSparkles, Sailboat, Grid3X3, Pickaxe } from 'lucide-react';
 import { usePresetHotkeys } from '@/hotkeys/usePresetHotkeys';
 import {
     getSettings,
@@ -1079,10 +1079,10 @@ export function SupportSidebar() {
                     <div className="inline-flex items-center gap-1">
                         <IconButton
                             onClick={handleSave}
-                            className={`!p-1.5 transition-colors ${saveStatus === 'saved' ? '!bg-green-600/30 !text-green-400 animate-pulse' : saveStatus === 'error' ? '!bg-red-600/30 !text-red-400' : '!text-green-400/70 hover:!text-green-400 hover:!bg-green-600/15'}`}
+                            className={`!p-1.5 transition-colors ${saveStatus === 'saved' ? '!bg-green-600/30 !text-green-400' : saveStatus === 'error' ? '!bg-red-600/30 !text-red-400' : '!text-green-400/70 hover:!text-green-400 hover:!bg-green-600/15'}`}
                             title={saveStatus !== 'idle' ? (saveStatus === 'saved' ? 'Saved' : 'Save failed') : 'Save settings'}
                         >
-                            <Save className="h-3.5 w-3.5" />
+                            {saveStatus === 'saved' ? <Check className="h-3.5 w-3.5" /> : <Save className="h-3.5 w-3.5" />}
                         </IconButton>
                         <IconButton
                             onClick={handleRestoreDefaults}

--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -1118,9 +1118,7 @@ export function SupportSidebar() {
                                     {activeKind === 'raft' ? (
                                         <>
                                             {!shouldUseOverflowCompactMode ? (
-                                                <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
-                                                    {renderPreviewBox('h-[220px]')}
-                                                </div>
+                                                renderPreviewBox('h-[220px]')
                                             ) : null}
                                             <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
                                                 <RaftSettingsCard
@@ -1132,9 +1130,7 @@ export function SupportSidebar() {
                                     ) : activeKind === 'grid' ? (
                                         <>
                                             {!shouldUseOverflowCompactMode ? (
-                                                <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
-                                                    {renderPreviewBox('h-[220px]')}
-                                                </div>
+                                                renderPreviewBox('h-[220px]')
                                             ) : null}
                                             <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
                                                 <GridSettingsCard
@@ -1146,9 +1142,7 @@ export function SupportSidebar() {
                                     ) : activeKind === 'stick' ? (
                                         <>
                                             {!shouldUseOverflowCompactMode ? (
-                                                <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
-                                                    {renderPreviewBox('h-[220px]')}
-                                                </div>
+                                                renderPreviewBox('h-[220px]')
                                             ) : null}
                                             <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
                                                 <AutoBracingSettingsCard
@@ -1167,7 +1161,7 @@ export function SupportSidebar() {
                                                 </div>
                                             ) : (
                                                 <div className="flex gap-2 items-stretch">
-                                                    <div className="flex-1 min-w-0 rounded-md border p-2 flex flex-col" style={SECTION_CARD_STYLE}>
+                                                    <div className="flex-1 min-w-0 flex flex-col">
                                                         {renderPreviewBox('flex-1 min-h-[340px]')}
                                                     </div>
 
@@ -1223,15 +1217,11 @@ export function SupportSidebar() {
                                         </>
                                     ) : (
                                         <>
-                                            <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
-                                                {renderPreviewBox('h-[250px]')}
-                                            </div>
+                                            {renderPreviewBox('h-[250px]')}
 
                                             <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
                                                 {supportGeometryFields}
                                             </div>
-
-                                            {/* Placement notes removed per design request */}
                                         </>
                                     )}
                                 </>

--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -36,7 +36,7 @@ import {
     GridSettingsCard,
     SupportKindTabs,
 } from './components';
-import { Button, Card, CardHeader, IconButton } from '@/components/ui/primitives';
+import { Card, CardHeader, IconButton } from '@/components/ui/primitives';
 import { NumberInput } from '@/components/ui/NumberInput';
 import { SelectDropdown } from '@/components/ui/SelectDropdown';
 import { SupportAnatomyPreviewSlot } from './AnatomyPreview/SupportAnatomyPreviewSlot';
@@ -173,6 +173,7 @@ export function SupportSidebar() {
     const settings = useSyncExternalStore(subscribeToSettings, getSettings, getSettings);
     const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'error'>('idle');
     const [autoBraceStatus, setAutoBraceStatus] = useState<{ kind: 'success' | 'warning' | 'error'; message: string } | null>(null);
+    const [defaultsAnimating, setDefaultsAnimating] = useState(false);
     const [expanded, setExpanded] = React.useState(true);
     const [devToolsOpen, setDevToolsOpen] = useState(false);
     const saveStatusTimeoutRef = React.useRef<number | null>(null);
@@ -567,6 +568,10 @@ export function SupportSidebar() {
         setSettings(createDefaultSettings());
         setRaftSettings(DEFAULT_RAFT_SETTINGS);
         setAnatomyPreviewActiveSettingKey(null);
+
+        // Trigger spin animation
+        setDefaultsAnimating(true);
+        setTimeout(() => setDefaultsAnimating(false), 600);
     }, []);
 
     const handleAutoBrace = React.useCallback(() => {
@@ -1071,9 +1076,21 @@ export function SupportSidebar() {
                     </>
                 )}
                 right={(
-                    <div className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5" style={{ borderColor: 'var(--border-subtle)' }}>
-                        <ActiveKindIcon className="h-3 w-3" style={{ color: 'var(--accent)' }} />
-                        <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>{activeKindMeta.label}</span>
+                    <div className="inline-flex items-center gap-1">
+                        <IconButton
+                            onClick={handleSave}
+                            className={`!p-1.5 transition-colors ${saveStatus === 'saved' ? '!bg-green-600/30 !text-green-400 animate-pulse' : saveStatus === 'error' ? '!bg-red-600/30 !text-red-400' : '!text-green-400/70 hover:!text-green-400 hover:!bg-green-600/15'}`}
+                            title={saveStatus !== 'idle' ? (saveStatus === 'saved' ? 'Saved' : 'Save failed') : 'Save settings'}
+                        >
+                            <Save className="h-3.5 w-3.5" />
+                        </IconButton>
+                        <IconButton
+                            onClick={handleRestoreDefaults}
+                            className={`!p-1.5 transition-colors ${defaultsAnimating ? '' : '!text-red-400/70 hover:!text-red-400 hover:!bg-red-600/15'}`}
+                            title="Restore defaults"
+                        >
+                            <RotateCcw className={`h-3.5 w-3.5 ${defaultsAnimating ? 'animate-spin-once text-orange-400' : ''}`} />
+                        </IconButton>
                     </div>
                 )}
             />
@@ -1222,42 +1239,6 @@ export function SupportSidebar() {
                         </div>
                     </div>
 
-                    {activeKind !== 'trunk' ? (
-                        <div className="space-y-1.5 px-0.5">
-                            {saveStatus !== 'idle' && (
-                                <div
-                                    className="text-[10px]"
-                                    style={{ color: saveStatus === 'saved' ? '#34d399' : '#f87171' }}
-                                >
-                                    {saveStatus === 'saved' ? 'Saved' : 'Save failed'}
-                                </div>
-                            )}
-
-                            <div className="grid grid-cols-2 gap-1.5">
-                                <Button
-                                    type="button"
-                                    onClick={handleSave}
-                                    variant="primary"
-                                    size="md"
-                                    className="w-full !h-10 !text-sm !font-semibold !inline-flex !items-center !justify-center !gap-2"
-                                >
-                                    <Save className="h-4 w-4" />
-                                    <span>Save</span>
-                                </Button>
-
-                                <Button
-                                    type="button"
-                                    onClick={handleRestoreDefaults}
-                                    variant="accent"
-                                    size="md"
-                                    className="w-full !h-10 !text-sm !font-semibold !inline-flex !items-center !justify-center !gap-2"
-                                >
-                                    <RotateCcw className="h-4 w-4" />
-                                    <span>Defaults</span>
-                                </Button>
-                            </div>
-                        </div>
-                    ) : null}
                 </div>
             )}
         </Card>

--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -1101,69 +1101,60 @@ export function SupportSidebar() {
                                     {activeKind === 'raft' ? (
                                         <>
                                             {!shouldUseOverflowCompactMode ? (
-                                                <Section title="Anatomy preview">
+                                                <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
                                                     {renderPreviewBox('h-[220px]')}
-                                                </Section>
+                                                </div>
                                             ) : null}
-                                            <Section title="Raft settings">
+                                            <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
                                                 <RaftSettingsCard
                                                     settings={raftSettings}
                                                     onChange={(partial) => updateRaftSettings(partial)}
                                                 />
-                                            </Section>
+                                            </div>
                                         </>
                                     ) : activeKind === 'grid' ? (
                                         <>
                                             {!shouldUseOverflowCompactMode ? (
-                                                <Section title="Anatomy preview">
+                                                <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
                                                     {renderPreviewBox('h-[220px]')}
-                                                </Section>
+                                                </div>
                                             ) : null}
-                                            <Section title="Grid settings">
+                                            <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
                                                 <GridSettingsCard
                                                     grid={settings.grid}
                                                     onChange={(partial) => updateGridSettings(partial)}
                                                 />
-                                            </Section>
+                                            </div>
                                         </>
                                     ) : activeKind === 'stick' ? (
                                         <>
                                             {!shouldUseOverflowCompactMode ? (
-                                                <Section title="Anatomy preview">
-                                                    {renderPreviewBox('h-[250px]')}
-                                                </Section>
+                                                <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
+                                                    {renderPreviewBox('h-[220px]')}
+                                                </div>
                                             ) : null}
-                                            <Section title="Auto bracing">
+                                            <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
                                                 <AutoBracingSettingsCard
                                                     settings={settings.autoBracing}
                                                     onChange={(partial) => updateAutoBracingSettings(partial)}
                                                     onAutoBrace={handleAutoBrace}
                                                     status={autoBraceStatus}
                                                 />
-                                            </Section>
+                                            </div>
                                         </>
                                     ) : activeKind === 'trunk' ? (
                                         <>
                                             {shouldUseCompactTrunkLayout ? (
                                                 <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
-                                                    <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-                                                        Support geometry
-                                                    </div>
                                                     {supportGeometryFields}
                                                 </div>
                                             ) : (
                                                 <div className="flex gap-2 items-stretch">
                                                     <div className="flex-1 min-w-0 rounded-md border p-2 flex flex-col" style={SECTION_CARD_STYLE}>
-                                                        <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-                                                            Anatomy preview
-                                                        </div>
                                                         {renderPreviewBox('flex-1 min-h-[340px]')}
                                                     </div>
 
                                                     <div className="flex-1 min-w-0 rounded-md border p-2" style={SECTION_CARD_STYLE}>
-                                                        <div className="mb-2 text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-                                                            Support geometry
-                                                        </div>
                                                         {supportGeometryFields}
                                                     </div>
                                                 </div>
@@ -1215,13 +1206,13 @@ export function SupportSidebar() {
                                         </>
                                     ) : (
                                         <>
-                                            <Section title="Anatomy preview">
+                                            <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
                                                 {renderPreviewBox('h-[250px]')}
-                                            </Section>
+                                            </div>
 
-                                            <Section title="Support geometry">
+                                            <div className="rounded-md border p-2" style={SECTION_CARD_STYLE}>
                                                 {supportGeometryFields}
-                                            </Section>
+                                            </div>
 
                                             {/* Placement notes removed per design request */}
                                         </>

--- a/src/supports/Settings/components/GridSettingsCard.tsx
+++ b/src/supports/Settings/components/GridSettingsCard.tsx
@@ -10,7 +10,10 @@ interface GridSettingsCardProps {
 }
 
 export function GridSettingsCard({ grid, onChange }: GridSettingsCardProps) {
-    const compactInputClass = 'ui-input w-full h-[36px] px-3 py-2 text-base no-spinners';
+    const unitHint = (unit: string) => (
+        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[11px] font-semibold" style={{ color: 'var(--text-muted)' }}>{unit}</span>
+    );
+    const compactInputClass = 'ui-input w-full h-[36px] px-3 py-2 text-base text-center no-spinners';
 
     const enabled = grid.enabled;
 
@@ -48,18 +51,22 @@ export function GridSettingsCard({ grid, onChange }: GridSettingsCardProps) {
             <div className={`grid grid-cols-1 gap-1.5 ${!enabled ? 'opacity-80' : ''}`}>
                 <label className="flex flex-col gap-0.5 w-full">
                     <span className="text-[11px] font-medium" style={{ color: !enabled ? 'color-mix(in srgb, var(--text-muted), black 32%)' : 'var(--text-muted)' }}>Spacing</span>
-                    <NumberInput
-                        value={grid.spacingMm}
-                        disabled={!enabled}
-                        step={0.1}
-                        onChange={(val) => {
-                            let safeVal = val;
-                            if (safeVal < 1) safeVal = 1;
-                            if (safeVal > 10) safeVal = 10;
-                            onChange({ spacingMm: safeVal });
-                        }}
-                        className={`${compactInputClass} w-full disabled:opacity-60 disabled:cursor-not-allowed`}
-                    />
+                    <div className="relative">
+                        <NumberInput
+                            value={grid.spacingMm}
+                            disabled={!enabled}
+                            step={0.1}
+                            showStepper={false}
+                            onChange={(val) => {
+                                let safeVal = val;
+                                if (safeVal < 1) safeVal = 1;
+                                if (safeVal > 10) safeVal = 10;
+                                onChange({ spacingMm: safeVal });
+                            }}
+                            className={`${compactInputClass} w-full disabled:opacity-60 disabled:cursor-not-allowed`}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </label>
             </div>
         </div>

--- a/src/supports/Settings/components/PresetSelector.tsx
+++ b/src/supports/Settings/components/PresetSelector.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import React, { useState, useEffect, useRef, useSyncExternalStore } from 'react';
-import { PenLine } from 'lucide-react';
+import ReactDOM from 'react-dom';
+import { PenLine, Pencil, Trash2, Save } from 'lucide-react';
+import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
 import { Button } from '@/components/ui/primitives';
 import {
     getPresetList,
@@ -38,6 +40,22 @@ export function PresetSelector({
     const [tempName, setTempName] = useState('');
     const [tempDescription, setTempDescription] = useState('');
     const [newPresetName, setNewPresetName] = useState('My Preset');
+    const [contextMenu, setContextMenu] = useState<{ x: number; y: number; presetId: string } | null>(null);
+    const contextMenuRef = useRef<HTMLDivElement | null>(null);
+
+    // Global click listener to dismiss the context menu
+    useEffect(() => {
+        if (!contextMenu) return;
+        const handleClick = (e: MouseEvent) => {
+            if (contextMenuRef.current && !contextMenuRef.current.contains(e.target as Node)) {
+                setContextMenu(null);
+            }
+        };
+        // Delay attachment so the right-click event doesn't immediately dismiss it
+        requestAnimationFrame(() => window.addEventListener('click', handleClick));
+        return () => window.removeEventListener('click', handleClick);
+    }, [contextMenu]);
+
     useEffect(() => {
         const unsubscribe = subscribeToPresets(() => {
             setPresets(getPresetList());
@@ -58,8 +76,6 @@ export function PresetSelector({
     const selectedPresetIsBuiltIn = selectedPreset?.isBuiltIn ?? false;
     const hoveredPreset = hoveredPresetId ? presets.find((preset) => preset.id === hoveredPresetId) ?? null : null;
     const previewDescription = hoveredPreset?.description ?? selectedPreset?.description ?? '';
-    const isInlineSaveConfirmOpen = Boolean(confirmId && selectedPreset && confirmId === selectedPreset.id);
-    const isInlineDeleteConfirmOpen = Boolean(deleteConfirmId && selectedPreset && deleteConfirmId === selectedPreset.id);
     const selectedPresetIsDirty = isPresetDirtyForSettings(effectiveSelectedPresetId, settings);
 
     useEffect(() => {
@@ -81,6 +97,8 @@ export function PresetSelector({
     const wrapperRef = useRef<HTMLDivElement | null>(null);
     const [computedMaxHeight, setComputedMaxHeight] = useState<string>('19rem');
 
+    // Dynamically calculate the available space for the preset list so it never
+    // overflows the outer Support Studio panel.
     useEffect(() => {
         function recalc() {
             if (!wrapperRef.current) return;
@@ -88,15 +106,8 @@ export function PresetSelector({
             const top = rect.top;
             const viewportHeight = window.innerHeight;
 
-            // Reserve space for inline panels when open; tuned empirically.
-            const confirmReserve = 120; // px reserved for inline confirm panel area
-            const defaultReserve = 48; // px reserved for normal footer/action area
-
-            const reserved = (isInlineSaveConfirmOpen || isInlineDeleteConfirmOpen) ? confirmReserve : defaultReserve;
-
-            const available = Math.max(120, viewportHeight - top - reserved - 24); // keep a sane minimum
-
-            // Clamp to a reasonable maximum roughly matching earlier rem-based sizes (19rem ≈ 304px)
+            // Reserve 48px for the action button row below the list.
+            const available = Math.max(120, viewportHeight - top - 48 - 24);
             const maxClamp = 304;
             const final = Math.min(available, maxClamp);
             setComputedMaxHeight(`${final}px`);
@@ -105,7 +116,7 @@ export function PresetSelector({
         recalc();
         window.addEventListener('resize', recalc);
         return () => window.removeEventListener('resize', recalc);
-    }, [isInlineSaveConfirmOpen, isInlineDeleteConfirmOpen]);
+    }, []);
 
     function renderPresetRow(preset: (typeof presets)[number]) {
         const isSelected = effectiveSelectedPresetId === preset.id;
@@ -117,6 +128,14 @@ export function PresetSelector({
                 className="w-full px-3 py-2 text-sm relative rounded-[5px] border transition-colors"
                 onClick={() => {
                     handlePresetSelect(preset.id);
+                }}
+                onContextMenu={(e) => {
+                    if (preset.isBuiltIn) return;
+                    e.preventDefault();
+                    e.stopPropagation();
+                    // Dismiss any other open context menus (e.g. the floating panel's "Reset this window" menu)
+                    window.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true }));
+                    setContextMenu({ x: e.clientX, y: e.clientY, presetId: preset.id });
                 }}
                 onMouseEnter={() => {
                     setHoveredPresetId(preset.id);
@@ -233,12 +252,9 @@ export function PresetSelector({
     return (
         <div className="space-y-2">
             <div className="space-y-1">
-                <h4 className="text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-                    Presets
-                </h4>
-                <div ref={wrapperRef} className="rounded-md border bg-[var(--surface-1)]" style={{ borderColor: 'var(--border-subtle)' }}>
+                <div ref={wrapperRef}>
                     <div className="overflow-y-auto custom-scrollbar py-1 transition-[max-height] duration-200" style={{ maxHeight: computedMaxHeight }}>
-                        <div className="grid grid-cols-2 gap-1 px-1">
+                        <div className="grid grid-cols-2 gap-1">
                             {builtInPresets.map((preset, index) => (
                                 <div key={preset.id} className={rowSpanClass(index, builtInPresets.length)}>
                                     {renderPresetRow(preset)}
@@ -267,187 +283,264 @@ export function PresetSelector({
                 ) : null}
             </div>
 
-            {isEditingName && selectedPreset && !selectedPresetIsBuiltIn ? (
-                <div className="space-y-1">
-                    <div className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>
-                        Edit preset details
-                    </div>
-                    <input
-                        type="text"
-                        value={tempName}
-                        onChange={(event) => setTempName(event.target.value)}
-                        onKeyDown={(event) => {
-                            if (event.key === 'Enter') {
-                                handleEditClick();
-                            } else if (event.key === 'Escape') {
-                                setTempName(selectedPreset.name);
-                                setIsEditingName(false);
-                            }
-                        }}
-                        className="ui-input h-8 w-full px-2.5 text-xs sm:text-sm"
-                        placeholder="Preset name"
-                    />
-                    <input
-                        type="text"
-                        value={tempDescription}
-                        onChange={(event) => setTempDescription(event.target.value)}
-                        onKeyDown={(event) => {
-                            if (event.key === 'Enter') {
-                                handleEditClick();
-                            } else if (event.key === 'Escape') {
-                                setTempName(selectedPreset.name);
-                                setTempDescription(selectedPreset.description ?? '');
+            {/* Action row */}
+            <div className="grid grid-cols-2 gap-1.5">
+                <Button
+                    type="button"
+                    variant="accent"
+                    size="md"
+                    className="h-9 text-[12px] font-semibold"
+                    onClick={handleCreateNewClick}
+                    title="Create a new preset from current settings"
+                >
+                    New
+                </Button>
+                <Button
+                    type="button"
+                    variant="primary"
+                    size="md"
+                    className="h-9 text-[12px] font-semibold"
+                    onClick={handleSaveRequest}
+                    disabled={!selectedPreset || selectedPresetIsBuiltIn}
+                    title={selectedPresetIsBuiltIn ? 'Built-in presets cannot be saved' : 'Save current settings to this preset'}
+                >
+                    Save
+                </Button>
+            </div>
+
+            {/* ── Overwrite Preset Modal ─────────────────────────────────── */}
+            <StructuredDialogModal
+                open={confirmId !== null && selectedPreset !== null && confirmId === selectedPreset.id}
+                ariaLabel="Overwrite preset"
+                title={`Save Over "${selectedPreset?.name ?? ''}"?`}
+                subtitle="This will replace the preset with your current settings."
+                icon={<Save className="h-4 w-4" />}
+                iconTone="accent"
+                zIndexClassName="z-[300]"
+                closeAriaLabel="Cancel overwrite"
+                onClose={() => setConfirmId(null)}
+                actions={(
+                    <>
+                        <button
+                            type="button"
+                            className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
+                            onClick={() => setConfirmId(null)}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            className="ui-button ui-button-primary !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                            onClick={() => {
+                                if (selectedPreset) {
+                                    savePreset(selectedPreset.id);
+                                }
+                                setConfirmId(null);
+                            }}
+                        >
+                            <Save className="h-3.5 w-3.5" />
+                            Save
+                        </button>
+                    </>
+                )}
+            >
+                <p className="text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+                    Overwrite the preset <strong style={{ color: 'var(--text-strong)' }}>{selectedPreset?.name ?? ''}</strong> with the current scene settings?
+                </p>
+            </StructuredDialogModal>
+
+            {/* ── Delete Preset Modal ────────────────────────────────────── */}
+            <StructuredDialogModal
+                open={deleteConfirmId !== null && selectedPreset !== null && deleteConfirmId === selectedPreset.id}
+                ariaLabel="Delete preset"
+                title={`Delete "${selectedPreset?.name ?? ''}"?`}
+                subtitle="This action cannot be undone."
+                icon={<Trash2 className="h-4 w-4" />}
+                iconTone="warning"
+                zIndexClassName="z-[300]"
+                closeAriaLabel="Cancel delete"
+                onClose={() => setDeleteConfirmId(null)}
+                actions={(
+                    <>
+                        <button
+                            type="button"
+                            className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
+                            onClick={() => setDeleteConfirmId(null)}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            className="ui-button !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                            style={{
+                                borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
+                                background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
+                                color: 'var(--danger)',
+                            }}
+                            onClick={() => {
+                                if (selectedPreset) {
+                                    deletePreset(selectedPreset.id);
+                                }
                                 setDeleteConfirmId(null);
                                 setIsEditingName(false);
-                            }
-                        }}
-                        className="ui-input h-8 w-full px-2.5 text-xs sm:text-sm"
-                        placeholder="Preset description"
-                    />
-                </div>
-            ) : null}
+                            }}
+                        >
+                            <Trash2 className="h-3.5 w-3.5" />
+                            Delete
+                        </button>
+                    </>
+                )}
+            >
+                <p className="text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+                    This will permanently remove the preset <strong style={{ color: 'var(--text-strong)' }}>{selectedPreset?.name ?? ''}</strong> and all of its saved settings.
+                </p>
+            </StructuredDialogModal>
 
-            {/* Action row: Create, Edit, or Rename/Delete */}
-            {confirmId && selectedPreset && confirmId === selectedPreset.id ? null : isEditingName && selectedPreset && !selectedPresetIsBuiltIn ? (
-                <>
-                    {deleteConfirmId === selectedPreset.id ? null : (
-                        <div className="grid grid-cols-2 gap-1.5">
-                            <Button
-                                type="button"
-                                variant="primary"
-                                size="md"
-                                className="h-9 text-[12px] font-semibold"
-                                onClick={handleEditClick}
-                                disabled={tempName.trim().length === 0}
-                                title="Apply preset details"
-                            >
-                                Apply
-                            </Button>
-                            <Button
-                                type="button"
-                                variant="danger"
-                                size="md"
-                                className="h-9 text-[12px] font-semibold"
-                                onClick={() => setDeleteConfirmId(selectedPreset.id)}
-                                title="Delete this preset"
-                            >
-                                Delete
-                            </Button>
+            {/* ── Edit Preset Modal ──────────────────────────────────────── */}
+            <StructuredDialogModal
+                open={isEditingName && selectedPreset !== null && !selectedPresetIsBuiltIn}
+                ariaLabel="Edit preset"
+                title="Edit Preset"
+                subtitle={`Update name and description for "${selectedPreset?.name ?? ''}"`}
+                icon={<Pencil className="h-4 w-4" />}
+                iconTone="accent"
+                zIndexClassName="z-[300]"
+                closeAriaLabel="Cancel editing"
+                onClose={() => {
+                    if (selectedPreset) {
+                        setTempName(selectedPreset.name);
+                        setTempDescription(selectedPreset.description ?? '');
+                    }
+                    setIsEditingName(false);
+                }}
+                actions={(
+                    <>
+                        <button
+                            type="button"
+                            className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
+                            onClick={() => {
+                                if (selectedPreset) {
+                                    setTempName(selectedPreset.name);
+                                    setTempDescription(selectedPreset.description ?? '');
+                                }
+                                setIsEditingName(false);
+                            }}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            className="ui-button ui-button-primary !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                            disabled={tempName.trim().length === 0}
+                            onClick={handleEditClick}
+                        >
+                            <Save className="h-3.5 w-3.5" />
+                            Apply
+                        </button>
+                    </>
+                )}
+            >
+                <div className="space-y-3">
+                    <div>
+                        <div className="text-[11px] font-medium mb-1" style={{ color: 'var(--text-muted)' }}>
+                            Preset Name
                         </div>
-                    )}
-                </>
-            ) : (
-                <div className="grid grid-cols-3 gap-1.5">
-                    <Button
-                        type="button"
-                        variant="accent"
-                        size="md"
-                        className="h-9 text-[12px] font-semibold"
-                        onClick={handleCreateNewClick}
-                        title="Create a new preset from current settings"
-                    >
-                        New
-                    </Button>
-                    <Button
-                        type="button"
-                        variant="primary"
-                        size="md"
-                        className="h-9 text-[12px] font-semibold"
-                        onClick={handleSaveRequest}
-                        disabled={!selectedPreset || selectedPresetIsBuiltIn}
-                        title={selectedPresetIsBuiltIn ? 'Built-in presets cannot be saved' : 'Save current settings to this preset'}
-                    >
-                        Save
-                    </Button>
-                    <Button
-                        type="button"
-                        variant="secondary"
-                        size="md"
-                        className="h-9 text-[12px] font-semibold"
-                        onClick={handleEditClick}
-                        disabled={!selectedPreset || selectedPresetIsBuiltIn}
-                        title={selectedPresetIsBuiltIn ? 'Built-in presets cannot be renamed' : 'Rename selected preset'}
-                    >
-                        More
-                    </Button>
-                </div>
-            )}
-
-            {confirmId && selectedPreset && confirmId === selectedPreset.id ? (
-                <div className="rounded-md border px-3 py-2 bg-[var(--surface-0)]" style={{ borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 72%)' }}>
-                    <div className="flex items-center justify-between gap-3">
-                        <div className="flex flex-col justify-center">
-                            <div className="text-[12px] font-medium" style={{ color: 'var(--text-strong)' }}>
-                                Overwrite Preset
-                            </div>
-                            <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
-                                Replace "{selectedPreset.name}" with the current settings?
-                            </div>
-                        </div>
-                        <div className="flex items-center gap-2">
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                size="sm"
-                                className="h-8 px-3 text-[12px] font-semibold"
-                                onClick={() => {
-                                    savePreset(selectedPreset.id);
-                                    setConfirmId(null);
-                                }}
-                            >
-                                Save
-                            </Button>
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                size="sm"
-                                className="h-8 px-3 text-[12px]"
-                                onClick={() => setConfirmId(null)}
-                            >
-                                Cancel
-                            </Button>
-                        </div>
-                    </div>
-                </div>
-            ) : null}
-
-            {deleteConfirmId && selectedPreset && deleteConfirmId === selectedPreset.id ? (
-                <div className="rounded-md border px-3 py-2 bg-[var(--surface-0)]" style={{ borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 72%)' }}>
-                    <div className="flex items-center justify-between gap-3">
-                        <div className="flex flex-col justify-center">
-                            <div className="text-[12px] font-medium" style={{ color: 'var(--text-strong)' }}>
-                                Delete Preset
-                            </div>
-                            <div className="text-[11px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
-                                Delete &quot;{selectedPreset.name}&quot;? This cannot be undone.
-                            </div>
-                        </div>
-                        <div className="flex items-center gap-2">
-                            <Button
-                                type="button"
-                                variant="danger"
-                                size="sm"
-                                className="h-8 px-3 text-[12px] font-semibold"
-                                onClick={() => {
-                                    deletePreset(selectedPreset.id);
-                                    setDeleteConfirmId(null);
+                        <input
+                            type="text"
+                            value={tempName}
+                            onChange={(event) => setTempName(event.target.value)}
+                            onKeyDown={(event) => {
+                                if (event.key === 'Enter' && tempName.trim().length > 0) {
+                                    handleEditClick();
+                                } else if (event.key === 'Escape') {
+                                    if (selectedPreset) {
+                                        setTempName(selectedPreset.name);
+                                    }
                                     setIsEditingName(false);
-                                }}
-                            >
-                                Delete
-                            </Button>
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                size="sm"
-                                className="h-8 px-3 text-[12px]"
-                                onClick={() => setDeleteConfirmId(null)}
-                            >
-                                Cancel
-                            </Button>
+                                }
+                            }}
+                            className="ui-input h-9 w-full px-3 text-sm"
+                            placeholder="Preset name"
+                            autoFocus
+                        />
+                    </div>
+                    <div>
+                        <div className="text-[11px] font-medium mb-1" style={{ color: 'var(--text-muted)' }}>
+                            Description
                         </div>
+                        <input
+                            type="text"
+                            value={tempDescription}
+                            onChange={(event) => setTempDescription(event.target.value)}
+                            onKeyDown={(event) => {
+                                if (event.key === 'Enter' && tempName.trim().length > 0) {
+                                    handleEditClick();
+                                } else if (event.key === 'Escape') {
+                                    if (selectedPreset) {
+                                        setTempName(selectedPreset.name);
+                                        setTempDescription(selectedPreset.description ?? '');
+                                    }
+                                    setIsEditingName(false);
+                                }
+                            }}
+                            className="ui-input h-9 w-full px-3 text-sm"
+                            placeholder="Preset description"
+                        />
                     </div>
                 </div>
+            </StructuredDialogModal>
+
+            {/* ── Right-click Context Menu ──────────────────────────────── */}
+            {contextMenu ? ReactDOM.createPortal(
+                <div
+                    ref={contextMenuRef}
+                    className="fixed z-[140] pointer-events-auto w-48 rounded-lg border p-1.5 shadow-xl"
+                    style={{
+                        left: contextMenu.x,
+                        top: contextMenu.y,
+                        borderColor: 'var(--border-subtle)',
+                        background: 'color-mix(in srgb, var(--surface-0), #000 10%)',
+                    }}
+                    onPointerDown={(e) => e.stopPropagation()}
+                >
+                    <button
+                        type="button"
+                        className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
+                        style={{ color: 'var(--text-strong)' }}
+                        onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)'; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                        onClick={() => {
+                            const preset = presets.find((p) => p.id === contextMenu.presetId);
+                            if (!preset || preset.isBuiltIn) return;
+                            handlePresetSelect(preset.id);
+                            setTempName(preset.name);
+                            setTempDescription(preset.description ?? '');
+                            setIsEditingName(true);
+                            setContextMenu(null);
+                        }}
+                    >
+                        <Pencil className="h-3.5 w-3.5" />
+                        Rename
+                    </button>
+                    <button
+                        type="button"
+                        className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
+                        style={{ color: 'var(--danger)' }}
+                        onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--danger), var(--surface-1) 90%)'; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                        onClick={() => {
+                            const preset = presets.find((p) => p.id === contextMenu.presetId);
+                            if (!preset || preset.isBuiltIn) return;
+                            handlePresetSelect(preset.id);
+                            setDeleteConfirmId(preset.id);
+                            setContextMenu(null);
+                        }}
+                    >
+                        <Trash2 className="h-3.5 w-3.5" />
+                        Delete
+                    </button>
+                </div>,
+                document.body
             ) : null}
         </div>
     );

--- a/src/supports/Settings/components/PresetSelector.tsx
+++ b/src/supports/Settings/components/PresetSelector.tsx
@@ -625,6 +625,35 @@ export function PresetSelector({
                         Save to Preset
                     </button>
 
+                    {(() => {
+                        const menuPreset = presets.find((p) => p.id === contextMenu.presetId);
+                        if (!menuPreset) return null;
+                        const isDirty = isPresetDirtyForSettings(menuPreset.id, settings);
+                        return (
+                            <button
+                                type="button"
+                                className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
+                                style={{ color: isDirty ? 'var(--text-strong)' : 'color-mix(in srgb, var(--text-muted), transparent 40%)' }}
+                                onMouseEnter={(e) => {
+                                    if (isDirty) e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)';
+                                }}
+                                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                                disabled={!isDirty}
+                                onClick={() => {
+                                    if (!isDirty) return;
+                                    setContextMenu(null);
+                                    handlePresetSelect(menuPreset.id);
+                                }}
+                            >
+                                <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                    <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                                    <path d="M3 3v5h5" />
+                                </svg>
+                                Revert Changes
+                            </button>
+                        );
+                    })()}
+
                     <div className="my-1 border-t" style={{ borderColor: 'var(--border-subtle)' }} />
 
                     {(() => {

--- a/src/supports/Settings/components/PresetSelector.tsx
+++ b/src/supports/Settings/components/PresetSelector.tsx
@@ -327,6 +327,7 @@ export function PresetSelector({
         }
 
         setContextMenu({ x, y, presetId: preset.id });
+        setPinSubmenuOpen(false);
     };
 
     const handleCreateNewClick = () => {
@@ -607,40 +608,43 @@ export function PresetSelector({
                         Rename
                     </button>
 
-                    <button
-                        type="button"
-                        className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
-                        style={{ color: 'var(--text-strong)' }}
-                        onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)'; }}
-                        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
-                        onClick={() => {
-                            const preset = presets.find((p) => p.id === contextMenu.presetId);
-                            if (!preset) return;
-                            setContextMenu(null);
-                            handlePresetSelect(preset.id);
-                            handleSaveRequest();
-                        }}
-                    >
-                        <Save className="h-3.5 w-3.5" />
-                        Save to Preset
-                    </button>
+                    {(() => {
+                        const menuPreset = presets.find((p) => p.id === contextMenu.presetId);
+                        if (!menuPreset) return null;
+                        const isDirty = isPresetDirtyForSettings(menuPreset.id, settings);
+                        if (!isDirty) return null;
+                        return (
+                            <button
+                                type="button"
+                                className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
+                                style={{ color: 'var(--text-strong)' }}
+                                onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)'; }}
+                                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                                onClick={() => {
+                                    setContextMenu(null);
+                                    handlePresetSelect(menuPreset.id);
+                                    handleSaveRequest();
+                                }}
+                            >
+                                <Save className="h-3.5 w-3.5" />
+                                Save Changes
+                            </button>
+                        );
+                    })()}
 
                     {(() => {
                         const menuPreset = presets.find((p) => p.id === contextMenu.presetId);
                         if (!menuPreset) return null;
                         const isDirty = isPresetDirtyForSettings(menuPreset.id, settings);
+                        if (!isDirty) return null;
                         return (
                             <button
                                 type="button"
                                 className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
-                                style={{ color: isDirty ? 'var(--text-strong)' : 'color-mix(in srgb, var(--text-muted), transparent 40%)' }}
-                                onMouseEnter={(e) => {
-                                    if (isDirty) e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)';
-                                }}
+                                style={{ color: 'var(--text-strong)' }}
+                                onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)'; }}
                                 onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
-                                disabled={!isDirty}
                                 onClick={() => {
-                                    if (!isDirty) return;
                                     setContextMenu(null);
                                     handlePresetSelect(menuPreset.id);
                                 }}
@@ -700,7 +704,7 @@ export function PresetSelector({
                                         onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
                                     >
                                         <Pin className="h-3.5 w-3.5" />
-                                        <span className="flex-1">Pin to Slot</span>
+                                        <span className="flex-1">{isPinned ? 'Move Slot' : 'Pin to Slot'}</span>
                                         <span className="text-[10px] opacity-50">{openLeft ? '◂' : '▸'}</span>
                                     </button>
                                     {pinSubmenuOpen ? (

--- a/src/supports/Settings/components/PresetSelector.tsx
+++ b/src/supports/Settings/components/PresetSelector.tsx
@@ -2,19 +2,22 @@
 
 import React, { useState, useEffect, useRef, useSyncExternalStore } from 'react';
 import ReactDOM from 'react-dom';
-import { PenLine, Pencil, Trash2, Save } from 'lucide-react';
+import { PenLine, Pencil, Trash2, Save, Pin, PinOff } from 'lucide-react';
 import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
-import { Button } from '@/components/ui/primitives';
 import {
     getPresetList,
     getActivePreset,
+    getPinnedPresets,
+    getUnpinnedPresets,
     setActivePreset,
     subscribeToPresets,
     savePreset,
     updateCustomPresetMetadata,
     createPreset,
     deletePreset,
+    setPresetPinnedSlot,
     isPresetDirtyForSettings,
+    restoreFactoryDefaults,
 } from '../presets';
 import { getSettings, subscribeToSettings } from '../state';
 import { setAnatomyPreviewHoveredPresetSettings } from '../AnatomyPreview/previewState';
@@ -37,11 +40,17 @@ export function PresetSelector({
     const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
     const [hoveredPresetId, setHoveredPresetId] = useState<string | null>(null);
     const [isEditingName, setIsEditingName] = useState(false);
+    const [renamingPresetId, setRenamingPresetId] = useState<string | null>(null);
+    const [renameValue, setRenameValue] = useState('');
+    const renameInputRef = useRef<HTMLInputElement | null>(null);
     const [tempName, setTempName] = useState('');
     const [tempDescription, setTempDescription] = useState('');
     const [newPresetName, setNewPresetName] = useState('My Preset');
     const [contextMenu, setContextMenu] = useState<{ x: number; y: number; presetId: string } | null>(null);
+    const [pinSubmenuOpen, setPinSubmenuOpen] = useState(false);
+    const [restoreConfirmOpen, setRestoreConfirmOpen] = useState(false);
     const contextMenuRef = useRef<HTMLDivElement | null>(null);
+    const pinSubmenuTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     // Global click listener to dismiss the context menu
     useEffect(() => {
@@ -64,8 +73,9 @@ export function PresetSelector({
         return unsubscribe;
     }, []);
 
-    const builtInPresets = presets.filter((preset) => preset.isBuiltIn);
-    const customPresets = presets.filter((preset) => !preset.isBuiltIn);
+    const pinnedPresets = getPinnedPresets();
+    const unpinnedPresets = getUnpinnedPresets();
+    const availableSlots = [1, 2, 3, 4, 5, 6].filter((slot) => !pinnedPresets.some((p) => p.pinnedSlot === slot));
 
     const effectiveSelectedPresetId = selectedPresetIdOverride === undefined
         ? activePreset?.id ?? null
@@ -129,14 +139,6 @@ export function PresetSelector({
                 onClick={() => {
                     handlePresetSelect(preset.id);
                 }}
-                onContextMenu={(e) => {
-                    if (preset.isBuiltIn) return;
-                    e.preventDefault();
-                    e.stopPropagation();
-                    // Dismiss any other open context menus (e.g. the floating panel's "Reset this window" menu)
-                    window.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true }));
-                    setContextMenu({ x: e.clientX, y: e.clientY, presetId: preset.id });
-                }}
                 onMouseEnter={() => {
                     setHoveredPresetId(preset.id);
                     setAnatomyPreviewHoveredPresetSettings(preset.settings);
@@ -155,14 +157,18 @@ export function PresetSelector({
                 }}
                 style={{
                     background: isSelected
-                        ? 'color-mix(in srgb, var(--primary-button-surface), var(--surface-0) 90%)'
+                        ? preset.pinnedSlot != null
+                            ? 'color-mix(in srgb, var(--accent-secondary), var(--surface-0) 88%)'
+                            : 'color-mix(in srgb, var(--primary-button-surface), var(--surface-0) 90%)'
                         : 'var(--surface-0)',
                     borderColor: isSelected
-                        ? 'color-mix(in srgb, var(--primary-button-surface), var(--border-subtle) 30%)'
+                        ? preset.pinnedSlot != null
+                            ? 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 25%)'
+                            : 'color-mix(in srgb, var(--primary-button-surface), var(--border-subtle) 30%)'
                         : 'var(--border-subtle)',
                 }}
             >
-                {isSelected ? (
+                {isSelected && preset.pinnedSlot == null ? (
                     <span
                         aria-hidden="true"
                         className="pointer-events-none absolute left-2 top-1/2 inline-block h-2 w-2 -translate-y-1/2 rounded-full border"
@@ -182,20 +188,51 @@ export function PresetSelector({
                         <PenLine className="h-3 w-3" />
                     </span>
                 ) : null}
-                <div className="w-full">
-                    <div className="flex items-center justify-center text-center">
-                        <div className="flex-1 truncate" style={{ color: isSelected ? 'var(--text-strong)' : undefined }}>
-                            {preset.name}
-                        </div>
+                <div className="w-full min-w-0">
+                    <div className="relative flex items-center justify-center text-center">
+                        {preset.pinnedSlot != null ? (
+                            <span
+                                className="absolute left-0 inline-flex h-4 w-4 items-center justify-center rounded-[3px] text-[11px] font-bold tabular-nums leading-none"
+                                style={{
+                                    background: 'color-mix(in srgb, var(--accent), transparent 78%)',
+                                    color: 'var(--accent)',
+                                }}
+                            >
+                                {preset.pinnedSlot}
+                            </span>
+                        ) : null}
+                        {renamingPresetId === preset.id ? (
+                            <input
+                                ref={renameInputRef}
+                                type="text"
+                                value={renameValue}
+                                onChange={(e) => setRenameValue(e.target.value)}
+                                onBlur={() => commitInlineRename()}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter') {
+                                        e.stopPropagation();
+                                        commitInlineRename();
+                                    } else if (e.key === 'Escape') {
+                                        e.stopPropagation();
+                                        cancelInlineRename();
+                                    }
+                                }}
+                                onClick={(e) => e.stopPropagation()}
+                                className="w-full bg-transparent text-center text-sm outline-none border-b"
+                                style={{
+                                    color: 'var(--text-strong)',
+                                    borderColor: 'var(--accent)',
+                                }}
+                            />
+                        ) : (
+                            <div className="flex-1 truncate" style={{ color: isSelected ? 'var(--text-strong)' : undefined }}>
+                                {preset.name}
+                            </div>
+                        )}
                     </div>
                 </div>
             </button>
         );
-    }
-
-    function rowSpanClass(index: number, total: number): string {
-        // If a row has only one tile (odd trailing item), let it fill the full row
-        return total % 2 === 1 && index === total - 1 ? 'col-span-2' : '';
     }
 
     const handlePresetSelect = (presetId: string) => {
@@ -216,6 +253,33 @@ export function PresetSelector({
     const handleSaveRequest = () => {
         if (!selectedPreset || selectedPresetIsBuiltIn) return;
         setConfirmId(selectedPreset.id);
+    };
+
+    const startInlineRename = (presetId: string) => {
+        const preset = presets.find((p) => p.id === presetId);
+        if (!preset) return;
+        setRenamingPresetId(presetId);
+        setRenameValue(preset.name);
+        // Auto-focus after render
+        requestAnimationFrame(() => {
+            renameInputRef.current?.focus();
+            renameInputRef.current?.select();
+        });
+    };
+
+    const commitInlineRename = () => {
+        if (!renamingPresetId) return;
+        const trimmed = renameValue.trim();
+        if (trimmed.length > 0) {
+            updateCustomPresetMetadata(renamingPresetId, trimmed, '');
+        }
+        setRenamingPresetId(null);
+        setRenameValue('');
+    };
+
+    const cancelInlineRename = () => {
+        setRenamingPresetId(null);
+        setRenameValue('');
     };
 
     const handleEditClick = () => {
@@ -242,70 +306,119 @@ export function PresetSelector({
         setIsEditingName(true);
     };
 
+    const handleContextMenu = (e: React.MouseEvent, presetId: string) => {
+        const preset = presets.find((p) => p.id === presetId);
+        if (!preset || preset.isBuiltIn) return;
+        e.preventDefault();
+        e.stopPropagation();
+        // Dismiss any other open context menus (e.g. the floating panel's "Reset this window" menu)
+        window.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true }));
+
+        const menuWidth = 192; // w-48
+        const menuEstimatedHeight = 300;
+        const margin = 10;
+        let x = e.clientX;
+        let y = e.clientY;
+        if (x + menuWidth + margin > window.innerWidth) {
+            x = window.innerWidth - menuWidth - margin;
+        }
+        if (y + menuEstimatedHeight + margin > window.innerHeight) {
+            y = window.innerHeight - menuEstimatedHeight - margin;
+        }
+
+        setContextMenu({ x, y, presetId: preset.id });
+    };
+
     const handleCreateNewClick = () => {
         const created = createPreset(newPresetName);
         setActivePreset(created.id);
         setConfirmId(null);
         setIsEditingName(false);
+        // Auto-enter inline rename for the new preset
+        setRenamingPresetId(created.id);
+        setRenameValue(created.name);
+        setNewPresetName('My Preset');
+        requestAnimationFrame(() => {
+            renameInputRef.current?.focus();
+            renameInputRef.current?.select();
+        });
     };
 
     return (
         <div className="space-y-2">
             <div className="space-y-1">
                 <div ref={wrapperRef}>
-                    <div className="overflow-y-auto custom-scrollbar py-1 transition-[max-height] duration-200" style={{ maxHeight: computedMaxHeight }}>
-                        <div className="grid grid-cols-2 gap-1">
-                            {builtInPresets.map((preset, index) => (
-                                <div key={preset.id} className={rowSpanClass(index, builtInPresets.length)}>
+                    <div
+                        className="overflow-y-auto custom-scrollbar py-1 transition-[max-height] duration-200"
+                        style={{ maxHeight: computedMaxHeight }}
+                        onContextMenu={(e) => {
+                            // Only handle clicks on the background/empty space, not on preset cells
+                            if ((e.target as HTMLElement).closest('[data-preset-cell]')) return;
+                            if (!effectiveSelectedPresetId) return;
+                            handleContextMenu(e, effectiveSelectedPresetId);
+                        }}
+                    >
+                        <div className="grid grid-cols-2 gap-1 px-1">
+                            {[1, 2, 3, 4, 5, 6].map((slot) => {
+                                const preset = pinnedPresets.find((p) => p.pinnedSlot === slot);
+                                return preset ? (
+                                    <div key={preset.id} data-preset-cell onContextMenu={(e) => handleContextMenu(e, preset.id)}>
+                                        {renderPresetRow(preset)}
+                                    </div>
+                                ) : (
+                                    <button
+                                        key={`empty-slot-${slot}`}
+                                        type="button"
+                                        disabled
+                                        className="w-full rounded-[5px] border border-dashed px-3 py-2 text-sm relative"
+                                        style={{
+                                            color: 'color-mix(in srgb, var(--text-muted), transparent 40%)',
+                                            borderColor: 'color-mix(in srgb, var(--border-subtle), transparent 40%)',
+                                        }}
+                                    >
+                                        <div className="w-full min-w-0">
+                                            <div className="relative flex items-center justify-center text-center">
+                                                <span
+                                                    className="absolute left-0 inline-flex h-4 w-4 items-center justify-center rounded-[3px] text-[11px] font-bold tabular-nums leading-none"
+                                                    style={{
+                                                        background: 'color-mix(in srgb, var(--text-muted), transparent 84%)',
+                                                        color: 'color-mix(in srgb, var(--text-muted), transparent 40%)',
+                                                    }}
+                                                >
+                                                    {slot}
+                                                </span>
+                                                <div className="flex-1 truncate">Slot {slot}</div>
+                                            </div>
+                                        </div>
+                                    </button>
+                                );
+                            })}
+                        </div>
+
+                        <div className="mx-3 mt-4 mb-3 border-t" style={{ borderColor: 'var(--border-subtle)' }} />
+                        <div className="grid grid-cols-2 gap-1 px-1">
+                            {unpinnedPresets.map((preset) => (
+                                <div key={preset.id} data-preset-cell onContextMenu={(e) => handleContextMenu(e, preset.id)}>
                                     {renderPresetRow(preset)}
                                 </div>
                             ))}
-                        </div>
-
-                        {customPresets.length > 0 ? (
-                            <>
-                                <div className="mx-3 my-2 border-t" style={{ borderColor: 'var(--border-subtle)' }} />
-                                <div className="grid grid-cols-2 gap-1 px-1">
-                                    {customPresets.map((preset, index) => (
-                                        <div key={preset.id} className={rowSpanClass(index, customPresets.length)}>
-                                            {renderPresetRow(preset)}
-                                        </div>
-                                    ))}
+                            <button
+                                type="button"
+                                onClick={() => handleCreateNewClick()}
+                                className="w-full rounded-[5px] border border-dashed px-3 py-2 text-sm transition-colors"
+                                style={{
+                                    color: 'var(--text-muted)',
+                                    borderColor: 'color-mix(in srgb, var(--border-subtle), transparent 20%)',
+                                }}
+                            >
+                                <div className="flex items-center justify-center gap-1.5">
+                                    <Save className="h-3.5 w-3.5" />
+                                    <span>New Preset</span>
                                 </div>
-                            </>
-                        ) : null}
+                            </button>
+                        </div>
                     </div>
                 </div>
-                {previewDescription ? (
-                    <div className="text-[11px] text-center" style={{ color: 'var(--text-muted)' }}>
-                        {previewDescription}
-                    </div>
-                ) : null}
-            </div>
-
-            {/* Action row */}
-            <div className="grid grid-cols-2 gap-1.5">
-                <Button
-                    type="button"
-                    variant="accent"
-                    size="md"
-                    className="h-9 text-[12px] font-semibold"
-                    onClick={handleCreateNewClick}
-                    title="Create a new preset from current settings"
-                >
-                    New
-                </Button>
-                <Button
-                    type="button"
-                    variant="primary"
-                    size="md"
-                    className="h-9 text-[12px] font-semibold"
-                    onClick={handleSaveRequest}
-                    disabled={!selectedPreset || selectedPresetIsBuiltIn}
-                    title={selectedPresetIsBuiltIn ? 'Built-in presets cannot be saved' : 'Save current settings to this preset'}
-                >
-                    Save
-                </Button>
             </div>
 
             {/* ── Overwrite Preset Modal ─────────────────────────────────── */}
@@ -396,98 +509,56 @@ export function PresetSelector({
                 </p>
             </StructuredDialogModal>
 
-            {/* ── Edit Preset Modal ──────────────────────────────────────── */}
+            {/* ── Restore Defaults Modal ──────────────────────────────────── */}
             <StructuredDialogModal
-                open={isEditingName && selectedPreset !== null && !selectedPresetIsBuiltIn}
-                ariaLabel="Edit preset"
-                title="Edit Preset"
-                subtitle={`Update name and description for "${selectedPreset?.name ?? ''}"`}
-                icon={<Pencil className="h-4 w-4" />}
-                iconTone="accent"
+                open={restoreConfirmOpen}
+                ariaLabel="Restore factory defaults"
+                title="Restore Factory Defaults?"
+                subtitle="Factory presets will be reset and user presets will be unpinned."
+                icon={
+                    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                        <path d="M3 3v5h5" />
+                    </svg>
+                }
+                iconTone="warning"
                 zIndexClassName="z-[300]"
-                closeAriaLabel="Cancel editing"
-                onClose={() => {
-                    if (selectedPreset) {
-                        setTempName(selectedPreset.name);
-                        setTempDescription(selectedPreset.description ?? '');
-                    }
-                    setIsEditingName(false);
-                }}
+                closeAriaLabel="Cancel restore"
+                onClose={() => setRestoreConfirmOpen(false)}
                 actions={(
                     <>
                         <button
                             type="button"
                             className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
-                            onClick={() => {
-                                if (selectedPreset) {
-                                    setTempName(selectedPreset.name);
-                                    setTempDescription(selectedPreset.description ?? '');
-                                }
-                                setIsEditingName(false);
-                            }}
+                            onClick={() => setRestoreConfirmOpen(false)}
                         >
                             Cancel
                         </button>
                         <button
                             type="button"
-                            className="ui-button ui-button-primary !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
-                            disabled={tempName.trim().length === 0}
-                            onClick={handleEditClick}
+                            className="ui-button !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                            style={{
+                                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 25%)',
+                                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                                color: 'var(--accent)',
+                            }}
+                            onClick={() => {
+                                restoreFactoryDefaults();
+                                setRestoreConfirmOpen(false);
+                            }}
                         >
-                            <Save className="h-3.5 w-3.5" />
-                            Apply
+                            <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                                <path d="M3 3v5h5" />
+                            </svg>
+                            Restore
                         </button>
                     </>
                 )}
             >
-                <div className="space-y-3">
-                    <div>
-                        <div className="text-[11px] font-medium mb-1" style={{ color: 'var(--text-muted)' }}>
-                            Preset Name
-                        </div>
-                        <input
-                            type="text"
-                            value={tempName}
-                            onChange={(event) => setTempName(event.target.value)}
-                            onKeyDown={(event) => {
-                                if (event.key === 'Enter' && tempName.trim().length > 0) {
-                                    handleEditClick();
-                                } else if (event.key === 'Escape') {
-                                    if (selectedPreset) {
-                                        setTempName(selectedPreset.name);
-                                    }
-                                    setIsEditingName(false);
-                                }
-                            }}
-                            className="ui-input h-9 w-full px-3 text-sm"
-                            placeholder="Preset name"
-                            autoFocus
-                        />
-                    </div>
-                    <div>
-                        <div className="text-[11px] font-medium mb-1" style={{ color: 'var(--text-muted)' }}>
-                            Description
-                        </div>
-                        <input
-                            type="text"
-                            value={tempDescription}
-                            onChange={(event) => setTempDescription(event.target.value)}
-                            onKeyDown={(event) => {
-                                if (event.key === 'Enter' && tempName.trim().length > 0) {
-                                    handleEditClick();
-                                } else if (event.key === 'Escape') {
-                                    if (selectedPreset) {
-                                        setTempName(selectedPreset.name);
-                                        setTempDescription(selectedPreset.description ?? '');
-                                    }
-                                    setIsEditingName(false);
-                                }
-                            }}
-                            className="ui-input h-9 w-full px-3 text-sm"
-                            placeholder="Preset description"
-                        />
-                    </div>
-                </div>
+                <p className="text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+                    This will reset <strong style={{ color: 'var(--text-strong)' }}>Detail</strong>, <strong style={{ color: 'var(--text-strong)' }}>Structure</strong>, and <strong style={{ color: 'var(--text-strong)' }}>Anchor</strong> to their factory settings and unpin all user presets. Your user presets will <strong style={{ color: 'var(--text-strong)' }}>not</strong> be deleted.
+                </p>
             </StructuredDialogModal>
 
             {/* ── Right-click Context Menu ──────────────────────────────── */}
@@ -510,18 +581,176 @@ export function PresetSelector({
                         onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)'; }}
                         onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
                         onClick={() => {
-                            const preset = presets.find((p) => p.id === contextMenu.presetId);
-                            if (!preset || preset.isBuiltIn) return;
-                            handlePresetSelect(preset.id);
-                            setTempName(preset.name);
-                            setTempDescription(preset.description ?? '');
-                            setIsEditingName(true);
                             setContextMenu(null);
+                            handleCreateNewClick();
+                        }}
+                    >
+                        <Save className="h-3.5 w-3.5" />
+                        New Preset
+                    </button>
+
+                    <button
+                        type="button"
+                        className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
+                        style={{ color: 'var(--text-strong)' }}
+                        onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)'; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                        onClick={() => {
+                            const preset = presets.find((p) => p.id === contextMenu.presetId);
+                            if (!preset) return;
+                            handlePresetSelect(preset.id);
+                            setContextMenu(null);
+                            startInlineRename(preset.id);
                         }}
                     >
                         <Pencil className="h-3.5 w-3.5" />
                         Rename
                     </button>
+
+                    <button
+                        type="button"
+                        className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
+                        style={{ color: 'var(--text-strong)' }}
+                        onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)'; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                        onClick={() => {
+                            const preset = presets.find((p) => p.id === contextMenu.presetId);
+                            if (!preset) return;
+                            setContextMenu(null);
+                            handlePresetSelect(preset.id);
+                            handleSaveRequest();
+                        }}
+                    >
+                        <Save className="h-3.5 w-3.5" />
+                        Save to Preset
+                    </button>
+
+                    <div className="my-1 border-t" style={{ borderColor: 'var(--border-subtle)' }} />
+
+                    {(() => {
+                        const menuPreset = presets.find((p) => p.id === contextMenu.presetId);
+                        if (!menuPreset) return null;
+                        const isPinned = menuPreset.pinnedSlot != null;
+                        const submenuWidth = 160; // w-40 = 10rem ≈ 160px
+                        const contextMenuWidth = 192; // w-48 = 12rem ≈ 192px
+                        const rightEdge = contextMenu.x + contextMenuWidth + submenuWidth + 12;
+                        const openLeft = rightEdge > window.innerWidth;
+                        return (
+                            <>
+                                {isPinned ? (
+                                    <button
+                                        type="button"
+                                        className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
+                                        style={{ color: 'var(--text-strong)' }}
+                                        onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)'; }}
+                                        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                                        onClick={() => {
+                                            setPresetPinnedSlot(menuPreset.id, null);
+                                            setContextMenu(null);
+                                        }}
+                                    >
+                                        <PinOff className="h-3.5 w-3.5" />
+                                        Unpin
+                                    </button>
+                                ) : null}
+                                <div
+                                    className="relative"
+                                    onMouseEnter={() => {
+                                        if (pinSubmenuTimerRef.current) clearTimeout(pinSubmenuTimerRef.current);
+                                        setPinSubmenuOpen(true);
+                                    }}
+                                    onMouseLeave={() => {
+                                        pinSubmenuTimerRef.current = setTimeout(() => setPinSubmenuOpen(false), 100);
+                                    }}
+                                >
+                                    <button
+                                        type="button"
+                                        className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
+                                        style={{ color: 'var(--text-strong)' }}
+                                        onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)'; }}
+                                        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                                    >
+                                        <Pin className="h-3.5 w-3.5" />
+                                        <span className="flex-1">Pin to Slot</span>
+                                        <span className="text-[10px] opacity-50">{openLeft ? '◂' : '▸'}</span>
+                                    </button>
+                                    {pinSubmenuOpen ? (
+                                        <div
+                                            className={`absolute top-0 z-[141] w-40 rounded-lg border p-1.5 shadow-xl ${openLeft ? 'right-full mr-1' : 'left-full ml-1'}`}
+                                            style={{
+                                                borderColor: 'var(--border-subtle)',
+                                                background: 'color-mix(in srgb, var(--surface-0), #000 10%)',
+                                            }}
+                                            onMouseEnter={() => {
+                                                if (pinSubmenuTimerRef.current) clearTimeout(pinSubmenuTimerRef.current);
+                                                setPinSubmenuOpen(true);
+                                            }}
+                                            onMouseLeave={() => {
+                                                pinSubmenuTimerRef.current = setTimeout(() => setPinSubmenuOpen(false), 100);
+                                            }}
+                                        >
+                                            {[1, 2, 3, 4, 5, 6].map((slot) => {
+                                                const alreadyPinned = pinnedPresets.some((p) => p.pinnedSlot === slot);
+                                                if (isPinned && menuPreset.pinnedSlot === slot) return null;
+                                                return (
+                                                    <button
+                                                        key={slot}
+                                                        type="button"
+                                                        className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
+                                                        style={{ color: 'var(--text-strong)' }}
+                                                        onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)'; }}
+                                                        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                                                        onClick={() => {
+                                                            setPresetPinnedSlot(menuPreset.id, slot);
+                                                            setContextMenu(null);
+                                                        }}
+                                                    >
+                                                        <span className="inline-flex h-4 w-4 items-center justify-center rounded-[3px] text-[10px] font-bold tabular-nums leading-none"
+                                                            style={{
+                                                                background: alreadyPinned
+                                                                    ? 'color-mix(in srgb, var(--text-muted), transparent 80%)'
+                                                                    : 'color-mix(in srgb, var(--accent), transparent 78%)',
+                                                                color: alreadyPinned ? 'var(--text-muted)' : 'var(--accent)',
+                                                            }}
+                                                        >
+                                                            {slot}
+                                                        </span>
+                                                        <span className="flex-1">Slot {slot}</span>
+                                                        {alreadyPinned ? (
+                                                            <span className="text-[10px] opacity-40">occupied</span>
+                                                        ) : null}
+                                                    </button>
+                                                );
+                                            })}
+                                        </div>
+                                    ) : null}
+                                </div>
+                            </>
+                        );
+                    })()}
+
+                    <div className="my-1 border-t" style={{ borderColor: 'var(--border-subtle)' }} />
+
+                    <button
+                        type="button"
+                        className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
+                        style={{ color: 'var(--text-strong)' }}
+                        onMouseEnter={(e) => { e.currentTarget.style.background = 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)'; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+                        onClick={() => {
+                            setContextMenu(null);
+                            setRestoreConfirmOpen(true);
+                        }}
+                    >
+                        <svg className="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                            <path d="M3 3v5h5" />
+                        </svg>
+                        Restore Defaults
+                    </button>
+
+                    <div className="my-1 border-t" style={{ borderColor: 'var(--border-subtle)' }} />
+
                     <button
                         type="button"
                         className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] font-medium transition-colors"
@@ -530,7 +759,7 @@ export function PresetSelector({
                         onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
                         onClick={() => {
                             const preset = presets.find((p) => p.id === contextMenu.presetId);
-                            if (!preset || preset.isBuiltIn) return;
+                            if (!preset) return;
                             handlePresetSelect(preset.id);
                             setDeleteConfirmId(preset.id);
                             setContextMenu(null);

--- a/src/supports/Settings/components/RaftSettingsCard.tsx
+++ b/src/supports/Settings/components/RaftSettingsCard.tsx
@@ -101,7 +101,10 @@ export function RaftSettingsCard({ settings, onChange, activeModelId, selectedMo
         </button>
     );
 
-    const compactInputClass = 'ui-input w-full h-[36px] px-3 py-2 text-base no-spinners';
+    const unitHint = (unit: string) => (
+        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[11px] font-semibold" style={{ color: 'var(--text-muted)' }}>{unit}</span>
+    );
+    const compactInputClass = 'ui-input w-full h-[36px] px-3 py-2 text-base text-center no-spinners';
 
     const isWallEnabled = settings.bottomMode === 'solid' && settings.wallEnabled;
 
@@ -129,20 +132,28 @@ export function RaftSettingsCard({ settings, onChange, activeModelId, selectedMo
                         <>
                             <label className="flex flex-col gap-0.5" {...makeFocusHandlers('raft.thickness')}>
                                 <span className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>Thickness</span>
-                                <NumberInput
-                                    value={settings.thickness}
-                                    onChange={(val) => onChange({ thickness: val })}
-                                    step={0.1}
-                                    className={compactInputClass}
-                                />
+                                <div className="relative">
+                                    <NumberInput
+                                        value={settings.thickness}
+                                        onChange={(val) => onChange({ thickness: val })}
+                                        step={0.1}
+                                        showStepper={false}
+                                        className={compactInputClass}
+                                    />
+                                    {unitHint('mm')}
+                                </div>
                             </label>
                             <label className="flex flex-col gap-0.5" {...makeFocusHandlers('raft.chamferAngle')}>
                                 <span className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>Chamfer Angle</span>
-                                <NumberInput
-                                    value={settings.chamferAngle}
-                                    onChange={(val) => onChange({ chamferAngle: val })}
-                                    className={compactInputClass}
-                                />
+                                <div className="relative">
+                                    <NumberInput
+                                        value={settings.chamferAngle}
+                                        onChange={(val) => onChange({ chamferAngle: val })}
+                                        showStepper={false}
+                                        className={compactInputClass}
+                                    />
+                                    {unitHint('°')}
+                                </div>
                             </label>
                         </>
                     )}
@@ -151,21 +162,29 @@ export function RaftSettingsCard({ settings, onChange, activeModelId, selectedMo
                         <>
                             <label className="flex flex-col gap-0.5" {...makeFocusHandlers('raft.lineWidthMm')}>
                                 <span className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>Line Width</span>
-                                <NumberInput
-                                    value={settings.lineWidthMm}
-                                    onChange={(val) => onChange({ lineWidthMm: val })}
-                                    step={0.1}
-                                    className={compactInputClass}
-                                />
+                                <div className="relative">
+                                    <NumberInput
+                                        value={settings.lineWidthMm}
+                                        onChange={(val) => onChange({ lineWidthMm: val })}
+                                        step={0.1}
+                                        showStepper={false}
+                                        className={compactInputClass}
+                                    />
+                                    {unitHint('mm')}
+                                </div>
                             </label>
                             <label className="flex flex-col gap-0.5" {...makeFocusHandlers('raft.lineHeightMm')}>
                                 <span className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>Line Height</span>
-                                <NumberInput
-                                    value={settings.lineHeightMm}
-                                    onChange={(val) => onChange({ lineHeightMm: val })}
-                                    step={0.1}
-                                    className={compactInputClass}
-                                />
+                                <div className="relative">
+                                    <NumberInput
+                                        value={settings.lineHeightMm}
+                                        onChange={(val) => onChange({ lineHeightMm: val })}
+                                        step={0.1}
+                                        showStepper={false}
+                                        className={compactInputClass}
+                                    />
+                                    {unitHint('mm')}
+                                </div>
                             </label>
                         </>
                     )}
@@ -174,39 +193,55 @@ export function RaftSettingsCard({ settings, onChange, activeModelId, selectedMo
                         <>
                             <label className="flex flex-col gap-0.5" {...makeFocusHandlers('raft.wallHeight')}>
                                 <span className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>Wall Height</span>
-                                <NumberInput
-                                    value={settings.wallHeight}
-                                    onChange={(val) => onChange({ wallHeight: val })}
-                                    step={0.1}
-                                    className={compactInputClass}
-                                />
+                                <div className="relative">
+                                    <NumberInput
+                                        value={settings.wallHeight}
+                                        onChange={(val) => onChange({ wallHeight: val })}
+                                        step={0.1}
+                                        showStepper={false}
+                                        className={compactInputClass}
+                                    />
+                                    {unitHint('mm')}
+                                </div>
                             </label>
                             <label className="flex flex-col gap-0.5" {...makeFocusHandlers('raft.wallThickness')}>
                                 <span className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>Wall Thickness</span>
-                                <NumberInput
-                                    value={settings.wallThickness}
-                                    onChange={(val) => onChange({ wallThickness: val })}
-                                    step={0.1}
-                                    className={compactInputClass}
-                                />
+                                <div className="relative">
+                                    <NumberInput
+                                        value={settings.wallThickness}
+                                        onChange={(val) => onChange({ wallThickness: val })}
+                                        step={0.1}
+                                        showStepper={false}
+                                        className={compactInputClass}
+                                    />
+                                    {unitHint('mm')}
+                                </div>
                             </label>
                             <label className="flex flex-col gap-0.5" {...makeFocusHandlers('raft.crenulationGapWidth')}>
                                 <span className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>Gap Width</span>
-                                <NumberInput
-                                    value={settings.crenulationGapWidth}
-                                    onChange={(val) => onChange({ crenulationGapWidth: val })}
-                                    step={0.1}
-                                    className={compactInputClass}
-                                />
+                                <div className="relative">
+                                    <NumberInput
+                                        value={settings.crenulationGapWidth}
+                                        onChange={(val) => onChange({ crenulationGapWidth: val })}
+                                        step={0.1}
+                                        showStepper={false}
+                                        className={compactInputClass}
+                                    />
+                                    {unitHint('mm')}
+                                </div>
                             </label>
                             <label className="flex flex-col gap-0.5" {...makeFocusHandlers('raft.crenulationSpacing')}>
                                 <span className="text-[11px] font-medium" style={{ color: 'var(--text-muted)' }}>Gap Spacing</span>
-                                <NumberInput
-                                    value={settings.crenulationSpacing}
-                                    onChange={(val) => onChange({ crenulationSpacing: val })}
-                                    step={0.1}
-                                    className={compactInputClass}
-                                />
+                                <div className="relative">
+                                    <NumberInput
+                                        value={settings.crenulationSpacing}
+                                        onChange={(val) => onChange({ crenulationSpacing: val })}
+                                        step={0.1}
+                                        showStepper={false}
+                                        className={compactInputClass}
+                                    />
+                                    {unitHint('mm')}
+                                </div>
                             </label>
                         </>
                     )}

--- a/src/supports/Settings/presets.ts
+++ b/src/supports/Settings/presets.ts
@@ -70,14 +70,17 @@ const DETAIL_PRESET: SupportPreset = {
     description: 'Fine supports for delicate features',
     hotkey: '1',
     icon: '🔬',
-    isBuiltIn: true,
+    isBuiltIn: false,
+    pinnedSlot: 1,
     settings: {
         tip: {
             shape: 'cone',
-            contactDiameterMm: 0.2,
+            contactDiameterMm: 0.22,
             bodyDiameterMm: 0.8,
-            lengthMm: 2.0,
+            lengthMm: 2.5,
             penetrationMm: 0,
+            coneAngleMode: 'adaptive',
+            adaptiveConeAngleOffsetDeg: 60,
             coneAngleDeg: 100,
             breakpointMm: 0,
         },
@@ -90,9 +93,9 @@ const DETAIL_PRESET: SupportPreset = {
         },
         roots: {
             shape: 'cylinder',
-            diameterMm: 4.0,
-            diskHeightMm: 0.3,
-            coneHeightMm: 1.2,
+            diameterMm: 2.0,
+            diskHeightMm: 0.5,
+            coneHeightMm: 1.0,
             neckDiameterMm: 0.8,
             neckBlend: 0.7,
         },
@@ -128,8 +131,27 @@ const STRUCTURE_PRESET: SupportPreset = {
     description: 'Balanced supports for general use',
     hotkey: '2',
     icon: '🏗️',
-    isBuiltIn: true,
-    settings: createDefaultSettings(),
+    isBuiltIn: false,
+    pinnedSlot: 2,
+    settings: {
+        ...createDefaultSettings(),
+        tip: {
+            ...createDefaultSettings().tip,
+            contactDiameterMm: 0.28,
+            lengthMm: 2.5,
+        },
+        shaft: {
+            ...createDefaultSettings().shaft,
+            diameterMm: 1.0,
+            secondaryDiameterMm: 1.0,
+        },
+        roots: {
+            ...createDefaultSettings().roots,
+            diameterMm: 2.0,
+            diskHeightMm: 0.5,
+            coneHeightMm: 1.0,
+        },
+    },
 };
 
 const ANCHOR_PRESET: SupportPreset = {
@@ -138,29 +160,32 @@ const ANCHOR_PRESET: SupportPreset = {
     description: 'Heavy supports for large overhangs',
     hotkey: '3',
     icon: '⚓',
-    isBuiltIn: true,
+    isBuiltIn: false,
+    pinnedSlot: 3,
     settings: {
         tip: {
             shape: 'cone',
             contactDiameterMm: 0.4,
             bodyDiameterMm: 1.5,
-            lengthMm: 3.0,
+            lengthMm: 2.5,
             penetrationMm: 0,
+            coneAngleMode: 'adaptive',
+            adaptiveConeAngleOffsetDeg: 60,
             coneAngleDeg: 100,
             breakpointMm: 0,
         },
         shaft: {
             shape: 'cylinder',
-            diameterMm: 1.5,
-            secondaryDiameterMm: 1.5,
+            diameterMm: 1.2,
+            secondaryDiameterMm: 1.2,
             isStraight: true,
             maxAngleDeg: 80,
         },
         roots: {
             shape: 'cylinder',
-            diameterMm: 7.0,
+            diameterMm: 2.0,
             diskHeightMm: 0.5,
-            coneHeightMm: 2.0,
+            coneHeightMm: 1.0,
             neckDiameterMm: 1.5,
             neckBlend: 0.7,
         },
@@ -229,6 +254,7 @@ function loadPresetsFromStorage(): PresetCollection {
                     defaults.byId[id] = {
                         ...fallbackPreset,
                         name: parsedPreset.name || fallbackPreset.name,
+                        pinnedSlot: parsedPreset.pinnedSlot ?? fallbackPreset.pinnedSlot,
                         settings: normalizePresetSettings(
                             parsedPreset.settings,
                             fallbackPreset.settings,
@@ -251,6 +277,7 @@ function loadPresetsFromStorage(): PresetCollection {
                         description: parsedPreset.description || 'User custom preset',
                         icon: parsedPreset.icon || '👤',
                         isBuiltIn: false,
+                        pinnedSlot: parsedPreset.pinnedSlot ?? undefined,
                         settings: normalizePresetSettings(
                             parsedPreset.settings,
                             createDefaultSettings(),
@@ -339,6 +366,50 @@ export function getPresetList(): SupportPreset[] {
     return presets.allIds.map((id) => presets.byId[id]).filter(Boolean);
 }
 
+export function getPinnedPresets(): SupportPreset[] {
+    return presets.allIds
+        .map((id) => presets.byId[id])
+        .filter((p): p is SupportPreset => Boolean(p && p.pinnedSlot != null))
+        .sort((a, b) => (a.pinnedSlot ?? 99) - (b.pinnedSlot ?? 99));
+}
+
+export function getUnpinnedPresets(): SupportPreset[] {
+    return presets.allIds
+        .map((id) => presets.byId[id])
+        .filter((p): p is SupportPreset => Boolean(p && p.pinnedSlot == null));
+}
+
+export function getPresetForPinnedSlot(slot: number): SupportPreset | null {
+    for (const preset of Object.values(presets.byId)) {
+        if (preset.pinnedSlot === slot) return preset;
+    }
+    return null;
+}
+
+export function setPresetPinnedSlot(id: string, slot: number | null): void {
+    if (!presets.byId[id]) {
+        console.warn('[PresetStore] Cannot pin, preset not found:', id);
+        return;
+    }
+
+    // If assigning a slot, unassign any other preset that currently has it
+    if (slot != null) {
+        for (const other of Object.values(presets.byId)) {
+            if (other.id !== id && other.pinnedSlot === slot) {
+                other.pinnedSlot = undefined;
+            }
+        }
+    }
+
+    presets.byId[id] = {
+        ...presets.byId[id],
+        pinnedSlot: slot ?? undefined,
+    };
+
+    savePresetsToStorage();
+    notify();
+}
+
 export function getPresetById(id: string): SupportPreset | undefined {
     return presets.byId[id];
 }
@@ -390,17 +461,19 @@ export function checkPresetDrift(current: SupportSettings): void {
     const presetSettings = presets.byId[activeId].settings;
 
     // Deep compare ESSENTIAL fields only.
-    // Exclude: grid, tip.coneAngleMode, tip.adaptiveConeAngleOffsetDeg, tip.coneAngleDeg
-    // (And raft is separate)
+    // Exclude: grid (And raft is separate)
 
     const isDifferent =
-        // Tip (excluding cone angles)
+        // Tip
         current.tip.shape !== presetSettings.tip.shape ||
         current.tip.contactDiameterMm !== presetSettings.tip.contactDiameterMm ||
         current.tip.bodyDiameterMm !== presetSettings.tip.bodyDiameterMm ||
         current.tip.lengthMm !== presetSettings.tip.lengthMm ||
         current.tip.penetrationMm !== presetSettings.tip.penetrationMm ||
         current.tip.breakpointMm !== presetSettings.tip.breakpointMm ||
+        current.tip.coneAngleMode !== presetSettings.tip.coneAngleMode ||
+        current.tip.adaptiveConeAngleOffsetDeg !== presetSettings.tip.adaptiveConeAngleOffsetDeg ||
+        current.tip.coneAngleDeg !== presetSettings.tip.coneAngleDeg ||
         // Shaft
         JSON.stringify(current.shaft) !== JSON.stringify(presetSettings.shaft) ||
         // Roots
@@ -444,13 +517,6 @@ export function setActivePreset(id: string | null): void {
         grid: {
             ...current.grid, // Use current, ignore preset
         },
-        // Preserve current Cone Control Angle settings (Tip)
-        tip: {
-            ...preset.settings.tip,
-            coneAngleMode: current.tip.coneAngleMode,
-            adaptiveConeAngleOffsetDeg: current.tip.adaptiveConeAngleOffsetDeg,
-            coneAngleDeg: current.tip.coneAngleDeg,
-        },
         // Preserve current Auto Bracing settings
         autoBracing: {
             ...current.autoBracing,
@@ -483,13 +549,6 @@ export function savePreset(id: string): void {
         ...current,
         grid: {
             ...existingPreset.settings.grid, // Keep what was in the preset
-        },
-        tip: {
-            ...current.tip,
-            // Restore cone angle settings from existing preset to avoid saving current ones
-            coneAngleMode: existingPreset.settings.tip.coneAngleMode,
-            adaptiveConeAngleOffsetDeg: existingPreset.settings.tip.adaptiveConeAngleOffsetDeg,
-            coneAngleDeg: existingPreset.settings.tip.coneAngleDeg,
         },
         autoBracing: {
             ...existingPreset.settings.autoBracing,
@@ -530,10 +589,7 @@ export function updateCustomPresetMetadata(id: string, name: string, description
         return;
     }
 
-    if (presets.byId[id].isBuiltIn) {
-        console.warn('[PresetStore] Cannot update built-in preset metadata:', id);
-        return;
-    }
+    // All presets are now editable (no built-in lock)
 
     const uniqueName = ensureUniqueName(name, id);
     const sanitizedDescription = sanitizePresetDescription(description);
@@ -606,25 +662,58 @@ export function createPreset(name: string): SupportPreset {
     return preset;
 }
 
+export function restoreFactoryDefaults(): void {
+    // Reset factory presets to their original definitions and re-pin to slots 1-3
+    const factoryPresets: Record<string, SupportPreset> = {
+        detail: { ...DETAIL_PRESET, pinnedSlot: 1 },
+        structure: { ...STRUCTURE_PRESET, pinnedSlot: 2 },
+        anchor: { ...ANCHOR_PRESET, pinnedSlot: 3 },
+    };
+
+    (['detail', 'structure', 'anchor'] as const).forEach((id) => {
+        presets.byId[id] = {
+            ...factoryPresets[id],
+            settings: normalizePresetSettings(
+                factoryPresets[id].settings,
+                createDefaultSettings(),
+            ),
+        };
+    });
+
+    // Unpin all user-created presets (anything that isn't detail/structure/anchor)
+    presets.allIds.forEach((id) => {
+        if (id === 'detail' || id === 'structure' || id === 'anchor') return;
+        const preset = presets.byId[id];
+        if (preset) {
+            presets.byId[id] = { ...preset, pinnedSlot: undefined };
+        }
+    });
+
+    // Ensure factory IDs are first in the ordering
+    const factoryIds = ['detail', 'structure', 'anchor'];
+    const userIds = presets.allIds.filter((id) => !factoryIds.includes(id));
+    presets.allIds = [...factoryIds, ...userIds];
+
+    savePresetsToStorage();
+    notify();
+    console.log('[PresetStore] Restored factory defaults, unpinned user presets');
+}
+
 export function deletePreset(id: string): void {
     if (!presets.byId[id]) {
         console.warn('[PresetStore] Cannot delete, preset not found:', id);
         return;
     }
 
-    // Prevent deleting built-in presets
-    if (presets.byId[id].isBuiltIn) {
-        console.warn('[PresetStore] Cannot delete built-in preset:', id);
-        return;
-    }
+    // All presets are now deletable (no built-in lock)
 
     // Remove from byId and allIds
     delete presets.byId[id];
     presets.allIds = presets.allIds.filter((pid) => pid !== id);
 
-    // If deleted preset was active, fall back to 'structure' if available
+    // If deleted preset was active, fall back to first available
     if (presets.activePresetId === id) {
-        presets.activePresetId = presets.byId['structure'] ? 'structure' : (presets.allIds[0] ?? null);
+        presets.activePresetId = presets.allIds[0] ?? null;
     }
 
     savePresetsToStorage();

--- a/src/supports/Settings/presets.ts
+++ b/src/supports/Settings/presets.ts
@@ -166,7 +166,7 @@ const ANCHOR_PRESET: SupportPreset = {
         tip: {
             shape: 'cone',
             contactDiameterMm: 0.4,
-            bodyDiameterMm: 1.5,
+            bodyDiameterMm: 1.2,
             lengthMm: 2.5,
             penetrationMm: 0,
             coneAngleMode: 'adaptive',

--- a/src/supports/Settings/state.ts
+++ b/src/supports/Settings/state.ts
@@ -120,14 +120,24 @@ export function getAutoBracingSettings() {
 // --- Setters ---
 
 export function setSettings(settings: SupportSettings): void {
-    currentSettings = mergeWithDefaults(settings);
+    const merged = mergeWithDefaults(settings);
+    // Clamp contact cone body diameter so it never exceeds the trunk diameter
+    if (merged.tip.bodyDiameterMm > merged.shaft.diameterMm) {
+        merged.tip.bodyDiameterMm = merged.shaft.diameterMm;
+    }
+    currentSettings = merged;
     notify();
 }
 
 export function updateTipProfile(tip: Partial<SupportSettings['tip']>): void {
+    const mergedTip = { ...currentSettings.tip, ...tip };
+    // Clamp contact cone body diameter so it never exceeds the trunk diameter
+    if (mergedTip.bodyDiameterMm > currentSettings.shaft.diameterMm) {
+        mergedTip.bodyDiameterMm = currentSettings.shaft.diameterMm;
+    }
     currentSettings = {
         ...currentSettings,
-        tip: { ...currentSettings.tip, ...tip },
+        tip: mergedTip,
     };
     notify();
 }

--- a/src/supports/Settings/types.ts
+++ b/src/supports/Settings/types.ts
@@ -232,6 +232,8 @@ export interface SupportPreset {
     hotkey?: string;
     icon?: string;
     isBuiltIn: boolean;
+    /** Pinned slot (1-4) for quick-access hotkeys, or undefined if unpinned. */
+    pinnedSlot?: number;
     settings: SupportSettings;
     createdAt?: number;
     updatedAt?: number;

--- a/src/supports/SupportProxyMeshLayer.tsx
+++ b/src/supports/SupportProxyMeshLayer.tsx
@@ -945,13 +945,19 @@ export function SupportProxyMeshLayer({
       // diameter + 0.1mm offset). Using profile.diameter alone produces the thin brace setting
       // value and loses the dynamic sizing that matches the attached trunk thickness.
       const profileDiameter = Math.max(0.001, brace.profile?.diameter ?? 1);
-      const startHostDiameter = Math.max(
-        0.001,
-        (startKnot.diameter ?? (profileDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+      const startHostDiameter = Math.min(
+        profileDiameter,
+        Math.max(
+          0.001,
+          (startKnot.diameter ?? (profileDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+        ),
       );
-      const endHostDiameter = Math.max(
-        0.001,
-        (endKnot.diameter ?? (profileDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+      const endHostDiameter = Math.min(
+        profileDiameter,
+        Math.max(
+          0.001,
+          (endKnot.diameter ?? (profileDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+        ),
       );
 
       const segmentId = `braceSegment:${brace.id}`;

--- a/src/supports/SupportRenderer.tsx
+++ b/src/supports/SupportRenderer.tsx
@@ -44,6 +44,7 @@ import type { ContactDiskProfile } from './SupportPrimitives/ContactCone/types';
 import { getRaftSettings, subscribeToRaftStore } from './Rafts/Crenelated/RaftState';
 import { JOINT_DIAMETER_OFFSET_MM } from './constants';
 import { DEBUG_SECTION_COLORS as AUTO_BRACING_DEBUG_SECTION_COLORS } from './autoBracing/settings';
+import { getAutoBracingSettings } from './Settings/state';
 import { VoronoiSeedDebugMarkers } from './autoBracing/VoronoiSeedDebugMarkers';
 import { clearSupportMarqueeHover, setSupportMarqueeHoverBlocked, useSupportMarqueeHoverState } from './interaction/shared/hover/sceneHoverMarquee';
 import { applySceneHoverWriteDecision, resolveSceneBatchedShaftHoverWriteDecision, resolveSceneBatchedShaftPointerOutWriteDecision, resolveSceneBatchedSupportHoverWriteDecision, shouldClearSceneHoverForSelectedPrimitiveSuppression, shouldClearSceneHoverForSelectionChange } from './interaction/shared/hover/sceneHoverController';
@@ -631,8 +632,9 @@ function buildBracePlacementPreviewBatch(id: string, preview: BracePreviewData):
     const dy = end.y - start.y;
     const dz = end.z - start.z;
     const lenSq = dx * dx + dy * dy + dz * dz;
-    const startDiameter = Math.max(0.001, preview.startDiameterMm);
-    const endDiameter = Math.max(0.001, preview.endDiameterMm);
+    const braceDia = getAutoBracingSettings().braceDiameterMm;
+    const startDiameter = Math.min(braceDia, Math.max(0.001, preview.startDiameterMm));
+    const endDiameter = Math.min(braceDia, Math.max(0.001, preview.endDiameterMm));
     const knotStartDiameter = Math.max(0.001, preview.startDiameterMm + 0.1);
     const knotEndDiameter = Math.max(0.001, preview.endDiameterMm + 0.1);
 
@@ -2061,13 +2063,19 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             if (!startKnot || !endKnot) continue;
 
             const profileDiameter = Math.max(0.001, brace.profile?.diameter ?? 1.0);
-            const startHostDiameter = Math.max(
-                0.001,
-                (startKnot.diameter ?? (profileDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+            const startHostDiameter = Math.min(
+                profileDiameter,
+                Math.max(
+                    0.001,
+                    (startKnot.diameter ?? (profileDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+                ),
             );
-            const endHostDiameter = Math.max(
-                0.001,
-                (endKnot.diameter ?? (profileDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+            const endHostDiameter = Math.min(
+                profileDiameter,
+                Math.max(
+                    0.001,
+                    (endKnot.diameter ?? (profileDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+                ),
             );
             const isTaperedBrace = Math.abs(startHostDiameter - endHostDiameter) > 1e-4;
 

--- a/src/supports/SupportTypes/Brace/BracePlacementController.tsx
+++ b/src/supports/SupportTypes/Brace/BracePlacementController.tsx
@@ -8,7 +8,7 @@ import { pushHistory } from '@/history/historyStore';
 import type { SnapTarget } from '../../interaction/SnappingManager';
 import type { Brace, Knot, Vec3 } from '../../types';
 import { SUPPORT_ADD_BRACE } from '../../history/actionTypes';
-import { getSettings } from '../../Settings/state';
+import { getSettings, getAutoBracingSettings } from '../../Settings/state';
 import { useKickstandStoreState } from '../Kickstand/kickstandStore';
 import { bracePlacementStore, useBracePlacementState } from './bracePlacementState';
 import { branchPlacementStore } from '../Branch/branchPlacementState';
@@ -804,8 +804,9 @@ export function BracePlacementController() {
                 if (!snap) return;
                 bracePlacementStore.setStart(snap);
                 const settings = getSettings();
+                const braceDia = getAutoBracingSettings().braceDiameterMm;
                 const fallbackDia = settings.shaft.diameterMm;
-                const startDiam = snap.hostDiameterMm ?? fallbackDia;
+                const startDiam = Math.min(snap.hostDiameterMm ?? fallbackDia, braceDia);
                 bracePlacementStore.setPreview({
                     start: snap.snappedPos,
                     end: snap.snappedPos,
@@ -826,9 +827,10 @@ export function BracePlacementController() {
                 if (!start.leafId || start.coneT === undefined) return;
 
                 const settings = getSettings();
+                const braceDia = getAutoBracingSettings().braceDiameterMm;
                 const fallback = settings.shaft.diameterMm;
-                const startDiam = start.hostDiameterMm ?? fallback;
-                const endDiam = endSnap.hostDiameterMm ?? fallback;
+                const startDiam = Math.min(start.hostDiameterMm ?? fallback, braceDia);
+                const endDiam = Math.min(endSnap.hostDiameterMm ?? fallback, braceDia);
 
                 const braceId = generateUuid();
                 const startKnotId = generateUuid();
@@ -894,9 +896,10 @@ export function BracePlacementController() {
             if (startModelId && endModelId && startModelId !== endModelId) return;
 
             const settings = getSettings();
+            const braceDia = getAutoBracingSettings().braceDiameterMm;
             const fallback = settings.shaft.diameterMm;
-            const startDiam = start.hostDiameterMm ?? fallback;
-            const endDiam = endSnap.hostDiameterMm ?? fallback;
+            const startDiam = Math.min(start.hostDiameterMm ?? fallback, braceDia);
+            const endDiam = Math.min(endSnap.hostDiameterMm ?? fallback, braceDia);
 
             const braceId = generateUuid();
             const startKnotId = generateUuid();
@@ -972,8 +975,9 @@ export function BracePlacementController() {
                 if (!snap) return;
                 bracePlacementStore.setStart(snap);
                 const settings = getSettings();
+                const braceDia = getAutoBracingSettings().braceDiameterMm;
                 const fallbackDia = settings.shaft.diameterMm;
-                const startDiam = snap.hostDiameterMm ?? fallbackDia;
+                const startDiam = Math.min(snap.hostDiameterMm ?? fallbackDia, braceDia);
                 bracePlacementStore.setPreview({
                     start: snap.snappedPos,
                     end: snap.snappedPos,
@@ -996,9 +1000,10 @@ export function BracePlacementController() {
                 if (!start.leafId || start.coneT === undefined) return;
 
                 const settings = getSettings();
+                const braceDia = getAutoBracingSettings().braceDiameterMm;
                 const fallback = settings.shaft.diameterMm;
-                const startDiam = start.hostDiameterMm ?? fallback;
-                const endDiam = endSnap.hostDiameterMm ?? fallback;
+                const startDiam = Math.min(start.hostDiameterMm ?? fallback, braceDia);
+                const endDiam = Math.min(endSnap.hostDiameterMm ?? fallback, braceDia);
 
                 const braceId = generateUuid();
                 const startKnotId = generateUuid();

--- a/src/supports/SupportTypes/Brace/BraceRenderer.tsx
+++ b/src/supports/SupportTypes/Brace/BraceRenderer.tsx
@@ -94,13 +94,19 @@ export const BraceRenderer = React.memo(function BraceRenderer({
     const endVec = useMemo(() => new THREE.Vector3(endKnot.pos.x, endKnot.pos.y, endKnot.pos.z), [endKnot.pos.x, endKnot.pos.y, endKnot.pos.z]);
 
     const uniformBraceDiameter = Math.max(0.001, brace.profile?.diameter ?? 1.0);
-    const startHostDiameter = Math.max(
-        0.001,
-        (startKnot.diameter ?? (uniformBraceDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+    const startHostDiameter = Math.min(
+        uniformBraceDiameter,
+        Math.max(
+            0.001,
+            (startKnot.diameter ?? (uniformBraceDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+        ),
     );
-    const endHostDiameter = Math.max(
-        0.001,
-        (endKnot.diameter ?? (uniformBraceDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+    const endHostDiameter = Math.min(
+        uniformBraceDiameter,
+        Math.max(
+            0.001,
+            (endKnot.diameter ?? (uniformBraceDiameter + JOINT_DIAMETER_OFFSET_MM)) - JOINT_DIAMETER_OFFSET_MM,
+        ),
     );
     const bezierCurve = brace.curve?.type === 'bezier' ? brace.curve : null;
     const isBezierBrace = !!bezierCurve;

--- a/src/supports/autoBracing/AutoBracingSettingsCard.tsx
+++ b/src/supports/autoBracing/AutoBracingSettingsCard.tsx
@@ -142,7 +142,7 @@ export function AutoBracingSettingsCard({
 
             {/* Row 4: Seed Spacing (full width) */}
             <label className="space-y-1 min-w-0">
-                <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Seed Spacing (Cells)</div>
+                <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Cluster Spacing</div>
                 <div className="grid grid-cols-3 gap-1.5">
                     {([['Low', 2], ['Mid', 5], ['High', 10]] as const).map(([label, value]) => {
                         const isActive = settings.seedSpacingMm === value;

--- a/src/supports/autoBracing/AutoBracingSettingsCard.tsx
+++ b/src/supports/autoBracing/AutoBracingSettingsCard.tsx
@@ -20,7 +20,10 @@ interface AutoBracingSettingsCardProps {
     } | null;
 }
 
-const compactInputClass = 'ui-input w-full h-[36px] px-3 py-2 text-base no-spinners';
+const unitHint = (unit: string) => (
+    <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[11px] font-semibold" style={{ color: 'var(--text-muted)' }}>{unit}</span>
+);
+const compactInputClass = 'ui-input w-full h-[36px] px-3 py-2 text-base text-center no-spinners';
 const compactFieldLabelClass = 'text-[11px] font-medium leading-tight';
 
 export function AutoBracingSettingsCard({
@@ -93,44 +96,60 @@ export function AutoBracingSettingsCard({
             {/* Row 1: Brace Diameter | Max Brace Distance */}
             <div className="grid grid-cols-2 gap-1.5 items-start">
                 <label className="space-y-1 min-w-0">
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Brace Diameter (mm)</div>
-                    <NumberInput
-                        value={settings.braceDiameterMm}
-                        onChange={(value) => onChange({ braceDiameterMm: value })}
-                        step={0.1}
-                        className={compactInputClass}
-                    />
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Brace Diameter</div>
+                    <div className="relative">
+                        <NumberInput
+                            value={settings.braceDiameterMm}
+                            onChange={(value) => onChange({ braceDiameterMm: value })}
+                            step={0.1}
+                            showStepper={false}
+                            className={compactInputClass}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </label>
                 <label className="space-y-1 min-w-0">
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Max Brace Distance (mm)</div>
-                    <NumberInput
-                        value={settings.maxBraceLengthMm}
-                        onChange={(value) => onChange({ maxBraceLengthMm: value })}
-                        step={0.1}
-                        className={compactInputClass}
-                    />
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Max Brace Distance</div>
+                    <div className="relative">
+                        <NumberInput
+                            value={settings.maxBraceLengthMm}
+                            onChange={(value) => onChange({ maxBraceLengthMm: value })}
+                            step={0.1}
+                            showStepper={false}
+                            className={compactInputClass}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </label>
             </div>
 
             {/* Row 2: Initial Distance | Repeat Interval */}
             <div className="grid grid-cols-2 gap-1.5 items-start">
                 <label className="space-y-1 min-w-0">
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Initial Distance (mm)</div>
-                    <NumberInput
-                        value={settings.initialDistanceMm}
-                        onChange={(value) => onChange({ initialDistanceMm: value })}
-                        step={0.1}
-                        className={compactInputClass}
-                    />
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Initial Distance</div>
+                    <div className="relative">
+                        <NumberInput
+                            value={settings.initialDistanceMm}
+                            onChange={(value) => onChange({ initialDistanceMm: value })}
+                            step={0.1}
+                            showStepper={false}
+                            className={compactInputClass}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </label>
                 <label className="space-y-1 min-w-0">
-                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Repeat Interval (mm)</div>
-                    <NumberInput
-                        value={settings.patternIntervalMm}
-                        onChange={(value) => onChange({ patternIntervalMm: value })}
-                        step={0.1}
-                        className={compactInputClass}
-                    />
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Repeat Interval</div>
+                    <div className="relative">
+                        <NumberInput
+                            value={settings.patternIntervalMm}
+                            onChange={(value) => onChange({ patternIntervalMm: value })}
+                            step={0.1}
+                            showStepper={false}
+                            className={compactInputClass}
+                        />
+                        {unitHint('mm')}
+                    </div>
                 </label>
             </div>
 

--- a/src/supports/autoBracing/AutoBracingSettingsCard.tsx
+++ b/src/supports/autoBracing/AutoBracingSettingsCard.tsx
@@ -5,8 +5,6 @@ import { NumberInput } from '@/components/ui/NumberInput';
 import { Button } from '@/components/ui/primitives';
 import { SelectDropdown } from '@/components/ui/SelectDropdown';
 import {
-    AUTO_BRACING_CONSTRAINTS,
-    AUTO_BRACING_HARD_RULES,
     AUTO_BRACING_PATTERN_OPTIONS,
     type AutoBracingSettings,
     type AutoBracingPattern,
@@ -81,7 +79,7 @@ export function AutoBracingSettingsCard({
                     onChange={(nextValue) => onPatternChange(nextValue as AutoBracingPattern)}
                     options={AUTO_BRACING_PATTERN_OPTIONS.map((pattern) => ({
                         value: pattern,
-                        label: pattern === 'singleDiagonal' ? 'Single diagonal' : 'Cross diagonal',
+                        label: pattern === 'singleDiagonal' ? 'Single Diagonal' : 'Cross Diagonal',
                     }))}
                     className="min-w-0 space-y-0"
                     selectClassName="h-[36px] px-3 py-2 text-base"
@@ -92,99 +90,86 @@ export function AutoBracingSettingsCard({
 
     return (
         <div className="space-y-1.5">
-            <div className="space-y-1.5">
-                {/* Global Settings */}
-                <div className="grid grid-cols-2 gap-1.5 items-start">
-                    <label className="space-y-1 min-w-0">
-                        <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Brace Diameter (mm)</div>
-                        <NumberInput
-                            value={settings.braceDiameterMm}
-                            onChange={(value) => onChange({ braceDiameterMm: value })}
-                            step={0.1}
-                            className={compactInputClass}
-                        />
-                    </label>
-                    <label className="space-y-1 min-w-0">
-                        <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Seed Spacing (Cells)</div>
-                        <NumberInput
-                            value={settings.seedSpacingMm}
-                            onChange={(value) => onChange({ seedSpacingMm: value })}
-                            className={compactInputClass}
-                        />
-                    </label>
-                </div>
-
-                {/* Initial Pattern Settings */}
-                <div className="grid grid-cols-2 gap-1.5 items-start">
-                    {renderPatternSelect('Initial Pattern', settings.initialPattern, (initialPattern) => onChange({ initialPattern }))}
-                    <label className="space-y-1 min-w-0">
-                        <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Initial Distance (mm)</div>
-                        <NumberInput
-                            value={settings.initialDistanceMm}
-                            onChange={(value) => onChange({ initialDistanceMm: value })}
-                            step={0.1}
-                            className={compactInputClass}
-                        />
-                    </label>
-                </div>
-
-                {/* Repeating Pattern Settings */}
-                <div className="grid grid-cols-2 gap-1.5 items-start">
-                    {renderPatternSelect('Repeating Pattern', settings.repeatingPattern, (repeatingPattern) => onChange({ repeatingPattern }))}
-                    <label className="space-y-1 min-w-0">
-                        <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Repeat Interval (mm)</div>
-                        <NumberInput
-                            value={settings.patternIntervalMm}
-                            onChange={(value) => onChange({ patternIntervalMm: value })}
-                            step={0.1}
-                            className={compactInputClass}
-                        />
-                    </label>
-                </div>
-
-                <div className="h-px w-full" style={{ background: 'var(--border-subtle)' }} />
-
-                {/* Tuning Settings */}
-                <div className="grid grid-cols-2 gap-1.5 items-start">
-                    <label className="space-y-1 min-w-0">
-                        <div className={compactFieldLabelClass} style={{ color: 'var(--text-secondary)' }}>Seed Jitter (Cells)</div>
-                        <NumberInput
-                            value={settings.seedJitterMm}
-                            onChange={(value) => onChange({ seedJitterMm: value })}
-                            className={compactInputClass}
-                        />
-                    </label>
-                    <label className="space-y-1 min-w-0">
-                        <div className={compactFieldLabelClass} style={{ color: 'var(--text-secondary)' }}>Max Brace Distance (mm)</div>
-                        <NumberInput
-                            value={settings.maxBraceLengthMm}
-                            onChange={(value) => onChange({ maxBraceLengthMm: value })}
-                            step={0.1}
-                            className={compactInputClass}
-                        />
-                    </label>
-                </div>
+            {/* Row 1: Brace Diameter | Max Brace Distance */}
+            <div className="grid grid-cols-2 gap-1.5 items-start">
+                <label className="space-y-1 min-w-0">
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Brace Diameter (mm)</div>
+                    <NumberInput
+                        value={settings.braceDiameterMm}
+                        onChange={(value) => onChange({ braceDiameterMm: value })}
+                        step={0.1}
+                        className={compactInputClass}
+                    />
+                </label>
+                <label className="space-y-1 min-w-0">
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Max Brace Distance (mm)</div>
+                    <NumberInput
+                        value={settings.maxBraceLengthMm}
+                        onChange={(value) => onChange({ maxBraceLengthMm: value })}
+                        step={0.1}
+                        className={compactInputClass}
+                    />
+                </label>
             </div>
 
-            <div className="grid grid-cols-2 gap-1.5">
-                <ToggleButton
-                    checked={settings.debugSectionColorsEnabled}
-                    onChange={() => onChange({ debugSectionColorsEnabled: !settings.debugSectionColorsEnabled })}
-                    label="Section Colors"
-                />
-                <ToggleButton
-                    checked={settings.debugVoronoiSeedsEnabled}
-                    onChange={() => onChange({ debugVoronoiSeedsEnabled: !settings.debugVoronoiSeedsEnabled })}
-                    label="Seed Markers"
-                />
+            {/* Row 2: Initial Distance | Repeat Interval */}
+            <div className="grid grid-cols-2 gap-1.5 items-start">
+                <label className="space-y-1 min-w-0">
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Initial Distance (mm)</div>
+                    <NumberInput
+                        value={settings.initialDistanceMm}
+                        onChange={(value) => onChange({ initialDistanceMm: value })}
+                        step={0.1}
+                        className={compactInputClass}
+                    />
+                </label>
+                <label className="space-y-1 min-w-0">
+                    <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Repeat Interval (mm)</div>
+                    <NumberInput
+                        value={settings.patternIntervalMm}
+                        onChange={(value) => onChange({ patternIntervalMm: value })}
+                        step={0.1}
+                        className={compactInputClass}
+                    />
+                </label>
             </div>
 
-            <div className="rounded-md border px-2.5 py-2 text-[11px] leading-snug" style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-0), transparent 6%)', color: 'var(--text-muted)' }}>
-                <div className="space-y-1">
-                    <div>Fixed rules: {AUTO_BRACING_HARD_RULES.braceAngleDeg}° brace angle, min group size {AUTO_BRACING_HARD_RULES.minGroupSize}, and {AUTO_BRACING_HARD_RULES.minAxisSeparationDeg}° min axis separation.</div>
-                    <div>Value limits: dia {AUTO_BRACING_CONSTRAINTS.braceDiameterMm.min}–{AUTO_BRACING_CONSTRAINTS.braceDiameterMm.max}, dist {AUTO_BRACING_CONSTRAINTS.maxBraceLengthMm.min}–{AUTO_BRACING_CONSTRAINTS.maxBraceLengthMm.max} mm.</div>
-                </div>
+            {/* Row 3: Initial Pattern | Repeating Pattern */}
+            <div className="grid grid-cols-2 gap-1.5 items-start">
+                {renderPatternSelect('Initial Pattern', settings.initialPattern, (initialPattern) => onChange({ initialPattern }))}
+                {renderPatternSelect('Repeating Pattern', settings.repeatingPattern, (repeatingPattern) => onChange({ repeatingPattern }))}
             </div>
+
+            {/* Row 4: Seed Spacing (full width) */}
+            <label className="space-y-1 min-w-0">
+                <div className={compactFieldLabelClass} style={{ color: 'var(--text-muted)' }}>Seed Spacing (Cells)</div>
+                <div className="grid grid-cols-3 gap-1.5">
+                    {([['Low', 2], ['Mid', 5], ['High', 10]] as const).map(([label, value]) => {
+                        const isActive = settings.seedSpacingMm === value;
+                        return (
+                            <button
+                                key={label}
+                                type="button"
+                                className="h-9 rounded-md border text-[12px] font-semibold transition-colors"
+                                style={isActive
+                                    ? {
+                                        borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
+                                        background: 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)',
+                                        color: 'color-mix(in srgb, var(--accent), var(--text-strong) 25%)',
+                                    }
+                                    : {
+                                        borderColor: 'var(--border-subtle)',
+                                        background: 'var(--surface-1)',
+                                        color: 'var(--text-muted)',
+                                    }}
+                                onClick={() => onChange({ seedSpacingMm: value })}
+                            >
+                                {label}
+                            </button>
+                        );
+                    })}
+                </div>
+            </label>
 
             {status && (
                 <div
@@ -209,15 +194,28 @@ export function AutoBracingSettingsCard({
                 </div>
             )}
 
-            <Button
+            <div className="h-2" />
+
+            <button
                 type="button"
                 onClick={onAutoBrace}
-                variant="primary"
-                size="sm"
-                className="w-full !h-10 !text-[12px] !font-semibold"
+                className="w-full !h-10 rounded-md border px-3 text-[12px] font-semibold inline-flex items-center justify-center gap-2 transition-colors"
+                style={{
+                    borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
+                    background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                    color: 'var(--accent)',
+                }}
             >
-                Auto Brace
-            </Button>
+                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M14.5 3.5 12 6l2.5 2.5L17 6l-2.5-2.5z" />
+                    <path d="M9.5 14.5 7 17l2.5 2.5L12 17l-2.5-2.5z" />
+                    <path d="M15 13l-3 3 2 2 3-3-2-2z" />
+                    <path d="M6 8l-3 3 2 2 3-3-2-2z" />
+                    <path d="M8 6l2-2" />
+                    <path d="M16 16l2 2" />
+                </svg>
+                Apply Auto Brace
+            </button>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

<table>
<tr>
<td width="430" valign="top">

<img width="410" alt="Trunk Support Presets UI" src="https://github.com/user-attachments/assets/1e4d7176-a0ba-4b56-8743-309f508f8693" />

</td>
<td valign="top">

### Trunk Support Presets

This PR introduces a completely new system for handling **Trunk Support Presets**.

We continue to ship three default profiles:

- **Detail**
- **Structure**
- **Anchor**

These are pinned to slots **1–3** by default.

Users can now freely configure pinned slots **1–6**, allowing them to create their own quick-access preset workflow and bind presets to hotkeys.

Default profiles are no longer special-cased. They can be:

- Edited
- Renamed
- Reassigned
- Deleted

just like any other user profile.

If a default profile is removed or modified, it can be restored at any time through the profile context menu.

</td>
</tr>
</table>

## Other UI Changes

### Transform Panel
- Updated to a unified design language.
- Scaling now always displays both:
  - Percentage (%)
  - Physical dimensions (mm)

### Mesh Smoothing
- Redesigned to match DragonFruit's Prepare Mode design language.

### Models Panel
- The panel is now resizable.
- Removed the **Import Mesh** and **Import Scene** buttons.
  - These actions remain available through the top-left logo context menu.

### Support Bracing
- The bracing menu now provides an accurate preview.

### Panel Auto-Collapse
- On small screens, instead of panel overlap, we collapse panels when required.

### Allow single-model arrange
- When trying to arrange a single model, it simply centers now

## Related PRs and Issues

- Closes #237 - Editable stock support profiles
- Closes #6 - Auto-bracing UI panel updates
- Closes #232
- Closes #41
- Implements #219