### PR TITLE
fix(ui): allow iOS file picker to show as valid all files (relax accept filter)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
+import { detectIsIOS } from '@/hooks/usePlatform';
 import * as THREE from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
 import { AlertTriangle, CheckCircle2, ChevronDown, Download, LayoutGrid, Loader2, Maximize2, Minimize2, Play, Plus, Printer, Redo2, RefreshCw, Trash2, Undo2, Wrench, X } from 'lucide-react';
@@ -8509,7 +8510,10 @@ export default function Home() {
 
       const input = document.createElement('input');
       input.type = 'file';
-      input.accept = accept;
+      // iOS WebKit greys out files whose extension it can't map to a known UTI
+      // (e.g. .stl, .3mf), and it ignores MIME hints too, so drop the filter
+      // there and rely on extension validation when the picked files are processed.
+      input.accept = detectIsIOS() ? '' : accept;
       input.multiple = multiple;
 
       input.onchange = () => {

--- a/src/hooks/usePlatform.ts
+++ b/src/hooks/usePlatform.ts
@@ -16,3 +16,13 @@ export function useIsLinux(): boolean {
   }, []);
   return isLinux;
 }
+
+// iOS WebKit greys out files whose extension it can't map to a known UTI
+// (e.g. .stl, .3mf), so callers relax a file input's `accept` on iOS and rely
+// on extension validation when the picked files are processed.
+export function detectIsIOS(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  const ua = navigator.userAgent ?? '';
+  // iPhone/iPod/iPad, plus iPadOS 13+ which reports as Macintosh but is touch.
+  return /iP(hone|od|ad)/.test(ua) || (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1);
+}


### PR DESCRIPTION
On iOS, WebKit greys out files in the picker whose extension it can't map to a known UTI, so .stl and .3mf are unselectable on iPhone/iPad, but .obj is fine.  Drop the accept filter on iOS in pickFilesWithWebInput so all files are selectable; the existing pipeline already classifies picked files by extension, so unsupported ones are ignored.

Add detectIsIOS() to usePlatform for the platform check.  Non-iOS platforms keep the strict extension filter.