### PR TITLE
feat: Add automatic notarizing of MacOS builds

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -499,6 +499,7 @@ jobs:
           DF_BUILD_TARGET_TRIPLE: universal-apple-darwin
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tauriScript: npx tauri
           args: --target universal-apple-darwin --bundles app,dmg

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -478,6 +478,12 @@ jobs:
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      - name: Install Apple Certificate
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASS }}
+
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
@@ -491,6 +497,8 @@ jobs:
         env:
           CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"
           DF_BUILD_TARGET_TRIPLE: universal-apple-darwin
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         with:
           tauriScript: npx tauri
           args: --target universal-apple-darwin --bundles app,dmg

--- a/.github/workflows/dev-prerelease.yml
+++ b/.github/workflows/dev-prerelease.yml
@@ -157,7 +157,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tauriScript: npx tauri
           args: ${{ matrix.args }}

--- a/.github/workflows/dev-prerelease.yml
+++ b/.github/workflows/dev-prerelease.yml
@@ -122,6 +122,13 @@ jobs:
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      - name: Install Apple Certificate
+        if: matrix.platform == 'macos-latest'
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASS }}
+
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
@@ -148,6 +155,9 @@ jobs:
           # TAURI_SIGNING_PRIVATE_KEY_PASSWORD — optional password set during key gen
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+
         with:
           tauriScript: npx tauri
           args: ${{ matrix.args }}

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -159,6 +159,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tauriScript: npx tauri
           args: ${{ matrix.args }}

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -122,6 +122,15 @@ jobs:
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+
+      - name: Install Apple Certificate
+        if: matrix.platform == 'macos-latest'
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASS }}
+
+
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
@@ -148,6 +157,8 @@ jobs:
           # TAURI_SIGNING_PRIVATE_KEY_PASSWORD — optional password set during key gen
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         with:
           tauriScript: npx tauri
           args: ${{ matrix.args }}

--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -71,6 +71,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tauriScript: npx tauri
           args: --target universal-apple-darwin --bundles app,dmg

--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -37,6 +37,13 @@ jobs:
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      - name: Install Apple Certificate
+        if: matrix.platform == 'macos-latest'
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASS }}
+
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
@@ -62,6 +69,8 @@ jobs:
           # TAURI_SIGNING_PRIVATE_KEY_PASSWORD — optional password set during key gen
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
         with:
           tauriScript: npx tauri
           args: --target universal-apple-darwin --bundles app,dmg

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -3,7 +3,9 @@
     "macOS": {
       "dmg": {
         "background": "nsis/assets/dmg-background.png"
-      }
+      },
+      "signingIdentity": "Developer ID Application: Pascal Krumme (MHNF3GA2MM)",
+      "providerShortName": "MHNF3GA2MM"
     },
     "externalBin": [
       "../rust/dragonfruit-voxl-thumbnail/target/release/dragonfruit-voxl-thumbnailer"


### PR DESCRIPTION
This PR enables notarizing the MacOS builds of Dragonfruit to get rid of the security warning on first execution

It depends on additional secrets to be added to the repo which have been shared beforehand with @PaulGD03 and will break the workflows if those aren't added before merging.