### PR TITLE
fix(i18n): apply language change on Apply, not immediately

### DIFF
--- a/src/components/settings/GeneralSettingsTab.tsx
+++ b/src/components/settings/GeneralSettingsTab.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Bug, ClipboardCopy, Database, Languages, LayoutGrid, RotateCcw } from 'lucide-react';
 import { LanguageSwitcher } from '@/components/ui/LanguageSwitcher';
+import { type Locale } from '@/i18n';
 import type { ImportDefaultsSettings } from '@/features/scene/importDefaultsPreferences';
 import {
   FLOATING_LAYOUT_DEBUG_REQUEST_EVENT,
@@ -18,6 +19,8 @@ interface GeneralSettingsTabProps {
   onDebugPrimitivesPanelVisibleChange: (enabled: boolean) => void;
   importDefaults: ImportDefaultsSettings;
   onImportDefaultsChange: (next: ImportDefaultsSettings) => void;
+  language: Locale;
+  onLanguageChange: (locale: Locale) => void;
 }
 
 export function GeneralSettingsTab({
@@ -28,6 +31,8 @@ export function GeneralSettingsTab({
   onDebugPrimitivesPanelVisibleChange,
   importDefaults,
   onImportDefaultsChange,
+  language,
+  onLanguageChange,
 }: GeneralSettingsTabProps) {
   const [layoutDump, setLayoutDump] = React.useState<string>('');
   const [dumpStatus, setDumpStatus] = React.useState<string | null>(null);
@@ -120,7 +125,7 @@ export function GeneralSettingsTab({
                 Applied immediately across the app.
               </div>
             </div>
-            <LanguageSwitcher />
+            <LanguageSwitcher value={language} onChange={onLanguageChange} />
           </div>
         </div>
       </section>

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { GeneralSettingsTab } from '@/components/settings/GeneralSettingsTab';
+import { useLocale } from '@/components/I18nClientProvider';
 import { CameraSettingsTab } from '@/components/settings/CameraSettingsTab';
 import { HotkeysSettingsTab } from '@/components/settings/HotkeysSettingsTab';
 import { MeshSettingsTab } from '@/components/settings/MeshSettingsTab';
@@ -237,6 +238,11 @@ export function SettingsModal({
 }: SettingsModalProps) {
   const [activeTab, setActiveTab] = useState<SettingsTabKey>(initialTab ?? 'general');
 
+  // Language is a draft like every other setting: changing the switcher only
+  // updates draftLocale; the actual loadLocale happens in handleApply.
+  const { locale: activeLocale, setLocale: applyLocale } = useLocale();
+  const [draftLocale, setDraftLocale] = useState(activeLocale);
+
   const [draftMeshColor, setDraftMeshColor] = useState(meshColor);
   const [draftShaderType, setDraftShaderType] = useState(shaderType);
   const [draftMatcapVariant, setDraftMatcapVariant] = useState(matcapVariant);
@@ -376,7 +382,9 @@ export function SettingsModal({
     setDraftSlicingThumbnailRenderSettings(slicingThumbnailRenderSettings ?? DEFAULT_SLICING_THUMBNAIL_RENDER_SETTINGS);
     setDraftUvToolsSettings(getSavedUvToolsSettings());
     setDraftLogLevel(getSavedLogLevel());
+    setDraftLocale(activeLocale);
   }, [
+    activeLocale,
     ambientIntensity,
     directionalIntensity,
     flatUseVertexColors,
@@ -753,6 +761,7 @@ export function SettingsModal({
   }, []);
 
   const handleApply = React.useCallback(() => {
+    applyLocale(draftLocale);
     onMeshColorChange(draftMeshColor);
     onShaderTypeChange(draftShaderType);
     onMatcapVariantChange(draftMatcapVariant);
@@ -811,6 +820,8 @@ export function SettingsModal({
     didCommitThemeDraftRef.current = true;
     onClose();
   }, [
+    applyLocale,
+    draftLocale,
     draftAmbientIntensity,
     draftDirectionalIntensity,
     draftFlatUseVertexColors,
@@ -1330,6 +1341,8 @@ export function SettingsModal({
                   onDebugPrimitivesPanelVisibleChange={setDraftDebugPrimitivesPanelVisible}
                   importDefaults={draftImportDefaults}
                   onImportDefaultsChange={setDraftImportDefaults}
+                  language={draftLocale}
+                  onLanguageChange={setDraftLocale}
                 />
               )}
               {activeTab === 'camera' && (

--- a/src/components/ui/LanguageSwitcher.tsx
+++ b/src/components/ui/LanguageSwitcher.tsx
@@ -11,14 +11,27 @@ const OPTIONS = SUPPORTED_LOCALES.map((locale) => ({
   label: LOCALE_LABELS[locale],
 }));
 
-export function LanguageSwitcher({ className = "" }: { className?: string }) {
+export function LanguageSwitcher({
+  className = "",
+  value,
+  onChange,
+}: {
+  className?: string;
+  // Controlled mode (e.g. the Settings modal's draft state): when provided, the
+  // switcher reports changes via onChange instead of switching the locale live.
+  // Falls back to the active locale / live switch when omitted.
+  value?: Locale;
+  onChange?: (locale: Locale) => void;
+}) {
   const { locale, setLocale } = useLocale();
+  const currentValue = value ?? locale;
+  const handleChange = onChange ?? setLocale;
 
   return (
     <SelectDropdown<Locale>
-      value={locale}
+      value={currentValue}
       options={OPTIONS}
-      onChange={setLocale}
+      onChange={handleChange}
       ariaLabel="Language"
       title="Language"
       // Fixed width so the trigger and the (width-matched) menu are the same


### PR DESCRIPTION
The language switcher in Settings > General called loadLocale() on every dropdown change instead of only on Apply.