### PR TITLE
feat: Support Separation

### DIFF
--- a/rust/dragonfruit-mesh-repair/src/analysis.rs
+++ b/rust/dragonfruit-mesh-repair/src/analysis.rs
@@ -94,75 +94,7 @@ pub fn analyze(mesh: &IndexedMesh) -> MeshAnalysis {
     let boundary_loops = boundary_loops_vec.len();
     let inconsistent_winding_edges = topo.inconsistent_edges();
 
-    // Non-manifold vertex: the one-ring fans break into ≥ 2 disconnected
-    // components around the vertex.
-    let non_manifold_vertices = {
-        let mut count = 0usize;
-        for (vi, faces) in topo.vertex_faces.iter().enumerate() {
-            if faces.len() < 2 {
-                continue;
-            }
-            let vi = vi as u32;
-            // Faces are connected if they share an edge containing `vi`.
-            let n = faces.len();
-            let mut parent: Vec<usize> = (0..n).collect();
-            fn find(p: &mut [usize], i: usize) -> usize {
-                let mut r = i;
-                while p[r] != r {
-                    r = p[r];
-                }
-                let mut cur = i;
-                while p[cur] != r {
-                    let next = p[cur];
-                    p[cur] = r;
-                    cur = next;
-                }
-                r
-            }
-            for i in 0..n {
-                for j in (i + 1)..n {
-                    let fa = mesh.triangles[faces[i] as usize];
-                    let fb = mesh.triangles[faces[j] as usize];
-                    // Other two verts in each.
-                    let oa: [u32; 2] = {
-                        let mut out = [0u32; 2];
-                        let mut k = 0;
-                        for &v in &fa {
-                            if v != vi && k < 2 {
-                                out[k] = v;
-                                k += 1;
-                            }
-                        }
-                        out
-                    };
-                    let ob: [u32; 2] = {
-                        let mut out = [0u32; 2];
-                        let mut k = 0;
-                        for &v in &fb {
-                            if v != vi && k < 2 {
-                                out[k] = v;
-                                k += 1;
-                            }
-                        }
-                        out
-                    };
-                    let shared = oa.iter().any(|a| ob.contains(a));
-                    if shared {
-                        let ri = find(&mut parent, i);
-                        let rj = find(&mut parent, j);
-                        if ri != rj {
-                            parent[ri] = rj;
-                        }
-                    }
-                }
-            }
-            let roots: ahash::AHashSet<usize> = (0..n).map(|i| find(&mut parent, i)).collect();
-            if roots.len() > 1 {
-                count += 1;
-            }
-        }
-        count
-    };
+    let non_manifold_vertices = count_non_manifold_vertices(mesh, &topo);
 
     let t_components = std::time::Instant::now();
     let connected_components = count_components(mesh);
@@ -211,6 +143,173 @@ pub fn analyze(mesh: &IndexedMesh) -> MeshAnalysis {
             total_ms,
         },
     }
+}
+
+/// Lightweight analysis that skips self-intersection detection (the most
+/// expensive phase). Suitable for classify-only paths where we only need
+/// basic topology stats to populate a report, not full defect diagnosis.
+pub fn analyze_lightweight(mesh: &IndexedMesh) -> MeshAnalysis {
+    let t_start = std::time::Instant::now();
+
+    let bbox = mesh.bbox();
+    let signed_volume = mesh.signed_volume();
+
+    let t_topo = std::time::Instant::now();
+    let topo = Topology::build(mesh);
+    let topology_ms = t_topo.elapsed().as_secs_f64() * 1000.0;
+
+    let mut degenerate_triangles = 0usize;
+    let mut duplicate_triangles = {
+        let mut set: ahash::AHashSet<(u32, u32, u32)> =
+            ahash::AHashSet::with_capacity(mesh.triangles.len());
+        let mut dups = 0usize;
+        for tri in &mesh.triangles {
+            let mut s = *tri;
+            s.sort();
+            let key = (s[0], s[1], s[2]);
+            if !set.insert(key) {
+                dups += 1;
+            }
+        }
+        dups
+    };
+    for tri in &mesh.triangles {
+        if tri[0] == tri[1] || tri[1] == tri[2] || tri[0] == tri[2] {
+            degenerate_triangles += 1;
+            continue;
+        }
+    }
+    if duplicate_triangles > mesh.triangles.len() {
+        duplicate_triangles = mesh.triangles.len();
+    }
+
+    let non_manifold_edges = topo.non_manifold_edges().len();
+    let boundary_edges_vec = topo.boundary_edges();
+    let boundary_edges = boundary_edges_vec.len();
+    let boundary_loops_vec = topo.boundary_loops();
+    let largest_boundary_loop = boundary_loops_vec
+        .iter()
+        .map(|l| l.len())
+        .max()
+        .unwrap_or(0);
+    let boundary_loops = boundary_loops_vec.len();
+    let inconsistent_winding_edges = topo.inconsistent_edges();
+
+    let non_manifold_vertices = count_non_manifold_vertices(mesh, &topo);
+
+    let t_components = std::time::Instant::now();
+    let connected_components = count_components(mesh);
+    let components_ms = t_components.elapsed().as_secs_f64() * 1000.0;
+
+    // Skip self-intersection detection — the expensive BVH-based pass.
+    let self_intersection_triangles = 0;
+    let self_intersections_ms = 0.0;
+
+    let is_watertight = boundary_edges == 0 && non_manifold_edges == 0;
+    let is_oriented = inconsistent_winding_edges == 0 && signed_volume >= 0.0;
+
+    let total_ms = t_start.elapsed().as_secs_f64() * 1000.0;
+
+    MeshAnalysis {
+        vertex_count: mesh.vertex_count(),
+        triangle_count: mesh.triangle_count(),
+        bbox_min: if bbox.min.x.is_finite() {
+            [bbox.min.x, bbox.min.y, bbox.min.z]
+        } else {
+            [0.0; 3]
+        },
+        bbox_max: if bbox.max.x.is_finite() {
+            [bbox.max.x, bbox.max.y, bbox.max.z]
+        } else {
+            [0.0; 3]
+        },
+        signed_volume,
+        duplicate_vertices: 0,
+        degenerate_triangles,
+        duplicate_triangles,
+        non_manifold_edges,
+        non_manifold_vertices,
+        boundary_edges,
+        boundary_loops,
+        largest_boundary_loop,
+        inconsistent_winding_edges,
+        self_intersection_triangles,
+        connected_components,
+        is_watertight,
+        is_oriented,
+        timings_ms: AnalysisTimings {
+            topology_ms,
+            self_intersections_ms,
+            components_ms,
+            total_ms,
+        },
+    }
+}
+
+fn count_non_manifold_vertices(mesh: &IndexedMesh, topo: &Topology) -> usize {
+    let mut count = 0usize;
+    for (vi, faces) in topo.vertex_faces.iter().enumerate() {
+        if faces.len() < 2 {
+            continue;
+        }
+        let vi = vi as u32;
+        let n = faces.len();
+        let mut parent: Vec<usize> = (0..n).collect();
+        fn find(p: &mut [usize], i: usize) -> usize {
+            let mut r = i;
+            while p[r] != r {
+                r = p[r];
+            }
+            let mut cur = i;
+            while p[cur] != r {
+                let next = p[cur];
+                p[cur] = r;
+                cur = next;
+            }
+            r
+        }
+        for i in 0..n {
+            for j in (i + 1)..n {
+                let fa = mesh.triangles[faces[i] as usize];
+                let fb = mesh.triangles[faces[j] as usize];
+                let oa: [u32; 2] = {
+                    let mut out = [0u32; 2];
+                    let mut k = 0;
+                    for &v in &fa {
+                        if v != vi && k < 2 {
+                            out[k] = v;
+                            k += 1;
+                        }
+                    }
+                    out
+                };
+                let ob: [u32; 2] = {
+                    let mut out = [0u32; 2];
+                    let mut k = 0;
+                    for &v in &fb {
+                        if v != vi && k < 2 {
+                            out[k] = v;
+                            k += 1;
+                        }
+                    }
+                    out
+                };
+                let shared = oa.iter().any(|a| ob.contains(a));
+                if shared {
+                    let ri = find(&mut parent, i);
+                    let rj = find(&mut parent, j);
+                    if ri != rj {
+                        parent[ri] = rj;
+                    }
+                }
+            }
+        }
+        let roots: ahash::AHashSet<usize> = (0..n).map(|i| find(&mut parent, i)).collect();
+        if roots.len() > 1 {
+            count += 1;
+        }
+    }
+    count
 }
 
 fn count_components(mesh: &IndexedMesh) -> usize {
@@ -301,7 +400,11 @@ pub fn count_self_intersections(mesh: &IndexedMesh) -> usize {
                     hit = true;
                 }
             });
-            if hit { 1 } else { 0 }
+            if hit {
+                1
+            } else {
+                0
+            }
         })
         .collect();
 

--- a/rust/dragonfruit-mesh-repair/src/analysis.rs
+++ b/rust/dragonfruit-mesh-repair/src/analysis.rs
@@ -246,6 +246,59 @@ pub fn analyze_lightweight(mesh: &IndexedMesh) -> MeshAnalysis {
     }
 }
 
