### PR TITLE
WIP: GOO V5.1

### DIFF
--- a/rust/dragonfruit-slicing-engine/Cargo.lock
+++ b/rust/dragonfruit-slicing-engine/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "libdeflater",
+ "md-5",
  "png",
  "rayon",
  "serde",
@@ -271,6 +272,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
 dependencies = [
  "libdeflate-sys",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]

--- a/rust/dragonfruit-slicing-engine/Cargo.toml
+++ b/rust/dragonfruit-slicing-engine/Cargo.toml
@@ -14,15 +14,15 @@ thiserror = "1"
 rayon = "1.10"
 libdeflater = "1"
 crc32fast = "1"
-png = { version = "0.17", default-features = false }   # needed by ctb_preview thumbnail decoder
+png = { version = "0.17", default-features = false }                          # needed by ctb_preview thumbnail decoder
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 base64 = "0.22"
 aes = "0.8"
 cbc = "0.1"
 sha2 = "0.10"
+md-5 = "0.10"
 time = "=0.3.36"
 time-core = "=0.1.2"
 crossbeam-channel = "0.5.15"
 
 [dev-dependencies]
-

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1466,6 +1466,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "libdeflater",
+ "md-5",
  "png",
  "rayon",
  "serde",
@@ -2960,6 +2961,16 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"


### PR DESCRIPTION
## Summary

Adds GOO V5.1 (Little Endian) encoder support for ELEGOO Jupiter 2 printers, matching ELEGOO SatelLite output format.

## Background

The Jupiter 2 uses GOO V5.1 which differs from the existing V1.2/V3.0 GOO format in three key ways:

1. **Endianness**: Little Endian (ARM native) instead of Big Endian
2. **Layer structure**: Per-layer settings are separated from RLE data — settings are stored as a contiguous 66-byte-per-layer block, with concatenated RLE data following
3. **Footer**: MD5 hash replaces the `00 00 00 <magic>` V1.2 footer

Additionally, a new T2 page table (2 entries per layer) sits between the per-layer settings pointer table and the settings data, used for virtual flash addressing on the Jupiter 2.

## Changes

| File | Description |
|------|-------------|
| `plugins/elegoo/slicing/rust/goo_v5_encoder.rs` | **New** — Full V5.1 LE encoder with header, per-layer defs, T2 page table, and MD5 footer |
| `plugins/elegoo/slicing/rust/goo_layout.rs` | Added `push_u16_le`, `push_u32_le`, `push_f32_le` primitives |
| `plugins/elegoo/slicing/rust/goo_types.rs` | Added `GOO_V5_FILE_VERSION` and `GOO_V5_LAYER_DEF_SIZE` constants |
| `plugins/elegoo/slicing/rust/encoder_impl.rs` | Version dispatch via `goo.formatVersion` metadata field |
| `plugins/elegoo/printers/jupiter-series.json` | Added Jupiter 2 GOO preset (15120x6230, `.goo v5`) |
| `rust/dragonfruit-slicing-engine/Cargo.toml` | Added `md-5 = "0.10"` for checksum footer |

## How It Works

When a printer preset specifies `"formatVersion": "v5"` with `.goo` output, the encoder automatically uses the V5.1 Little Endian path. All existing `.goo` printers (Saturn 4, Mars 5) continue using V1.2 Big Endian — no regression.

### GOO Format Version Differences

| Aspect | V1.2 / V3.0 | V5.1 (Jupiter 2) |
|--------|-------------|-------------------|
| **Endianness** | Big Endian | Little Endian |
| **Version string** | `V1.2` or `V3.0` | `V5.1` |
| **Header size** | 195,477 bytes | 195,477 bytes (same) |
| **Header field layout** | Identical structure | Identical structure, LE encoding |
| **Layer definition** | Inline per-layer: 68-byte header + delimiter + 4-byte length + RLE + delimiter (70+ bytes overhead/layer) | Separate: 66-byte settings block (u16 Pause + 15*f32 + u16 PWM + CRLF), RLE data concatenated separately |
| **T2 page table** | Not present | 2 entries per layer (16 bytes/layer), virtual flash addressing |
| **Section header** | Not present | 16-byte header at start of layer section |
| **RLE delimiter** | `0D 0A` between each layer's RLE block | No delimiter between layers (concatenated) |
| **Footer** | `00 00 00` + 8-byte magic (`07 00 00 00 44 4C 50 00`) | Zero-padding + CRLF + 32-char ASCII hex MD5 hash |
| **PerLayerSettings** | Supported (flag in header) | Static mode: PLS=0 (all layers same motion params); Dynamic mode: PLS=1 (per-layer motion can vary) |
| **Printers** | Saturn 4, Mars 4/5 | Jupiter 2 |

**Note**
The V5 format was reverse-engineered from ELEGOO SatelLite reference files. The header layout is byte-identical to V1.2 — only the endianness changed. However, the layer section was completely restructured: per-layer settings and RLE data were decoupled, and a new T2 virtual-memory page table was introduced for Jupiter 2's flash addressing. The file ends with an MD5 hash instead of the V1.2 magic footer.

## Testing

- `cargo build` passes cleanly
- Output structure matches byte-level analysis of ELEGOO SatelLite V5.1 reference files
- MD5 footer format verified against SatelLite output
