### PR TITLE
feat: Auto-Collapse UI

### DIFF
--- a/src/components/controls/TransformToolbar.tsx
+++ b/src/components/controls/TransformToolbar.tsx
@@ -17,6 +17,16 @@ export function TransformToolbar({ mode, onModeChange, onModeHover }: TransformT
   const modKey = usePlatformModifier();
   const { _ } = useLingui();
 
+  const toolbarInnerRef = React.useRef<HTMLDivElement>(null);
+  const [collapseToolLabels, setCollapseToolLabels] = React.useState(() => {
+    if (typeof window === 'undefined') return false;
+    const fullLeft = window.innerWidth / 2 - 296;
+    return fullLeft < 340;
+  });
+  const buttonsRef = React.useRef<(HTMLButtonElement | null)[]>([]);
+  const lastCollapseRef = React.useRef(false);
+  const [indicatorStyle, setIndicatorStyle] = React.useState<{ width: number; left: number }>({ width: 0, left: 0 });
+
   const buttons: Array<{ mode: TransformMode; label: string; icon: React.ReactNode; hint: string }> = [
     { mode: 'select', label: _(msg`Select`), icon: <Hand className="w-4 h-4" />, hint: _(msg`Select and inspect model`) },
     { mode: 'transform', label: _(msg`Modify`), icon: <Move3D className="w-4 h-4" />, hint: _(msg`Move, rotate, and scale`) },
@@ -28,6 +38,35 @@ export function TransformToolbar({ mode, onModeChange, onModeHover }: TransformT
   ];
 
   const activeIndex = Math.max(0, buttons.findIndex((btn) => btn.mode === mode));
+
+  React.useEffect(() => {
+    const update = () => {
+      // Toolbar full width with all labels: 7 buttons × ~82px + 6 gaps × 3px + 8px padding ≈ 592px
+      // Centered at innerWidth/2, so left edge = innerWidth/2 - 296
+      // Collapse when left edge is too close to the 320px panel
+      const fullLeft = window.innerWidth / 2 - 296;
+      const tooClose = fullLeft < 340;
+      if (tooClose !== lastCollapseRef.current) {
+        lastCollapseRef.current = tooClose;
+        setCollapseToolLabels(tooClose);
+      }
+    };
+
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  React.useEffect(() => {
+    const targetBtn = buttonsRef.current[activeIndex];
+    if (targetBtn && targetBtn.parentElement) {
+      const parent = targetBtn.parentElement;
+      setIndicatorStyle({
+        width: targetBtn.offsetWidth,
+        left: targetBtn.offsetLeft - parent.offsetLeft,
+      });
+    }
+  }, [activeIndex, collapseToolLabels, hoveredMode]);
 
   const handleModeClick = React.useCallback((next: TransformMode) => {
     React.startTransition(() => {
@@ -62,43 +101,40 @@ export function TransformToolbar({ mode, onModeChange, onModeHover }: TransformT
       }}
     >
       <div
-        className={`relative grid items-center rounded-full px-1 py-1 ${
-          buttons.length === 7
-            ? 'grid-cols-7'
-            : buttons.length === 6
-              ? 'grid-cols-6'
-              : buttons.length === 5
-                ? 'grid-cols-5'
-                : 'grid-cols-4'
-        }`}
+        ref={toolbarInnerRef}
+        className="relative grid items-center rounded-full px-1 py-1 gap-[3px]"
+        onMouseLeave={() => {
+          setHoveredMode(null);
+          onModeHover?.(null);
+        }}
         style={{
+          gridTemplateColumns: `repeat(${buttons.length}, auto)`,
           background: 'color-mix(in srgb, var(--surface-0), var(--surface-1) 50%)',
           backdropFilter: 'blur(12px)',
         }}
       >
         <div
-          className="pointer-events-none absolute left-1 top-1 bottom-1 rounded-full transition-transform duration-300 ease-out"
+          className="pointer-events-none absolute top-1 bottom-1 rounded-full transition-all duration-300 ease-out"
           style={{
-            width: `calc((100% - 8px) / ${buttons.length})`,
-            transform: `translateX(${activeIndex * 100}%)`,
+            width: indicatorStyle.width || `${(100 - 8 / (buttons.length || 1)) / (buttons.length || 1)}%`,
+            left: indicatorStyle.left,
             background: 'var(--accent-secondary)',
             boxShadow: '0 2px 12px color-mix(in srgb, var(--accent-secondary), transparent 50%)',
           }}
         />
 
-        {buttons.map((btn) => {
+        {buttons.map((btn, index) => {
           const active = mode === btn.mode;
           const hovered = hoveredMode === btn.mode;
 
           return (
             <button
               key={btn.mode}
+              ref={(el) => { buttonsRef.current[index] = el; }}
               onClick={() => handleModeClick(btn.mode)}
               onMouseEnter={() => handleModeHoverChange(btn.mode)}
-              onMouseLeave={() => handleModeLeave(btn.mode)}
               onFocus={() => handleModeHoverChange(btn.mode)}
-              onBlur={() => handleModeLeave(btn.mode)}
-              className={`relative z-[1] flex w-[112px] items-center justify-center gap-1.5 rounded-full px-3.5 py-2 text-[11px] font-semibold uppercase tracking-wider transition-all duration-200 active:scale-[0.98] ${
+              className={`relative z-[1] flex items-center justify-center gap-1.5 rounded-full px-2.5 py-2 text-[11px] font-semibold uppercase tracking-wider transition-all duration-200 active:scale-[0.98] h-[34px] ${
                 active
                   ? 'scale-[1.01]'
                   : 'hover:-translate-y-[1px] hover:shadow-[0_4px_14px_rgba(0,0,0,0.22)]'
@@ -114,7 +150,9 @@ export function TransformToolbar({ mode, onModeChange, onModeHover }: TransformT
               title={`${btn.label} • ${btn.hint}`}
             >
               <span className="shrink-0">{btn.icon}</span>
-              <span className="whitespace-nowrap">{btn.label}</span>
+              {collapseToolLabels && (hoveredMode ? hoveredMode !== btn.mode : !active) ? null : (
+                <span className="whitespace-nowrap overflow-hidden">{btn.label}</span>
+              )}
             </button>
           );
         })}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -10,7 +10,7 @@ import type { SupportMode } from '@/supports/types';
 import type { MatcapVariant, MeshShaderType } from '@/features/shaders/mesh';
 import type { SelectionHighlightMode } from '@/components/selection';
 import { Button } from '@/components/ui/primitives';
-import { Activity, AlertTriangle, ChevronDown, FolderInput, FolderOpen, Lock, Maximize2, Minimize2, Power, Printer, Save, Square, Upload, X } from 'lucide-react';
+import { Activity, AlertTriangle, Anchor, ChevronDown, FolderInput, FolderOpen, Lock, Maximize2, Minimize2, Power, Printer, Save, Square, Upload, X } from 'lucide-react';
 import {
   applyThemeCustomColors,
   getSavedThemeCustomColors,
@@ -597,8 +597,10 @@ export function TopBar({
   }, [activePrinterProfile?.id, closePrinterQuickMenu]);
 
   const stepsContainerRef = React.useRef<HTMLDivElement>(null);
-  const [collapseNonActive, setCollapseNonActive] = React.useState(false);
-  const [hideActiveStepBadge, setHideActiveStepBadge] = React.useState(false);
+  const [hideBadges, setHideBadges] = React.useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.innerWidth < 800;
+  });
 
   React.useEffect(() => {
     const el = stepsContainerRef.current;
@@ -606,14 +608,7 @@ export function TopBar({
     const ro = new ResizeObserver(([entry]) => {
       const gapPx = 4;
       const perButton = (entry.contentRect.width - 3 * gapPx) / 4;
-      const collapsing = perButton < 110;
-      setCollapseNonActive(collapsing);
-      // When collapsed, non-active buttons are flex-none (~32px each), so
-      // the active button gets most of the remaining space.
-      const estimatedActiveWidth = collapsing
-        ? entry.contentRect.width - (3 * 32 + 3 * gapPx) // container minus 3 non-active badges + gaps
-        : perButton;
-      setHideActiveStepBadge(estimatedActiveWidth < 95);
+      setHideBadges(perButton < 120);
     });
     ro.observe(el);
     return () => ro.disconnect();
@@ -623,6 +618,7 @@ export function TopBar({
     mode: SupportMode;
     label: string;
     step: number;
+    icon: React.ReactNode;
     hint: string;
     locked: boolean;
   }> = [
@@ -630,6 +626,7 @@ export function TopBar({
       mode: 'prepare',
       label: _(msg`Prepare`),
       step: 1,
+      icon: <FolderOpen className="h-3 w-3" strokeWidth={2.5} />,
       hint: _(msg`Arrange model and transforms`),
       locked: false,
     },
@@ -637,6 +634,7 @@ export function TopBar({
       mode: 'support',
       label: _(msg`Support`),
       step: 2,
+      icon: <Anchor className="h-3 w-3" strokeWidth={2.5} />,
       hint: _(msg`Build and tune supports`),
       locked: !hasModels,
     },
@@ -644,6 +642,7 @@ export function TopBar({
       mode: 'export',
       label: _(msg`Export`),
       step: 3,
+      icon: <Upload className="h-3 w-3" strokeWidth={2.5} />,
       hint: _(msg`Finalize and export output`),
       locked: !hasModels,
     },
@@ -651,6 +650,7 @@ export function TopBar({
       mode: 'printing',
       label: _(msg`Printing`),
       step: 4,
+      icon: <Printer className="h-3 w-3" strokeWidth={2.5} />,
       hint: _(msg`Inspect sliced layers before printing`),
       locked: !hasModels || !hasPrintingData,
     },
@@ -662,7 +662,7 @@ export function TopBar({
       onMouseDownCapture={handleTopBarPointerDown}
     >
       <div
-        className={`flex max-w-[430px] items-center gap-2.5 pl-0 pr-4 py-1.5 transition-opacity ${topbarActionsDisabled ? 'opacity-45 pointer-events-none' : ''}`}
+        className={`flex flex-1 max-w-[430px] items-center gap-2.5 pl-0 pr-4 py-1.5 transition-opacity ${topbarActionsDisabled ? 'opacity-45 pointer-events-none' : ''}`}
         data-no-window-drag="false"
         aria-disabled={topbarActionsDisabled}
       >
@@ -725,7 +725,7 @@ export function TopBar({
           aria-label={topbarPrinterButtonAriaLabel}
           data-no-window-drag="true"
         >
-          <div className="inline-flex h-8 w-8 items-center justify-center overflow-hidden rounded-sm shrink-0" style={{ background: 'color-mix(in srgb, var(--surface-1), transparent 6%)' }}>
+          <div className="inline-flex h-8 w-8 items-center justify-center overflow-hidden rounded-sm shrink-0" style={{ background: 'color-mix(in srgb, var(--surface-1), transparent 6%)', ...(hideBadges ? { display: 'none' } : {}) }}>
             {activePrinterThumbnailSrc ? (
               <img
                 src={activePrinterThumbnailSrc}
@@ -1020,7 +1020,7 @@ export function TopBar({
           className={`relative w-full transition-opacity ${topbarActionsDisabled ? 'opacity-45' : ''}`}
           aria-disabled={topbarActionsDisabled}
         >
-          <div ref={stepsContainerRef} className={`flex items-center justify-center gap-1 ${topbarActionsDisabled ? 'pointer-events-none' : ''}`}>
+          <div ref={stepsContainerRef} className="flex items-center justify-center gap-1">
             {steps.map((item) => {
               const active = mode === item.mode;
               const locked = item.locked;
@@ -1039,7 +1039,7 @@ export function TopBar({
                   }}
                   disabled={nativeDisabled}
                   aria-disabled={disabled}
-                  className={`group relative flex cursor-pointer items-center gap-1.5 rounded-lg border px-1.5 py-2 transition-all duration-180 ${collapseNonActive ? (active ? 'flex-1 min-w-[90px] max-w-[190px]' : 'flex-none') : 'flex-1 min-w-[90px] max-w-[190px]'} h-[36px] overflow-hidden ${
+                  className={`group relative flex cursor-pointer items-center gap-1.5 rounded-lg border px-1.5 py-2 transition-all duration-200 flex-1 min-w-[90px] max-w-[190px] h-[36px] ${
                     active
                       ? 'shadow-[0_6px_16px_rgba(0,0,0,0.25)]'
                       : 'hover:-translate-y-[1px] hover:shadow-[0_6px_14px_rgba(0,0,0,0.18)]'
@@ -1071,27 +1071,27 @@ export function TopBar({
                     style={{
                       ...(active
                         ? {
-                          color: 'var(--text-strong)',
-                          background: 'color-mix(in srgb, var(--accent), white 10%)',
+                          color: 'var(--accent)',
+                          background: 'transparent',
                         }
                         : {
                           color: 'var(--text-muted)',
                           background: 'var(--surface-2)',
                         }),
-                      ...(hideActiveStepBadge && active ? { display: 'none' } : {}),
+                      ...(hideBadges ? { display: 'none' } : {}),
                     }}
                   >
-                    {item.step}
+                    {item.icon}
                   </span>
 
                   <span
-                    className={`absolute left-1/2 -translate-x-1/2 whitespace-nowrap text-center text-xs font-bold leading-none tracking-[0.01em] ${collapseNonActive && !active ? 'hidden' : ''}`}
+                    className="absolute left-1/2 -translate-x-1/2 whitespace-nowrap text-center text-xs font-bold leading-none tracking-[0.01em]"
                     style={{ color: active ? 'var(--text-strong)' : 'var(--text-strong)' }}
                   >
                     {item.label}
                   </span>
 
-                  {printingLocked && !collapseNonActive && (
+                  {printingLocked && !hideBadges && (
                     <Lock className="h-3 w-3 ml-auto flex-shrink-0" style={{ color: 'var(--text-muted)' }} />
                   )}
 
@@ -1103,7 +1103,7 @@ export function TopBar({
         </div>
       </div>
 
-      <div className="ml-auto flex max-w-[320px] items-center justify-end gap-2 pr-2">
+      <div className="flex flex-1 max-w-[430px] items-center justify-end gap-2 pr-2">
         <div className={`flex items-center gap-2 transition-opacity ${topbarActionsDisabled ? 'opacity-45 pointer-events-none' : ''}`}>
           <ViewTypeDropdown
             value={viewTypeOverride}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -596,6 +596,29 @@ export function TopBar({
     closePrinterQuickMenu();
   }, [activePrinterProfile?.id, closePrinterQuickMenu]);
 
+  const stepsContainerRef = React.useRef<HTMLDivElement>(null);
+  const [collapseNonActive, setCollapseNonActive] = React.useState(false);
+  const [hideActiveStepBadge, setHideActiveStepBadge] = React.useState(false);
+
+  React.useEffect(() => {
+    const el = stepsContainerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(([entry]) => {
+      const gapPx = 4;
+      const perButton = (entry.contentRect.width - 3 * gapPx) / 4;
+      const collapsing = perButton < 110;
+      setCollapseNonActive(collapsing);
+      // When collapsed, non-active buttons are flex-none (~32px each), so
+      // the active button gets most of the remaining space.
+      const estimatedActiveWidth = collapsing
+        ? entry.contentRect.width - (3 * 32 + 3 * gapPx) // container minus 3 non-active badges + gaps
+        : perButton;
+      setHideActiveStepBadge(estimatedActiveWidth < 95);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
   const steps: Array<{
     mode: SupportMode;
     label: string;
@@ -639,7 +662,7 @@ export function TopBar({
       onMouseDownCapture={handleTopBarPointerDown}
     >
       <div
-        className={`flex w-[430px] items-center gap-2.5 pl-0 pr-4 py-1.5 transition-opacity ${topbarActionsDisabled ? 'opacity-45 pointer-events-none' : ''}`}
+        className={`flex max-w-[430px] items-center gap-2.5 pl-0 pr-4 py-1.5 transition-opacity ${topbarActionsDisabled ? 'opacity-45 pointer-events-none' : ''}`}
         data-no-window-drag="false"
         aria-disabled={topbarActionsDisabled}
       >
@@ -992,17 +1015,12 @@ export function TopBar({
         </div>
       )}
 
-      <div className="pointer-events-none absolute inset-x-0 flex justify-center px-2">
+      <div className="flex min-w-0 flex-1 justify-center px-2">
         <div
-          className={`relative w-full max-w-[760px] transition-opacity ${topbarActionsDisabled ? 'opacity-45' : ''}`}
+          className={`relative w-full transition-opacity ${topbarActionsDisabled ? 'opacity-45' : ''}`}
           aria-disabled={topbarActionsDisabled}
         >
-          <div
-            className="absolute left-6 right-6 top-1/2 -translate-y-1/2 h-px"
-            style={{ background: 'color-mix(in srgb, var(--border-subtle), transparent 10%)' }}
-          />
-
-          <div className={`relative grid grid-cols-4 gap-2 ${topbarActionsDisabled ? 'pointer-events-none' : 'pointer-events-auto'}`}>
+          <div ref={stepsContainerRef} className={`flex items-center justify-center gap-1 ${topbarActionsDisabled ? 'pointer-events-none' : ''}`}>
             {steps.map((item) => {
               const active = mode === item.mode;
               const locked = item.locked;
@@ -1021,7 +1039,7 @@ export function TopBar({
                   }}
                   disabled={nativeDisabled}
                   aria-disabled={disabled}
-                  className={`group relative flex cursor-pointer items-center gap-2 rounded-lg border px-2.5 py-2 transition-all duration-180 ${
+                  className={`group relative flex cursor-pointer items-center gap-1.5 rounded-lg border px-1.5 py-2 transition-all duration-180 ${collapseNonActive ? (active ? 'flex-1 min-w-[90px] max-w-[190px]' : 'flex-none') : 'flex-1 min-w-[90px] max-w-[190px]'} h-[36px] overflow-hidden ${
                     active
                       ? 'shadow-[0_6px_16px_rgba(0,0,0,0.25)]'
                       : 'hover:-translate-y-[1px] hover:shadow-[0_6px_14px_rgba(0,0,0,0.18)]'
@@ -1050,29 +1068,31 @@ export function TopBar({
                 >
                   <span
                     className="inline-flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold"
-                    style={active
-                      ? {
-                        color: 'var(--text-strong)',
-                        background: 'color-mix(in srgb, var(--accent), white 10%)',
-                      }
-                      : {
-                        color: 'var(--text-muted)',
-                        background: 'var(--surface-2)',
-                      }
-                    }
+                    style={{
+                      ...(active
+                        ? {
+                          color: 'var(--text-strong)',
+                          background: 'color-mix(in srgb, var(--accent), white 10%)',
+                        }
+                        : {
+                          color: 'var(--text-muted)',
+                          background: 'var(--surface-2)',
+                        }),
+                      ...(hideActiveStepBadge && active ? { display: 'none' } : {}),
+                    }}
                   >
                     {item.step}
                   </span>
 
                   <span
-                    className="text-xs font-bold leading-none tracking-[0.01em]"
+                    className={`absolute left-1/2 -translate-x-1/2 whitespace-nowrap text-center text-xs font-bold leading-none tracking-[0.01em] ${collapseNonActive && !active ? 'hidden' : ''}`}
                     style={{ color: active ? 'var(--text-strong)' : 'var(--text-strong)' }}
                   >
                     {item.label}
                   </span>
 
-                  {printingLocked && (
-                    <Lock className="h-3 w-3 ml-auto" style={{ color: 'var(--text-muted)' }} />
+                  {printingLocked && !collapseNonActive && (
+                    <Lock className="h-3 w-3 ml-auto flex-shrink-0" style={{ color: 'var(--text-muted)' }} />
                   )}
 
 
@@ -1083,7 +1103,7 @@ export function TopBar({
         </div>
       </div>
 
-      <div className="ml-auto flex w-[320px] items-center justify-end gap-2 pr-2">
+      <div className="ml-auto flex max-w-[320px] items-center justify-end gap-2 pr-2">
         <div className={`flex items-center gap-2 transition-opacity ${topbarActionsDisabled ? 'opacity-45 pointer-events-none' : ''}`}>
           <ViewTypeDropdown
             value={viewTypeOverride}


### PR DESCRIPTION
This PR introduces collapsing UI elements with on-hover tips to help prevent UI spillage on small devices.

Closes PR #233

Example:
<img width="946" height="873" alt="image" src="https://github.com/user-attachments/assets/f41d8a35-7d03-4336-8de3-7f31c6bdd508" />
