### PR TITLE
fix: non-uniform scaling now works

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1549,6 +1549,7 @@ export default function Home() {
 
   // 2. Transform Management (needs geom for bounds)
   const transformMgr = useTransformManager({ geom: scene.geom });
+  const [uniformScaling, setUniformScaling] = React.useState(true);
 
   // Ref for supports group (used for export)
   const supportsRef = React.useRef<THREE.Group | null>(null);
@@ -18624,6 +18625,8 @@ export default function Home() {
                   transformMgr.transformHook.setScale(x, y, z);
                 }}
                 onResetScale={transformMgr.transformHook.resetScale}
+                uniformScaling={uniformScaling}
+                onUniformScalingChange={setUniformScaling}
                 modelBBox={scene.geom.bbox}
                 autoLift={transformMgr.autoLift}
                 onAutoLiftChange={handleAutoLiftChange}
@@ -19298,6 +19301,7 @@ export default function Home() {
             voxelOpacity={islands.voxelOpacity}
             transformMode={transformMgr.transformMode}
             transform={transformMgr.transform}
+            uniformScaling={uniformScaling}
             autoLift={transformMgr.autoLift}
             liftDistance={transformMgr.liftDistance}
             autoSnapEnabled={transformMgr.autoSnapEnabled}

--- a/src/components/controls/TransformControls.tsx
+++ b/src/components/controls/TransformControls.tsx
@@ -35,6 +35,8 @@ interface TransformControlsProps {
   scale: THREE.Vector3;
   onScaleChange: (x: number, y: number, z: number) => void;
   onResetScale: () => void;
+  uniformScaling: boolean;
+  onUniformScalingChange: (value: boolean) => void;
   
   // Shared
   modelBBox: THREE.Box3 | null;
@@ -61,6 +63,8 @@ export function TransformControls({
   scale,
   onScaleChange,
   onResetScale,
+  uniformScaling,
+  onUniformScalingChange,
   modelBBox,
   autoLift,
   onAutoLiftChange,
@@ -71,7 +75,6 @@ export function TransformControls({
   onTransformCommit,
 }: TransformControlsProps) {
   const [expanded, setExpanded] = useFloatingPanelCollapse(true);
-  const [uniformScaling, setUniformScaling] = useState(true);
   const [snapEnabled, setSnapEnabled] = useState(() => {
     try { return localStorage.getItem(SNAP_STORAGE_KEY) === 'true'; } catch { return false; }
   });
@@ -407,7 +410,7 @@ export function TransformControls({
               <div className="flex-1 flex justify-end">
                 <button
                 type="button"
-                onClick={() => setUniformScaling(!uniformScaling)}
+                onClick={() => onUniformScalingChange(!uniformScaling)}
                 className="h-7 min-w-[64px] rounded-md border px-2 text-[10px] font-semibold uppercase tracking-wide transition-colors"
                 style={uniformScaling
                   ? {

--- a/src/components/gizmo/TransformGizmo.tsx
+++ b/src/components/gizmo/TransformGizmo.tsx
@@ -183,6 +183,7 @@ export function TransformGizmo({
   disableRingBillboard,
   disableViewCull,
   axisVisualFlip,
+  uniformScaling = true,
 }: TransformGizmoProps) {
   const { isDragging: isGlobalDragging } = usePicking();
   const { camera } = useThree();
@@ -683,6 +684,7 @@ export function TransformGizmo({
               suppressHover={suppressHover}
               opacityScale={partOpacityScale('scale-x')}
               interactionsEnabled={partIsInteractable('scale-x')}
+              isUniform={uniformScaling}
               gizmoPosition={posVec}
               onDragStart={(isUniform: boolean) => handleDragStart('scale-x', isUniform)}
               onDrag={(factor: number, isUniform: boolean) => handleScaleDrag('x', factor, isUniform)}
@@ -701,6 +703,7 @@ export function TransformGizmo({
               suppressHover={suppressHover}
               opacityScale={partOpacityScale('scale-y')}
               interactionsEnabled={partIsInteractable('scale-y')}
+              isUniform={uniformScaling}
               gizmoPosition={posVec}
               onDragStart={(isUniform: boolean) => handleDragStart('scale-y', isUniform)}
               onDrag={(factor: number, isUniform: boolean) => handleScaleDrag('y', factor, isUniform)}
@@ -719,6 +722,7 @@ export function TransformGizmo({
               suppressHover={suppressHover}
               opacityScale={partOpacityScale('scale-z')}
               interactionsEnabled={partIsInteractable('scale-z')}
+              isUniform={uniformScaling}
               gizmoPosition={posVec}
               onDragStart={(isUniform: boolean) => handleDragStart('scale-z', isUniform)}
               onDrag={(factor: number, isUniform: boolean) => handleScaleDrag('z', factor, isUniform)}

--- a/src/components/gizmo/scale/GizmoScale.tsx
+++ b/src/components/gizmo/scale/GizmoScale.tsx
@@ -18,6 +18,7 @@ interface GizmoScaleProps {
   suppressHover?: boolean;
   opacityScale?: number;
   interactionsEnabled?: boolean;
+  isUniform?: boolean;
   gizmoPosition: THREE.Vector3;
   onDragStart: (isUniform: boolean) => boolean | void;
   onDrag: (factor: number, isUniform: boolean) => void;
@@ -38,6 +39,7 @@ export function GizmoScale({
   suppressHover = false,
   opacityScale = 1,
   interactionsEnabled = true,
+  isUniform: isUniformProp = true,
   gizmoPosition,
   onDragStart,
   onDrag,
@@ -144,8 +146,7 @@ export function GizmoScale({
     e.stopPropagation();
     (e as any).stopped = true; // Mark event as handled for OrbitControls
     
-    // Only left-click (uniform) scaling is now allowed
-    const isUniform = true;
+    const isUniform = isUniformProp;
     setIsUniformScale(isUniform);
     
     // Store initial distance from gizmo center

--- a/src/components/gizmo/scale/__tests__/applyScaleFactor.test.ts
+++ b/src/components/gizmo/scale/__tests__/applyScaleFactor.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import * as THREE from "three";
+import { applyScaleFactor } from "../applyScaleFactor";
+
+const vec = (x: number, y: number, z: number) => new THREE.Vector3(x, y, z);
+
+describe("applyScaleFactor", () => {
+  describe("uniform", () => {
+    it("scales all three axes by the factor", () => {
+      const result = applyScaleFactor(vec(1, 2, 3), "uniform", 2);
+      assert.equal(result.x, 2);
+      assert.equal(result.y, 4);
+      assert.equal(result.z, 6);
+    });
+
+    it("factor of 1 returns the same values", () => {
+      const result = applyScaleFactor(vec(3, 5, 7), "uniform", 1);
+      assert.equal(result.x, 3);
+      assert.equal(result.y, 5);
+      assert.equal(result.z, 7);
+    });
+
+    it("clamps factor to 0.0001 minimum", () => {
+      const result = applyScaleFactor(vec(2, 2, 2), "uniform", 0);
+      assert.equal(result.x, 0.0002);
+      assert.equal(result.y, 0.0002);
+      assert.equal(result.z, 0.0002);
+    });
+
+    it("does not mutate the input vector", () => {
+      const initial = vec(1, 1, 1);
+      applyScaleFactor(initial, "uniform", 5);
+      assert.equal(initial.x, 1);
+    });
+  });
+
+  describe("per-axis", () => {
+    it("x: only scales the x component", () => {
+      const result = applyScaleFactor(vec(2, 3, 4), "x", 3);
+      assert.equal(result.x, 6);
+      assert.equal(result.y, 3);
+      assert.equal(result.z, 4);
+    });
+
+    it("y: only scales the y component", () => {
+      const result = applyScaleFactor(vec(2, 3, 4), "y", 2);
+      assert.equal(result.x, 2);
+      assert.equal(result.y, 6);
+      assert.equal(result.z, 4);
+    });
+
+    it("z: only scales the z component", () => {
+      const result = applyScaleFactor(vec(2, 3, 4), "z", 0.5);
+      assert.equal(result.x, 2);
+      assert.equal(result.y, 3);
+      assert.equal(result.z, 2);
+    });
+
+    it("clamps factor to 0.0001 minimum on a single axis", () => {
+      const result = applyScaleFactor(vec(1, 1, 1), "x", -5);
+      assert.equal(result.x, 0.0001);
+      assert.equal(result.y, 1);
+      assert.equal(result.z, 1);
+    });
+
+    it("does not mutate the input vector", () => {
+      const initial = vec(2, 3, 4);
+      applyScaleFactor(initial, "y", 10);
+      assert.equal(initial.y, 3);
+    });
+  });
+});

--- a/src/components/gizmo/scale/applyScaleFactor.ts
+++ b/src/components/gizmo/scale/applyScaleFactor.ts
@@ -1,0 +1,17 @@
+import * as THREE from 'three';
+import type { GizmoAxis } from '../types';
+
+const AXIS_INDEX: Record<GizmoAxis, 0 | 1 | 2> = { x: 0, y: 1, z: 2 };
+
+export function applyScaleFactor(
+  initial: THREE.Vector3,
+  axis: GizmoAxis | 'uniform',
+  factor: number,
+): THREE.Vector3 {
+  const clamped = Math.max(0.0001, factor);
+  if (axis === 'uniform') {
+    return initial.clone().multiplyScalar(clamped);
+  }
+  const i = AXIS_INDEX[axis];
+  return initial.clone().setComponent(i, initial.getComponent(i) * clamped);
+}

--- a/src/components/gizmo/types.ts
+++ b/src/components/gizmo/types.ts
@@ -97,6 +97,9 @@ export interface GizmoConfig {
   // as displayY = -cutterY in HolePunchGizmo).
   axisVisualFlip?: { x?: number; y?: number; z?: number };
 
+  // Scale behavior
+  uniformScaling?: boolean;
+
   // Suppress face-camera behaviors
   disableArrowFlip?: boolean;
   disableRingBillboard?: boolean;

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -134,6 +134,7 @@ import {
   toggleSupportPathfindingDebugEnabled,
   toggleSupportPathfindingDebugTuningEnabled,
 } from '@/supports/PlacementLogic/Pathfinding/pathfindingDebugState';
+import { applyScaleFactor } from '@/components/gizmo/scale/applyScaleFactor';
 
 const Canvas = dynamic(() => import('@react-three/fiber').then(m => m.Canvas), { ssr: false });
 
@@ -343,6 +344,7 @@ export function SceneCanvas({
   voxelOpacity,
   transformMode,
   transform,
+  uniformScaling = true,
   autoLift = false,
   liftDistance = 5,
   autoSnapEnabled = true,
@@ -460,6 +462,7 @@ export function SceneCanvas({
   voxelOpacity?: number;
   transformMode?: TransformMode;
   transform?: ModelTransform;
+  uniformScaling?: boolean;
   autoLift?: boolean;
   liftDistance?: number;
   autoSnapEnabled?: boolean;
@@ -5984,6 +5987,7 @@ export function SceneCanvas({
                   enableMove
                   enableRotate={!isMultiGizmoSelection}
                   enableScale
+                  uniformScaling={uniformScaling}
                   enableLighting
                   onDragStateChange={setIsGizmoDragging}
                   onRetargetingChange={setIsGizmoRetargeting}
@@ -6317,11 +6321,10 @@ export function SceneCanvas({
                     }
                     return true;
                   }}
-                  onScale={(_axis, value) => {
+                  onScale={(axis, value) => {
                     if (activeGroupRef.current) {
-                      const scalarValue = Number(value);
-                      const safeScalar = Number.isFinite(scalarValue) ? scalarValue : 1;
-                      const nextScale = initialScaleRef.current.clone().multiplyScalar(Math.max(0.0001, safeScalar));
+                      const safeScalar = Number.isFinite(Number(value)) ? Number(value) : 1;
+                      const nextScale = applyScaleFactor(initialScaleRef.current, axis, safeScalar);
                       activeGroupRef.current.scale.copy(nextScale);
                       applySupportGroupDelta();
                       const live = captureActiveGroupTransform();


### PR DESCRIPTION
The Uniform toggle in the Scale panel had no effect on the 3D gizmo:
`isUniform` was hardcoded to true since 61cc0d0dc, where we made a contract
to use right-click always for orbital control regardless of the cursor
position, and never fully implemented non-uniform scaling.