### PR TITLE
feat: 3MF Splitting, loading fixes, faster mesh geometry loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dragonfruit",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dragonfruit",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@lingui/core": "^6.3.0",
         "@lingui/react": "^6.3.0",
@@ -22,6 +22,7 @@
         "clipper-lib": "^6.4.2",
         "express": "^5.2.1",
         "express-ws": "^5.0.2",
+        "fast-3mf-loader": "^0.0.7",
         "fflate": "^0.8.2",
         "ffmpeg-static": "^5.3.0",
         "highlight.js": "^11.11.1",
@@ -4810,6 +4811,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/easysax": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/easysax/-/easysax-0.4.2.tgz",
+      "integrity": "sha512-gh0lVWdWNTu28bRzYw3NDWm9UUs8gFh0LvWjOpA2QrBW+sOBNKRIYEiV0k5U/oCT8S+wQ7++1NwDQF0Nq3KrIw=="
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5656,6 +5662,16 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-3mf-loader": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/fast-3mf-loader/-/fast-3mf-loader-0.0.7.tgz",
+      "integrity": "sha512-xz8kRIo3bZk5/nWaKBOGGaAHwiWcKPN6/DGQE1hoBZLcHDJp+tPAcpJ4YZ46SscIOG6lqHX77/RkmtylwHoajw==",
+      "license": "MIT",
+      "dependencies": {
+        "easysax": "^0.4.0",
+        "fflate": "^0.8.2"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "clipper-lib": "^6.4.2",
     "express": "^5.2.1",
     "express-ws": "^5.0.2",
+    "fast-3mf-loader": "^0.0.7",
     "fflate": "^0.8.2",
     "ffmpeg-static": "^5.3.0",
     "highlight.js": "^11.11.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1382,6 +1382,7 @@ dependencies = [
  "futures-util",
  "if-addrs",
  "log",
+ "meshopt",
  "rayon",
  "reqwest 0.12.28",
  "rfd",
@@ -1702,6 +1703,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2964,6 +2974,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "meshopt"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01e77ead21976b3a9f01ec1724f766923da74f0726364e2b0f425658935d71a"
+dependencies = [
+ "bitflags 2.11.0",
+ "cc",
+ "float-cmp",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ dragonfruit-sdf = { path = "../rust/dragonfruit-sdf" }
 dragonfruit-astar = { path = "../rust/dragonfruit-astar" }
 flate2 = "1.1.9"
 bytemuck = "1"
+meshopt = "0.6.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri-plugin-macos-fps = "0.1.0"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3324,6 +3324,7 @@ fn main() {
             mesh_repair::mesh_punch_from_captured_source,
             mesh_repair::mesh_punch_read_positions,
             mesh_repair::mesh_repair_read_positions,
+            mesh_repair::load_stl_file,
             sdf::compute_sdf_from_staged,
             sdf::compute_heightmap_from_staged,
             sdf::invalidate_sdf_cache,

--- a/src-tauri/src/mesh_repair.rs
+++ b/src-tauri/src/mesh_repair.rs
@@ -12,12 +12,9 @@
 //! - `mesh_repair_read_positions` — raw-binary response of the current staged
 //!   positions (little-endian f32, 9 per triangle), for frontend hydration.
 
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
-use std::{
-    collections::{HashMap, HashSet},
-    io::{BufReader, Read, Seek, SeekFrom},
-};
 
 use dragonfruit_mesh_repair::{
     analyze, classify_support_split, hollow_voxel, io, punch_cylinders, repair, HolePunchOptions,
@@ -843,10 +840,15 @@ fn read_binary_stl_vertex(record: &[u8; 50], offset: usize) -> Vec3 {
     Vec3::new(read_f32(offset), read_f32(offset + 4), read_f32(offset + 8))
 }
 
-fn binary_stl_preview_stats(
-    path: &std::path::Path,
-    triangle_count: u32,
-) -> Result<(Vec3, Vec3, f64), String> {
+struct PreviewTempDir(PathBuf);
+
+impl Drop for PreviewTempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn binary_stl_bounds(path: &std::path::Path, triangle_count: u32) -> Result<(Vec3, Vec3), String> {
     let file =
         std::fs::File::open(path).map_err(|e| format!("Failed to open STL preview source: {e}"))?;
     let mut reader = BufReader::with_capacity(1024 * 1024, file);
@@ -856,97 +858,17 @@ fn binary_stl_preview_stats(
     let mut record = [0u8; 50];
     let mut min = Vec3::new(f32::INFINITY, f32::INFINITY, f32::INFINITY);
     let mut max = Vec3::new(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
-    let mut sampled_edge_sum = 0.0f64;
-    let mut sampled_edge_count = 0u64;
-
     for triangle_index in 0..triangle_count {
         reader
             .read_exact(&mut record)
             .map_err(|e| format!("Truncated binary STL at triangle {triangle_index}: {e}"))?;
-        let vertices = [
-            read_binary_stl_vertex(&record, 12),
-            read_binary_stl_vertex(&record, 24),
-            read_binary_stl_vertex(&record, 36),
-        ];
-        for vertex in vertices {
+        for offset in [12, 24, 36] {
+            let vertex = read_binary_stl_vertex(&record, offset);
             min = min.min(vertex);
             max = max.max(vertex);
         }
-        if triangle_index % 64 == 0 {
-            sampled_edge_sum += vertices[1].sub(vertices[0]).length() as f64;
-            sampled_edge_sum += vertices[2].sub(vertices[1]).length() as f64;
-            sampled_edge_sum += vertices[0].sub(vertices[2]).length() as f64;
-            sampled_edge_count += 3;
-        }
     }
-
-    let average_edge = if sampled_edge_count > 0 {
-        sampled_edge_sum / sampled_edge_count as f64
-    } else {
-        0.0
-    };
-    Ok((min, max, average_edge))
-}
-
-fn cluster_binary_stl_pass(
-    path: &std::path::Path,
-    triangle_count: u32,
-    bbox_min: Vec3,
-    cell_size: f32,
-    hard_triangle_limit: usize,
-) -> Result<Option<IndexedMesh>, String> {
-    let file =
-        std::fs::File::open(path).map_err(|e| format!("Failed to open STL preview source: {e}"))?;
-    let mut reader = BufReader::with_capacity(1024 * 1024, file);
-    reader
-        .seek(SeekFrom::Start(84))
-        .map_err(|e| format!("Failed seeking STL: {e}"))?;
-    let mut record = [0u8; 50];
-    let inv_cell = 1.0 / cell_size.max(1e-9);
-    let mut vertex_cells: HashMap<(i32, i32, i32), u32> = HashMap::new();
-    let mut positions: Vec<Vec3> = Vec::new();
-    let mut triangles: Vec<[u32; 3]> = Vec::new();
-    let mut seen_triangles: HashSet<(u32, u32, u32)> = HashSet::new();
-
-    for triangle_index in 0..triangle_count {
-        reader
-            .read_exact(&mut record)
-            .map_err(|e| format!("Truncated binary STL at triangle {triangle_index}: {e}"))?;
-        let vertices = [
-            read_binary_stl_vertex(&record, 12),
-            read_binary_stl_vertex(&record, 24),
-            read_binary_stl_vertex(&record, 36),
-        ];
-        let mut indices = [0u32; 3];
-        for (slot, vertex) in vertices.into_iter().enumerate() {
-            let key = (
-                ((vertex.x - bbox_min.x) * inv_cell).floor() as i32,
-                ((vertex.y - bbox_min.y) * inv_cell).floor() as i32,
-                ((vertex.z - bbox_min.z) * inv_cell).floor() as i32,
-            );
-            indices[slot] = *vertex_cells.entry(key).or_insert_with(|| {
-                let index = positions.len() as u32;
-                positions.push(vertex);
-                index
-            });
-        }
-        if indices[0] == indices[1] || indices[1] == indices[2] || indices[0] == indices[2] {
-            continue;
-        }
-        let mut canonical = indices;
-        canonical.sort_unstable();
-        if seen_triangles.insert((canonical[0], canonical[1], canonical[2])) {
-            triangles.push(indices);
-            if triangles.len() > hard_triangle_limit {
-                return Ok(None);
-            }
-        }
-    }
-
-    Ok(Some(IndexedMesh {
-        positions,
-        triangles,
-    }))
+    Ok((min, max))
 }
 
 fn load_binary_stl_preview(
@@ -954,44 +876,142 @@ fn load_binary_stl_preview(
     triangle_count: u32,
     target_triangles: usize,
 ) -> Result<IndexedMesh, String> {
-    let (bbox_min, bbox_max, average_edge) = binary_stl_preview_stats(path, triangle_count)?;
-    let diagonal = bbox_max.sub(bbox_min).length().max(1e-6);
-    let reduction = (triangle_count as f64 / target_triangles as f64).sqrt() as f32;
-    let mut cell_size = (average_edge as f32 * reduction).clamp(diagonal / 8192.0, diagonal / 16.0);
-    let mut best: Option<IndexedMesh> = None;
-
-    for attempt in 0..6 {
-        log::info!(
-            "[load_stl_file] Preview clustering pass {} with {:.6} mm cells",
-            attempt + 1,
-            cell_size
-        );
-        match cluster_binary_stl_pass(
-            path,
-            triangle_count,
-            bbox_min,
-            cell_size,
-            target_triangles * 5 / 4,
-        )? {
-            None => cell_size *= 1.6,
-            Some(mesh) if mesh.triangles.len() > target_triangles => {
-                let factor = (mesh.triangles.len() as f64 / target_triangles as f64).sqrt() as f32;
-                cell_size *= factor.max(1.1);
+    let bucket_divisions = if triangle_count < 1_000_000 { 1 } else { 4 };
+    let bucket_count = bucket_divisions * bucket_divisions * bucket_divisions;
+    let (bbox_min, bbox_max) = binary_stl_bounds(path, triangle_count)?;
+    let extent = bbox_max.sub(bbox_min);
+    let temp_path = std::env::temp_dir().join(format!(
+        "dragonfruit-stl-preview-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    std::fs::create_dir(&temp_path)
+        .map_err(|e| format!("Failed creating STL preview workspace: {e}"))?;
+    let temp_dir = PreviewTempDir(temp_path);
+    let mut writers: Vec<Option<BufWriter<std::fs::File>>> =
+        (0..bucket_count).map(|_| None).collect();
+    let mut bucket_counts = vec![0usize; bucket_count];
+    let file =
+        std::fs::File::open(path).map_err(|e| format!("Failed to open STL preview source: {e}"))?;
+    let mut reader = BufReader::with_capacity(1024 * 1024, file);
+    reader
+        .seek(SeekFrom::Start(84))
+        .map_err(|e| format!("Failed seeking STL: {e}"))?;
+    let mut record = [0u8; 50];
+    let total = triangle_count as usize;
+    for triangle_index in 0..total {
+        reader
+            .read_exact(&mut record)
+            .map_err(|e| format!("Truncated binary STL at triangle {triangle_index}: {e}"))?;
+        let a = read_binary_stl_vertex(&record, 12);
+        let b = read_binary_stl_vertex(&record, 24);
+        let c = read_binary_stl_vertex(&record, 36);
+        let centroid = a.add(b).add(c).scale(1.0 / 3.0);
+        let axis_bucket = |value: f32, min: f32, span: f32| -> usize {
+            if span <= 1e-9 {
+                0
+            } else {
+                (((value - min) / span) * bucket_divisions as f32)
+                    .floor()
+                    .clamp(0.0, (bucket_divisions - 1) as f32) as usize
             }
-            Some(mesh) => {
-                let count = mesh.triangles.len();
-                best = Some(mesh);
-                if count >= target_triangles * 2 / 3 || attempt == 5 {
-                    break;
-                }
-                let factor = (count.max(1) as f64 / target_triangles as f64).sqrt() as f32;
-                cell_size *= factor.clamp(0.45, 0.9);
+        };
+        let x = axis_bucket(centroid.x, bbox_min.x, extent.x);
+        let y = axis_bucket(centroid.y, bbox_min.y, extent.y);
+        let z = axis_bucket(centroid.z, bbox_min.z, extent.z);
+        let bucket = x + bucket_divisions * (y + bucket_divisions * z);
+        if writers[bucket].is_none() {
+            let bucket_file = std::fs::File::create(temp_dir.0.join(format!("{bucket}.bin")))
+                .map_err(|e| format!("Failed creating STL preview bucket: {e}"))?;
+            writers[bucket] = Some(BufWriter::with_capacity(64 * 1024, bucket_file));
+        }
+        writers[bucket]
+            .as_mut()
+            .unwrap()
+            .write_all(&record)
+            .map_err(|e| format!("Failed writing STL preview bucket: {e}"))?;
+        bucket_counts[bucket] += 1;
+    }
+    for writer in writers.iter_mut().flatten() {
+        writer
+            .flush()
+            .map_err(|e| format!("Failed flushing STL preview bucket: {e}"))?;
+    }
+    drop(writers);
+
+    let target_ratio = (target_triangles as f64 / triangle_count as f64).min(1.0);
+    let mut output = IndexedMesh {
+        positions: Vec::with_capacity(target_triangles.saturating_mul(3)),
+        triangles: Vec::with_capacity(target_triangles),
+    };
+    for (bucket, &bucket_triangle_count) in bucket_counts.iter().enumerate() {
+        if bucket_triangle_count == 0 {
+            continue;
+        }
+        let bucket_file = std::fs::File::open(temp_dir.0.join(format!("{bucket}.bin")))
+            .map_err(|e| format!("Failed opening STL preview bucket: {e}"))?;
+        let mut bucket_reader = BufReader::with_capacity(1024 * 1024, bucket_file);
+        let mut soup = Vec::with_capacity(bucket_triangle_count * 9);
+        for _ in 0..bucket_triangle_count {
+            bucket_reader
+                .read_exact(&mut record)
+                .map_err(|e| format!("Failed reading STL preview bucket: {e}"))?;
+            for offset in [12, 24, 36] {
+                let vertex = read_binary_stl_vertex(&record, offset);
+                soup.extend_from_slice(&[vertex.x, vertex.y, vertex.z]);
             }
         }
+        let chunk = IndexedMesh::from_triangle_soup(&soup, 1e-8);
+        let indices: Vec<u32> = chunk
+            .triangles
+            .iter()
+            .flat_map(|triangle| triangle.iter().copied())
+            .collect();
+        let target_index_count =
+            ((indices.len() as f64 * target_ratio).floor() as usize).max(3) / 3 * 3;
+        let vertex_bytes: &[u8] = bytemuck::cast_slice(&chunk.positions);
+        let vertices =
+            meshopt::VertexDataAdapter::new(vertex_bytes, std::mem::size_of::<Vec3>(), 0)
+                .map_err(|e| format!("Failed preparing preview simplifier: {e}"))?;
+        let simplified = meshopt::simplify(
+            &indices,
+            &vertices,
+            target_index_count,
+            1.0,
+            meshopt::SimplifyOptions::LockBorder | meshopt::SimplifyOptions::Regularize,
+            None,
+        );
+        let selected = if simplified.is_empty() {
+            &indices
+        } else {
+            &simplified
+        };
+
+        for triangle in selected.chunks_exact(3) {
+            let base = output.positions.len() as u32;
+            output.positions.push(chunk.positions[triangle[0] as usize]);
+            output.positions.push(chunk.positions[triangle[1] as usize]);
+            output.positions.push(chunk.positions[triangle[2] as usize]);
+            output.triangles.push([base, base + 1, base + 2]);
+        }
+
+        log::info!(
+            "[load_stl_file] Topology-safe preview region {}/{}: {} source triangles, {} total output triangles",
+            bucket + 1,
+            bucket_count,
+            bucket_triangle_count,
+            output.triangles.len()
+        );
     }
 
-    best.filter(|mesh| !mesh.triangles.is_empty())
-        .ok_or_else(|| "Could not build a bounded preview for this STL".to_string())
+    if output.triangles.is_empty() {
+        Err("Could not build a bounded preview for this STL".to_string())
+    } else {
+        Ok(output)
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/mesh_repair.rs
+++ b/src-tauri/src/mesh_repair.rs
@@ -20,6 +20,7 @@ use dragonfruit_mesh_repair::{
     analyze, classify_support_split, hollow_voxel, io, punch_cylinders, repair, HolePunchOptions,
     HollowOptions, HollowSession, IndexedMesh, RepairOptions, Vec3,
 };
+use rayon::prelude::*;
 use serde::Deserialize;
 use tauri::ipc::Response;
 
@@ -772,9 +773,7 @@ fn encode_stl_response(
     is_preview: bool,
 ) -> Result<Vec<u8>, String> {
     let tri_count = mesh.triangles.len();
-    let soup = mesh.to_triangle_soup(); // Vec<f32>, 9 floats per triangle
-    let positions_bytes: &[u8] = bytemuck::cast_slice(&soup);
-    let positions_len = positions_bytes.len();
+    let positions_len = tri_count * 9 * std::mem::size_of::<f32>();
     let normals_len = tri_count * 9 * std::mem::size_of::<f32>();
     let response_len = STL_RESPONSE_HEADER_BYTES
         .checked_add(positions_len)
@@ -798,32 +797,44 @@ fn encode_stl_response(
     );
     result.extend_from_slice(&original_triangle_count.to_le_bytes());
     result.extend_from_slice(&(tri_count as u32).to_le_bytes());
-    result.extend_from_slice(positions_bytes);
-
-    // Compute per-vertex normals from the indexed mesh.
-    // For each triangle: face normal = normalize(cross(v1-v0, v2-v0))
-    for tri in &mesh.triangles {
-        let p0 = mesh.positions[tri[0] as usize];
-        let p1 = mesh.positions[tri[1] as usize];
-        let p2 = mesh.positions[tri[2] as usize];
-
-        let e1 = p1.sub(p0);
-        let e2 = p2.sub(p0);
-        let face_normal = e1.cross(e2);
-        let len = face_normal.length();
-        let n = if len > 1e-10 {
-            face_normal.scale(1.0 / len)
-        } else {
-            Vec3::ZERO
-        };
-
-        // Three vertices, same face normal
-        for _ in 0..3 {
-            result.extend_from_slice(&n.x.to_le_bytes());
-            result.extend_from_slice(&n.y.to_le_bytes());
-            result.extend_from_slice(&n.z.to_le_bytes());
-        }
-    }
+    result.resize(response_len, 0);
+    let (position_output, normal_output) =
+        result[STL_RESPONSE_HEADER_BYTES..].split_at_mut(positions_len);
+    position_output
+        .par_chunks_mut(9 * std::mem::size_of::<f32>())
+        .zip(mesh.triangles.par_iter())
+        .for_each(|(output, triangle)| {
+            let vertices = [
+                mesh.positions[triangle[0] as usize],
+                mesh.positions[triangle[1] as usize],
+                mesh.positions[triangle[2] as usize],
+            ];
+            for (vertex_output, vertex) in output.chunks_exact_mut(12).zip(vertices) {
+                vertex_output[0..4].copy_from_slice(&vertex.x.to_le_bytes());
+                vertex_output[4..8].copy_from_slice(&vertex.y.to_le_bytes());
+                vertex_output[8..12].copy_from_slice(&vertex.z.to_le_bytes());
+            }
+        });
+    normal_output
+        .par_chunks_mut(9 * std::mem::size_of::<f32>())
+        .zip(mesh.triangles.par_iter())
+        .for_each(|(output, triangle)| {
+            let p0 = mesh.positions[triangle[0] as usize];
+            let p1 = mesh.positions[triangle[1] as usize];
+            let p2 = mesh.positions[triangle[2] as usize];
+            let face_normal = p1.sub(p0).cross(p2.sub(p0));
+            let len = face_normal.length();
+            let normal = if len > 1e-10 {
+                face_normal.scale(1.0 / len)
+            } else {
+                Vec3::ZERO
+            };
+            for normal_output in output.chunks_exact_mut(12) {
+                normal_output[0..4].copy_from_slice(&normal.x.to_le_bytes());
+                normal_output[4..8].copy_from_slice(&normal.y.to_le_bytes());
+                normal_output[8..12].copy_from_slice(&normal.z.to_le_bytes());
+            }
+        });
 
     log::info!(
         "[load_stl_file] {} triangles, {} MB positions + {} MB normals",
@@ -869,6 +880,64 @@ fn binary_stl_bounds(path: &std::path::Path, triangle_count: u32) -> Result<(Vec
         }
     }
     Ok((min, max))
+}
+
+fn simplify_preview_region(
+    path: &std::path::Path,
+    triangle_count: usize,
+    target_ratio: f64,
+) -> Result<IndexedMesh, String> {
+    let bucket_file =
+        std::fs::File::open(path).map_err(|e| format!("Failed opening STL preview bucket: {e}"))?;
+    let mut reader = BufReader::with_capacity(1024 * 1024, bucket_file);
+    let mut record = [0u8; 50];
+    let mut soup = Vec::with_capacity(triangle_count * 9);
+    for _ in 0..triangle_count {
+        reader
+            .read_exact(&mut record)
+            .map_err(|e| format!("Failed reading STL preview bucket: {e}"))?;
+        for offset in [12, 24, 36] {
+            let vertex = read_binary_stl_vertex(&record, offset);
+            soup.extend_from_slice(&[vertex.x, vertex.y, vertex.z]);
+        }
+    }
+
+    let chunk = IndexedMesh::from_triangle_soup(&soup, 1e-8);
+    let indices: Vec<u32> = chunk
+        .triangles
+        .iter()
+        .flat_map(|triangle| triangle.iter().copied())
+        .collect();
+    let target_index_count =
+        ((indices.len() as f64 * target_ratio).floor() as usize).max(3) / 3 * 3;
+    let vertex_bytes: &[u8] = bytemuck::cast_slice(&chunk.positions);
+    let vertices = meshopt::VertexDataAdapter::new(vertex_bytes, std::mem::size_of::<Vec3>(), 0)
+        .map_err(|e| format!("Failed preparing preview simplifier: {e}"))?;
+    let simplified = meshopt::simplify(
+        &indices,
+        &vertices,
+        target_index_count,
+        1.0,
+        meshopt::SimplifyOptions::LockBorder | meshopt::SimplifyOptions::Regularize,
+        None,
+    );
+    let selected = if simplified.is_empty() {
+        &indices
+    } else {
+        &simplified
+    };
+    let mut output = IndexedMesh {
+        positions: Vec::with_capacity(selected.len()),
+        triangles: Vec::with_capacity(selected.len() / 3),
+    };
+    for triangle in selected.chunks_exact(3) {
+        let base = output.positions.len() as u32;
+        output.positions.push(chunk.positions[triangle[0] as usize]);
+        output.positions.push(chunk.positions[triangle[1] as usize]);
+        output.positions.push(chunk.positions[triangle[2] as usize]);
+        output.triangles.push([base, base + 1, base + 2]);
+    }
+    Ok(output)
 }
 
 fn load_binary_stl_preview(
@@ -947,57 +1016,44 @@ fn load_binary_stl_preview(
         positions: Vec::with_capacity(target_triangles.saturating_mul(3)),
         triangles: Vec::with_capacity(target_triangles),
     };
-    for (bucket, &bucket_triangle_count) in bucket_counts.iter().enumerate() {
-        if bucket_triangle_count == 0 {
-            continue;
-        }
-        let bucket_file = std::fs::File::open(temp_dir.0.join(format!("{bucket}.bin")))
-            .map_err(|e| format!("Failed opening STL preview bucket: {e}"))?;
-        let mut bucket_reader = BufReader::with_capacity(1024 * 1024, bucket_file);
-        let mut soup = Vec::with_capacity(bucket_triangle_count * 9);
-        for _ in 0..bucket_triangle_count {
-            bucket_reader
-                .read_exact(&mut record)
-                .map_err(|e| format!("Failed reading STL preview bucket: {e}"))?;
-            for offset in [12, 24, 36] {
-                let vertex = read_binary_stl_vertex(&record, offset);
-                soup.extend_from_slice(&[vertex.x, vertex.y, vertex.z]);
-            }
-        }
-        let chunk = IndexedMesh::from_triangle_soup(&soup, 1e-8);
-        let indices: Vec<u32> = chunk
-            .triangles
-            .iter()
-            .flat_map(|triangle| triangle.iter().copied())
-            .collect();
-        let target_index_count =
-            ((indices.len() as f64 * target_ratio).floor() as usize).max(3) / 3 * 3;
-        let vertex_bytes: &[u8] = bytemuck::cast_slice(&chunk.positions);
-        let vertices =
-            meshopt::VertexDataAdapter::new(vertex_bytes, std::mem::size_of::<Vec3>(), 0)
-                .map_err(|e| format!("Failed preparing preview simplifier: {e}"))?;
-        let simplified = meshopt::simplify(
-            &indices,
-            &vertices,
-            target_index_count,
-            1.0,
-            meshopt::SimplifyOptions::LockBorder | meshopt::SimplifyOptions::Regularize,
-            None,
+    let regions: Vec<(usize, usize)> = bucket_counts
+        .iter()
+        .copied()
+        .enumerate()
+        .filter(|(_, count)| *count > 0)
+        .collect();
+    let worker_count = std::thread::available_parallelism()
+        .map(|count| count.get())
+        .unwrap_or(2)
+        .min(4);
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(worker_count)
+        .thread_name(|index| format!("stl-preview-{index}"))
+        .build()
+        .map_err(|e| format!("Failed creating STL preview worker pool: {e}"))?;
+    let simplified_regions: Vec<Result<(usize, usize, IndexedMesh), String>> = pool.install(|| {
+        regions
+            .par_iter()
+            .map(|&(bucket, count)| {
+                simplify_preview_region(
+                    &temp_dir.0.join(format!("{bucket}.bin")),
+                    count,
+                    target_ratio,
+                )
+                .map(|mesh| (bucket, count, mesh))
+            })
+            .collect()
+    });
+    for region in simplified_regions {
+        let (bucket, bucket_triangle_count, region) = region?;
+        let vertex_base = output.positions.len() as u32;
+        output.positions.extend(region.positions);
+        output.triangles.extend(
+            region
+                .triangles
+                .into_iter()
+                .map(|[a, b, c]| [a + vertex_base, b + vertex_base, c + vertex_base]),
         );
-        let selected = if simplified.is_empty() {
-            &indices
-        } else {
-            &simplified
-        };
-
-        for triangle in selected.chunks_exact(3) {
-            let base = output.positions.len() as u32;
-            output.positions.push(chunk.positions[triangle[0] as usize]);
-            output.positions.push(chunk.positions[triangle[1] as usize]);
-            output.positions.push(chunk.positions[triangle[2] as usize]);
-            output.triangles.push([base, base + 1, base + 2]);
-        }
-
         log::info!(
             "[load_stl_file] Topology-safe preview region {}/{}: {} source triangles, {} total output triangles",
             bucket + 1,

--- a/src-tauri/src/mesh_repair.rs
+++ b/src-tauri/src/mesh_repair.rs
@@ -14,10 +14,14 @@
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
+use std::{
+    collections::{HashMap, HashSet},
+    io::{BufReader, Read, Seek, SeekFrom},
+};
 
 use dragonfruit_mesh_repair::{
     analyze, classify_support_split, hollow_voxel, io, punch_cylinders, repair, HolePunchOptions,
-    HollowOptions, HollowSession, IndexedMesh, RepairOptions,
+    HollowOptions, HollowSession, IndexedMesh, RepairOptions, Vec3,
 };
 use serde::Deserialize;
 use tauri::ipc::Response;
@@ -695,6 +699,364 @@ pub async fn mesh_punch_read_positions() -> Result<Response, String> {
 pub async fn mesh_repair_read_positions() -> Result<Response, String> {
     let bytes = read_staging_bytes()?;
     Ok(Response::new(bytes))
+}
+
+/// Parses a binary or ASCII STL file in Rust and returns the vertex positions
+/// and per-vertex normals as a flat byte buffer.
+///
+/// Byte layout: a 16-byte `DFST` header containing flags and the original/output
+/// triangle counts, followed by little-endian f32 positions and normals.
+///
+/// Processing the file in Rust avoids loading the entire raw STL into the
+/// webview's memory space, which can save ~1 GB for a large binary STL.
+#[tauri::command]
+pub async fn load_stl_file(file_path: String) -> Result<Response, String> {
+    use dragonfruit_mesh_repair::io;
+
+    let path = std::path::Path::new(&file_path);
+
+    log::info!("[load_stl_file] Starting native STL load: {file_path}");
+
+    // The current IPC format expands every triangle to positions plus normals
+    // (72 bytes/triangle), before Three.js builds its BVH and uploads buffers.
+    // Reject inputs that cannot fit that representation before the repair
+    // loader reads and indexes the entire STL in memory.
+    const MAX_NATIVE_STL_TRIANGLES: u64 = 6_000_000;
+    const PREVIEW_TARGET_TRIANGLES: usize = 2_000_000;
+    const MAX_NATIVE_ASCII_STL_BYTES: u64 = 300_000_000;
+    let file_size = std::fs::metadata(path)
+        .map_err(|e| format!("Failed to inspect STL '{}': {e}", file_path))?
+        .len();
+    let mut header = [0u8; 84];
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| format!("Failed to open STL '{}': {e}", file_path))?;
+    let header_len = file
+        .read(&mut header)
+        .map_err(|e| format!("Failed to read STL header '{}': {e}", file_path))?;
+
+    if header_len == header.len() {
+        let triangle_count = u32::from_le_bytes(header[80..84].try_into().unwrap()) as u64;
+        let expected_binary_size = 84u64.saturating_add(triangle_count.saturating_mul(50));
+        if expected_binary_size == file_size && triangle_count > MAX_NATIVE_STL_TRIANGLES {
+            drop(file);
+            let preview =
+                load_binary_stl_preview(path, triangle_count as u32, PREVIEW_TARGET_TRIANGLES)?;
+            log::info!(
+                "[load_stl_file] Streaming preview complete: {} -> {} triangles",
+                triangle_count,
+                preview.triangles.len()
+            );
+            return encode_stl_response(&preview, triangle_count as u32, true).map(Response::new);
+        }
+    }
+    if file_size > MAX_NATIVE_ASCII_STL_BYTES && header.starts_with(b"solid") {
+        return Err(format!(
+            "ASCII STL is too large for the current renderer ({:.2} GB on disk; limit {:.2} GB). Decimate or convert it before importing.",
+            file_size as f64 / 1_000_000_000.0,
+            MAX_NATIVE_ASCII_STL_BYTES as f64 / 1_000_000_000.0,
+        ));
+    }
+    drop(file);
+
+    let mesh =
+        io::stl::load(path).map_err(|e| format!("Failed to load STL '{}': {e}", file_path))?;
+
+    let tri_count = mesh.triangles.len();
+    encode_stl_response(&mesh, tri_count as u32, false).map(Response::new)
+}
+
+const STL_RESPONSE_MAGIC: &[u8; 4] = b"DFST";
+const STL_RESPONSE_HEADER_BYTES: usize = 16;
+const STL_RESPONSE_FLAG_PREVIEW: u32 = 1;
+
+fn encode_stl_response(
+    mesh: &IndexedMesh,
+    original_triangle_count: u32,
+    is_preview: bool,
+) -> Result<Vec<u8>, String> {
+    let tri_count = mesh.triangles.len();
+    let soup = mesh.to_triangle_soup(); // Vec<f32>, 9 floats per triangle
+    let positions_bytes: &[u8] = bytemuck::cast_slice(&soup);
+    let positions_len = positions_bytes.len();
+    let normals_len = tri_count * 9 * std::mem::size_of::<f32>();
+    let response_len = STL_RESPONSE_HEADER_BYTES
+        .checked_add(positions_len)
+        .and_then(|size| size.checked_add(normals_len))
+        .ok_or_else(|| "STL response size overflow".to_string())?;
+    let mut result = Vec::new();
+    result.try_reserve_exact(response_len).map_err(|_| {
+        format!(
+            "Not enough memory for the STL response ({:.2} GB)",
+            response_len as f64 / 1_000_000_000.0
+        )
+    })?;
+    result.extend_from_slice(STL_RESPONSE_MAGIC);
+    result.extend_from_slice(
+        &(if is_preview {
+            STL_RESPONSE_FLAG_PREVIEW
+        } else {
+            0
+        })
+        .to_le_bytes(),
+    );
+    result.extend_from_slice(&original_triangle_count.to_le_bytes());
+    result.extend_from_slice(&(tri_count as u32).to_le_bytes());
+    result.extend_from_slice(positions_bytes);
+
+    // Compute per-vertex normals from the indexed mesh.
+    // For each triangle: face normal = normalize(cross(v1-v0, v2-v0))
+    for tri in &mesh.triangles {
+        let p0 = mesh.positions[tri[0] as usize];
+        let p1 = mesh.positions[tri[1] as usize];
+        let p2 = mesh.positions[tri[2] as usize];
+
+        let e1 = p1.sub(p0);
+        let e2 = p2.sub(p0);
+        let face_normal = e1.cross(e2);
+        let len = face_normal.length();
+        let n = if len > 1e-10 {
+            face_normal.scale(1.0 / len)
+        } else {
+            Vec3::ZERO
+        };
+
+        // Three vertices, same face normal
+        for _ in 0..3 {
+            result.extend_from_slice(&n.x.to_le_bytes());
+            result.extend_from_slice(&n.y.to_le_bytes());
+            result.extend_from_slice(&n.z.to_le_bytes());
+        }
+    }
+
+    log::info!(
+        "[load_stl_file] {} triangles, {} MB positions + {} MB normals",
+        tri_count,
+        positions_len / (1024 * 1024),
+        normals_len / (1024 * 1024),
+    );
+
+    Ok(result)
+}
+
+fn read_binary_stl_vertex(record: &[u8; 50], offset: usize) -> Vec3 {
+    let read_f32 = |at: usize| f32::from_le_bytes(record[at..at + 4].try_into().unwrap());
+    Vec3::new(read_f32(offset), read_f32(offset + 4), read_f32(offset + 8))
+}
+
+fn binary_stl_preview_stats(
+    path: &std::path::Path,
+    triangle_count: u32,
+) -> Result<(Vec3, Vec3, f64), String> {
+    let file =
+        std::fs::File::open(path).map_err(|e| format!("Failed to open STL preview source: {e}"))?;
+    let mut reader = BufReader::with_capacity(1024 * 1024, file);
+    reader
+        .seek(SeekFrom::Start(84))
+        .map_err(|e| format!("Failed seeking STL: {e}"))?;
+    let mut record = [0u8; 50];
+    let mut min = Vec3::new(f32::INFINITY, f32::INFINITY, f32::INFINITY);
+    let mut max = Vec3::new(f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY);
+    let mut sampled_edge_sum = 0.0f64;
+    let mut sampled_edge_count = 0u64;
+
+    for triangle_index in 0..triangle_count {
+        reader
+            .read_exact(&mut record)
+            .map_err(|e| format!("Truncated binary STL at triangle {triangle_index}: {e}"))?;
+        let vertices = [
+            read_binary_stl_vertex(&record, 12),
+            read_binary_stl_vertex(&record, 24),
+            read_binary_stl_vertex(&record, 36),
+        ];
+        for vertex in vertices {
+            min = min.min(vertex);
+            max = max.max(vertex);
+        }
+        if triangle_index % 64 == 0 {
+            sampled_edge_sum += vertices[1].sub(vertices[0]).length() as f64;
+            sampled_edge_sum += vertices[2].sub(vertices[1]).length() as f64;
+            sampled_edge_sum += vertices[0].sub(vertices[2]).length() as f64;
+            sampled_edge_count += 3;
+        }
+    }
+
+    let average_edge = if sampled_edge_count > 0 {
+        sampled_edge_sum / sampled_edge_count as f64
+    } else {
+        0.0
+    };
+    Ok((min, max, average_edge))
+}
+
+fn cluster_binary_stl_pass(
+    path: &std::path::Path,
+    triangle_count: u32,
+    bbox_min: Vec3,
+    cell_size: f32,
+    hard_triangle_limit: usize,
+) -> Result<Option<IndexedMesh>, String> {
+    let file =
+        std::fs::File::open(path).map_err(|e| format!("Failed to open STL preview source: {e}"))?;
+    let mut reader = BufReader::with_capacity(1024 * 1024, file);
+    reader
+        .seek(SeekFrom::Start(84))
+        .map_err(|e| format!("Failed seeking STL: {e}"))?;
+    let mut record = [0u8; 50];
+    let inv_cell = 1.0 / cell_size.max(1e-9);
+    let mut vertex_cells: HashMap<(i32, i32, i32), u32> = HashMap::new();
+    let mut positions: Vec<Vec3> = Vec::new();
+    let mut triangles: Vec<[u32; 3]> = Vec::new();
+    let mut seen_triangles: HashSet<(u32, u32, u32)> = HashSet::new();
+
+    for triangle_index in 0..triangle_count {
+        reader
+            .read_exact(&mut record)
+            .map_err(|e| format!("Truncated binary STL at triangle {triangle_index}: {e}"))?;
+        let vertices = [
+            read_binary_stl_vertex(&record, 12),
+            read_binary_stl_vertex(&record, 24),
+            read_binary_stl_vertex(&record, 36),
+        ];
+        let mut indices = [0u32; 3];
+        for (slot, vertex) in vertices.into_iter().enumerate() {
+            let key = (
+                ((vertex.x - bbox_min.x) * inv_cell).floor() as i32,
+                ((vertex.y - bbox_min.y) * inv_cell).floor() as i32,
+                ((vertex.z - bbox_min.z) * inv_cell).floor() as i32,
+            );
+            indices[slot] = *vertex_cells.entry(key).or_insert_with(|| {
+                let index = positions.len() as u32;
+                positions.push(vertex);
+                index
+            });
+        }
+        if indices[0] == indices[1] || indices[1] == indices[2] || indices[0] == indices[2] {
+            continue;
+        }
+        let mut canonical = indices;
+        canonical.sort_unstable();
+        if seen_triangles.insert((canonical[0], canonical[1], canonical[2])) {
+            triangles.push(indices);
+            if triangles.len() > hard_triangle_limit {
+                return Ok(None);
+            }
+        }
+    }
+
+    Ok(Some(IndexedMesh {
+        positions,
+        triangles,
+    }))
+}
+
+fn load_binary_stl_preview(
+    path: &std::path::Path,
+    triangle_count: u32,
+    target_triangles: usize,
+) -> Result<IndexedMesh, String> {
+    let (bbox_min, bbox_max, average_edge) = binary_stl_preview_stats(path, triangle_count)?;
+    let diagonal = bbox_max.sub(bbox_min).length().max(1e-6);
+    let reduction = (triangle_count as f64 / target_triangles as f64).sqrt() as f32;
+    let mut cell_size = (average_edge as f32 * reduction).clamp(diagonal / 8192.0, diagonal / 16.0);
+    let mut best: Option<IndexedMesh> = None;
+
+    for attempt in 0..6 {
+        log::info!(
+            "[load_stl_file] Preview clustering pass {} with {:.6} mm cells",
+            attempt + 1,
+            cell_size
+        );
+        match cluster_binary_stl_pass(
+            path,
+            triangle_count,
+            bbox_min,
+            cell_size,
+            target_triangles * 5 / 4,
+        )? {
+            None => cell_size *= 1.6,
+            Some(mesh) if mesh.triangles.len() > target_triangles => {
+                let factor = (mesh.triangles.len() as f64 / target_triangles as f64).sqrt() as f32;
+                cell_size *= factor.max(1.1);
+            }
+            Some(mesh) => {
+                let count = mesh.triangles.len();
+                best = Some(mesh);
+                if count >= target_triangles * 2 / 3 || attempt == 5 {
+                    break;
+                }
+                let factor = (count.max(1) as f64 / target_triangles as f64).sqrt() as f32;
+                cell_size *= factor.clamp(0.45, 0.9);
+            }
+        }
+    }
+
+    best.filter(|mesh| !mesh.triangles.is_empty())
+        .ok_or_else(|| "Could not build a bounded preview for this STL".to_string())
+}
+
+#[cfg(test)]
+mod stl_preview_tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn streaming_preview_is_nonempty_and_bounded() {
+        let grid_size = 80u32;
+        let triangle_count = grid_size * grid_size * 2;
+        let path = std::env::temp_dir().join(format!(
+            "dragonfruit-stl-preview-{}.stl",
+            std::process::id()
+        ));
+        let mut file = std::io::BufWriter::new(std::fs::File::create(&path).unwrap());
+        file.write_all(&[0u8; 80]).unwrap();
+        file.write_all(&triangle_count.to_le_bytes()).unwrap();
+        for y in 0..grid_size {
+            for x in 0..grid_size {
+                let x = x as f32;
+                let y = y as f32;
+                for vertices in [
+                    [[x, y, 0.0], [x + 1.0, y, 0.0], [x + 1.0, y + 1.0, 0.0]],
+                    [[x, y, 0.0], [x + 1.0, y + 1.0, 0.0], [x, y + 1.0, 0.0]],
+                ] {
+                    file.write_all(&[0u8; 12]).unwrap();
+                    for vertex in vertices {
+                        for component in vertex {
+                            file.write_all(&component.to_le_bytes()).unwrap();
+                        }
+                    }
+                    file.write_all(&[0u8; 2]).unwrap();
+                }
+            }
+        }
+        file.flush().unwrap();
+        drop(file);
+
+        let preview = load_binary_stl_preview(&path, triangle_count, 500).unwrap();
+        std::fs::remove_file(path).unwrap();
+        assert!(!preview.triangles.is_empty());
+        assert!(preview.triangles.len() <= 500);
+    }
+
+    #[test]
+    #[ignore = "requires DRAGONFRUIT_LARGE_STL_TEST_PATH"]
+    fn streaming_preview_external_stl() {
+        let path = std::path::PathBuf::from(
+            std::env::var("DRAGONFRUIT_LARGE_STL_TEST_PATH")
+                .expect("DRAGONFRUIT_LARGE_STL_TEST_PATH must point to a binary STL"),
+        );
+        let mut file = std::fs::File::open(&path).unwrap();
+        let mut header = [0u8; 84];
+        file.read_exact(&mut header).unwrap();
+        let triangle_count = u32::from_le_bytes(header[80..84].try_into().unwrap());
+        let preview = load_binary_stl_preview(&path, triangle_count, 2_000_000).unwrap();
+        eprintln!(
+            "previewed {triangle_count} triangles as {} triangles / {} vertices",
+            preview.triangles.len(),
+            preview.positions.len()
+        );
+        assert!(!preview.triangles.is_empty());
+        assert!(preview.triangles.len() <= 2_000_000);
+    }
 }
 
 // --- internal helpers ----------------------------------------------------

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10228,6 +10228,10 @@ export default function Home() {
     scene.ungroupGroup(groupId);
   }, [scene]);
 
+  const handleSplitImportGroup = React.useCallback((modelId: string) => {
+    scene.splitImportGroup(modelId);
+  }, [scene]);
+
   const handleRenameFolder = React.useCallback((groupId: string, nextName: string) => {
     scene.renameGroup(groupId, nextName);
   }, [scene]);
@@ -18546,6 +18550,7 @@ export default function Home() {
               onGroupModels={handleGroupSelectedModels}
               onUngroupModels={handleUngroupSelectedModels}
               onUngroupGroup={handleUngroupFolder}
+              onSplitImportGroup={handleSplitImportGroup}
               onRenameGroup={handleRenameFolder}
               onRenameModel={handleRenameModel}
               onModelContextMenu={handleModelListContextMenu}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8429,6 +8429,15 @@ export default function Home() {
     setTimeout(resolve, 0);
   }), []);
 
+  const createPathBackedStlFile = React.useCallback((sourcePath: string, name: string): File => {
+    const file = new File([], name, {
+      type: getDroppedFileMimeType(name),
+      lastModified: Date.now(),
+    });
+    (file as File & { filePath?: string }).filePath = sourcePath;
+    return file;
+  }, []);
+
   const pickFilesWithNativeDialog = React.useCallback(async (category: 'mesh' | 'scene', multiple: boolean): Promise<File[] | null> => {
     if (!isDesktopRuntime()) return null;
 
@@ -8470,13 +8479,16 @@ export default function Home() {
             progress: null,
           });
 
-          const bytes = await core.invoke<ArrayBuffer>('read_print_file_bytes', { sourcePath });
           const name = resolvedName;
-
-          files.push(new File([new Uint8Array(bytes)], name, {
-            type: getDroppedFileMimeType(name),
-            lastModified: Date.now(),
-          }));
+          if (getFileExtensionLower(name) === '.stl') {
+            files.push(createPathBackedStlFile(sourcePath, name));
+          } else {
+            const bytes = await core.invoke<ArrayBuffer>('read_print_file_bytes', { sourcePath });
+            files.push(new File([new Uint8Array(bytes)], name, {
+              type: getDroppedFileMimeType(name),
+              lastModified: Date.now(),
+            }));
+          }
         } catch (error) {
           console.warn(`[Picker] Failed reading picked file path: ${entry.path}`, error);
         }
@@ -8498,7 +8510,7 @@ export default function Home() {
       console.warn(`[Picker] Native ${category} picker failed, falling back to web input.`, error);
       return null;
     }
-  }, [isDesktopRuntime, waitForUiTick]);
+  }, [createPathBackedStlFile, isDesktopRuntime, waitForUiTick]);
 
   const pickFilesWithWebInput = React.useCallback((accept: string, multiple: boolean): Promise<File[]> => {
     return new Promise((resolve) => {
@@ -8596,7 +8608,7 @@ export default function Home() {
       if (nativeFiles.length === 0) return;
       const expanded = await expandPickedFilesWithZip(nativeFiles, 'mesh');
       if (expanded.meshFiles.length > 0) {
-        scene.onFileChange(buildSyntheticFileChangeEvent(expanded.meshFiles));
+        void scene.loadFiles(expanded.meshFiles);
       }
       if (expanded.sceneFiles.length > 0) {
         await importSceneFilesWithPluginWarning(expanded.sceneFiles, { resultingScenePath: null });
@@ -9899,12 +9911,16 @@ export default function Home() {
 
       for (const sourcePath of normalizedSupportedPaths) {
         try {
-          const bytes = await core.invoke<ArrayBuffer>('read_print_file_bytes', { sourcePath });
           const name = getFileNameFromPath(sourcePath);
-          files.push(new File([new Uint8Array(bytes)], name, {
-            type: getDroppedFileMimeType(name),
-            lastModified: Date.now(),
-          }));
+          if (getFileExtensionLower(name) === '.stl') {
+            files.push(createPathBackedStlFile(sourcePath, name));
+          } else {
+            const bytes = await core.invoke<ArrayBuffer>('read_print_file_bytes', { sourcePath });
+            files.push(new File([new Uint8Array(bytes)], name, {
+              type: getDroppedFileMimeType(name),
+              lastModified: Date.now(),
+            }));
+          }
         } catch (error) {
           console.warn(`[DragDrop] Failed reading dropped file path: ${sourcePath}`, error);
         }
@@ -9914,7 +9930,7 @@ export default function Home() {
     } catch {
       return [] as File[];
     }
-  }, []);
+  }, [createPathBackedStlFile]);
 
   const sceneModeRef = React.useRef(scene.mode);
   const createFilesFromTauriDroppedPathsRef = React.useRef(createFilesFromTauriDroppedPaths);

--- a/src/components/controls/ModelManagerPanel.tsx
+++ b/src/components/controls/ModelManagerPanel.tsx
@@ -16,6 +16,7 @@ import {
   Info,
   Crosshair,
   Wrench,
+  Scissors,
 } from 'lucide-react';
 import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import { Card, CardHeader, IconButton } from '@/components/ui/primitives';
@@ -37,6 +38,8 @@ interface ModelManagerPanelProps {
   onGroupModels?: (modelIds: string[]) => void;
   onUngroupModels?: (modelIds: string[]) => void;
   onUngroupGroup?: (groupId: string) => void;
+  /** Splits a multi-body 3MF model into independent models (pre-computed split bodies). */
+  onSplitImportGroup?: (modelId: string) => void;
   onRenameGroup?: (groupId: string, nextName: string) => void;
   onRenameModel?: (id: string, nextName: string) => void;
   onModelContextMenu?: (id: string, position: { x: number; y: number }) => void;
@@ -93,6 +96,7 @@ export function ModelManagerPanel({
   onGroupModels,
   onUngroupModels,
   onUngroupGroup,
+  onSplitImportGroup,
   onRenameGroup,
   onRenameModel,
   onModelContextMenu,
@@ -393,6 +397,7 @@ export function ModelManagerPanel({
                 const isGroupFullySelected = selectedCount > 0 && selectedCount === group.models.length;
                 const isGroupPartiallySelected = selectedCount > 0 && !isGroupFullySelected;
                 const showHeader = group.isGrouped;
+                const showChildren = !showHeader || !isCollapsed;
 
                 return (
                   <div
@@ -405,36 +410,36 @@ export function ModelManagerPanel({
                         }
                       : undefined}
                   >
-                        {showHeader && (
-                          <div
-                            className="px-1.5 py-1 rounded border flex items-center gap-1.5 cursor-pointer transition-colors"
-                            style={isGroupFullySelected
-                              ? {
-                                  background: 'color-mix(in srgb, var(--accent), var(--surface-2) 90%)',
-                                  borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
-                                }
-                              : isGroupPartiallySelected
-                                ? {
-                                    background: 'color-mix(in srgb, var(--accent), var(--surface-2) 94%)',
-                                    borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
-                                  }
-                                : { borderColor: 'var(--border-subtle)', background: 'var(--surface-2)' }}
-                            onClick={(e) => {
-                              const mode: GroupSelectMode = (e.ctrlKey || e.metaKey || e.shiftKey) ? 'add' : 'single';
-                              selectFolder(group, mode);
-                            }}
-                            onContextMenu={(e) => {
-                              e.preventDefault();
-                              e.stopPropagation();
-                              setContextMenu({
-                                x: e.clientX,
-                                y: e.clientY,
-                                groupId: group.id,
-                                groupName: group.name,
-                                isSystemGroup: group.isSystemGroup,
-                              });
-                            }}
-                          >
+                    {showHeader && (
+                      <div
+                        className="px-1.5 py-1 rounded border flex items-center gap-1.5 cursor-pointer transition-colors"
+                        style={isGroupFullySelected
+                          ? {
+                              background: 'color-mix(in srgb, var(--accent), var(--surface-2) 90%)',
+                              borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                            }
+                          : isGroupPartiallySelected
+                            ? {
+                                background: 'color-mix(in srgb, var(--accent), var(--surface-2) 94%)',
+                                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
+                              }
+                            : { borderColor: 'var(--border-subtle)', background: 'var(--surface-2)' }}
+                        onClick={(e) => {
+                          const mode: GroupSelectMode = (e.ctrlKey || e.metaKey || e.shiftKey) ? 'add' : 'single';
+                          selectFolder(group, mode);
+                        }}
+                        onContextMenu={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          setContextMenu({
+                            x: e.clientX,
+                            y: e.clientY,
+                            groupId: group.id,
+                            groupName: group.name,
+                            isSystemGroup: group.isSystemGroup,
+                          });
+                        }}
+                      >
                         <button
                           type="button"
                           className="inline-flex items-center justify-center rounded p-0.5 hover:bg-black/20"
@@ -492,7 +497,7 @@ export function ModelManagerPanel({
                       </div>
                     )}
 
-                    {(!showHeader || !isCollapsed) && (
+                    {showChildren && (
                       <div
                         className={showHeader ? 'ml-1.5 space-y-1 pl-1' : 'space-y-1'}
                       >
@@ -784,6 +789,24 @@ export function ModelManagerPanel({
                     <Wrench className="h-3.5 w-3.5" />
                     <span>Repair Mesh…</span>
                   </button>
+                )}
+
+                {contextModel.splitBodies && onSplitImportGroup && (
+                  <>
+                    <div className="my-1 h-px" style={{ background: 'var(--border-subtle)' }} />
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-medium hover:bg-white/5"
+                      style={{ color: 'var(--text-strong)' }}
+                      onClick={() => {
+                        onSplitImportGroup(contextModel.id);
+                        closeContextMenu();
+                      }}
+                    >
+                      <Scissors className="h-3.5 w-3.5" />
+                      <span>Split to Bodies</span>
+                    </button>
+                  </>
                 )}
 
                 {onModelContextMenu && (

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 import * as THREE from 'three';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
-import { loadMeshGeometry, processGeometry, type GeometryWithBounds } from '@/hooks/useStlGeometry';
+import { loadMeshGeometry, load3mfGeometryMulti, processGeometry, type GeometryWithBounds, type ProcessGeometryOptions } from '@/hooks/useStlGeometry';
 import type { MeshHealthReport, MeshAnalysisJson } from '@/utils/meshRepair';
 import { computeFlatteningPlanes } from '@/features/placeOnFace/logic/computeFlatteningPlanes';
 import { isVoxlBinaryV2, parseVoxlBinaryV2, parseVoxlDocument, type VoxlDocumentV1, type VoxlMeshRef } from '@/features/scene/voxl';
@@ -1958,10 +1958,12 @@ export function useSceneCollectionManager() {
 
         try {
           console.log(`[SceneCollection] Loading ${file.name}...`);
-          const geom = await loadMeshGeometry(url, file.name, {
+
+          // Shared loading options for all mesh types
+          const loadOptions = {
             nativeProcessingMode: getSavedImportDefaultsSettings().autoRepair ? 'auto' : 'none',
             filePath: (file as File & { filePath?: string }).filePath,
-            onNativeProcessingStage: (stage) => {
+            onNativeProcessingStage: (stage: string) => {
               if (stage === 'repairing') {
                 setImportProgress({
                   active: true,
@@ -2000,7 +2002,7 @@ export function useSceneCollectionManager() {
                 });
               }
             },
-            onConfirmHeavyRepair: async (analysis) => {
+            onConfirmHeavyRepair: async (analysis: MeshAnalysisJson) => {
               const choice = await requestMeshRepairConfirmation({ fileName: file.name, analysis });
               if (choice === 'cancel_import') {
                 throw new Error('MESH_IMPORT_CANCELLED_BY_USER');
@@ -2018,95 +2020,80 @@ export function useSceneCollectionManager() {
               }
               return choice === 'repair';
             },
-          });
+          } satisfies ProcessGeometryOptions;
 
-          // Keep mesh color metadata only; avoid eager vertex color buffer allocation.
+          // Determine if this is a 3MF file for multi-body import
+          const is3mf = file.name.toLowerCase().endsWith('.3mf');
+
+          // Load geometries — single for most formats, multi-body for 3MF
+          const geoms: GeometryWithBounds[] = is3mf
+            ? await load3mfGeometryMulti(url, loadOptions)
+            : [await loadMeshGeometry(url, file.name, loadOptions)];
+
+          if (geoms.length === 0) {
+            throw new Error(`No geometry loaded from ${file.name}.`);
+          }
+
           const color = preferredMeshColor;
+          const modelIdsForGroup: string[] = [];
 
-          // Calculate initial transform with auto-lift
-          // By default, loaded geometry is centered at 0,0,0 but bottom might be < 0 or > 0 depending on normalization.
-          // loadStlGeometry normalizes: center X/Z at 0, set bottom Y (mapped to Z here?) to 0?
-          // Wait, loadStlGeometry: geometry.translate(-preCenter.x, -preBBox.min.y, -preCenter.z);
-          // This puts the bottom at Y=0.
-          // When rendered, we use Y-up or Z-up? SceneCanvas uses Z-up logic in some places, but Three.js is Y-up.
-          // StlMesh rotates geometry? No.
-          // Let's assume standard orientation: we want bottom at Z=0 (platform) or Z=liftDistance.
-          // Since loadStlGeometry normalizes bottom to Y=0, and we usually rotate meshes -90X or similar...
-          // Actually, `loadStlGeometry` normalizes it such that "bottom" is at Y=0.
-          // In `SceneCanvas` / `StlMesh`, we render it directly.
-          // If the model is oriented Z-up (common for 3D printing), `loadStlGeometry` might have put it on its side if it used Y for height.
-          // Let's check `loadStlGeometry` normalization: `geometry.translate(-preCenter.x, -preBBox.min.y, -preCenter.z);`
-          // This zeroes the Y minimum.
+          for (let bodyIndex = 0; bodyIndex < geoms.length; bodyIndex++) {
+            const geom = geoms[bodyIndex];
 
-          // The `computeLowestZ` util takes a matrix.
-          // Default transform is identity.
-          // If we assume the model is upright after load (or we don't rotate it yet), the lowest point is 0.
+            // Calculate initial transform with auto-lift (same logic as single import)
+            const bbox = geom.bbox;
+            const center = geom.center;
+            const heightOffset = center.z - bbox.min.z;
+            const initialZ = autoLift ? heightOffset + liftDistance : heightOffset;
 
-          // However, `useTransformManager` uses `computeLowestZ` to find the world Z bottom.
-          // If we want to lift it, we set Z position.
+            // Number body names for multi-body 3MF imports
+            const modelName = geoms.length > 1
+              ? `${file.name.replace(/\.3mf$/i, '')} (${bodyIndex + 1})`
+              : file.name;
 
-          // Let's calculate the default Z position.
-          // If the geometry is already normalized to sit at 0, then:
-          // platformZ = 0.
-          // liftZ = liftDistance.
+            const model: LoadedModel = {
+              id: generateId(),
+              name: modelName,
+              fileUrl: url,
+              fileSizeBytes: file.size,
+              sourcePath: (file as File & { filePath?: string }).filePath,
+              geometry: geom,
+              transform: {
+                position: new THREE.Vector3(defaultImportCenterXY.x, defaultImportCenterXY.y, initialZ),
+                rotation: new THREE.Euler(0, 0, 0),
+                scale: new THREE.Vector3(1, 1, 1)
+              },
+              visible: true,
+              color,
+              polygonCount: geom.nativePreview?.originalTriangleCount
+                ?? geom.geometry.getAttribute('position').count / 3
+            };
 
-          // But wait, `StlMesh` applies `centerOffset` to the geometry: 
-          // `position={new THREE.Vector3(-centerOffset.x, -centerOffset.y, -centerOffset.z)}`
-          // `centerOffset` is `bbox.getCenter()`.
-          // So the mesh is centered at (0,0,0) inside the group.
-          // The group is at `transform.position`.
-          // So if we want the bottom of the mesh to be at `targetZ`, we need to know the distance from center to bottom.
-          // halfHeight = (max.z - min.z) / 2.
-          // targetGroupZ = targetZ + halfHeight.
+            const assignedCenter = findFreeSpotCentersForModels([...stagedNewModels, model], 5).at(-1);
+            if (assignedCenter) {
+              model.transform.position.set(assignedCenter.x, assignedCenter.y, model.transform.position.z);
+            }
 
-          // Wait, `useTransformManager` uses `computeLowestZ`.
-          // Let's stick to the logic that `useTransformManager` uses, but applied initially.
-          // Actually, `useTransformManager` logic:
-          // `const heightOffset = center.z - bbox.min.z;`
-          // `const finalZ = autoLift ? heightOffset + liftDistance : heightOffset;`
+            stagedNewModels.push(model);
+            modelIdsForGroup.push(model.id);
+            if (!firstLoadedModelId) {
+              firstLoadedModelId = model.id;
+            }
 
-          // So we replicate that logic.
-          const bbox = geom.bbox;
-          const center = geom.center;
-          const heightOffset = center.z - bbox.min.z;
-          const initialZ = autoLift ? heightOffset + liftDistance : heightOffset;
+            setModels((prev) => [...prev, model]);
 
-          const model: LoadedModel = {
-            id: generateId(),
-            name: file.name,
-            fileUrl: url,
-            fileSizeBytes: file.size,
-            sourcePath: (file as File & { filePath?: string }).filePath,
-            geometry: geom,
-            transform: {
-              position: new THREE.Vector3(defaultImportCenterXY.x, defaultImportCenterXY.y, initialZ),
-              rotation: new THREE.Euler(0, 0, 0),
-              scale: new THREE.Vector3(1, 1, 1)
-            },
-            visible: true,
-            color,
-            polygonCount: geom.nativePreview?.originalTriangleCount
-              ?? geom.geometry.getAttribute('position').count / 3
-          };
-
-          const assignedCenter = findFreeSpotCentersForModels([...stagedNewModels, model], 5).at(-1);
-          if (assignedCenter) {
-            model.transform.position.set(assignedCenter.x, assignedCenter.y, model.transform.position.z);
+            if (geom.meshDefects?.nativeRepairReport) {
+              repairReports.push({
+                id: model.id,
+                modelName,
+                report: geom.meshDefects.nativeRepairReport,
+              });
+            }
           }
 
-          stagedNewModels.push(model);
-          if (!firstLoadedModelId) {
-            firstLoadedModelId = model.id;
-          }
-
-          setModels((prev) => [...prev, model]);
-
-          if (geom.meshDefects?.nativeRepairReport) {
-            repairReports.push({
-              id: model.id,
-              modelName: file.name,
-              report: geom.meshDefects.nativeRepairReport,
-            });
+          // Auto-group multi-body 3MF imports
+          if (is3mf && modelIdsForGroup.length > 1) {
+            groupModels(modelIdsForGroup);
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
@@ -2135,8 +2122,10 @@ export function useSceneCollectionManager() {
         const importedIds = stagedNewModels.map((model) => model.id);
 
         if (importedIds.length > 1) {
-          // For multi-file mesh imports, select all imported models so tinting and
-          // immediate transform actions apply uniformly.
+          // For multi-file mesh imports, auto-group all imported models (same
+          // treatment as multi-body 3MF) and select them so tinting/transform
+          // actions apply uniformly.
+          groupModels(importedIds);
           setActiveModelId(importedIds[0]);
           setSelectedModelIds(importedIds);
         } else if (!hadActiveModelAtStart) {

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -2376,10 +2376,29 @@ export function useSceneCollectionManager() {
     // the geometry has changed (e.g. after hole punch / hollowing).  Compute it
     // only if the old geometry had one (i.e. the user has edge lines enabled),
     // and skip during deferred post-processing to avoid blocking the UI.
+    // Skip for very large meshes — EdgesGeometry uses `for...in` over a hash map
+    // of unique edges and V8 throws "Too many properties to enumerate" beyond ~2M entries.
     const hadEdgeGeometry = !!target.geometry.edgeGeometry;
-    const nextEdgeGeometry = hadEdgeGeometry && !options?.deferPostProcessing
-      ? new THREE.EdgesGeometry(nextBufferGeometry, 30)
-      : target.geometry.edgeGeometry;
+    let nextEdgeGeometry: THREE.EdgesGeometry | undefined;
+    if (hadEdgeGeometry && !options?.deferPostProcessing) {
+      const triCount = (nextBufferGeometry.getIndex()?.count ?? nextBufferGeometry.getAttribute('position')?.count ?? 0) / 3;
+      if (triCount < 800_000) {
+        try {
+          nextEdgeGeometry = new THREE.EdgesGeometry(nextBufferGeometry, 30);
+        } catch (edgeError) {
+          console.warn(
+            '[SceneCollection] Edge geometry recompute failed for large mesh',
+            edgeError,
+          );
+        }
+      } else {
+        console.warn(
+          `[SceneCollection] Skipping edge geometry recompute for large mesh (${Math.round(triCount).toLocaleString()} triangles).`,
+        );
+      }
+    } else {
+      nextEdgeGeometry = target.geometry.edgeGeometry;
+    }
 
     const nextGeometry: GeometryWithBounds = {
       geometry: nextBufferGeometry,

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 import * as THREE from 'three';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
-import { loadMeshGeometry, load3mfGeometryMulti, processGeometry, type GeometryWithBounds, type ProcessGeometryOptions } from '@/hooks/useStlGeometry';
+import { loadMeshGeometry, load3mfGeometryMergedWithSplitData, processGeometry, type GeometryWithBounds, type ProcessGeometryOptions } from '@/hooks/useStlGeometry';
 import type { MeshHealthReport, MeshAnalysisJson } from '@/utils/meshRepair';
 import { computeFlatteningPlanes } from '@/features/placeOnFace/logic/computeFlatteningPlanes';
 import { isVoxlBinaryV2, parseVoxlBinaryV2, parseVoxlDocument, type VoxlDocumentV1, type VoxlMeshRef } from '@/features/scene/voxl';
@@ -768,6 +768,10 @@ export interface LoadedModel {
   visible: boolean;
   color: string;
   polygonCount: number;
+  /** Pre-processed individual body geometries for multi-body 3MF imports.
+   *  When set, "Split to Bodies" replaces this single model with separate
+   *  models for each entry — instant, no reprocessing needed. */
+  splitBodies?: GeometryWithBounds[];
   meshModifiers?: ModelMeshModifiers;
   ignoreAutoLift?: boolean;
   manualZMoveOverride?: boolean;
@@ -2025,48 +2029,36 @@ export function useSceneCollectionManager() {
           // Determine if this is a 3MF file for multi-body import
           const is3mf = file.name.toLowerCase().endsWith('.3mf');
 
-          // Load geometries — single for most formats, multi-body for 3MF
-          const geoms: GeometryWithBounds[] = is3mf
-            ? await load3mfGeometryMulti(url, loadOptions)
-            : [await loadMeshGeometry(url, file.name, loadOptions)];
-
-          if (geoms.length === 0) {
-            throw new Error(`No geometry loaded from ${file.name}.`);
-          }
-
           const color = preferredMeshColor;
-          const modelIdsForGroup: string[] = [];
 
-          for (let bodyIndex = 0; bodyIndex < geoms.length; bodyIndex++) {
-            const geom = geoms[bodyIndex];
+          if (is3mf) {
+            // Use the merged+split loader: returns a single merged geometry
+            // (preserving body positions) and pre-processed individual bodies
+            // for instant "Split to Bodies".
+            const { merged, splitBodies } = await load3mfGeometryMergedWithSplitData(url, loadOptions);
 
-            // Calculate initial transform with auto-lift (same logic as single import)
-            const bbox = geom.bbox;
-            const center = geom.center;
+            const bbox = merged.bbox;
+            const center = merged.center;
             const heightOffset = center.z - bbox.min.z;
             const initialZ = autoLift ? heightOffset + liftDistance : heightOffset;
 
-            // Number body names for multi-body 3MF imports
-            const modelName = geoms.length > 1
-              ? `${file.name.replace(/\.3mf$/i, '')} (${bodyIndex + 1})`
-              : file.name;
-
             const model: LoadedModel = {
               id: generateId(),
-              name: modelName,
+              name: file.name,
               fileUrl: url,
               fileSizeBytes: file.size,
               sourcePath: (file as File & { filePath?: string }).filePath,
-              geometry: geom,
+              geometry: merged,
+              splitBodies: splitBodies.length > 1 ? splitBodies : undefined,
               transform: {
                 position: new THREE.Vector3(defaultImportCenterXY.x, defaultImportCenterXY.y, initialZ),
                 rotation: new THREE.Euler(0, 0, 0),
-                scale: new THREE.Vector3(1, 1, 1)
+                scale: new THREE.Vector3(1, 1, 1),
               },
               visible: true,
               color,
-              polygonCount: geom.nativePreview?.originalTriangleCount
-                ?? geom.geometry.getAttribute('position').count / 3
+              polygonCount: merged.nativePreview?.originalTriangleCount
+                ?? merged.geometry.getAttribute('position').count / 3,
             };
 
             const assignedCenter = findFreeSpotCentersForModels([...stagedNewModels, model], 5).at(-1);
@@ -2075,25 +2067,57 @@ export function useSceneCollectionManager() {
             }
 
             stagedNewModels.push(model);
-            modelIdsForGroup.push(model.id);
-            if (!firstLoadedModelId) {
-              firstLoadedModelId = model.id;
+            if (!firstLoadedModelId) firstLoadedModelId = model.id;
+            setModels((prev) => [...prev, model]);
+
+            if (merged.meshDefects?.nativeRepairReport) {
+              repairReports.push({
+                id: model.id,
+                modelName: file.name,
+                report: merged.meshDefects.nativeRepairReport,
+              });
+            }
+          } else {
+            const geom = await loadMeshGeometry(url, file.name, loadOptions);
+            const bbox = geom.bbox;
+            const center = geom.center;
+            const heightOffset = center.z - bbox.min.z;
+            const initialZ = autoLift ? heightOffset + liftDistance : heightOffset;
+
+            const model: LoadedModel = {
+              id: generateId(),
+              name: file.name,
+              fileUrl: url,
+              fileSizeBytes: file.size,
+              sourcePath: (file as File & { filePath?: string }).filePath,
+              geometry: geom,
+              transform: {
+                position: new THREE.Vector3(defaultImportCenterXY.x, defaultImportCenterXY.y, initialZ),
+                rotation: new THREE.Euler(0, 0, 0),
+                scale: new THREE.Vector3(1, 1, 1),
+              },
+              visible: true,
+              color,
+              polygonCount: geom.nativePreview?.originalTriangleCount
+                ?? geom.geometry.getAttribute('position').count / 3,
+            };
+
+            const assignedCenter = findFreeSpotCentersForModels([...stagedNewModels, model], 5).at(-1);
+            if (assignedCenter) {
+              model.transform.position.set(assignedCenter.x, assignedCenter.y, model.transform.position.z);
             }
 
+            stagedNewModels.push(model);
+            if (!firstLoadedModelId) firstLoadedModelId = model.id;
             setModels((prev) => [...prev, model]);
 
             if (geom.meshDefects?.nativeRepairReport) {
               repairReports.push({
                 id: model.id,
-                modelName,
+                modelName: file.name,
                 report: geom.meshDefects.nativeRepairReport,
               });
             }
-          }
-
-          // Auto-group multi-body 3MF imports
-          if (is3mf && modelIdsForGroup.length > 1) {
-            groupModels(modelIdsForGroup);
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
@@ -2122,10 +2146,8 @@ export function useSceneCollectionManager() {
         const importedIds = stagedNewModels.map((model) => model.id);
 
         if (importedIds.length > 1) {
-          // For multi-file mesh imports, auto-group all imported models (same
-          // treatment as multi-body 3MF) and select them so tinting/transform
-          // actions apply uniformly.
-          groupModels(importedIds);
+          // For multi-file mesh imports, select all imported models so tinting and
+          // immediate transform actions apply uniformly.
           setActiveModelId(importedIds[0]);
           setSelectedModelIds(importedIds);
         } else if (!hadActiveModelAtStart) {
@@ -2570,6 +2592,42 @@ export function useSceneCollectionManager() {
         ? { ...model, groupId: undefined, groupName: undefined }
         : model
     )));
+  }, []);
+
+  /** Splits a multi-body 3MF model into independent models using the
+   *  pre-processed `splitBodies` geometries. Instant — no reprocessing. */
+  const splitImportGroup = useCallback((modelId: string) => {
+    const source = modelsRef.current.find((m) => m.id === modelId);
+    if (!source?.splitBodies || source.splitBodies.length < 2) return;
+
+    const newModels: LoadedModel[] = source.splitBodies.map((bodyGeom, i) => ({
+      id: generateId(),
+      name: `${source.name.replace(/\.3mf$/i, '')} (${i + 1})`,
+      fileUrl: source.fileUrl,
+      fileSizeBytes: source.fileSizeBytes,
+      sourcePath: source.sourcePath,
+      geometry: bodyGeom,
+      transform: {
+        position: source.transform.position.clone(),
+        rotation: source.transform.rotation.clone(),
+        scale: source.transform.scale.clone(),
+      },
+      visible: source.visible,
+      color: source.color,
+      polygonCount: bodyGeom.nativePreview?.originalTriangleCount
+        ?? bodyGeom.geometry.getAttribute('position').count / 3,
+    }));
+
+    // Remove the merged source, add individual models
+    setModels((prev) => [
+      ...prev.filter((m) => m.id !== modelId),
+      ...newModels,
+    ]);
+
+    // Select all new bodies
+    const newIds = newModels.map((m) => m.id);
+    setActiveModelId(newIds[0]);
+    setSelectedModelIds(newIds);
   }, []);
 
   const renameGroup = useCallback((groupId: string, nextName: string) => {
@@ -4367,6 +4425,7 @@ export function useSceneCollectionManager() {
     groupModels,
     ungroupModels,
     ungroupGroup,
+    splitImportGroup,
     renameGroup,
     selectGroup,
     deleteModels,

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -761,6 +761,8 @@ export interface LoadedModel {
   groupName?: string;
   fileUrl: string;
   fileSizeBytes?: number;
+  /** Original on-disk mesh retained when `geometry` is a reduced native preview. */
+  sourcePath?: string;
   geometry: GeometryWithBounds;
   transform: ModelTransform;
   visible: boolean;
@@ -1952,10 +1954,13 @@ export function useSceneCollectionManager() {
           progress: null,
         });
 
+        console.log(`[SceneCollection] Loading ${file.name}... (${(file.size / 1_000_000).toFixed(0)} MB)`);
+
         try {
           console.log(`[SceneCollection] Loading ${file.name}...`);
           const geom = await loadMeshGeometry(url, file.name, {
             nativeProcessingMode: getSavedImportDefaultsSettings().autoRepair ? 'auto' : 'none',
+            filePath: (file as File & { filePath?: string }).filePath,
             onNativeProcessingStage: (stage) => {
               if (stage === 'repairing') {
                 setImportProgress({
@@ -2071,6 +2076,7 @@ export function useSceneCollectionManager() {
             name: file.name,
             fileUrl: url,
             fileSizeBytes: file.size,
+            sourcePath: (file as File & { filePath?: string }).filePath,
             geometry: geom,
             transform: {
               position: new THREE.Vector3(defaultImportCenterXY.x, defaultImportCenterXY.y, initialZ),
@@ -2079,7 +2085,8 @@ export function useSceneCollectionManager() {
             },
             visible: true,
             color,
-            polygonCount: geom.geometry.getAttribute('position').count / 3
+            polygonCount: geom.nativePreview?.originalTriangleCount
+              ?? geom.geometry.getAttribute('position').count / 3
           };
 
           const assignedCenter = findFreeSpotCentersForModels([...stagedNewModels, model], 5).at(-1);
@@ -4036,6 +4043,11 @@ export function useSceneCollectionManager() {
     if (entry.kind === 'scene') {
       await importSceneFile(file);
       return true;
+    }
+
+    // Pass the on-disk file path through to enable Rust-side STL loading.
+    if (entry.sourcePath) {
+      (file as File & { filePath?: string }).filePath = entry.sourcePath;
     }
 
     await loadFiles([file]);

--- a/src/hooks/__tests__/useStlGeometryStreaming.test.ts
+++ b/src/hooks/__tests__/useStlGeometryStreaming.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { loadStlBinaryStreaming } from '../useStlGeometry';
+
+function writeTriangle(target: Uint8Array, offset: number, values: number[]) {
+  const view = new DataView(target.buffer, target.byteOffset + offset, 50);
+  for (let i = 0; i < 9; i++) {
+    view.setFloat32(12 + i * 4, values[i], true);
+  }
+}
+
+test('streaming STL parser preserves a partial first triangle across chunks', async () => {
+  const bytes = new Uint8Array(84 + 2 * 50);
+  new DataView(bytes.buffer).setUint32(80, 2, true);
+  const expected = [
+    0, 0, 0, 1, 0, 0, 0, 1, 0,
+    0, 0, 1, 1, 0, 1, 0, 1, 1,
+  ];
+  writeTriangle(bytes, 84, expected.slice(0, 9));
+  writeTriangle(bytes, 134, expected.slice(9));
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes.slice(0, 84 + 49));
+      controller.enqueue(bytes.slice(84 + 49));
+      controller.close();
+    },
+  }));
+
+  try {
+    const geometry = await loadStlBinaryStreaming('blob:test');
+    assert.ok(geometry);
+    const positions = geometry.getAttribute('position').array;
+    assert.deepEqual(Array.from(positions), expected);
+    assert.ok(Array.from(positions).every(Number.isFinite));
+    geometry.dispose();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/src/hooks/useStlGeometry.ts
+++ b/src/hooks/useStlGeometry.ts
@@ -115,6 +115,12 @@ const IN_PLACE_PROCESSING_VERTEX_THRESHOLD = 12_000_000;
 // practical benefit in auto-import flows. In auto mode, skip native processing
 // beyond this size and let users opt-in via manual Repair.
 const AUTO_NATIVE_PROCESSING_TRIANGLE_THRESHOLD = 3_000_000;
+// EdgesGeometry builds an internal hash map keyed by unique edge hashes using
+// a plain object, then iterates it with `for...in`. V8 throws "Too many
+// properties to enumerate" when the hash map exceeds ~2M entries. Skip
+// precomputation for meshes above this threshold to avoid the wasted work.
+// The Higher Contrast Model Edges overlay simply won't be available for that model.
+const EDGE_GEOMETRY_MAX_TRIANGLES = 800_000;
 
 type NativeRepairQualityGateDecision = {
   reject: boolean;
@@ -445,17 +451,24 @@ export async function processGeometry(bufferGeometry: THREE.BufferGeometry, opti
   // Yield before edge geometry computation (can be expensive for large meshes)
   await new Promise<void>(r => setTimeout(r, 0));
 
-  console.log(`[${new Date().toISOString()}] [processGeometry] Computing Edge Geometry`);
-  const startEdges = performance.now();
   let edgeGeometry: THREE.EdgesGeometry | undefined;
-  try {
-    edgeGeometry = new THREE.EdgesGeometry(geometry, 30);
-    console.log(`[${new Date().toISOString()}] [processGeometry] Edge Geometry finished. Took ${(performance.now() - startEdges).toFixed(2)}ms`);
-  } catch (edgeError) {
+  if (sourceTriangleEstimate >= EDGE_GEOMETRY_MAX_TRIANGLES) {
     console.warn(
-      `[processGeometry] Edge geometry computation failed for large mesh (${sourceTriangleEstimate.toLocaleString()} triangles).`,
-      edgeError,
+      `[processGeometry] Skipping edge geometry for large mesh (` +
+      `${sourceTriangleEstimate.toLocaleString()} triangles, threshold=${EDGE_GEOMETRY_MAX_TRIANGLES.toLocaleString()}).`,
     );
+  } else {
+    console.log(`[${new Date().toISOString()}] [processGeometry] Computing Edge Geometry`);
+    const startEdges = performance.now();
+    try {
+      edgeGeometry = new THREE.EdgesGeometry(geometry, 30);
+      console.log(`[${new Date().toISOString()}] [processGeometry] Edge Geometry finished. Took ${(performance.now() - startEdges).toFixed(2)}ms`);
+    } catch (edgeError) {
+      console.warn(
+        `[processGeometry] Edge geometry computation failed for large mesh (${sourceTriangleEstimate.toLocaleString()} triangles).`,
+        edgeError,
+      );
+    }
   }
 
   const shouldSurfaceDefects = meshDefects.hasDefects || meshDefects.nativeRepairReport != null;

--- a/src/hooks/useStlGeometry.ts
+++ b/src/hooks/useStlGeometry.ts
@@ -925,6 +925,96 @@ export async function load3mfGeometry(fileUrl: string, options?: ProcessGeometry
   });
 }
 
+/**
+ * Collects individual geometries from a 3MF scene group, preserving each
+ * mesh's world transform. Returns one geometry per mesh child — used for
+ * multi-body 3MF import where each body becomes a separate model.
+ */
+function collectIndividualGeometriesFromObject3d(root: THREE.Object3D): THREE.BufferGeometry[] {
+  root.updateMatrixWorld(true);
+
+  const geometries: THREE.BufferGeometry[] = [];
+
+  root.traverse((node) => {
+    const mesh = node as THREE.Mesh;
+    if (!mesh.isMesh) return;
+    if (!(mesh.geometry instanceof THREE.BufferGeometry)) return;
+
+    const cloned = mesh.geometry.clone();
+    // DragonFruit controls mesh tinting centrally; ignore per-file vertex colors.
+    if (cloned.getAttribute('color')) {
+      cloned.deleteAttribute('color');
+    }
+    cloned.applyMatrix4(mesh.matrixWorld);
+    geometries.push(cloned);
+  });
+
+  return geometries;
+}
+
+/**
+ * Loads a 3MF file and returns individual geometries for each mesh body,
+ * processing each one independently (centering, auto-lift etc.) like loading
+ * separate files. Used for multi-body 3MF import where each body becomes a
+ * separate `LoadedModel` with auto-grouping.
+ *
+ * Returns an array of `GeometryWithBounds` — one per mesh found in the 3MF.
+ * If the file contains a single mesh, returns a single-element array.
+ */
+export async function load3mfGeometryMulti(fileUrl: string, options?: ProcessGeometryOptions): Promise<GeometryWithBounds[]> {
+  // Try the fast SAX/worker-based loader first for large archives
+  const fastGroup = await tryLoadFast3mf(fileUrl);
+  if (fastGroup) {
+    console.log(`[${new Date().toISOString()}] [load3mfGeometryMulti] fast-3mf-loader succeeded, processing individual geometries.`);
+    try {
+      const individualGeometries = collectIndividualGeometriesFromObject3d(fastGroup);
+      if (individualGeometries.length === 0) {
+        throw new Error('3MF contains no mesh geometry.');
+      }
+      const results: GeometryWithBounds[] = [];
+      for (const geom of individualGeometries) {
+        results.push(await processGeometry(geom, options));
+      }
+      return results;
+    } catch (error) {
+      console.warn('[load3mfGeometryMulti] fast-3mf-loader geometry processing failed; falling back to ThreeMFLoader.', error);
+    }
+  }
+
+  // Fall back to the original ThreeMFLoader
+  return new Promise((resolve, reject) => {
+    const loader = new ThreeMFLoader();
+    console.log(`[${new Date().toISOString()}] [load3mfGeometryMulti] Starting ThreeMFLoader load for ${fileUrl}`);
+    const startLoad = performance.now();
+
+    loader.load(
+      fileUrl,
+      async (object) => {
+        console.log(`[${new Date().toISOString()}] [load3mfGeometryMulti] ThreeMFLoader finished. Took ${(performance.now() - startLoad).toFixed(2)}ms`);
+
+        try {
+          const individualGeometries = collectIndividualGeometriesFromObject3d(object);
+          if (individualGeometries.length === 0) {
+            reject(new Error('3MF contains no mesh geometry.'));
+            return;
+          }
+          const results: GeometryWithBounds[] = [];
+          for (const geom of individualGeometries) {
+            results.push(await processGeometry(geom, options));
+          }
+          resolve(results);
+        } catch (error) {
+          reject(error);
+        }
+      },
+      undefined,
+      (error) => {
+        reject(error);
+      }
+    );
+  });
+}
+
 export async function loadObjGeometry(fileUrl: string, options?: ProcessGeometryOptions): Promise<GeometryWithBounds> {
   return new Promise((resolve, reject) => {
     const loader = new OBJLoader();

--- a/src/hooks/useStlGeometry.ts
+++ b/src/hooks/useStlGeometry.ts
@@ -447,8 +447,16 @@ export async function processGeometry(bufferGeometry: THREE.BufferGeometry, opti
 
   console.log(`[${new Date().toISOString()}] [processGeometry] Computing Edge Geometry`);
   const startEdges = performance.now();
-  const edgeGeometry = new THREE.EdgesGeometry(geometry, 30);
-  console.log(`[${new Date().toISOString()}] [processGeometry] Edge Geometry finished. Took ${(performance.now() - startEdges).toFixed(2)}ms`);
+  let edgeGeometry: THREE.EdgesGeometry | undefined;
+  try {
+    edgeGeometry = new THREE.EdgesGeometry(geometry, 30);
+    console.log(`[${new Date().toISOString()}] [processGeometry] Edge Geometry finished. Took ${(performance.now() - startEdges).toFixed(2)}ms`);
+  } catch (edgeError) {
+    console.warn(
+      `[processGeometry] Edge geometry computation failed for large mesh (${sourceTriangleEstimate.toLocaleString()} triangles).`,
+      edgeError,
+    );
+  }
 
   const shouldSurfaceDefects = meshDefects.hasDefects || meshDefects.nativeRepairReport != null;
   return { geometry, bbox, center, size, flatteningPlanes, edgeGeometry, ...(shouldSurfaceDefects ? { meshDefects } : {}) };

--- a/src/hooks/useStlGeometry.ts
+++ b/src/hooks/useStlGeometry.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import * as THREE from 'three';
 import { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js';
 import { ThreeMFLoader } from 'three/examples/jsm/loaders/3MFLoader.js';
+import { Fast3MFLoader, fast3mfBuilder } from 'fast-3mf-loader';
 import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import { accelerateGeometry } from '@/utils/bvh';
@@ -540,7 +541,44 @@ function collectMergedGeometryFromObject3d(root: THREE.Object3D, sourceLabel: '3
   return merged;
 }
 
+/**
+ * Loads a 3MF file using the fast-3mf-loader (SAX parsing + WebWorkers).
+ * Falls back to ThreeMFLoader if the fast loader fails or encounters
+ * unsupported features (e.g. metallic display properties, print tickets).
+ */
+async function tryLoadFast3mf(fileUrl: string): Promise<THREE.Group | null> {
+  try {
+    const response = await fetch(fileUrl);
+    const buffer = await response.arrayBuffer();
+
+    const loader = new Fast3MFLoader();
+    const data3mf = await loader.parse(buffer);
+    const group = fast3mfBuilder(data3mf);
+
+    if (group && group.type === 'Group' && group.children.length > 0) {
+      return group;
+    }
+    return null;
+  } catch (fastError) {
+    console.warn('[load3mfGeometry] fast-3mf-loader failed; falling back to ThreeMFLoader.', fastError);
+    return null;
+  }
+}
+
 export async function load3mfGeometry(fileUrl: string, options?: ProcessGeometryOptions): Promise<GeometryWithBounds> {
+  // Try the fast SAX/worker-based loader first for large archives
+  const fastGroup = await tryLoadFast3mf(fileUrl);
+  if (fastGroup) {
+    console.log(`[${new Date().toISOString()}] [load3mfGeometry] fast-3mf-loader succeeded, processing geometry.`);
+    try {
+      const mergedGeometry = collectMergedGeometryFromObject3d(fastGroup, '3MF');
+      return await processGeometry(mergedGeometry, options);
+    } catch (error) {
+      console.warn('[load3mfGeometry] fast-3mf-loader geometry processing failed; falling back to ThreeMFLoader.', error);
+    }
+  }
+
+  // Fall back to the original ThreeMFLoader
   return new Promise((resolve, reject) => {
     const loader = new ThreeMFLoader();
     console.log(`[${new Date().toISOString()}] [load3mfGeometry] Starting ThreeMFLoader load for ${fileUrl}`);

--- a/src/hooks/useStlGeometry.ts
+++ b/src/hooks/useStlGeometry.ts
@@ -1015,6 +1015,102 @@ export async function load3mfGeometryMulti(fileUrl: string, options?: ProcessGeo
   });
 }
 
+/**
+ * Loads a 3MF file and returns both a single merged geometry (all bodies
+ * combined, preserving their relative positions) and individually-processed
+ * body geometries for instant splitting.
+ *
+ * The merged result is used for the initial single-model import. The
+ * `splitBodies` array stores each body independently centered (as if
+ * imported separately) so "Split to Bodies" is instantaneous.
+ */
+export async function load3mfGeometryMergedWithSplitData(
+  fileUrl: string,
+  options?: ProcessGeometryOptions,
+): Promise<{ merged: GeometryWithBounds; splitBodies: GeometryWithBounds[] }> {
+  // Get raw individual geometries with their world transforms applied
+  const getRawGeometries = async (group: THREE.Group): Promise<THREE.BufferGeometry[]> => {
+    group.updateMatrixWorld(true);
+    const geoms: THREE.BufferGeometry[] = [];
+    group.traverse((node) => {
+      const mesh = node as THREE.Mesh;
+      if (!mesh.isMesh) return;
+      if (!(mesh.geometry instanceof THREE.BufferGeometry)) return;
+      const cloned = mesh.geometry.clone();
+      if (cloned.getAttribute('color')) cloned.deleteAttribute('color');
+      cloned.applyMatrix4(mesh.matrixWorld);
+      geoms.push(cloned);
+    });
+    return geoms;
+  };
+
+  // Try fast loader first
+  const fastGroup = await tryLoadFast3mf(fileUrl);
+  if (fastGroup) {
+    console.log(`[${new Date().toISOString()}] [load3mfGeometryMerged] fast-3mf-loader succeeded.`);
+    try {
+      const rawGeoms = await getRawGeometries(fastGroup);
+      if (rawGeoms.length === 0) throw new Error('3MF contains no mesh geometry.');
+
+      // Merge raw geometries (preserving relative positions) → single model
+      const mergedBuf = rawGeoms.length === 1
+        ? rawGeoms[0]
+        : mergeGeometries(rawGeoms, false);
+      if (!mergedBuf) throw new Error('Failed to merge 3MF bodies.');
+      const merged = await processGeometry(mergedBuf, options);
+
+      // Process each body independently (with centering) → split bodies
+      const splitBodies: GeometryWithBounds[] = [];
+      for (const raw of rawGeoms) {
+        splitBodies.push(await processGeometry(raw, options));
+      }
+
+      return { merged, splitBodies };
+    } catch (error) {
+      console.warn('[load3mfGeometryMerged] fast-3mf-loader failed; falling back to ThreeMFLoader.', error);
+    }
+  }
+
+  // Fall back to ThreeMFLoader
+  return new Promise((resolve, reject) => {
+    const loader = new ThreeMFLoader();
+    console.log(`[${new Date().toISOString()}] [load3mfGeometryMerged] ThreeMFLoader fallback for ${fileUrl}`);
+
+    loader.load(
+      fileUrl,
+      async (object) => {
+        try {
+          const rawGeoms = await getRawGeometries(object);
+          if (rawGeoms.length === 0) {
+            reject(new Error('3MF contains no mesh geometry.'));
+            return;
+          }
+
+          const mergedBuf = rawGeoms.length === 1
+            ? rawGeoms[0]
+            : mergeGeometries(rawGeoms, false);
+          if (!mergedBuf) {
+            reject(new Error('Failed to merge 3MF bodies.'));
+            return;
+          }
+          const merged = await processGeometry(mergedBuf, options);
+
+          const splitBodies: GeometryWithBounds[] = [];
+          for (const raw of rawGeoms) {
+            splitBodies.push(await processGeometry(raw, options));
+          }
+
+          resolve({ merged, splitBodies });
+        } catch (error) {
+          reject(error);
+        }
+      },
+      undefined,
+      reject,
+    );
+  });
+}
+
 export async function loadObjGeometry(fileUrl: string, options?: ProcessGeometryOptions): Promise<GeometryWithBounds> {
   return new Promise((resolve, reject) => {
     const loader = new OBJLoader();

--- a/src/hooks/useStlGeometry.ts
+++ b/src/hooks/useStlGeometry.ts
@@ -580,7 +580,7 @@ function concatUint8Arrays(a: Uint8Array, b: Uint8Array): Uint8Array {
  *
  * Falls back to null on any error (caller should use STLLoader).
  */
-async function loadStlBinaryStreaming(fileUrl: string): Promise<THREE.BufferGeometry | null> {
+export async function loadStlBinaryStreaming(fileUrl: string): Promise<THREE.BufferGeometry | null> {
   let response: Response;
   try {
     response = await fetch(fileUrl);
@@ -634,10 +634,21 @@ async function loadStlBinaryStreaming(fileUrl: string): Promise<THREE.BufferGeom
 
     // --- Phase 2: Process any triangle data already in the first chunk (after the 84-byte header) ---
     const firstTriData = firstChunk.subarray(STL_HEADER_SIZE);
-    posIndex = parseStlTrianglesInto(positions, firstTriData, posIndex);
+    const firstCompleteBytes = Math.floor(firstTriData.byteLength / BINARY_STL_TRIANGLE_BYTES)
+      * BINARY_STL_TRIANGLE_BYTES;
+    if (firstCompleteBytes > 0) {
+      posIndex = parseStlTrianglesInto(
+        positions,
+        firstTriData.subarray(0, firstCompleteBytes),
+        posIndex,
+      );
+    }
 
     // --- Phase 3: Stream remaining chunks ---
-    let pendingBuffer: Uint8Array | null = null;
+    const firstRemaining = firstTriData.byteLength - firstCompleteBytes;
+    let pendingBuffer: Uint8Array | null = firstRemaining > 0
+      ? firstTriData.slice(firstCompleteBytes)
+      : null;
 
     while (true) {
       const { value: chunk, done } = await reader.read();
@@ -657,10 +668,10 @@ async function loadStlBinaryStreaming(fileUrl: string): Promise<THREE.BufferGeom
 
       // Keep leftover bytes for next chunk
       const remaining: number = data.byteLength - completeBytes;
-      pendingBuffer = remaining > 0 ? data.subarray(completeBytes) : null;
+      pendingBuffer = remaining > 0 ? data.slice(completeBytes) : null;
     }
 
-    if (posIndex !== positions.length) {
+    if (pendingBuffer?.byteLength || posIndex !== positions.length) {
       console.warn(
         `[loadStlGeometry] Expected ${positions.length} position floats but got ${posIndex}. ` +
         `STL file may be truncated.`,

--- a/src/hooks/useStlGeometry.ts
+++ b/src/hooks/useStlGeometry.ts
@@ -51,6 +51,11 @@ export type GeometryWithBounds = {
    * Computed once during import to avoid synchronous lag when toggling the setting on.
    */
   edgeGeometry?: THREE.EdgesGeometry;
+  /** Present when an oversized native source was reduced for interactive use. */
+  nativePreview?: {
+    originalTriangleCount: number;
+    previewTriangleCount: number;
+  };
 };
 
 /**
@@ -105,6 +110,21 @@ export interface ProcessGeometryOptions {
    * Useful for surfacing progress text in import loading overlays.
    */
   onNativeProcessingStage?: (stage: 'analyzing' | 'repairing' | 'classifying' | 'postprocess') => void;
+  /**
+   * When running in Tauri, the on-disk file path for native (Rust-side) mesh
+   * loading. If provided, `loadStlGeometry` will use a Tauri IPC command to
+   * parse the STL in Rust and return pre-computed positions + normals,
+   * avoiding holding the raw file data in webview memory.
+   */
+  filePath?: string;
+  /**
+   * Skip `computeVertexNormals()` — the geometry already has a `normal`
+   * attribute (e.g. from the Rust-side STL parser).
+   * @internal
+   */
+  _skipComputeNormals?: boolean;
+  /** Skip nonessential analysis for a native reduced-detail preview. @internal */
+  _isNativePreview?: boolean;
 }
 
 // Cloning extremely large position buffers can require hundreds of MB and can
@@ -122,6 +142,12 @@ const AUTO_NATIVE_PROCESSING_TRIANGLE_THRESHOLD = 3_000_000;
 // precomputation for meshes above this threshold to avoid the wasted work.
 // The Higher Contrast Model Edges overlay simply won't be available for that model.
 const EDGE_GEOMETRY_MAX_TRIANGLES = 800_000;
+// Loading an STL file larger than this will be rejected with a user-facing
+// error. A 300 MB binary STL contains ~6M triangles, which after Three.js
+// processing (positions + normals + BVH) can consume 1-2 GB of RAM.
+// STL files above this vertex count skip non-critical post-processing
+// (flattening planes) to keep memory pressure manageable.
+const HUGE_STL_VERTEX_THRESHOLD = 15_000_000;
 
 type NativeRepairQualityGateDecision = {
   reject: boolean;
@@ -412,8 +438,12 @@ export async function processGeometry(bufferGeometry: THREE.BufferGeometry, opti
   // Yield to let the loading indicator repaint before each heavy synchronous op
   await new Promise<void>(r => setTimeout(r, 0));
 
-  console.log(`[${new Date().toISOString()}] [processGeometry] Computing Normals`);
-  geometry.computeVertexNormals();
+  if (!options._skipComputeNormals) {
+    console.log(`[${new Date().toISOString()}] [processGeometry] Computing Normals`);
+    geometry.computeVertexNormals();
+  } else {
+    console.log(`[${new Date().toISOString()}] [processGeometry] Normals already present — skipping computeVertexNormals`);
+  }
 
   console.log(`[${new Date().toISOString()}] [processGeometry] Computing BBox`);
   geometry.computeBoundingBox();
@@ -444,10 +474,22 @@ export async function processGeometry(bufferGeometry: THREE.BufferGeometry, opti
   // Yield before ConvexHull / flattening planes computation
   await new Promise<void>(r => setTimeout(r, 0));
 
-  console.log(`[${new Date().toISOString()}] [processGeometry] Computing Flattening Planes`);
-  const startPlanes = performance.now();
-  const flatteningPlanes = computeFlatteningPlanes(geometry);
-  console.log(`[${new Date().toISOString()}] [processGeometry] Flattening Planes finished. Took ${(performance.now() - startPlanes).toFixed(2)}ms`);
+  // Skip flattening planes for gigantic meshes — the ConvexHull + grid
+  // decimation still processes every vertex, adding measurable time and
+  // allocations for meshes with 15M+ vertices.
+  let flatteningPlanes: FlatteningPlane[];
+  if (options._isNativePreview || sourceVertexCount >= HUGE_STL_VERTEX_THRESHOLD) {
+    console.warn(
+      `[processGeometry] Skipping flattening planes for huge mesh (` +
+      `${sourceVertexCount.toLocaleString()} vertices).`,
+    );
+    flatteningPlanes = [];
+  } else {
+    console.log(`[${new Date().toISOString()}] [processGeometry] Computing Flattening Planes`);
+    const startPlanes = performance.now();
+    flatteningPlanes = computeFlatteningPlanes(geometry);
+    console.log(`[${new Date().toISOString()}] [processGeometry] Flattening Planes finished. Took ${(performance.now() - startPlanes).toFixed(2)}ms`);
+  }
 
   // Yield before edge geometry computation (can be expensive for large meshes)
   await new Promise<void>(r => setTimeout(r, 0));
@@ -476,7 +518,273 @@ export async function processGeometry(bufferGeometry: THREE.BufferGeometry, opti
   return { geometry, bbox, center, size, flatteningPlanes, edgeGeometry, ...(shouldSurfaceDefects ? { meshDefects } : {}) };
 }
 
-export async function loadStlGeometry(fileUrl: string, options?: ProcessGeometryOptions): Promise<GeometryWithBounds> {
+/** Number of bytes per triangle in a binary STL: 12 byte normal + 36 byte vertices + 2 byte attribute */
+const BINARY_STL_TRIANGLE_BYTES = 50;
+/** Offset of the triangle count in a binary STL header */
+const STL_HEADER_TRIANGLE_COUNT_OFFSET = 80;
+/** Total binary STL header size: 80 byte comment + 4 byte count */
+const STL_HEADER_SIZE = 84;
+/**
+ * Binary STL triangle: vertices start at byte 12 (after 12-byte normal),
+ * span 36 bytes (3 vertices × 3 floats × 4 bytes).
+ */
+const STL_TRIANGLE_VERTEX_OFFSET = 12;
+const STL_TRIANGLE_VERTEX_BYTES = 36;
+// Leave headroom for normals, BVH nodes, renderer uploads, and the rest of the
+// application. Chromium terminates the process with 0xe0000008 when a typed
+// array allocation cannot be satisfied, so this must be checked beforehand.
+const MAX_WEBVIEW_STL_POSITION_BYTES = 1_000_000_000;
+
+class StlWebviewMemoryError extends Error {}
+
+/**
+ * Parse complete binary STL triangles from a Uint8Array and write their
+ * vertex positions into the target Float32Array starting at `posIndex`.
+ * `posIndex` is the float-offset into `target`, updated in-place.
+ */
+function parseStlTrianglesInto(
+  target: Float32Array,
+  data: Uint8Array,
+  startFloatIndex: number,
+): number {
+  const triCount = Math.floor(data.byteLength / BINARY_STL_TRIANGLE_BYTES);
+  let fi = startFloatIndex;
+  for (let t = 0; t < triCount; t++) {
+    const triByteOffset = t * BINARY_STL_TRIANGLE_BYTES + STL_TRIANGLE_VERTEX_OFFSET;
+    const dv = new DataView(data.buffer, data.byteOffset + triByteOffset, STL_TRIANGLE_VERTEX_BYTES);
+    target[fi++] = dv.getFloat32(0, true);
+    target[fi++] = dv.getFloat32(4, true);
+    target[fi++] = dv.getFloat32(8, true);
+    target[fi++] = dv.getFloat32(12, true);
+    target[fi++] = dv.getFloat32(16, true);
+    target[fi++] = dv.getFloat32(20, true);
+    target[fi++] = dv.getFloat32(24, true);
+    target[fi++] = dv.getFloat32(28, true);
+    target[fi++] = dv.getFloat32(32, true);
+  }
+  return fi;
+}
+
+/** Concatenate two Uint8Arrays into a new one. */
+function concatUint8Arrays(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const result = new Uint8Array(a.byteLength + b.byteLength);
+  result.set(a, 0);
+  result.set(b, a.byteLength);
+  return result;
+}
+
+/**
+ * Streams a binary STL file, parsing triangles incrementally into a
+ * pre-allocated Float32Array. Avoids holding the entire file in memory
+ * as a single ArrayBuffer (can save ~1GB for a 20M-triangle file).
+ *
+ * Falls back to null on any error (caller should use STLLoader).
+ */
+async function loadStlBinaryStreaming(fileUrl: string): Promise<THREE.BufferGeometry | null> {
+  let response: Response;
+  try {
+    response = await fetch(fileUrl);
+  } catch {
+    return null;
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) return null;
+
+  try {
+    // --- Phase 1: Read first chunk — must contain the 84-byte header ---
+    const firstRead = await reader.read();
+    if (firstRead.done || !firstRead.value || firstRead.value.byteLength < STL_HEADER_SIZE) return null;
+
+    const firstChunk = new Uint8Array(firstRead.value.buffer, firstRead.value.byteOffset, firstRead.value.byteLength);
+
+    // Check for ASCII STL signature ("solid ")
+    const asciiSig = 'solid ';
+    let isAscii = true;
+    for (let i = 0; i < asciiSig.length; i++) {
+      if (String.fromCharCode(firstChunk[i]) !== asciiSig[i]) {
+        isAscii = false;
+        break;
+      }
+    }
+    if (isAscii) return null; // ASCII STL — fall back to STLLoader
+
+    // Read triangle count from bytes 80-83
+    const triCount = new DataView(firstChunk.buffer, firstChunk.byteOffset + STL_HEADER_TRIANGLE_COUNT_OFFSET, 4).getUint32(0, true);
+    if (triCount === 0) return null;
+
+    const expectedStlSize = STL_HEADER_SIZE + triCount * BINARY_STL_TRIANGLE_BYTES;
+    const positionBytes = triCount * 9 * Float32Array.BYTES_PER_ELEMENT;
+    if (!Number.isSafeInteger(positionBytes) || positionBytes > MAX_WEBVIEW_STL_POSITION_BYTES) {
+      throw new StlWebviewMemoryError(
+        `This STL contains ${triCount.toLocaleString()} triangles and needs at least ` +
+        `${(positionBytes / 1_000_000_000).toFixed(2)} GB for positions in the WebView. ` +
+        'Open it from a desktop file path so DragonFruit can use the native STL loader.',
+      );
+    }
+    console.warn(
+      `[loadStlGeometry] Streaming ${triCount.toLocaleString()} triangles ` +
+      `(${(expectedStlSize / 1_000_000_000).toFixed(2)} GB file). ` +
+      `Pre-allocating ${((triCount * 9 * 4) / 1_000_000_000).toFixed(2)} GB position buffer.`,
+    );
+
+    // Pre-allocate the position buffer (9 floats per triangle: 3 vertices × 3 coords)
+    const positions = new Float32Array(triCount * 9);
+    let posIndex = 0;
+
+    // --- Phase 2: Process any triangle data already in the first chunk (after the 84-byte header) ---
+    const firstTriData = firstChunk.subarray(STL_HEADER_SIZE);
+    posIndex = parseStlTrianglesInto(positions, firstTriData, posIndex);
+
+    // --- Phase 3: Stream remaining chunks ---
+    let pendingBuffer: Uint8Array | null = null;
+
+    while (true) {
+      const { value: chunk, done } = await reader.read();
+      if (done) break;
+      if (!chunk) continue;
+
+      // Combine with any pending bytes from previous iteration
+      const data: Uint8Array = pendingBuffer
+        ? concatUint8Arrays(pendingBuffer, new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength))
+        : new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+
+      // Count complete triangles in this buffer
+      const completeBytes = Math.floor(data.byteLength / BINARY_STL_TRIANGLE_BYTES) * BINARY_STL_TRIANGLE_BYTES;
+      if (completeBytes > 0) {
+        posIndex = parseStlTrianglesInto(positions, data.subarray(0, completeBytes), posIndex);
+      }
+
+      // Keep leftover bytes for next chunk
+      const remaining: number = data.byteLength - completeBytes;
+      pendingBuffer = remaining > 0 ? data.subarray(completeBytes) : null;
+    }
+
+    if (posIndex !== positions.length) {
+      console.warn(
+        `[loadStlGeometry] Expected ${positions.length} position floats but got ${posIndex}. ` +
+        `STL file may be truncated.`,
+      );
+    }
+
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(
+      posIndex === positions.length ? positions : positions.slice(0, posIndex),
+      3,
+    ));
+
+    return geometry;
+  } catch (error) {
+    if (error instanceof StlWebviewMemoryError) throw error;
+    console.warn('[loadStlGeometry] Streaming STL failed; falling back to STLLoader.', error);
+    return null;
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+}
+
+/**
+ * Use the Rust-side STL parser via Tauri IPC. Returns a BufferGeometry with
+ * pre-computed vertex normals, skipping the expensive JS-side computation.
+ * Uses dynamic import to avoid loading @tauri-apps/api at module init time.
+ */
+type NativeStlLoadResult = {
+  geometry: THREE.BufferGeometry;
+  originalTriangleCount: number;
+  previewTriangleCount: number;
+  isPreview: boolean;
+};
+
+async function loadStlViaTauri(filePath: string): Promise<NativeStlLoadResult | null> {
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const bytes = await invoke<ArrayBuffer>('load_stl_file', { filePath });
+    if (!bytes || bytes.byteLength === 0) return null;
+
+    if (bytes.byteLength < 16) return null;
+    const header = new DataView(bytes, 0, 16);
+    const hasMagic = header.getUint8(0) === 0x44
+      && header.getUint8(1) === 0x46
+      && header.getUint8(2) === 0x53
+      && header.getUint8(3) === 0x54;
+    if (!hasMagic) throw new Error('Native STL loader returned an unsupported response.');
+
+    const flags = header.getUint32(4, true);
+    const originalTriangleCount = header.getUint32(8, true);
+    const previewTriangleCount = header.getUint32(12, true);
+    const expectedBytes = 16 + previewTriangleCount * 18 * Float32Array.BYTES_PER_ELEMENT;
+    if (previewTriangleCount === 0 || bytes.byteLength !== expectedBytes) {
+      throw new Error('Native STL loader returned a truncated response.');
+    }
+
+    const positions = new Float32Array(bytes, 16, previewTriangleCount * 9);
+    const normals = new Float32Array(
+      bytes,
+      16 + previewTriangleCount * 9 * Float32Array.BYTES_PER_ELEMENT,
+      previewTriangleCount * 9,
+    );
+
+    const geometry = new THREE.BufferGeometry();
+    // Both attributes retain the IPC ArrayBuffer. Avoiding slice() here removes
+    // two full-size allocation spikes immediately after the native transfer.
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
+
+    console.log(
+      `[loadStlGeometry] Tauri Rust parser loaded ${previewTriangleCount.toLocaleString()} triangles ` +
+      `(${(bytes.byteLength / 1_000_000).toFixed(0)} MB IPC transfer).`,
+    );
+    if ((flags & 1) !== 0) {
+      console.warn(
+        `[loadStlGeometry] Using a reduced native preview: ` +
+        `${originalTriangleCount.toLocaleString()} -> ${previewTriangleCount.toLocaleString()} triangles.`,
+      );
+    }
+    return {
+      geometry,
+      originalTriangleCount,
+      previewTriangleCount,
+      isPreview: (flags & 1) !== 0,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[loadStlGeometry] Tauri Rust parser failed.', error);
+    throw new Error(message || 'Native STL loading failed.');
+  }
+}
+
+export async function loadStlGeometry(fileUrl: string, options: ProcessGeometryOptions = {}): Promise<GeometryWithBounds> {
+  // In Tauri with a file path, use the Rust-side STL parser.
+  // It reads the file directly from disk, computes normals, and avoids
+  // holding the raw STL bytes in webview memory — critical for huge files.
+  if (isTauriRuntime() && options.filePath) {
+    const nativeResult = await loadStlViaTauri(options.filePath);
+    if (nativeResult) {
+      // Normals are already computed — skip computeVertexNormals in processGeometry
+      const processed = await processGeometry(nativeResult.geometry, {
+        ...options,
+        _skipComputeNormals: true,
+        _isNativePreview: nativeResult.isPreview,
+        ...(nativeResult.isPreview ? { nativeProcessingMode: 'none' as const } : {}),
+      });
+      if (nativeResult.isPreview) {
+        processed.nativePreview = {
+          originalTriangleCount: nativeResult.originalTriangleCount,
+          previewTriangleCount: nativeResult.previewTriangleCount,
+        };
+      }
+      return processed;
+    }
+  }
+
+  // Try streaming binary STL parser — avoids holding the entire file as ArrayBuffer
+  const streamed = await loadStlBinaryStreaming(fileUrl);
+  if (streamed) {
+    console.log(`[${new Date().toISOString()}] [loadStlGeometry] Streaming parser succeeded, processing geometry.`);
+    return processGeometry(streamed, options);
+  }
+
+  // Fall back to Three.js STLLoader (handles ASCII STL, edge cases, etc.)
   return new Promise((resolve, reject) => {
     const loader = new STLLoader();
     console.log(`[${new Date().toISOString()}] [loadStlGeometry] Starting STLLoader load for ${fileUrl}`);


### PR DESCRIPTION
This PR introduces multiple improvements for mesh geometry loading, including Rust sideloading to support even 2GB STL files, ignoring 3MF 3rd party extension, and allowing users to split 3MF multi-body files into individual bodies.