### PR TITLE
ci: enable Windows long paths for Tauri builds

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -367,6 +367,12 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Enable Windows long paths
+        if: runner.os == 'Windows'
+        run: |
+          git config --system core.longpaths true
+          reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
+
       - name: Build Tauri bundle (Windows)
         if: matrix.build_kind == 'tauri'
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/dev-prerelease.yml
+++ b/.github/workflows/dev-prerelease.yml
@@ -130,6 +130,12 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Enable Windows long paths
+        if: runner.os == 'Windows'
+        run: |
+          git config --system core.longpaths true
+          reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
+
       - name: Build Tauri bundle
         if: matrix.build_kind == 'tauri'
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -130,6 +130,12 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
+      - name: Enable Windows long paths
+        if: runner.os == 'Windows'
+        run: |
+          git config --system core.longpaths true
+          reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
+
       - name: Build Tauri bundle
         if: matrix.build_kind == 'tauri'
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
The Windows Tauri builds fail when `manifold-csg-sys` fetches `oneTBB` via CMake FetchContent: git checkout of the TBB source tree hits the 260-char (thanks windows) `MAX_PATH` limit on a deeply nested file
(rfcs/proposed/task_group_dynamic_dependencies/assets/...png) (ref: https://github.com/Open-Resin-Alliance/DragonFruit/actions/runs/27854440318/job/82439180344#step:8:640) under the cargo target build dir, aborting the cmake configure step.

Enable `git core.longpaths` and the OS LongPathsEnabled flag on the Windows runner before building so the long TBB paths can be written.