### PR TITLE
fix: model hover highlight fails from certain camera angles (#228)

### DIFF
--- a/src/components/picking/PickingRenderer.tsx
+++ b/src/components/picking/PickingRenderer.tsx
@@ -134,7 +134,10 @@ export function PickingRenderer({
         depthTest: !noDepthTest,
         depthWrite: !noDepthTest,
         transparent: false,
-        side: THREE.FrontSide,
+        // STL/3MF models often have inconsistent winding order; with FrontSide, those
+        // back-facing triangles vanish from the 3×3 pick buffer even when visually in
+        // front. DoubleSide fixes false misses — depth testing still picks the nearest hit.
+        side: THREE.DoubleSide,
       });
       materialCacheRef.current.set(cacheKey, material);
     }

--- a/src/components/picking/pickingUtils.ts
+++ b/src/components/picking/pickingUtils.ts
@@ -151,8 +151,10 @@ export function createPickingMaterial(pickId: number): THREE.MeshBasicMaterial {
     depthWrite: true,
     // No transparency
     transparent: false,
-    // Single side for performance
-    side: THREE.FrontSide,
+    // STL/3MF models often have inconsistent winding order; with FrontSide, those
+    // back-facing triangles vanish from the 3×3 pick buffer even when visually in
+    // front. DoubleSide fixes false misses — depth testing still picks the nearest hit.
+    side: THREE.DoubleSide,
   });
 }
 
@@ -172,7 +174,10 @@ export function createPickingMaterialNoDepth(pickId: number): THREE.MeshBasicMat
     depthTest: false,
     depthWrite: false,
     transparent: false,
-    side: THREE.FrontSide,
+    // STL/3MF models often have inconsistent winding order; with FrontSide, those
+    // back-facing triangles vanish from the 3×3 pick buffer even when visually in
+    // front. DoubleSide fixes false misses — depth testing still picks the nearest hit.
+    side: THREE.DoubleSide,
   });
 }
 


### PR DESCRIPTION
Picking materials used THREE.FrontSide, which culls triangles whose winding
order is inverted (common in STL/3MF exports.)  Those triangles vanished from
the 3×3 GPU pick buffer even when visually in front of the camera.
Switching to DoubleSide fixes false misses and depth testing still ensures the
nearest surface wins.

Closes #228.