+/// Minimal analysis for classification-only paths. Only computes O(n) cheap
+/// stats (bbox, volume, vertex/triangle counts) and accepts the component
+/// count from the caller (already computed by the classifier's own
+/// `triangle_components` pass). Skips half-edge topology, self-intersection
+/// detection, duplicate/degenerate detection, and boundary-loop extraction.
+/// Runs in a single pass over positions + a single pass over triangles.
+pub fn minimal_analysis(mesh: &IndexedMesh, component_count: usize) -> MeshAnalysis {
+    let t_start = std::time::Instant::now();
+
+    let bbox = mesh.bbox();
+    let signed_volume = mesh.signed_volume();
+
+    let total_ms = t_start.elapsed().as_secs_f64() * 1000.0;
+
+    let is_watertight = false; // not computed
+    let is_oriented = signed_volume >= 0.0;
+
+    MeshAnalysis {
+        vertex_count: mesh.vertex_count(),
+        triangle_count: mesh.triangle_count(),
+        bbox_min: if bbox.min.x.is_finite() {
+            [bbox.min.x, bbox.min.y, bbox.min.z]
+        } else {
+            [0.0; 3]
+        },
+        bbox_max: if bbox.max.x.is_finite() {
+            [bbox.max.x, bbox.max.y, bbox.max.z]
+        } else {
+            [0.0; 3]
+        },
+        signed_volume,
+        duplicate_vertices: 0,
+        degenerate_triangles: 0,
+        duplicate_triangles: 0,
+        non_manifold_edges: 0,
+        non_manifold_vertices: 0,
+        boundary_edges: 0,
+        boundary_loops: 0,
+        largest_boundary_loop: 0,
+        inconsistent_winding_edges: 0,
+        self_intersection_triangles: 0,
+        connected_components: component_count,
+        is_watertight,
+        is_oriented,
+        timings_ms: AnalysisTimings {
+            topology_ms: 0.0,
+            self_intersections_ms: 0.0,
+            components_ms: 0.0,
+            total_ms,
+        },
+    }
+}
+
 fn count_non_manifold_vertices(mesh: &IndexedMesh, topo: &Topology) -> usize {
     let mut count = 0usize;
     for (vi, faces) in topo.vertex_faces.iter().enumerate() {

--- a/rust/dragonfruit-mesh-repair/src/lib.rs
+++ b/rust/dragonfruit-mesh-repair/src/lib.rs
@@ -12,7 +12,7 @@ pub mod io;
 pub mod repair;
 pub mod report;
 
-pub use crate::analysis::{analyze, analyze_lightweight, MeshAnalysis};
+pub use crate::analysis::{analyze, minimal_analysis, MeshAnalysis};
 pub use crate::core::mesh::{IndexedMesh, Vec3};
 pub use crate::hollowing::{
     hollow_voxel, punch_cylinders, DrainHoleSpec, HolePunchOptions, HolePunchOutcome,

--- a/rust/dragonfruit-mesh-repair/src/lib.rs
+++ b/rust/dragonfruit-mesh-repair/src/lib.rs
@@ -12,7 +12,7 @@ pub mod io;
 pub mod repair;
 pub mod report;
 
-pub use crate::analysis::{analyze, MeshAnalysis};
+pub use crate::analysis::{analyze, analyze_lightweight, MeshAnalysis};
 pub use crate::core::mesh::{IndexedMesh, Vec3};
 pub use crate::hollowing::{
     hollow_voxel, punch_cylinders, DrainHoleSpec, HolePunchOptions, HolePunchOutcome,

--- a/rust/dragonfruit-mesh-repair/src/repair.rs
+++ b/rust/dragonfruit-mesh-repair/src/repair.rs
@@ -18,7 +18,7 @@ use ahash::{AHashMap, AHashSet};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::analysis::{analyze, analyze_lightweight, MeshAnalysis};
+use crate::analysis::{analyze, minimal_analysis, MeshAnalysis};
 use crate::arrangement::corefine_self_intersections;
 use crate::core::bvh::Bvh;
 use crate::core::halfedge::{edge_key, Topology};
@@ -671,7 +671,7 @@ pub fn repair(mut mesh: IndexedMesh, options: &RepairOptions) -> RepairOutcome {
     // per-section tinting can still work.
     if report.model_triangle_count.is_none() {
         let t = std::time::Instant::now();
-        if let Some((model_tri_count, likely_support_geometry)) =
+        if let Some((model_tri_count, likely_support_geometry, _comp_count)) =
             classify_and_reorder_model_support_triangles(&mut mesh)
         {
             report.model_triangle_count = Some(model_tri_count);
@@ -748,15 +748,15 @@ pub fn repair(mut mesh: IndexedMesh, options: &RepairOptions) -> RepairOutcome {
 pub fn classify_support_split(mut mesh: IndexedMesh) -> RepairOutcome {
     let t_start = std::time::Instant::now();
 
-    // Use lightweight analysis — classification doesn't need expensive
-    // self-intersection detection. The pre-analysis is treated as both
-    // pre and post since the classifier only reorders triangles, it does
-    // not alter topology.
-    let pre = analyze_lightweight(&mesh);
-    let mut report = MeshHealthReport::new(pre.clone());
+    // Pre-analysis with placeholder component count — the classifier
+    // computes union-find internally and returns the real count, which
+    // we use for both pre and post (classification only reorders
+    // triangles; topology — and therefore component count — is unchanged).
+    let pre = minimal_analysis(&mesh, 0);
+    let mut report = MeshHealthReport::new(pre);
 
     let t = std::time::Instant::now();
-    if let Some((model_tri_count, likely_support_geometry)) =
+    let component_count = if let Some((model_tri_count, likely_support_geometry, cc)) =
         classify_and_reorder_model_support_triangles(&mut mesh)
     {
         report.model_triangle_count = Some(model_tri_count);
@@ -770,6 +770,7 @@ pub fn classify_support_split(mut mesh: IndexedMesh) -> RepairOutcome {
             )),
             elapsed_ms: t.elapsed().as_secs_f64() * 1000.0,
         });
+        cc
     } else {
         report.steps.push(RepairStepReport {
             name: "classify_support_geometry_split".into(),
@@ -777,13 +778,19 @@ pub fn classify_support_split(mut mesh: IndexedMesh) -> RepairOutcome {
             notes: Some("classify-only split: no reliable model/support partition found".into()),
             elapsed_ms: t.elapsed().as_secs_f64() * 1000.0,
         });
-    }
+        // Fall back to computing components ourselves for the report.
+        triangle_components(&mesh)
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(0) as usize
+            + 1
+    };
 
-    // Post-analysis: run lightweight after the triangle reorder. Since the
-    // classifier only permutes triangle order (no topology changes), pre and
-    // post are nearly identical. A full analyze() would waste time on BVH
-    // self-intersection detection for zero benefit here.
-    report.post = analyze_lightweight(&mesh);
+    // Patch the pre-analysis with the real component count and build the
+    // post-analysis (identical since only triangle order changed).
+    report.pre.connected_components = component_count;
+    report.post = minimal_analysis(&mesh, component_count);
     report.fully_repaired = true;
     report.residual_issues = Vec::new();
     report.total_ms = t_start.elapsed().as_secs_f64() * 1000.0;
@@ -2271,8 +2278,12 @@ fn cull_interior_components(mesh: &mut IndexedMesh) -> (usize, usize) {
 /// support sections by connected component height bands, then reorders the
 /// mesh triangles so model section comes first and support section follows.
 ///
-/// Returns `(model_triangle_count, likely_support_geometry)` on success.
-fn classify_and_reorder_model_support_triangles(mesh: &mut IndexedMesh) -> Option<(usize, bool)> {
+/// Returns `(model_triangle_count, likely_support_geometry, component_count)`
+/// on success.  The component count is the total number of connected components
+/// before reordering, which the caller can reuse to avoid a second union-find.
+fn classify_and_reorder_model_support_triangles(
+    mesh: &mut IndexedMesh,
+) -> Option<(usize, bool, usize)> {
     if mesh.triangles.len() < 8 || mesh.positions.is_empty() {
         return None;
     }
@@ -2422,7 +2433,7 @@ fn classify_and_reorder_model_support_triangles(mesh: &mut IndexedMesh) -> Optio
         support_input_triangles,
     );
 
-    Some((model_triangles_out, likely_support_geometry))
+    Some((model_triangles_out, likely_support_geometry, n_comps))
 }
 
 /// Assign a component id to each triangle via union-find over shared edges;

--- a/rust/dragonfruit-mesh-repair/src/repair.rs
+++ b/rust/dragonfruit-mesh-repair/src/repair.rs
@@ -18,7 +18,7 @@ use ahash::{AHashMap, AHashSet};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::analysis::{analyze, MeshAnalysis};
+use crate::analysis::{analyze, analyze_lightweight, MeshAnalysis};
 use crate::arrangement::corefine_self_intersections;
 use crate::core::bvh::Bvh;
 use crate::core::halfedge::{edge_key, Topology};
@@ -747,8 +747,13 @@ pub fn repair(mut mesh: IndexedMesh, options: &RepairOptions) -> RepairOutcome {
 /// can apply section-specific tinting while honoring "Load As-Is" behavior.
 pub fn classify_support_split(mut mesh: IndexedMesh) -> RepairOutcome {
     let t_start = std::time::Instant::now();
-    let pre = analyze(&mesh);
-    let mut report = MeshHealthReport::new(pre);
+
+    // Use lightweight analysis — classification doesn't need expensive
+    // self-intersection detection. The pre-analysis is treated as both
+    // pre and post since the classifier only reorders triangles, it does
+    // not alter topology.
+    let pre = analyze_lightweight(&mesh);
+    let mut report = MeshHealthReport::new(pre.clone());
 
     let t = std::time::Instant::now();
     if let Some((model_tri_count, likely_support_geometry)) =
@@ -774,8 +779,11 @@ pub fn classify_support_split(mut mesh: IndexedMesh) -> RepairOutcome {
         });
     }
 
-    report.post = analyze(&mesh);
-    // Classification-only path does not attempt topology repair.
+    // Post-analysis: run lightweight after the triangle reorder. Since the
+    // classifier only permutes triangle order (no topology changes), pre and
+    // post are nearly identical. A full analyze() would waste time on BVH
+    // self-intersection detection for zero benefit here.
+    report.post = analyze_lightweight(&mesh);
     report.fully_repaired = true;
     report.residual_issues = Vec::new();
     report.total_ms = t_start.elapsed().as_secs_f64() * 1000.0;

--- a/rust/dragonfruit-slicing-engine/src/engine.rs
+++ b/rust/dragonfruit-slicing-engine/src/engine.rs
@@ -533,16 +533,32 @@ struct SupportMaskLayer {
 }
 
 impl SupportMaskContext {
-    fn from_job(job: &SliceJobV3) -> Option<Self> {
+    fn from_job(job: &SliceJobV3, triangles_xyz: &[f32]) -> Option<Self> {
         if job.aa_on_supports {
+            eprintln!(
+                "[SupportAA] full-mask support context disabled: aa_on_supports=true"
+            );
             return None;
         }
 
-        let total_triangles = job.triangles_xyz.len() / 9;
+        let total_triangles = triangles_xyz.len() / 9;
         let model_triangle_count = (job.model_triangle_count as usize).min(total_triangles);
         if model_triangle_count == 0 || model_triangle_count >= total_triangles {
+            eprintln!(
+                "[SupportAA] full-mask support context disabled: model_triangles={} total_triangles={}",
+                model_triangle_count, total_triangles
+            );
             return None;
         }
+
+        eprintln!(
+            "[SupportAA] full-mask support context enabled: model_triangles={} support_triangles={} total_triangles={} mode={} level={}",
+            model_triangle_count,
+            total_triangles - model_triangle_count,
+            total_triangles,
+            job.anti_aliasing_mode,
+            job.anti_aliasing_level,
+        );
 
         let mut support_job = job.clone();
         support_job.anti_aliasing_level = "Off".to_string();
@@ -552,7 +568,7 @@ impl SupportMaskContext {
         support_job.aa_on_supports = true;
         support_job.model_triangle_count = 0;
 
-        let mut triangles = parse_triangles(&support_job.triangles_xyz);
+        let mut triangles = parse_triangles(triangles_xyz);
         project_triangles_inplace(&mut triangles, &support_job);
         let layer_index = build_layer_index(
             &triangles,
@@ -1975,7 +1991,11 @@ fn rasterize_vertical_aa_streaming_v3(
     // They are recovered at the end via `encode_handle_guard.finish()`.
     // ──────────────────────────────────────────────────────────────────────────
 
-    let mut support_mask_context = SupportMaskContext::from_job(raster_job);
+    // `raster_job.triangles_xyz` is intentionally cleared above to avoid a
+    // multi-GB duplicate. Build support masking from the real external mesh
+    // buffer or classified model/support boundaries silently disappear.
+    let mut support_mask_context =
+        SupportMaskContext::from_job(raster_job, &raster_triangles_xyz);
     let model_active_layer_window = resolve_model_active_layer_window(raster_job);
 
     // Pending queue for symmetric forward-compensation blending.
@@ -3396,6 +3416,18 @@ pub fn slice_and_rasterize_rle_v3(
         } else {
             None
         };
+    eprintln!(
+        "[SupportAA] RLE raster partition: enabled={} model_triangles={} support_triangles={} total_triangles={} aa_on_supports={} mode={} level={}",
+        support_split_model_triangle_count.is_some(),
+        support_split_model_triangle_count.unwrap_or(triangles.len()),
+        support_split_model_triangle_count
+            .map(|count| triangles.len().saturating_sub(count))
+            .unwrap_or(0),
+        triangles.len(),
+        job.aa_on_supports,
+        job.anti_aliasing_mode,
+        job.anti_aliasing_level,
+    );
     let index_start = std::time::Instant::now();
     let layer_index = build_layer_index(
         &triangles,
@@ -3516,6 +3548,16 @@ pub fn slice_and_rasterize_perturb_3daa_rle_v3(
     } else {
         None
     };
+    eprintln!(
+        "[SupportAA] perturb-3DAA RLE partition: enabled={} model_triangles={} support_triangles={} total_triangles={} aa_on_supports={}",
+        support_split_model_triangle_count.is_some(),
+        support_split_model_triangle_count.unwrap_or(triangles.len()),
+        support_split_model_triangle_count
+            .map(|count| triangles.len().saturating_sub(count))
+            .unwrap_or(0),
+        triangles.len(),
+        job.aa_on_supports,
+    );
 
     let index_start = std::time::Instant::now();
     let layer_index = build_layer_index(
@@ -3906,6 +3948,20 @@ pub fn slice_and_rasterize_rle_encoded_v3(
         } else {
             None
         };
+    eprintln!(
+        "[SupportAA] encoded-RLE raster partition: enabled={} model_triangles={} support_triangles={} total_triangles={} aa_on_supports={} mode={} level={} blur_radius={} ssaa_factor={}",
+        support_split_model_triangle_count.is_some(),
+        support_split_model_triangle_count.unwrap_or(triangles.len()),
+        support_split_model_triangle_count
+            .map(|count| triangles.len().saturating_sub(count))
+            .unwrap_or(0),
+        triangles.len(),
+        job.aa_on_supports,
+        job.anti_aliasing_mode,
+        job.anti_aliasing_level,
+        blur_radius,
+        ssaa_factor,
+    );
     let index_start = std::time::Instant::now();
     let layer_index = build_layer_index(
         &triangles,
@@ -4660,6 +4716,23 @@ mod tests {
     }
 
     #[test]
+    fn perturb_3daa_rle_keeps_classified_support_geometry_binary() {
+        let mut job = base_perturb_3daa_rle_test_job();
+        job.model_triangle_count = 12;
+
+        // Keep model geometry above layer 0 so that layer contains only the
+        // classified support half of the combined triangle stream.
+        push_box_triangles(&mut job.triangles_xyz, 0.0, 0.0, 2.0, 3.0, 20.0, 20.0);
+        push_box_triangles(&mut job.triangles_xyz, 0.0, 0.0, 0.0, 0.8, 20.0, 20.0);
+
+        let support_layer = render_perturb_3daa_rle_test_layer(&job, 0);
+        assert!(
+            support_layer.iter().all(|&px| px == 0 || px == 255),
+            "classified support geometry must bypass perturbation and post-process AA"
+        );
+    }
+
+    #[test]
     fn perturb_3daa_rle_path_applies_xy_blur_without_full_mask_pump() {
         let mut unblurred = base_perturb_3daa_rle_test_job();
         unblurred.blur_brush_radius_px = 0;
@@ -4818,7 +4891,9 @@ mod tests {
         push_box_triangles(&mut flat, 0.0, 0.0, 0.0, 0.8, 20.0, 20.0);
 
         job.triangles_xyz = flat;
-        let mut ctx = super::SupportMaskContext::from_job(&job).expect(
+        let mut context_job = job.clone();
+        context_job.triangles_xyz.clear();
+        let mut ctx = super::SupportMaskContext::from_job(&context_job, &job.triangles_xyz).expect(
             "split support metadata should enable support masking when support AA is disabled",
         );
         let support_layer = ctx

--- a/rust/dragonfruit-slicing-engine/src/pipeline.rs
+++ b/rust/dragonfruit-slicing-engine/src/pipeline.rs
@@ -260,8 +260,19 @@ fn rasterize_layer_rle_with_support_split(
         rasterize_layer_rle(job, triangles, &model_layer_indices, layer, false).0
     };
 
+    // Support geometry must be binary before it is held aside from the model
+    // AA post-process. This matters for perturbation 3DAA, whose rasterizer
+    // itself emits grayscale coverage before the later XY/Z blur stages.
+    let mut support_job = job.clone();
+    support_job.anti_aliasing_level = "Off".to_string();
+    support_job.anti_aliasing_mode = "Coverage".to_string();
+    support_job.blur_brush_radius_px = 0;
+    support_job.minimum_aa_alpha_percent = 100.0;
+    support_job.aa_on_supports = true;
+    support_job.model_triangle_count = 0;
+
     let (support_runs, support_stats) = rasterize_layer_rle(
-        job,
+        &support_job,
         triangles,
         &support_layer_indices,
         layer,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1400,6 +1400,49 @@ async fn slice_solid_native_to_temp_path(
             metadata_json: meta.metadata_json,
         };
 
+        eprintln!(
+            "[SupportAA] native job decoded: model_triangles={} support_triangles={} total_triangles={} aa_on_supports={} mode={} level={} mesh_encoding={}",
+            job.model_triangle_count,
+            (job.triangles_xyz.len() / 9).saturating_sub(job.model_triangle_count as usize),
+            job.triangles_xyz.len() / 9,
+            job.aa_on_supports,
+            job.anti_aliasing_mode,
+            job.anti_aliasing_level,
+            meta.mesh_encoding.as_deref().unwrap_or("raw_f32"),
+        );
+        let fingerprint = |start: usize, end: usize| {
+            let mut hash = 0x811c9dc5u32;
+            for value in &job.triangles_xyz[start.min(job.triangles_xyz.len())
+                ..end.min(job.triangles_xyz.len())]
+            {
+                hash ^= value.to_bits();
+                hash = hash.wrapping_mul(0x01000193);
+            }
+            format!("{hash:08x}")
+        };
+        let multiset_fingerprint = |start: usize, end: usize| {
+            let mut xor = 0u32;
+            let mut sum = 0u32;
+            for value in &job.triangles_xyz[start.min(job.triangles_xyz.len())
+                ..end.min(job.triangles_xyz.len())]
+            {
+                let bits = value.to_bits();
+                xor ^= bits;
+                sum = sum.wrapping_add(bits);
+            }
+            format!("{xor:08x}:{sum:08x}")
+        };
+        let model_float_end = (job.model_triangle_count as usize)
+            .saturating_mul(9)
+            .min(job.triangles_xyz.len());
+        eprintln!(
+            "[SupportAA] native geometry fingerprints: model={} support={} model_multiset={} support_multiset={}",
+            fingerprint(0, model_float_end),
+            fingerprint(model_float_end, job.triangles_xyz.len()),
+            multiset_fingerprint(0, model_float_end),
+            multiset_fingerprint(model_float_end, job.triangles_xyz.len()),
+        );
+
         let progress_cb = make_throttled_progress_cb(win);
         let requested_output_path = requested_output_path.clone();
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3543,11 +3543,17 @@ export default function Home() {
       ];
     }
 
+    const activeModel = scene.activeModelId
+      ? scene.models.find((m) => m.id === scene.activeModelId)
+      : undefined;
+    const canSplitSupports = !!activeModel?.geometry.meshDefects?.nativeRepairReport?.model_triangle_count;
+
     return [
       ...(!scene.activeModelId ? (['delete', 'cut', 'copy', 'repair'] as const) : []),
       ...(!scene.canPasteModel ? (['paste'] as const) : []),
+      ...(!canSplitSupports ? (['split-supports'] as const) : []),
     ];
-  }, [scene.activeModelId, scene.canPasteModel, scene.mode, supportsCanAddJoint, supportsCanToggleCurve]);
+  }, [scene.activeModelId, scene.canPasteModel, scene.mode, scene.models, supportsCanAddJoint, supportsCanToggleCurve]);
 
   const clearPrintingLayerPreviewUrls = React.useCallback(() => {
     printingLayerPreviewLoadInFlightRef.current.clear();
@@ -10937,6 +10943,15 @@ export default function Home() {
               pushSupportEditHistory('Create stick joint', beforeSnapshot, captureSupportEditSnapshot());
             }
           }
+        }
+        break;
+      }
+      case 'split-supports': {
+        const targetId = scene.activeModelId;
+        if (targetId) {
+          closeEditorContextMenu();
+          scene.splitSupports(targetId);
+          return;
         }
         break;
       }

--- a/src/components/modals/AaSupportWarningModal.tsx
+++ b/src/components/modals/AaSupportWarningModal.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
+
+type AaSupportWarningModalProps = {
+  isOpen: boolean;
+  modelName: string;
+  onCancel: () => void;
+  onProceed: () => void;
+};
+
+export function AaSupportWarningModal({
+  isOpen,
+  modelName,
+  onCancel,
+  onProceed,
+}: AaSupportWarningModalProps) {
+  return (
+    <StructuredDialogModal
+      open={isOpen}
+      ariaLabel="Anti-aliasing with possible support geometry"
+      title="Anti-Aliasing Warning"
+      subtitle="Possible unclassified support geometry"
+      icon={<AlertTriangle className="h-4 w-4" />}
+      iconTone="warning"
+      zIndexClassName="z-[130]"
+      closeAriaLabel="Close modal"
+      onClose={onCancel}
+      onBackdropClick={onCancel}
+      actions={(
+        <>
+          <button
+            type="button"
+            className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="ui-button ui-button-accent !h-9 w-full px-3 text-xs"
+            onClick={onProceed}
+          >
+            Use Anyway
+          </button>
+        </>
+      )}
+    >
+      <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+        <strong className="text-sm font-medium" style={{ color: 'var(--text-strong)' }}>{modelName}</strong>{' '}
+        was imported as an STL file. Our analysis could not determine whether this model contains
+        support geometry baked into the mesh.
+      </p>
+      <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+        When anti-aliasing is enabled, we disable it for identified support geometry to preserve
+        fine support structure detail. Since we were unable to identify support geometry in this
+        model, we cannot guarantee print quality.
+      </p>
+    </StructuredDialogModal>
+  );
+}

--- a/src/components/ui/EditorContextMenu.tsx
+++ b/src/components/ui/EditorContextMenu.tsx
@@ -9,6 +9,7 @@ import {
   Scissors,
   ClipboardPaste,
   Trash2,
+  Split,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -18,6 +19,7 @@ export type EditorMenuAction =
   | 'copy'
   | 'paste'
   | 'repair'
+  | 'split-supports'
   | 'supports-toggle-curve'
   | 'supports-add-joint';
 
@@ -48,6 +50,7 @@ const MENU_ITEMS: MenuItemDef[] = [
   { id: 'copy',   label: msg`Copy`,   icon: Copy },
   { id: 'paste',  label: msg`Paste`,  icon: ClipboardPaste },
   { id: 'repair', label: msg`Repair`, icon: Wrench },
+  { id: 'split-supports', label: msg`Split Supports`, icon: Split },
 ];
 
 const MENU_WIDTH = 176;

--- a/src/features/mesh-modifiers/__tests__/prepareModelGeometry.test.ts
+++ b/src/features/mesh-modifiers/__tests__/prepareModelGeometry.test.ts
@@ -47,8 +47,6 @@ test('classified support shells are materialized as a support-only slice model',
 
   const prepared = await prepareLoadedModelsForOutput([source]);
   try {
-    assert.equal(prepared.classifiedSplitCount, 1);
-    assert.equal(prepared.classifiedSupportTriangleCount, 1);
     assert.equal(prepared.models.length, 2);
     const [modelPart, supportPart] = prepared.models;
     assert.equal(modelPart.polygonCount, 1);

--- a/src/features/mesh-modifiers/__tests__/prepareModelGeometry.test.ts
+++ b/src/features/mesh-modifiers/__tests__/prepareModelGeometry.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as THREE from 'three';
+import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
+import { prepareLoadedModelsForOutput } from '../prepareModelGeometry';
+
+test('classified support shells are materialized as a support-only slice model', async () => {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute([
+    0, 0, 0, 2, 0, 0, 0, 2, 0,
+    10, 0, 0, 12, 0, 0, 10, 2, 0,
+  ], 3));
+  // Classification is recorded against the reordered position soup. A later
+  // index must not redefine the model/support boundary.
+  geometry.setIndex([3, 4, 5, 0, 1, 2]);
+  geometry.computeBoundingBox();
+  const bbox = geometry.boundingBox?.clone() ?? new THREE.Box3();
+  const center = bbox.getCenter(new THREE.Vector3());
+  const size = bbox.getSize(new THREE.Vector3());
+  const source = {
+    id: 'combined',
+    name: 'combined.stl',
+    visible: true,
+    polygonCount: 2,
+    geometry: {
+      geometry,
+      bbox,
+      center,
+      size,
+      flatteningPlanes: [],
+      meshDefects: {
+        hasDefects: false,
+        repairedFloats: 0,
+        totalVertices: 6,
+        nativeRepairReport: {
+          model_triangle_count: 1,
+          likely_support_geometry: false,
+        },
+      },
+    },
+    transform: {
+      position: new THREE.Vector3(3, 4, 5),
+      rotation: new THREE.Euler(0, 0, Math.PI / 4),
+      scale: new THREE.Vector3(2, 3, 1),
+    },
+  } as unknown as LoadedModel;
+
+  const prepared = await prepareLoadedModelsForOutput([source]);
+  try {
+    assert.equal(prepared.classifiedSplitCount, 1);
+    assert.equal(prepared.classifiedSupportTriangleCount, 1);
+    assert.equal(prepared.models.length, 2);
+    const [modelPart, supportPart] = prepared.models;
+    assert.equal(modelPart.polygonCount, 1);
+    assert.equal(supportPart.polygonCount, 1);
+    assert.equal(modelPart.geometry.geometry.getIndex(), null);
+    assert.equal(supportPart.geometry.geometry.getIndex(), null);
+    assert.equal(
+      modelPart.polygonCount + supportPart.polygonCount,
+      source.polygonCount,
+    );
+    assert.deepEqual(
+      Array.from(modelPart.geometry.geometry.getAttribute('position').array),
+      [0, 0, 0, 2, 0, 0, 0, 2, 0],
+    );
+    assert.deepEqual(
+      Array.from(supportPart.geometry.geometry.getAttribute('position').array),
+      [10, 0, 0, 12, 0, 0, 10, 2, 0],
+    );
+    assert.equal(
+      supportPart.geometry.meshDefects?.nativeRepairReport?.likely_support_geometry,
+      true,
+    );
+    assert.equal(
+      supportPart.geometry.meshDefects?.nativeRepairReport?.model_triangle_count,
+      null,
+    );
+
+    const sourceVertex = new THREE.Vector3(10, 0, 0)
+      .sub(source.geometry.center)
+      .multiply(source.transform.scale)
+      .applyEuler(source.transform.rotation)
+      .add(source.transform.position);
+    const supportPosition = supportPart.geometry.geometry.getAttribute('position');
+    const preparedVertex = new THREE.Vector3(
+      supportPosition.getX(0),
+      supportPosition.getY(0),
+      supportPosition.getZ(0),
+    )
+      .sub(supportPart.geometry.center)
+      .multiply(supportPart.transform.scale)
+      .applyEuler(supportPart.transform.rotation)
+      .add(supportPart.transform.position);
+
+    assert.ok(sourceVertex.distanceTo(preparedVertex) < 1e-6);
+  } finally {
+    prepared.dispose();
+    geometry.dispose();
+  }
+});

--- a/src/features/mesh-modifiers/prepareModelGeometry.ts
+++ b/src/features/mesh-modifiers/prepareModelGeometry.ts
@@ -14,8 +14,6 @@ export type PreparedModelGeometry = {
 export type PreparedLoadedModelsForOutput = {
   models: LoadedModel[];
   modifiedModelCount: number;
-  classifiedSplitCount: number;
-  classifiedSupportTriangleCount: number;
   dispose: () => void;
 };
 
@@ -108,50 +106,12 @@ function splitClassifiedModelForOutput(model: LoadedModel): {
 
   const geometry = model.geometry.geometry;
   const position = geometry.getAttribute('position');
-  if (!position) {
-    console.warn('[SupportAA] output split skipped: missing position attribute', {
-      modelId: model.id,
-      modelName: model.name,
-      modelTriangleCount,
-    });
-    return null;
-  }
+  if (!position) return null;
   const totalTriangleCount = Math.floor((geometry.getIndex()?.count ?? position.count) / 3);
-  const supportSection = model.geometry.meshDefects?.supportSectionGeometry;
-  const supportSectionPosition = supportSection?.getAttribute('position');
-  const supportSectionTriangleCount = Math.floor(
-    (supportSection?.getIndex()?.count ?? supportSectionPosition?.count ?? 0) / 3,
-  );
-  console.warn('[SupportAA] output split input', {
-    modelId: model.id,
-    modelName: model.name,
-    totalTriangleCount,
-    modelTriangleCount,
-    classifiedSupportTriangleCount: Math.max(0, totalTriangleCount - modelTriangleCount),
-    supportSectionTriangleCount,
-    likelySupportGeometry: report?.likely_support_geometry === true,
-    hasNativeRepairReport: report != null,
-  });
-
-  if (modelTriangleCount <= 0 || modelTriangleCount >= totalTriangleCount) {
-    console.warn('[SupportAA] output split skipped: invalid classification boundary', {
-      modelId: model.id,
-      modelName: model.name,
-      totalTriangleCount,
-      modelTriangleCount,
-    });
-    return null;
-  }
+  if (modelTriangleCount <= 0 || modelTriangleCount >= totalTriangleCount) return null;
 
   const split = splitClassifiedSupportGeometry(model);
-  if (!split) {
-    console.warn('[SupportAA] output split skipped: shared splitter rejected geometry', {
-      modelId: model.id,
-      modelName: model.name,
-      indexed: geometry.getIndex() != null,
-    });
-    return null;
-  }
+  if (!split) return null;
 
   const sourceDefects = model.geometry.meshDefects;
   const modelDefects = sourceDefects ? {
@@ -195,16 +155,6 @@ function splitClassifiedModelForOutput(model: LoadedModel): {
       scale: model.transform.scale.clone(),
     },
   };
-
-  console.warn('[SupportAA] output split complete', {
-    sourceModelId: model.id,
-    sourceModelName: model.name,
-    modelPartId: modelPart.id,
-    supportPartId: supportPart.id,
-    modelTriangles: modelPart.polygonCount,
-    supportTriangles: supportPart.polygonCount,
-    totalTriangles: modelPart.polygonCount + supportPart.polygonCount,
-  });
 
   return {
     models: [modelPart, supportPart],
@@ -341,16 +291,12 @@ export async function prepareLoadedModelsForOutput(models: LoadedModel[]): Promi
   const preparedModels: LoadedModel[] = [];
   const temporaryGeometries: THREE.BufferGeometry[] = [];
   let modifiedModelCount = 0;
-  let classifiedSplitCount = 0;
-  let classifiedSupportTriangleCount = 0;
 
   try {
     const slicingModels: LoadedModel[] = [];
     for (const model of models) {
       const split = splitClassifiedModelForOutput(model);
       if (split) {
-        classifiedSplitCount += 1;
-        classifiedSupportTriangleCount += split.models[1]?.polygonCount ?? 0;
         slicingModels.push(...split.models);
         temporaryGeometries.push(...split.geometries);
       } else {
@@ -394,8 +340,6 @@ export async function prepareLoadedModelsForOutput(models: LoadedModel[]): Promi
   return {
     models: preparedModels,
     modifiedModelCount,
-    classifiedSplitCount,
-    classifiedSupportTriangleCount,
     dispose: () => {
       for (const geometry of temporaryGeometries) {
         geometry.dispose();

--- a/src/features/mesh-modifiers/prepareModelGeometry.ts
+++ b/src/features/mesh-modifiers/prepareModelGeometry.ts
@@ -3,6 +3,7 @@ import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import type { ModelHolePunchPlacement } from './types';
 import { hollowFromGeometry, type HollowOptions } from '@/utils/meshHollowing';
 import { punchFromGeometry, type PunchOptions } from '@/utils/meshPunching';
+import { splitClassifiedSupportGeometry } from '@/features/scene/splitClassifiedSupports';
 
 export type PreparedModelGeometry = {
   model: LoadedModel;
@@ -13,6 +14,8 @@ export type PreparedModelGeometry = {
 export type PreparedLoadedModelsForOutput = {
   models: LoadedModel[];
   modifiedModelCount: number;
+  classifiedSplitCount: number;
+  classifiedSupportTriangleCount: number;
   dispose: () => void;
 };
 
@@ -94,6 +97,119 @@ function createGeometryFromPositions(positions: Float32Array): THREE.BufferGeome
   const geometry = new THREE.BufferGeometry();
   geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
   return geometry;
+}
+
+function splitClassifiedModelForOutput(model: LoadedModel): {
+  models: LoadedModel[];
+  geometries: THREE.BufferGeometry[];
+} | null {
+  const report = model.geometry.meshDefects?.nativeRepairReport;
+  const modelTriangleCount = Math.floor(report?.model_triangle_count ?? 0);
+
+  const geometry = model.geometry.geometry;
+  const position = geometry.getAttribute('position');
+  if (!position) {
+    console.warn('[SupportAA] output split skipped: missing position attribute', {
+      modelId: model.id,
+      modelName: model.name,
+      modelTriangleCount,
+    });
+    return null;
+  }
+  const totalTriangleCount = Math.floor((geometry.getIndex()?.count ?? position.count) / 3);
+  const supportSection = model.geometry.meshDefects?.supportSectionGeometry;
+  const supportSectionPosition = supportSection?.getAttribute('position');
+  const supportSectionTriangleCount = Math.floor(
+    (supportSection?.getIndex()?.count ?? supportSectionPosition?.count ?? 0) / 3,
+  );
+  console.warn('[SupportAA] output split input', {
+    modelId: model.id,
+    modelName: model.name,
+    totalTriangleCount,
+    modelTriangleCount,
+    classifiedSupportTriangleCount: Math.max(0, totalTriangleCount - modelTriangleCount),
+    supportSectionTriangleCount,
+    likelySupportGeometry: report?.likely_support_geometry === true,
+    hasNativeRepairReport: report != null,
+  });
+
+  if (modelTriangleCount <= 0 || modelTriangleCount >= totalTriangleCount) {
+    console.warn('[SupportAA] output split skipped: invalid classification boundary', {
+      modelId: model.id,
+      modelName: model.name,
+      totalTriangleCount,
+      modelTriangleCount,
+    });
+    return null;
+  }
+
+  const split = splitClassifiedSupportGeometry(model);
+  if (!split) {
+    console.warn('[SupportAA] output split skipped: shared splitter rejected geometry', {
+      modelId: model.id,
+      modelName: model.name,
+      indexed: geometry.getIndex() != null,
+    });
+    return null;
+  }
+
+  const sourceDefects = model.geometry.meshDefects;
+  const modelDefects = sourceDefects ? {
+    ...sourceDefects,
+    nativeRepairReport: undefined,
+    supportSectionGeometry: undefined,
+  } : undefined;
+  const supportDefects = sourceDefects ? {
+    ...sourceDefects,
+    supportSectionGeometry: undefined,
+    nativeRepairReport: report ? {
+      ...report,
+      model_triangle_count: null,
+      likely_support_geometry: true,
+    } : undefined,
+  } : undefined;
+
+  const modelBounds = { ...split.modelGeometry, meshDefects: modelDefects };
+  const supportBounds = { ...split.supportGeometry, meshDefects: supportDefects };
+
+  const modelPart: LoadedModel = {
+    ...model,
+    geometry: modelBounds,
+    polygonCount: split.modelTriangleCount,
+    transform: {
+      position: split.modelPosition,
+      rotation: model.transform.rotation.clone(),
+      scale: model.transform.scale.clone(),
+    },
+  };
+  const supportPart: LoadedModel = {
+    ...model,
+    id: `${model.id}:slice-supports`,
+    name: `${model.name} (Supports)`,
+    geometry: supportBounds,
+    polygonCount: split.supportTriangleCount,
+    meshModifiers: undefined,
+    transform: {
+      position: split.supportPosition,
+      rotation: model.transform.rotation.clone(),
+      scale: model.transform.scale.clone(),
+    },
+  };
+
+  console.warn('[SupportAA] output split complete', {
+    sourceModelId: model.id,
+    sourceModelName: model.name,
+    modelPartId: modelPart.id,
+    supportPartId: supportPart.id,
+    modelTriangles: modelPart.polygonCount,
+    supportTriangles: supportPart.polygonCount,
+    totalTriangles: modelPart.polygonCount + supportPart.polygonCount,
+  });
+
+  return {
+    models: [modelPart, supportPart],
+    geometries: [modelBounds.geometry, supportBounds.geometry],
+  };
 }
 
 function buildPunchOptionsFromPlacements(
@@ -225,9 +341,24 @@ export async function prepareLoadedModelsForOutput(models: LoadedModel[]): Promi
   const preparedModels: LoadedModel[] = [];
   const temporaryGeometries: THREE.BufferGeometry[] = [];
   let modifiedModelCount = 0;
+  let classifiedSplitCount = 0;
+  let classifiedSupportTriangleCount = 0;
 
   try {
+    const slicingModels: LoadedModel[] = [];
     for (const model of models) {
+      const split = splitClassifiedModelForOutput(model);
+      if (split) {
+        classifiedSplitCount += 1;
+        classifiedSupportTriangleCount += split.models[1]?.polygonCount ?? 0;
+        slicingModels.push(...split.models);
+        temporaryGeometries.push(...split.geometries);
+      } else {
+        slicingModels.push(model);
+      }
+    }
+
+    for (const model of slicingModels) {
       const prepared = await prepareModelGeometryForOutput(model);
       const geometryChanged = prepared.geometry !== model.geometry.geometry;
 
@@ -263,6 +394,8 @@ export async function prepareLoadedModelsForOutput(models: LoadedModel[]): Promi
   return {
     models: preparedModels,
     modifiedModelCount,
+    classifiedSplitCount,
+    classifiedSupportTriangleCount,
     dispose: () => {
       for (const geometry of temporaryGeometries) {
         geometry.dispose();

--- a/src/features/scene/splitClassifiedSupports.ts
+++ b/src/features/scene/splitClassifiedSupports.ts
@@ -1,0 +1,108 @@
+import * as THREE from 'three';
+import type { GeometryWithBounds } from '@/hooks/useStlGeometry';
+import type { LoadedModel } from './useSceneCollectionManager';
+import { accelerateGeometry } from '@/utils/bvh';
+import { computeFlatteningPlanes } from '@/features/placeOnFace/logic/computeFlatteningPlanes';
+
+export type ClassifiedSupportGeometrySplit = {
+  modelGeometry: GeometryWithBounds;
+  supportGeometry: GeometryWithBounds;
+  modelPosition: THREE.Vector3;
+  supportPosition: THREE.Vector3;
+  modelTriangleCount: number;
+  supportTriangleCount: number;
+  totalTriangleCount: number;
+};
+
+function buildGeometryWithBounds(
+  positions: Float32Array,
+  triangleCount: number,
+  interactive: boolean,
+): GeometryWithBounds {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  if (interactive) geometry.computeVertexNormals();
+  geometry.computeBoundingBox();
+  const bbox = geometry.boundingBox?.clone() ?? new THREE.Box3();
+  const center = bbox.getCenter(new THREE.Vector3());
+  const size = bbox.getSize(new THREE.Vector3());
+
+  if (!interactive) {
+    return { geometry, bbox, center, size, flatteningPlanes: [] };
+  }
+
+  accelerateGeometry(geometry);
+  const flatteningPlanes = triangleCount * 3 < 15_000_000
+    ? computeFlatteningPlanes(geometry)
+    : [];
+  let edgeGeometry: THREE.EdgesGeometry | undefined;
+  if (triangleCount < 2_000_000) {
+    try {
+      edgeGeometry = new THREE.EdgesGeometry(geometry, 30);
+    } catch {
+      // Edge geometry is optional for very large meshes.
+    }
+  }
+
+  return { geometry, bbox, center, size, flatteningPlanes, edgeGeometry };
+}
+
+export function splitClassifiedSupportGeometry(
+  source: LoadedModel,
+  options: { interactive?: boolean } = {},
+): ClassifiedSupportGeometrySplit | null {
+  const modelTriangleCount = Math.floor(
+    source.geometry.meshDefects?.nativeRepairReport?.model_triangle_count ?? 0,
+  );
+  if (modelTriangleCount <= 0) return null;
+
+  const geometry = source.geometry.geometry;
+  const position = geometry.getAttribute('position') as THREE.BufferAttribute | null;
+  if (!position) return null;
+
+  const sourcePositions = position.array;
+  const positions = sourcePositions instanceof Float32Array
+    ? sourcePositions
+    : new Float32Array(sourcePositions as unknown as ArrayLike<number>);
+  const totalTriangleCount = Math.floor(positions.length / 9);
+  const supportTriangleCount = totalTriangleCount - modelTriangleCount;
+  if (supportTriangleCount <= 0) return null;
+
+  const modelFloatEnd = modelTriangleCount * 9;
+  if (modelFloatEnd >= positions.length) return null;
+
+  // Native classification rewrites the position soup model-first. The
+  // context-menu behavior that is known to work slices this storage directly;
+  // an index may be attached later and must not redefine this boundary.
+  const modelPositions = positions.slice(0, modelFloatEnd);
+  const supportPositions = positions.slice(modelFloatEnd);
+  const interactive = options.interactive === true;
+  const modelGeometry = buildGeometryWithBounds(
+    modelPositions,
+    modelTriangleCount,
+    interactive,
+  );
+  const supportGeometry = buildGeometryWithBounds(
+    supportPositions,
+    supportTriangleCount,
+    interactive,
+  );
+
+  const originalCenter = source.geometry.center;
+  const rotation = new THREE.Quaternion().setFromEuler(source.transform.rotation);
+  const adjustedPosition = (partCenter: THREE.Vector3) => {
+    const offset = partCenter.clone().sub(originalCenter);
+    offset.multiply(source.transform.scale).applyQuaternion(rotation);
+    return source.transform.position.clone().add(offset);
+  };
+
+  return {
+    modelGeometry,
+    supportGeometry,
+    modelPosition: adjustedPosition(modelGeometry.center),
+    supportPosition: adjustedPosition(supportGeometry.center),
+    modelTriangleCount,
+    supportTriangleCount,
+    totalTriangleCount,
+  };
+}

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -3,7 +3,7 @@ import * as THREE from 'three';
 import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import { loadMeshGeometry, load3mfGeometryMergedWithSplitData, processGeometry, type GeometryWithBounds, type ProcessGeometryOptions } from '@/hooks/useStlGeometry';
 import type { MeshHealthReport, MeshAnalysisJson } from '@/utils/meshRepair';
-import { computeFlatteningPlanes } from '@/features/placeOnFace/logic/computeFlatteningPlanes';
+import { computeFlatteningPlanes, type FlatteningPlane } from '@/features/placeOnFace/logic/computeFlatteningPlanes';
 import { isVoxlBinaryV2, parseVoxlBinaryV2, parseVoxlDocument, type VoxlDocumentV1, type VoxlMeshRef } from '@/features/scene/voxl';
 import { clearPaintToBase } from '@/components/analysis/MeshPainter';
 import { getSnapshot, loadFromImportFormat, mergeFromImportFormat, reassignAllSupportModelIds, setSnapshot as setSupportSnapshot, transformAllSupportsForSingleModel, transformSupportsForModel } from '@/supports/state';
@@ -2630,6 +2630,185 @@ export function useSceneCollectionManager() {
     setSelectedModelIds(newIds);
   }, []);
 
+  /** Splits a model that has a classified model/support triangle split
+   *  (from the native repair engine) into two independent models:
+   *  one for the model body and one for the support geometry.
+   *  Requires `model_triangle_count` in the native repair report. */
+  const splitSupports = useCallback(async (modelId: string) => {
+    const source = modelsRef.current.find((m) => m.id === modelId);
+    if (!source) return;
+
+    const report = source.geometry.meshDefects?.nativeRepairReport;
+    const modelTriCount = report?.model_triangle_count;
+    if (!modelTriCount || modelTriCount <= 0) return;
+
+    const geometry = source.geometry.geometry;
+    const posAttr = geometry.getAttribute('position') as THREE.BufferAttribute;
+    const allPos = posAttr.array as Float32Array;
+    const modelFloatEnd = modelTriCount * 9; // 3 vertices × 3 floats per tri
+
+    if (modelFloatEnd >= allPos.length) return;
+
+    const totalTris = allPos.length / 9;
+    const supportTriCount = totalTris - modelTriCount;
+    if (modelTriCount <= 0 || supportTriCount <= 0) return;
+
+    // Split the position buffer into model and support sections.
+    // The native repair engine has already reordered triangles:
+    // model triangles first, then support triangles.
+    const modelPositions = allPos.slice(0, modelFloatEnd);
+    const supportPositions = allPos.slice(modelFloatEnd);
+
+    // Build and process each geometry inline — skip the Rust classifier
+    // round-trip since the data is already clean and split correctly.
+    const buildGeometryWithBounds = (positions: Float32Array, triCount: number): GeometryWithBounds => {
+      const geo = new THREE.BufferGeometry();
+      geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+      geo.computeVertexNormals();
+      geo.computeBoundingBox();
+      const bbox = geo.boundingBox ? geo.boundingBox.clone() : new THREE.Box3();
+      const center = bbox.getCenter(new THREE.Vector3());
+      const size = bbox.getSize(new THREE.Vector3());
+
+      // Yield to avoid blocking the UI thread between heavy ops
+      // (BVH and flattening planes are synchronous and expensive).
+
+      accelerateGeometry(geo);
+
+      let flatteningPlanes: FlatteningPlane[] = [];
+      const vertexCount = triCount * 3;
+      if (vertexCount < 15_000_000) {
+        flatteningPlanes = computeFlatteningPlanes(geo);
+      }
+
+      let edgeGeometry: THREE.EdgesGeometry | undefined;
+      if (triCount < 2_000_000) {
+        try {
+          edgeGeometry = new THREE.EdgesGeometry(geo, 30);
+        } catch { /* skip if OOM */ }
+      }
+
+      return { geometry: geo, bbox, center, size, flatteningPlanes, edgeGeometry };
+    };
+
+    // Process each piece — yield between them so React can keep the UI alive
+    const modelGeom = buildGeometryWithBounds(modelPositions, modelTriCount);
+    await new Promise<void>(r => setTimeout(r, 0));
+
+    // Tag the support geometry so the renderer uses orange hover/select tints
+    // (the `likely_support_geometry` flag drives tint color in SceneCanvas).
+    const supportGeom = buildGeometryWithBounds(supportPositions, supportTriCount);
+    supportGeom.meshDefects = {
+      hasDefects: false,
+      repairedFloats: 0,
+      totalVertices: supportTriCount * 3,
+      nativeRepairReport: {
+        version: 1,
+        source_path: null,
+        pre: {
+          triangle_count: supportTriCount,
+          vertex_count: supportTriCount * 3,
+          non_manifold_edges: 0,
+          non_manifold_vertices: 0,
+          boundary_edges: 0,
+          boundary_loops: 0,
+          inconsistent_edges: 0,
+          degenerate_triangles: 0,
+          duplicate_triangles: 0,
+          component_count: 0,
+          self_intersections: 0,
+          signed_volume: 0,
+          is_watertight: false,
+          timings_ms: { topology_ms: 0, self_intersections_ms: 0, components_ms: 0, total_ms: 0 },
+        },
+        post: {
+          triangle_count: supportTriCount,
+          vertex_count: supportTriCount * 3,
+          non_manifold_edges: 0,
+          non_manifold_vertices: 0,
+          boundary_edges: 0,
+          boundary_loops: 0,
+          inconsistent_edges: 0,
+          degenerate_triangles: 0,
+          duplicate_triangles: 0,
+          component_count: 0,
+          self_intersections: 0,
+          signed_volume: 0,
+          is_watertight: false,
+          timings_ms: { topology_ms: 0, self_intersections_ms: 0, components_ms: 0, total_ms: 0 },
+        },
+        steps: [],
+        likely_support_geometry: true,
+        residual_issues: [],
+        fully_repaired: true,
+        total_ms: 0,
+      },
+    };
+
+    const currentActiveModelId = activeModelIdRef.current;
+    const currentSelectedModelIds = selectedModelIdsRef.current;
+
+    const before = captureSceneSnapshot(
+      modelsRef.current,
+      currentActiveModelId,
+      currentSelectedModelIds,
+      { includeSupportState: true },
+    );
+
+    const baseName = source.name.replace(/\.(stl|obj|3mf)$/i, '');
+    const modelModel: LoadedModel = {
+      id: generateId(),
+      name: `${baseName} (Model)`,
+      fileUrl: source.fileUrl,
+      fileSizeBytes: source.fileSizeBytes ? Math.round(source.fileSizeBytes * (modelTriCount / totalTris)) : undefined,
+      sourcePath: source.sourcePath,
+      geometry: modelGeom,
+      transform: {
+        position: source.transform.position.clone(),
+        rotation: source.transform.rotation.clone(),
+        scale: source.transform.scale.clone(),
+      },
+      visible: source.visible,
+      color: source.color,
+      polygonCount: modelTriCount,
+    };
+
+    const supportModel: LoadedModel = {
+      id: generateId(),
+      name: `${baseName} (Supports)`,
+      fileUrl: source.fileUrl,
+      fileSizeBytes: source.fileSizeBytes ? Math.round(source.fileSizeBytes * (supportTriCount / totalTris)) : undefined,
+      sourcePath: source.sourcePath,
+      geometry: supportGeom,
+      transform: {
+        position: source.transform.position.clone(),
+        rotation: source.transform.rotation.clone(),
+        scale: source.transform.scale.clone(),
+      },
+      visible: source.visible,
+      color: source.color,
+      polygonCount: supportTriCount,
+    };
+
+    const nextModels = [
+      ...modelsRef.current.filter((m) => m.id !== modelId),
+      modelModel,
+      supportModel,
+    ];
+
+    setModels(nextModels);
+    setActiveModelId(modelModel.id);
+    setSelectedModelIds([modelModel.id, supportModel.id]);
+
+    const after = captureSceneSnapshot(
+      nextModels,
+      modelModel.id,
+      [modelModel.id, supportModel.id],
+      { includeSupportState: true },
+    );
+    pushSceneSnapshotHistory(before, after, `Split Supports from ${source.name}`);
+  }, []);
+
   const renameGroup = useCallback((groupId: string, nextName: string) => {
     const trimmed = nextName.trim();
     if (!trimmed) return;
@@ -4426,6 +4605,7 @@ export function useSceneCollectionManager() {
     ungroupModels,
     ungroupGroup,
     splitImportGroup,
+    splitSupports,
     renameGroup,
     selectGroup,
     deleteModels,

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -2659,8 +2659,12 @@ export function useSceneCollectionManager() {
     const modelPositions = allPos.slice(0, modelFloatEnd);
     const supportPositions = allPos.slice(modelFloatEnd);
 
-    // Build and process each geometry inline — skip the Rust classifier
-    // round-trip since the data is already clean and split correctly.
+    // StlMesh translates every mesh by -boundingBoxCenter.  Since each split
+    // piece has a different center than the original composite, we compensate
+    // by nudging the model's world-space transform so the vertices land at the
+    // same world positions they occupied inside the composite.
+    const origCenter = source.geometry.center.clone();
+
     const buildGeometryWithBounds = (positions: Float32Array, triCount: number): GeometryWithBounds => {
       const geo = new THREE.BufferGeometry();
       geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
@@ -2669,9 +2673,6 @@ export function useSceneCollectionManager() {
       const bbox = geo.boundingBox ? geo.boundingBox.clone() : new THREE.Box3();
       const center = bbox.getCenter(new THREE.Vector3());
       const size = bbox.getSize(new THREE.Vector3());
-
-      // Yield to avoid blocking the UI thread between heavy ops
-      // (BVH and flattening planes are synchronous and expensive).
 
       accelerateGeometry(geo);
 
@@ -2694,10 +2695,22 @@ export function useSceneCollectionManager() {
     // Process each piece — yield between them so React can keep the UI alive
     const modelGeom = buildGeometryWithBounds(modelPositions, modelTriCount);
     await new Promise<void>(r => setTimeout(r, 0));
+    const supportGeom = buildGeometryWithBounds(supportPositions, supportTriCount);
+
+    // Compute the world-space position adjustment needed to compensate for
+    // StlMesh's -boundingBoxCenter offset differing between pieces.
+    const modelPosAdjust = modelGeom.center.clone().sub(origCenter);
+    const supportPosAdjust = supportGeom.center.clone().sub(origCenter);
+    // Apply rotation & scale so the local-space delta is correct in world space
+    const sourceRot = new THREE.Quaternion().setFromEuler(source.transform.rotation);
+    modelPosAdjust.applyQuaternion(sourceRot).multiply(source.transform.scale);
+    supportPosAdjust.applyQuaternion(sourceRot).multiply(source.transform.scale);
+
+    const modelPosition = source.transform.position.clone().add(modelPosAdjust);
+    const supportPosition = source.transform.position.clone().add(supportPosAdjust);
 
     // Tag the support geometry so the renderer uses orange hover/select tints
     // (the `likely_support_geometry` flag drives tint color in SceneCanvas).
-    const supportGeom = buildGeometryWithBounds(supportPositions, supportTriCount);
     supportGeom.meshDefects = {
       hasDefects: false,
       repairedFloats: 0,
@@ -2764,13 +2777,15 @@ export function useSceneCollectionManager() {
       sourcePath: source.sourcePath,
       geometry: modelGeom,
       transform: {
-        position: source.transform.position.clone(),
+        position: modelPosition,
         rotation: source.transform.rotation.clone(),
         scale: source.transform.scale.clone(),
       },
       visible: source.visible,
       color: source.color,
       polygonCount: modelTriCount,
+      ignoreAutoLift: source.ignoreAutoLift,
+      manualZMoveOverride: source.manualZMoveOverride,
     };
 
     const supportModel: LoadedModel = {
@@ -2781,13 +2796,15 @@ export function useSceneCollectionManager() {
       sourcePath: source.sourcePath,
       geometry: supportGeom,
       transform: {
-        position: source.transform.position.clone(),
+        position: supportPosition,
         rotation: source.transform.rotation.clone(),
         scale: source.transform.scale.clone(),
       },
       visible: source.visible,
       color: source.color,
       polygonCount: supportTriCount,
+      ignoreAutoLift: source.ignoreAutoLift,
+      manualZMoveOverride: source.manualZMoveOverride,
     };
 
     const nextModels = [

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -2635,6 +2635,16 @@ export function useSceneCollectionManager() {
    *  one for the model body and one for the support geometry.
    *  Requires `model_triangle_count` in the native repair report. */
   const splitSupports = useCallback(async (modelId: string) => {
+    setImportProgress({
+      active: true,
+      type: 'mesh',
+      label: 'Splitting Supports…',
+      detail: 'Separating model and support geometry…',
+      progress: null,
+    });
+    await waitForUiYield();
+
+    try {
     const source = modelsRef.current.find((m) => m.id === modelId);
     if (!source) return;
 
@@ -2692,9 +2702,13 @@ export function useSceneCollectionManager() {
       return { geometry: geo, bbox, center, size, flatteningPlanes, edgeGeometry };
     };
 
-    // Process each piece — yield between them so React can keep the UI alive
+    // Process model geometry first, yield, then support geometry.
+    setImportProgress((p) => ({ ...p, detail: 'Processing model geometry…' }));
+    await waitForUiYield();
     const modelGeom = buildGeometryWithBounds(modelPositions, modelTriCount);
-    await new Promise<void>(r => setTimeout(r, 0));
+
+    setImportProgress((p) => ({ ...p, detail: 'Processing support geometry…' }));
+    await waitForUiYield();
     const supportGeom = buildGeometryWithBounds(supportPositions, supportTriCount);
 
     // Compute the world-space position adjustment needed to compensate for
@@ -2708,6 +2722,9 @@ export function useSceneCollectionManager() {
 
     const modelPosition = source.transform.position.clone().add(modelPosAdjust);
     const supportPosition = source.transform.position.clone().add(supportPosAdjust);
+
+    setImportProgress((p) => ({ ...p, detail: 'Finalizing…' }));
+    await waitForUiYield();
 
     // Tag the support geometry so the renderer uses orange hover/select tints
     // (the `likely_support_geometry` flag drives tint color in SceneCanvas).
@@ -2824,7 +2841,10 @@ export function useSceneCollectionManager() {
       { includeSupportState: true },
     );
     pushSceneSnapshotHistory(before, after, `Split Supports from ${source.name}`);
-  }, []);
+    } finally {
+      setImportProgress({ active: false, type: null, label: '', detail: '', progress: null });
+    }
+  }, [pushSceneSnapshotHistory, setImportProgress, waitForUiYield]);
 
   const renameGroup = useCallback((groupId: string, nextName: string) => {
     const trimmed = nextName.trim();

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -803,6 +803,7 @@ import { computeRaftOuterBoundary } from '@/supports/Rafts/Crenelated/geometry/c
 import type { SupportBaseCircle } from '@/supports/Rafts/Crenelated/RaftTypes';
 import { beginKickstandStoreBatch, endKickstandStoreBatch } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 import { getImportDefaultsRaftPatch, getSavedImportDefaultsSettings } from '@/features/scene/importDefaultsPreferences';
+import { readNativeFileSize } from '@/utils/pluginNetworkBridge';
 
 type ImportProgressState = {
   active: boolean;
@@ -1782,7 +1783,7 @@ export function useSceneCollectionManager() {
   const trackRecentOpenedFiles = useCallback((
     files: File[],
     kind: RecentOpenedFileKind,
-    options?: { sourcePaths?: Array<string | null | undefined> },
+    options?: { sourcePaths?: Array<string | null | undefined>; fileSizes?: Array<number | undefined> },
   ) => {
     if (files.length === 0) return;
 
@@ -1795,18 +1796,19 @@ export function useSceneCollectionManager() {
         const name = file.name?.trim();
         if (!name) return;
 
-        const sourcePath = kind === 'scene'
-          ? (typeof options?.sourcePaths?.[index] === 'string' && options.sourcePaths[index]!.trim().length > 0
-              ? options.sourcePaths[index]!.trim()
-              : undefined)
-          : undefined;
+        const sourcePath = (typeof options?.sourcePaths?.[index] === 'string' && options.sourcePaths[index]!.trim().length > 0
+          ? options.sourcePaths[index]!.trim()
+          : undefined);
 
-        const sizeBytes = Number.isFinite(file.size) ? file.size : undefined;
+        // Use the resolved on-disk file size (for path-backed files whose
+        // File.size is 0) when available, falling back to the File API size.
+        const sizeBytes = options?.fileSizes?.[index] ?? (Number.isFinite(file.size) && file.size > 0 ? file.size : undefined);
 
         // When a concrete sourcePath is known, use it as the primary dedup key,
         // ignoring sizeBytes. This prevents duplicates when Ctrl+S re-saves the
-        // file with an updated thumbnail (changing its size).
-        const matchBySourcePath = kind === 'scene' && sourcePath != null;
+        // file with an updated thumbnail (changing its size), and ensures mesh
+        // files backed by a disk path can be re-opened via the Rust sideload.
+        const matchBySourcePath = sourcePath != null;
 
         const isMatchingEntry = (entry: RecentOpenedFileEntry): boolean => {
           if (entry.kind !== kind || entry.name !== name) return false;
@@ -1920,7 +1922,24 @@ export function useSceneCollectionManager() {
 
     await waitForUiYield();
 
-    trackRecentOpenedFiles(files, 'mesh');
+    // Collect on-disk file paths so recent-file entries can re-open via the
+    // Rust sideload (which reads directly from disk) instead of restoring from
+    // the empty IndexedDB blob created by createPathBackedStlFile. Also resolve
+    // the real file size for path-backed files (file.size is 0 for those).
+    const meshSourcePaths: Array<string | undefined> = [];
+    const meshFileSizes: Array<number | undefined> = [];
+    for (const f of files) {
+      const fp = (f as File & { filePath?: string }).filePath;
+      meshSourcePaths.push(fp);
+      if (fp && f.size === 0) {
+        // Path-backed STL — read the actual file size from disk.
+        const realSize = await readNativeFileSize(fp).catch(() => null);
+        meshFileSizes.push(realSize ?? undefined);
+      } else {
+        meshFileSizes.push(f.size > 0 ? f.size : undefined);
+      }
+    }
+    trackRecentOpenedFiles(files, 'mesh', { sourcePaths: meshSourcePaths, fileSizes: meshFileSizes });
 
     // Read auto-lift settings from storage (mirroring useTransformManager logic)
     let autoLift = false;
@@ -4235,20 +4254,39 @@ export function useSceneCollectionManager() {
     const entry = recentOpenedFiles.find((item) => item.id === entryId);
     if (!entry) return false;
 
+    // If this is a mesh with a known on-disk path, skip IndexedDB entirely and
+    // create a path-backed file so the Rust sideload reads from disk directly.
+    // IndexedDB blobs for these files were stored empty (0 bytes) because
+    // createPathBackedStlFile builds the File object with an empty blob.
+    if (entry.kind === 'mesh' && entry.sourcePath) {
+      const pathFile = new File([], entry.name, {
+        type: 'application/octet-stream',
+        lastModified: Date.now(),
+      });
+      (pathFile as File & { filePath?: string }).filePath = entry.sourcePath;
+      await loadFiles([pathFile]);
+      return true;
+    }
+
     const file = await readRecentOpenedFileBlob(entry);
     if (!file) {
       console.warn('[SceneCollection] Unable to restore recent file from local cache.');
       return false;
     }
 
+    // Recovered file is empty and there is no disk path to fall back to — the
+    // entry is broken (e.g. created before sourcePath was tracked for meshes).
+    if (entry.kind === 'mesh' && file.size === 0) {
+      console.warn(
+        '[SceneCollection] Recent mesh file blob is empty and no on-disk path is available. ' +
+        'The file may need to be re-imported from the original location.',
+      );
+      return false;
+    }
+
     if (entry.kind === 'scene') {
       await importSceneFile(file);
       return true;
-    }
-
-    // Pass the on-disk file path through to enable Rust-side STL loading.
-    if (entry.sourcePath) {
-      (file as File & { filePath?: string }).filePath = entry.sourcePath;
     }
 
     await loadFiles([file]);

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -38,6 +38,7 @@ import {
   subscribeToProfileStore,
 } from '@/features/profiles/profileStore';
 import type { ModelMeshModifiers } from '@/features/mesh-modifiers/types';
+import { splitClassifiedSupportGeometry } from '@/features/scene/splitClassifiedSupports';
 
 type PersistedMeshAppearance = {
   v: 1;
@@ -2648,80 +2649,17 @@ export function useSceneCollectionManager() {
     const source = modelsRef.current.find((m) => m.id === modelId);
     if (!source) return;
 
-    const report = source.geometry.meshDefects?.nativeRepairReport;
-    const modelTriCount = report?.model_triangle_count;
-    if (!modelTriCount || modelTriCount <= 0) return;
-
-    const geometry = source.geometry.geometry;
-    const posAttr = geometry.getAttribute('position') as THREE.BufferAttribute;
-    const allPos = posAttr.array as Float32Array;
-    const modelFloatEnd = modelTriCount * 9; // 3 vertices × 3 floats per tri
-
-    if (modelFloatEnd >= allPos.length) return;
-
-    const totalTris = allPos.length / 9;
-    const supportTriCount = totalTris - modelTriCount;
-    if (modelTriCount <= 0 || supportTriCount <= 0) return;
-
-    // Split the position buffer into model and support sections.
-    // The native repair engine has already reordered triangles:
-    // model triangles first, then support triangles.
-    const modelPositions = allPos.slice(0, modelFloatEnd);
-    const supportPositions = allPos.slice(modelFloatEnd);
-
-    // StlMesh translates every mesh by -boundingBoxCenter.  Since each split
-    // piece has a different center than the original composite, we compensate
-    // by nudging the model's world-space transform so the vertices land at the
-    // same world positions they occupied inside the composite.
-    const origCenter = source.geometry.center.clone();
-
-    const buildGeometryWithBounds = (positions: Float32Array, triCount: number): GeometryWithBounds => {
-      const geo = new THREE.BufferGeometry();
-      geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-      geo.computeVertexNormals();
-      geo.computeBoundingBox();
-      const bbox = geo.boundingBox ? geo.boundingBox.clone() : new THREE.Box3();
-      const center = bbox.getCenter(new THREE.Vector3());
-      const size = bbox.getSize(new THREE.Vector3());
-
-      accelerateGeometry(geo);
-
-      let flatteningPlanes: FlatteningPlane[] = [];
-      const vertexCount = triCount * 3;
-      if (vertexCount < 15_000_000) {
-        flatteningPlanes = computeFlatteningPlanes(geo);
-      }
-
-      let edgeGeometry: THREE.EdgesGeometry | undefined;
-      if (triCount < 2_000_000) {
-        try {
-          edgeGeometry = new THREE.EdgesGeometry(geo, 30);
-        } catch { /* skip if OOM */ }
-      }
-
-      return { geometry: geo, bbox, center, size, flatteningPlanes, edgeGeometry };
-    };
-
-    // Process model geometry first, yield, then support geometry.
-    setImportProgress((p) => ({ ...p, detail: 'Processing model geometry…' }));
-    await waitForUiYield();
-    const modelGeom = buildGeometryWithBounds(modelPositions, modelTriCount);
-
-    setImportProgress((p) => ({ ...p, detail: 'Processing support geometry…' }));
-    await waitForUiYield();
-    const supportGeom = buildGeometryWithBounds(supportPositions, supportTriCount);
-
-    // Compute the world-space position adjustment needed to compensate for
-    // StlMesh's -boundingBoxCenter offset differing between pieces.
-    const modelPosAdjust = modelGeom.center.clone().sub(origCenter);
-    const supportPosAdjust = supportGeom.center.clone().sub(origCenter);
-    // Apply rotation & scale so the local-space delta is correct in world space
-    const sourceRot = new THREE.Quaternion().setFromEuler(source.transform.rotation);
-    modelPosAdjust.applyQuaternion(sourceRot).multiply(source.transform.scale);
-    supportPosAdjust.applyQuaternion(sourceRot).multiply(source.transform.scale);
-
-    const modelPosition = source.transform.position.clone().add(modelPosAdjust);
-    const supportPosition = source.transform.position.clone().add(supportPosAdjust);
+    const split = splitClassifiedSupportGeometry(source, { interactive: true });
+    if (!split) return;
+    const {
+      modelGeometry: modelGeom,
+      supportGeometry: supportGeom,
+      modelPosition,
+      supportPosition,
+      modelTriangleCount: modelTriCount,
+      supportTriangleCount: supportTriCount,
+      totalTriangleCount: totalTris,
+    } = split;
 
     setImportProgress((p) => ({ ...p, detail: 'Finalizing…' }));
     await waitForUiYield();

--- a/src/features/slicing/components/SlicingPanel.tsx
+++ b/src/features/slicing/components/SlicingPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { ChevronDown, CircleHelp, Cpu, Download, Edit3, ExternalLink, Layers3, Loader2, Play, Printer, Timer, X } from 'lucide-react';
+import { AlertTriangle, ChevronDown, CircleHelp, Cpu, Download, Edit3, ExternalLink, Layers3, Loader2, Play, Printer, Timer, X } from 'lucide-react';
 import { MouseTooltip } from '@/components/ui/MouseTooltip';
 import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import { KNOWN_SOURCE_EXTENSION_STRIP_RE } from '@/features/plugins/pluginFileTypeExtensions';
@@ -43,6 +43,7 @@ import {
 } from '@/components/settings/uvToolsPreferences';
 import { cleanupStalePrintTempArtifacts, cleanupAllPrintTempArtifacts, getSlicerEngineVersion } from '@/features/slicing/tauri/nativeSlicerBridge';
 import { computePhysicalAaConfig, type AaPreset as AaAutoPreset } from '@/features/slicing/autoAaPhysics';
+import { AaSupportWarningModal } from '@/components/modals/AaSupportWarningModal';
 import {
   LutCurveSelector,
   LutCurveEditorModal,
@@ -807,6 +808,9 @@ export function SlicingPanel({
   const [slicingModalStage, setSlicingModalStage] = useState<'running' | 'finished' | 'failed' | 'cancelled'>('running');
   const [displayProgressPercent, setDisplayProgressPercent] = useState(0);
   const [aaMode, setAaMode] = useState<'Off' | 'Blur' | '3DAA'>(resolveInitialAaMode);
+  const [showAaWarningModal, setShowAaWarningModal] = useState(false);
+  const [pendingAaTarget, setPendingAaTarget] = useState<'Off' | 'Blur' | '3DAA' | null>(null);
+  const [aaWarningModelName, setAaWarningModelName] = useState('');
   const [aaLevel, setAaLevel] = useState<AaStrengthLevel>(resolveInitialAaLevel);
   const [useCustomAaLevel, setUseCustomAaLevel] = useState<boolean>(() => {
     const initialSteps = parseAaLevelSteps(resolveInitialAaLevel()) ?? 4;
@@ -1203,6 +1207,48 @@ export function SlicingPanel({
     && (phaseKind === 'preparing' || phaseKind === 'staging' || phaseKind === 'slicing');
 
   const slicingElapsedLabel = useMemo(() => formatElapsedClock(currentElapsedMs), [currentElapsedMs]);
+
+  // When the user enables AA on an STL whose support geometry analysis didn't
+  // produce a model/support split, warn that we can't disable AA for possible
+  // support geometry.
+  const handleAaModeChange = useCallback((mode: 'Off' | 'Blur' | '3DAA') => {
+    if (mode === 'Off') {
+      setAaMode('Off');
+      return;
+    }
+
+    // Check visible models for STL files with unclassified support geometry.
+    const stlWithoutSupportSplit = models.filter((m) => {
+      if (!m.visible) return false;
+      if (!m.name.toLowerCase().endsWith('.stl')) return false;
+      const report = m.geometry.meshDefects?.nativeRepairReport;
+      if (!report) return true; // No analysis report at all
+      const hasSplit = report.model_triangle_count != null && report.model_triangle_count > 0;
+      const isSupportGeometry = report.likely_support_geometry === true;
+      return !hasSplit && !isSupportGeometry;
+    });
+
+    if (stlWithoutSupportSplit.length > 0) {
+      setAaWarningModelName(stlWithoutSupportSplit[0].name);
+      setPendingAaTarget(mode);
+      setShowAaWarningModal(true);
+    } else {
+      setAaMode(mode);
+    }
+  }, [models]);
+
+  const handleAaWarningProceed = useCallback(() => {
+    if (pendingAaTarget) {
+      setAaMode(pendingAaTarget);
+    }
+    setShowAaWarningModal(false);
+    setPendingAaTarget(null);
+  }, [pendingAaTarget]);
+
+  const handleAaWarningCancel = useCallback(() => {
+    setShowAaWarningModal(false);
+    setPendingAaTarget(null);
+  }, []);
 
   const visibleModels = useMemo(() => models.filter((model) => model.visible), [models]);
   const activePrinterProfileId = (activePrinterProfile?.id ?? '').trim();
@@ -2883,7 +2929,7 @@ export function SlicingPanel({
                                 background: 'var(--surface-0)',
                                 color: 'var(--text-muted)',
                               }}
-                          onClick={() => setAaMode(mode)}
+                          onClick={() => handleAaModeChange(mode)}
                         >
                           {mode}
                         </button>
@@ -4078,6 +4124,13 @@ export function SlicingPanel({
         </div>,
         document.body,
       )}
+
+      <AaSupportWarningModal
+        isOpen={showAaWarningModal}
+        modelName={aaWarningModelName}
+        onCancel={handleAaWarningCancel}
+        onProceed={handleAaWarningProceed}
+      />
     </Card>
   );
 }

--- a/src/features/slicing/rasterLayerZipExport.ts
+++ b/src/features/slicing/rasterLayerZipExport.ts
@@ -1431,76 +1431,121 @@ function buildWorldTriangles(models: LoadedModel[]): WorldTriangle[] {
   return triangles;
 }
 
-function appendModelWorldTrianglesToCollector(
-  models: LoadedModel[],
+function appendModelTrianglesInRange(
+  model: LoadedModel,
   collector: TriangleFloatCollector,
+  startTri: number,
+  endTri: number,
 ): void {
+  const matrix = composeModelMatrix(model.transform);
+  const center = model.geometry.center;
+  const geometry = model.geometry.geometry;
+  const position = geometry.getAttribute('position');
+  const index = geometry.getIndex();
+  if (!position) return;
+
   const v0 = new THREE.Vector3();
   const v1 = new THREE.Vector3();
   const v2 = new THREE.Vector3();
 
-  for (const model of models) {
-    const matrix = composeModelMatrix(model.transform);
-    const center = model.geometry.center;
-    const geometry = model.geometry.geometry;
-    const position = geometry.getAttribute('position');
-    const index = geometry.getIndex();
+  const readVertex = (vertexIndex: number, target: THREE.Vector3) => {
+    target.set(
+      position.getX(vertexIndex) - center.x,
+      position.getY(vertexIndex) - center.y,
+      position.getZ(vertexIndex) - center.z,
+    );
+    target.applyMatrix4(matrix);
+    return target;
+  };
 
-    if (!position) continue;
-
-    const readVertex = (vertexIndex: number, target: THREE.Vector3) => {
-      target.set(
-        position.getX(vertexIndex) - center.x,
-        position.getY(vertexIndex) - center.y,
-        position.getZ(vertexIndex) - center.z,
-      );
-      target.applyMatrix4(matrix);
-      return target;
-    };
-
-    if (index) {
-      const idx = index.array;
-      for (let i = 0; i < idx.length; i += 3) {
-        const a = Number(idx[i]);
-        const b = Number(idx[i + 1]);
-        const c = Number(idx[i + 2]);
-
-        readVertex(a, v0);
-        readVertex(b, v1);
-        readVertex(c, v2);
-
-        collector.pushTriangle(v0.x, v0.y, v0.z, v1.x, v1.y, v1.z, v2.x, v2.y, v2.z);
-      }
-    } else {
-      const count = position.count;
-      for (let i = 0; i < count; i += 3) {
-        readVertex(i, v0);
-        readVertex(i + 1, v1);
-        readVertex(i + 2, v2);
-
-        collector.pushTriangle(v0.x, v0.y, v0.z, v1.x, v1.y, v1.z, v2.x, v2.y, v2.z);
-      }
+  if (index) {
+    const idx = index.array;
+    const triStart = startTri * 3;
+    const triEnd = Math.min(endTri * 3, idx.length);
+    for (let i = triStart; i < triEnd; i += 3) {
+      readVertex(Number(idx[i]), v0);
+      readVertex(Number(idx[i + 1]), v1);
+      readVertex(Number(idx[i + 2]), v2);
+      collector.pushTriangle(v0.x, v0.y, v0.z, v1.x, v1.y, v1.z, v2.x, v2.y, v2.z);
+    }
+  } else {
+    const triStart = startTri * 3;
+    const triEnd = Math.min(endTri * 3, position.count);
+    for (let i = triStart; i < triEnd; i += 3) {
+      readVertex(i, v0);
+      readVertex(i + 1, v1);
+      readVertex(i + 2, v2);
+      collector.pushTriangle(v0.x, v0.y, v0.z, v1.x, v1.y, v1.z, v2.x, v2.y, v2.z);
     }
   }
 }
 
+/** Returns the number of triangles in a model that belong to the actual
+ *  model body (excluding imported support geometry).  When the repair
+ *  report has identified a clear model/support split this is the split
+ *  point; when the mesh is flagged as entirely support-dominant the count
+ *  is zero. */
+function effectiveModelTriangleCount(model: LoadedModel): number {
+  const totalTriCount = getModelTriangleCount(model);
+  const report = model.geometry.meshDefects?.nativeRepairReport;
+  const modelTriCount = report?.model_triangle_count;
+  if (modelTriCount != null && modelTriCount > 0) {
+    return Math.min(Math.floor(modelTriCount), totalTriCount);
+  }
+  if (report?.likely_support_geometry) return 0;
+  return totalTriCount;
+}
+
+/** Returns the total triangle count for a model's geometry
+ *  (used for both counting and iteration bounds). */
+function getModelTriangleCount(model: LoadedModel): number {
+  const geometry = model.geometry.geometry;
+  const position = geometry.getAttribute('position');
+  if (!position) return 0;
+  const index = geometry.getIndex();
+  if (index) return Math.floor(index.count / 3);
+  return Math.floor(position.count / 3);
+}
+
 function countModelWorldTriangles(models: LoadedModel[]): number {
   let count = 0;
-
   for (const model of models) {
-    const geometry = model.geometry.geometry;
-    const position = geometry.getAttribute('position');
-    if (!position) continue;
-
-    const index = geometry.getIndex();
-    if (index) {
-      count += Math.floor(index.count / 3);
-    } else {
-      count += Math.floor(position.count / 3);
-    }
+    count += effectiveModelTriangleCount(model);
   }
-
   return count;
+}
+
+function fingerprintTriangleFloats(
+  floats: Float32Array,
+  startFloat: number,
+  endFloat: number,
+): string {
+  const start = Math.max(0, Math.min(floats.length, Math.floor(startFloat)));
+  const end = Math.max(start, Math.min(floats.length, Math.floor(endFloat)));
+  const words = new Uint32Array(floats.buffer, floats.byteOffset, floats.length);
+  let hash = 0x811c9dc5;
+  for (let i = start; i < end; i += 1) {
+    hash ^= words[i];
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+function fingerprintTriangleFloatMultiset(
+  floats: Float32Array,
+  startFloat: number,
+  endFloat: number,
+): string {
+  const start = Math.max(0, Math.min(floats.length, Math.floor(startFloat)));
+  const end = Math.max(start, Math.min(floats.length, Math.floor(endFloat)));
+  const words = new Uint32Array(floats.buffer, floats.byteOffset, floats.length);
+  let xor = 0;
+  let sum = 0;
+  for (let i = start; i < end; i += 1) {
+    xor ^= words[i];
+    sum = (sum + words[i]) >>> 0;
+  }
+  return `${(xor >>> 0).toString(16).padStart(8, '0')}:${sum.toString(16).padStart(8, '0')}`;
 }
 
 export function buildProjectedCrossSectionZRange(models: LoadedModel[]): { min: number; max: number } | null {
@@ -2113,13 +2158,48 @@ export async function buildSolidSliceMeshForWasm(options: RasterLayerZipExportOp
   const perfSettings = getSavedSlicingPerformanceSettings();
 
   const modelTriangleCount = countModelWorldTriangles(visibleModels);
+  console.warn('[SupportAA] collector input partitions', {
+    models: visibleModels.map((model) => {
+      const totalTriangles = getModelTriangleCount(model);
+      const effectiveModelTriangles = effectiveModelTriangleCount(model);
+      const report = model.geometry.meshDefects?.nativeRepairReport;
+      return {
+        id: model.id,
+        name: model.name,
+        totalTriangles,
+        effectiveModelTriangles,
+        effectiveSupportTriangles: totalTriangles - effectiveModelTriangles,
+        reportModelTriangles: report?.model_triangle_count ?? null,
+        likelySupportGeometry: report?.likely_support_geometry === true,
+        geometryCenter: model.geometry.center.toArray(),
+        position: model.transform.position.toArray(),
+        rotation: model.transform.rotation.toArray().slice(0, 3),
+        scale: model.transform.scale.toArray(),
+      };
+    }),
+    modelTriangleCount,
+  });
   const collector = new TriangleFloatCollector(
     modelTriangleCount + 4096,
     options.flushBinaryMeshChunk,
     options.meshChunkTargetBytes,
   );
 
-  appendModelWorldTrianglesToCollector(visibleModels, collector);
+  // Push model-only triangles first (across all models), then support-only.
+  // This produces the same collector layout as manually splitting before slicing.
+  for (const model of visibleModels) {
+    const modelTriCount = effectiveModelTriangleCount(model);
+    if (modelTriCount > 0) {
+      appendModelTrianglesInRange(model, collector, 0, modelTriCount);
+    }
+  }
+  for (const model of visibleModels) {
+    const totalTris = getModelTriangleCount(model);
+    const modelTriCount = effectiveModelTriangleCount(model);
+    if (modelTriCount < totalTris) {
+      appendModelTrianglesInRange(model, collector, modelTriCount, totalTris);
+    }
+  }
   emitMeshPrepDiagnostic('Mesh prep: models', 1, 4, {
     modelTriangleEstimate: modelTriangleCount,
     triangleCountAfterModels: collector.triangleCount,
@@ -2145,10 +2225,40 @@ export async function buildSolidSliceMeshForWasm(options: RasterLayerZipExportOp
   const totalLayers = Math.max(1, Math.ceil(tallestObjectHeightMm / settings.layerHeightMm));
 
   const trianglesXYZ = await collector.finalize();
+  console.warn('[SupportAA] collector finalized', {
+    modelTriangleCount,
+    totalTriangleCount: collector.triangleCount,
+    supportTriangleCount: Math.max(0, collector.triangleCount - modelTriangleCount),
+    triangleFloatCount: trianglesXYZ.length,
+    streamed: options.flushBinaryMeshChunk != null,
+    modelFloatFingerprint: fingerprintTriangleFloats(
+      trianglesXYZ,
+      0,
+      Math.min(trianglesXYZ.length, modelTriangleCount * 9),
+    ),
+    supportFloatFingerprint: fingerprintTriangleFloats(
+      trianglesXYZ,
+      Math.min(trianglesXYZ.length, modelTriangleCount * 9),
+      trianglesXYZ.length,
+    ),
+    modelFloatMultisetFingerprint: fingerprintTriangleFloatMultiset(
+      trianglesXYZ,
+      0,
+      Math.min(trianglesXYZ.length, modelTriangleCount * 9),
+    ),
+    supportFloatMultisetFingerprint: fingerprintTriangleFloatMultiset(
+      trianglesXYZ,
+      Math.min(trianglesXYZ.length, modelTriangleCount * 9),
+      trianglesXYZ.length,
+    ),
+    meshBounds: collector.meshBounds,
+  });
   emitMeshPrepDiagnostic('Mesh prep: finalize', 3, 4, {
     triangleFloatCount: trianglesXYZ.length,
     triangleBytes: trianglesXYZ.byteLength,
     totalLayers,
+    modelTriangleCount,
+    totalCollectorTris: collector.triangleCount,
   });
 
   const manifest = {

--- a/src/features/slicing/sliceExportOrchestrator.ts
+++ b/src/features/slicing/sliceExportOrchestrator.ts
@@ -637,8 +637,6 @@ export async function runSliceExportOrchestrator(options: SliceExportOrchestrato
     visibleModelCount: visibleModels.length,
     preparedModelCount: preparedModelsForOutput.models.length,
     modifiedModelCount: preparedModelsForOutput.modifiedModelCount,
-    classifiedSplitCount: preparedModelsForOutput.classifiedSplitCount,
-    classifiedSupportTriangleCount: preparedModelsForOutput.classifiedSupportTriangleCount,
     modifierBakeMs,
   });
   const meshPrepStartMs = performance.now();
@@ -806,20 +804,6 @@ export async function runSliceExportOrchestrator(options: SliceExportOrchestrato
       options.printerProfile.display.outputFormat,
     ),
   };
-
-  logDebug('[SupportAA] native job handoff', {
-    antiAliasingLevel: nativeJob.antiAliasingLevel,
-    antiAliasingMode: nativeJob.antiAliasingMode,
-    aaOnSupports: nativeJob.aaOnSupports,
-    modelTriangleCount: nativeJob.modelTriangleCount,
-    totalTriangleCount: nativeJob.trianglesXYZ.length / 9,
-    stagedTriangleCount: cumulativeBytesStage > 0
-      ? cumulativeBytesStage / (meshTransportEncoding === 'quantized_u16' ? 18 : 36)
-      : 0,
-    meshTransferMode,
-    classifiedSplitCount: preparedModelsForOutput.classifiedSplitCount,
-    classifiedSupportTriangleCount: preparedModelsForOutput.classifiedSupportTriangleCount,
-  });
 
   const coreStartMs = performance.now();
   logDebug('Native slicing starting…');

--- a/src/features/slicing/sliceExportOrchestrator.ts
+++ b/src/features/slicing/sliceExportOrchestrator.ts
@@ -614,9 +614,31 @@ export async function runSliceExportOrchestrator(options: SliceExportOrchestrato
   options.onProgress?.(0, 1, 'Baking Modifiers');
   const preparedModelsForOutput = await prepareLoadedModelsForOutput(visibleModels);
   const modifierBakeMs = performance.now() - modifierBakeStartMs;
+
+  const survivingCombinedModels = preparedModelsForOutput.models.filter((model) => {
+    const modelTriangleCount = model.geometry.meshDefects?.nativeRepairReport?.model_triangle_count;
+    if (!modelTriangleCount || modelTriangleCount <= 0) return false;
+    const position = model.geometry.geometry.getAttribute('position');
+    const totalTriangleCount = Math.floor(
+      (model.geometry.geometry.getIndex()?.count ?? position?.count ?? 0) / 3,
+    );
+    return modelTriangleCount < totalTriangleCount;
+  });
+  if (survivingCombinedModels.length > 0) {
+    preparedModelsForOutput.dispose();
+    throw new Error(
+      `Classified support geometry was not separated before slicing: ${survivingCombinedModels
+        .map((model) => model.name)
+        .join(', ')}`,
+    );
+  }
+
   logDebug('Prepared models for slice/export handoff', {
     visibleModelCount: visibleModels.length,
+    preparedModelCount: preparedModelsForOutput.models.length,
     modifiedModelCount: preparedModelsForOutput.modifiedModelCount,
+    classifiedSplitCount: preparedModelsForOutput.classifiedSplitCount,
+    classifiedSupportTriangleCount: preparedModelsForOutput.classifiedSupportTriangleCount,
     modifierBakeMs,
   });
   const meshPrepStartMs = performance.now();
@@ -784,6 +806,20 @@ export async function runSliceExportOrchestrator(options: SliceExportOrchestrato
       options.printerProfile.display.outputFormat,
     ),
   };
+
+  logDebug('[SupportAA] native job handoff', {
+    antiAliasingLevel: nativeJob.antiAliasingLevel,
+    antiAliasingMode: nativeJob.antiAliasingMode,
+    aaOnSupports: nativeJob.aaOnSupports,
+    modelTriangleCount: nativeJob.modelTriangleCount,
+    totalTriangleCount: nativeJob.trianglesXYZ.length / 9,
+    stagedTriangleCount: cumulativeBytesStage > 0
+      ? cumulativeBytesStage / (meshTransportEncoding === 'quantized_u16' ? 18 : 36)
+      : 0,
+    meshTransferMode,
+    classifiedSplitCount: preparedModelsForOutput.classifiedSplitCount,
+    classifiedSupportTriangleCount: preparedModelsForOutput.classifiedSupportTriangleCount,
+  });
 
   const coreStartMs = performance.now();
   logDebug('Native slicing starting…');

--- a/src/hooks/useStlGeometry.ts
+++ b/src/hooks/useStlGeometry.ts
@@ -272,20 +272,23 @@ export async function processGeometry(bufferGeometry: THREE.BufferGeometry, opti
   // unless the user explicitly requests manual repair.
   // In the browser we fall back to the legacy Manifold WASM path (which only
   // activates when NaN defects were detected).
+  let nativeModifiedGeometry = false;
   if (isTauriRuntime()) {
     const nativeMode = options.nativeProcessingMode ?? 'auto';
     const skipAutoNativeProcessingForSize = nativeMode === 'auto'
       && sourceTriangleEstimate >= AUTO_NATIVE_PROCESSING_TRIANGLE_THRESHOLD;
 
     if (nativeMode === 'none') {
-      console.log('[processGeometry] Native processing skipped (mode=none)');
-    } else if (skipAutoNativeProcessingForSize) {
+      console.log('[processGeometry] Native repair skipped (mode=none) — running classification for support geometry detection');
+    }
+
+    if (skipAutoNativeProcessingForSize) {
       console.warn(
         `[processGeometry] Skipping native auto repair/classification for gigantic mesh (` +
         `${sourceTriangleEstimate.toLocaleString()} triangles). Use manual Repair to force.`
       );
     } else try {
-      let classifyOnly = nativeMode === 'classify-only';
+      let classifyOnly = nativeMode === 'classify-only' || nativeMode === 'none';
       const forceRepair = nativeMode === 'repair';
 
       // If a confirmation callback is wired up, run a quick pre-repair analysis
@@ -371,6 +374,7 @@ export async function processGeometry(bufferGeometry: THREE.BufferGeometry, opti
 
         if (shouldApplyPositions) {
           applyRepairedPositions(geometry, effectiveResult.positions);
+          nativeModifiedGeometry = true;
         }
 
         const { report } = effectiveResult;
@@ -438,8 +442,8 @@ export async function processGeometry(bufferGeometry: THREE.BufferGeometry, opti
   // Yield to let the loading indicator repaint before each heavy synchronous op
   await new Promise<void>(r => setTimeout(r, 0));
 
-  if (!options._skipComputeNormals) {
-    console.log(`[${new Date().toISOString()}] [processGeometry] Computing Normals`);
+  if (!options._skipComputeNormals || nativeModifiedGeometry) {
+    console.log(`[${new Date().toISOString()}] [processGeometry] Computing Normals${nativeModifiedGeometry ? ' (geometry modified by native processing)' : ''}`);
     geometry.computeVertexNormals();
   } else {
     console.log(`[${new Date().toISOString()}] [processGeometry] Normals already present — skipping computeVertexNormals`);


### PR DESCRIPTION
This PR implements best-effort analysis of mesh files to separate model geometry from support geometry, allowing us to split supports off the model using the new Split Supports function in the context menu.

<img width="236" height="312" alt="image" src="https://github.com/user-attachments/assets/471d21f6-a3d7-4b20-ae45-25388618e5df" />

----------------------------------------------------------

Secondly, we can now identify support geometry to correctly mask it off from anti-aliasing, as AA on supports is known to cause print failures when strong enough.