### PR TITLE
fix: Add ability to report and block 3D-mouse-like devices (#281)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import { useLingui } from '@lingui/react';
 import { detectIsIOS } from '@/hooks/usePlatform';
 import * as THREE from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
-import { AlertTriangle, CheckCircle2, ChevronDown, Download, LayoutGrid, Loader2, Maximize2, Minimize2, Play, Plus, Printer, Redo2, RefreshCw, Trash2, Undo2, Wrench, X } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, ChevronDown, Download, Gamepad2, LayoutGrid, Loader2, Maximize2, Minimize2, Play, Plus, Printer, Redo2, RefreshCw, Trash2, Undo2, Wrench, X } from 'lucide-react';
 import { SceneCanvas } from '@/components/scene/SceneCanvas';
 import { FloatingPanelStack } from '@/components/layout/FloatingPanelStack';
 import { TopBar } from '@/components/layout/TopBar';
@@ -1658,6 +1658,9 @@ export default function Home() {
     lastPushApplied: null,
     lastAt: null,
   });
+  const [newDeviceToast, setNewDeviceToast] = React.useState<string | null>(null);
+  const [isNewDeviceToastVisible, setIsNewDeviceToastVisible] = React.useState(false);
+  const newDeviceToastTimeoutRef = React.useRef<number | null>(null);
   const [historyActionToast, setHistoryActionToast] = React.useState<{ id: number; text: string; direction: 'undo' | 'redo' } | null>(null);
   const [isHistoryActionToastVisible, setIsHistoryActionToastVisible] = React.useState(false);
   const [isSceneImportToastVisible, setIsSceneImportToastVisible] = React.useState(false);
@@ -10613,6 +10616,26 @@ export default function Home() {
       }
     };
   }, [scene.sceneImportReport]);
+
+  const handleNewDeviceDetected = React.useCallback((deviceId: string) => {
+    setNewDeviceToast(deviceId);
+    setIsNewDeviceToastVisible(true);
+    if (newDeviceToastTimeoutRef.current !== null) {
+      window.clearTimeout(newDeviceToastTimeoutRef.current);
+    }
+    newDeviceToastTimeoutRef.current = window.setTimeout(() => {
+      setIsNewDeviceToastVisible(false);
+      newDeviceToastTimeoutRef.current = null;
+    }, 9000);
+  }, []);
+
+  React.useEffect(() => {
+    return () => {
+      if (newDeviceToastTimeoutRef.current !== null) {
+        window.clearTimeout(newDeviceToastTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const handleExportSuccess = React.useCallback((savedPath: string) => {
     setExportSuccessToast({ id: Date.now(), path: savedPath });
@@ -19730,6 +19753,7 @@ export default function Home() {
             freezeViewportActive={isSlicingBusy && scene.mode === 'export'}
             indicatorPlaneZ={scene.mode === 'printing' ? printingCurrentHeightMm : null}
             indicatorPlaneColor={scene.selectionColor || '#ec2a77'}
+            onNewDeviceDetected={handleNewDeviceDetected}
           >
             {scene.mode === 'prepare' && transformMgr.transformMode === 'smoothing' && (
               <MeshSmoothingBrushCursor />
@@ -23249,6 +23273,32 @@ export default function Home() {
             </div>
           </div>
         </div>
+      )}
+
+      {newDeviceToast && (
+        <ToastViewport zIndex={127} offset="1.25rem">
+          <Toast
+            tone="warning"
+            shape="rounded"
+            animated
+            visible={isNewDeviceToastVisible}
+            className="flex items-center gap-3 max-w-sm pointer-events-auto"
+          >
+            <Gamepad2 className="h-4 w-4 flex-shrink-0" />
+            <span className="flex-1 text-[12px] leading-snug">
+              New input device detected.<br />
+              <span style={{ fontWeight: 400, opacity: 0.8 }}>Go to Settings → 3D Mouse to configure or block it.</span>
+            </span>
+            <button
+              type="button"
+              onClick={() => setIsNewDeviceToastVisible(false)}
+              className="flex-shrink-0 rounded px-2 py-0.5 text-[11px] font-semibold"
+              style={{ background: 'color-mix(in srgb, #f59e0b, transparent 80%)', color: 'var(--text-strong)' }}
+            >
+              Dismiss
+            </button>
+          </Toast>
+        </ToastViewport>
       )}
 
       {isSaveToastVisible && (

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -421,6 +421,7 @@ export function SceneCanvas({
   freezeViewportActive = false,
   cavityGeometryByModelId,
   onClearSelection,
+  onNewDeviceDetected,
 }: {
   models?: LoadedModel[];
   cavityGeometryByModelId?: Map<string, THREE.BufferGeometry>;
@@ -602,6 +603,7 @@ export function SceneCanvas({
   indicatorPlaneColor?: string;
   deferCameraIntro?: boolean;
   freezeViewportActive?: boolean;
+  onNewDeviceDetected?: (deviceId: string) => void;
 }) {
   const DROP_ANIMATION_DURATION_MS = 760;
   const selectedMarker = React.useMemo(() => {
@@ -6643,6 +6645,7 @@ export function SceneCanvas({
             mouseOrbitDragRunId={mouseOrbitDragRunId}
             onNavigationActiveChange={setSpaceMouseNavigationActive}
             onNavigationFrame={handleSpaceMouseNavigationFrame}
+            onNewDeviceDetected={onNewDeviceDetected}
           />
         )}
         {cameraInteractionCycleEnabled && (

--- a/src/components/scene/camera/SpaceMouseController.tsx
+++ b/src/components/scene/camera/SpaceMouseController.tsx
@@ -36,17 +36,25 @@ function deadzoneAxis(value: number, deadzone: number) {
   return Math.sign(value) * normalized;
 }
 
-function getActiveSpaceMousePad(): Gamepad | null {
-  if (typeof navigator === 'undefined' || typeof navigator.getGamepads !== 'function') return null;
-  const pads = navigator.getGamepads();
-  const list = Array.from(pads).filter((pad): pad is Gamepad => !!pad);
-  if (list.length === 0) return null;
+export const NAMED_3D_MOUSE = /spacemouse|3dconnexion|space navigator|spacepilot/i;
+const KNOWN_NON_3D_MOUSE = /xbox|wireless controller|dualshock|dualsense|joy-?con|switch pro|stadia|hotas|joystick|throttle|flight|rudder|pedal/i;
 
-  const named = list.find((pad) => /spacemouse|3dconnexion|space navigator|spacepilot/i.test(pad.id));
-  if (named && named.axes.length >= 6) return named;
+// Module-level: survives component remounts (e.g. cameraInteractionCycleEnabled toggling).
+const seenDeviceIds = new Set<string>();
 
-  const nonSpaceMouseGamepads = /xbox|wireless controller|dualshock|dualsense|joy-?con|switch pro|stadia/i;
-  return list.find((pad) => pad.axes.length >= 6 && !nonSpaceMouseGamepads.test(pad.id)) ?? null;
+export function getCandidateGamepads(): Gamepad[] {
+  if (typeof navigator === 'undefined' || typeof navigator.getGamepads !== 'function') return [];
+  return Array.from(navigator.getGamepads()).filter((pad): pad is Gamepad => !!pad && pad.axes.length >= 6);
+}
+
+function getActiveSpaceMousePad(candidates: Gamepad[], blockedDeviceIds: string[]): Gamepad | null {
+  const unblocked = candidates.filter((pad) => !blockedDeviceIds.includes(pad.id));
+  if (unblocked.length === 0) return null;
+
+  const named = unblocked.find((pad) => NAMED_3D_MOUSE.test(pad.id));
+  if (named) return named;
+
+  return unblocked.find((pad) => !KNOWN_NON_3D_MOUSE.test(pad.id)) ?? null;
 }
 
 /**
@@ -86,6 +94,7 @@ export function SpaceMouseController({
   mouseOrbitDragRunId,
   onNavigationActiveChange,
   onNavigationFrame,
+  onNewDeviceDetected,
 }: {
   pivotPoint?: THREE.Vector3 | null;
   pivotCandidates?: THREE.Vector3[];
@@ -93,6 +102,7 @@ export function SpaceMouseController({
   mouseOrbitDragRunId?: number;
   onNavigationActiveChange?: (active: boolean) => void;
   onNavigationFrame?: () => void;
+  onNewDeviceDetected?: (deviceId: string) => void;
 }) {
   const { camera, controls, scene } = useThree();
 
@@ -293,7 +303,27 @@ export function SpaceMouseController({
       return;
     }
 
-    const pad = getActiveSpaceMousePad();
+    // Capture once per frame — shared by detection loop and active-pad selection.
+    const allCandidates = getCandidateGamepads();
+
+    // Detect newly connected candidate devices and notify once per app session.
+    // Only notify for unrecognized fallback devices that aren't already blocked —
+    // named SpaceMice need no action, and blocked devices were handled intentionally.
+    for (const candidate of allCandidates) {
+      if (!seenDeviceIds.has(candidate.id)) {
+        seenDeviceIds.add(candidate.id);
+        if (NAMED_3D_MOUSE.test(candidate.id)) {
+          console.info(`[3DMouse] Named device detected: "${candidate.id}" (${candidate.axes.length} axes)`);
+        } else {
+          console.warn(`[3DMouse] Fallback device detected: "${candidate.id}" (${candidate.axes.length} axes). Block it in Settings → 3D Mouse if it is not a 3D mouse.`);
+          if (!settings.blockedDeviceIds.includes(candidate.id)) {
+            onNewDeviceDetected?.(candidate.id);
+          }
+        }
+      }
+    }
+
+    const pad = getActiveSpaceMousePad(allCandidates, settings.blockedDeviceIds);
     if (!pad) {
       if (isNavigatingRef.current) {
         isNavigatingRef.current = false;

--- a/src/components/settings/SpaceMouseSettingsTab.tsx
+++ b/src/components/settings/SpaceMouseSettingsTab.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import React from 'react';
-import { ArrowLeftRight, Gamepad2, MousePointer2, SlidersHorizontal } from 'lucide-react';
+import { ArrowLeftRight, Ban, CheckCircle2, Gamepad2, MousePointer2, SlidersHorizontal } from 'lucide-react';
 import type { SpaceMouseSettings } from '@/components/settings/spacemousePreferences';
+import { getCandidateGamepads, NAMED_3D_MOUSE } from '@/components/scene/camera/SpaceMouseController';
 import { Select } from '@/components/ui/primitives';
 
 type SpaceMouseSettingsTabProps = {
@@ -15,27 +16,22 @@ function formatNumber(value: number) {
 }
 
 export function SpaceMouseSettingsTab({ settings, onChange }: SpaceMouseSettingsTabProps) {
-  const [connectedDevice, setConnectedDevice] = React.useState<string | null>(null);
+  const [candidatePads, setCandidatePads] = React.useState<Gamepad[]>([]);
 
   React.useEffect(() => {
     if (typeof window === 'undefined' || typeof navigator === 'undefined') return;
 
-    const matchSpaceMouse = () => {
-      const pads = navigator.getGamepads?.() ?? [];
-      const found = Array.from(pads).find((pad) => pad && /spacemouse|3dconnexion|space navigator|spacepilot/i.test(pad.id));
-      setConnectedDevice(found?.id ?? null);
-    };
+    const refresh = () => setCandidatePads(getCandidateGamepads());
 
-    matchSpaceMouse();
-    const interval = window.setInterval(matchSpaceMouse, 800);
-
-    window.addEventListener('gamepadconnected', matchSpaceMouse);
-    window.addEventListener('gamepaddisconnected', matchSpaceMouse);
+    refresh();
+    const interval = window.setInterval(refresh, 800);
+    window.addEventListener('gamepadconnected', refresh);
+    window.addEventListener('gamepaddisconnected', refresh);
 
     return () => {
       window.clearInterval(interval);
-      window.removeEventListener('gamepadconnected', matchSpaceMouse);
-      window.removeEventListener('gamepaddisconnected', matchSpaceMouse);
+      window.removeEventListener('gamepadconnected', refresh);
+      window.removeEventListener('gamepaddisconnected', refresh);
     };
   }, []);
 
@@ -100,20 +96,72 @@ export function SpaceMouseSettingsTab({ settings, onChange }: SpaceMouseSettings
         </div>
 
         <div className="mt-2 rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
-          <div className="flex items-start gap-2">
-            <Gamepad2 className="h-4 w-4 mt-0.5" style={{ color: connectedDevice ? 'var(--accent)' : 'var(--text-muted)' }} />
-            <div className="min-w-0">
-              <div className="text-xs font-semibold" style={{ color: 'var(--text-strong)' }}>
-                Device status
-              </div>
-              <div className="text-[11px] break-words" style={{ color: 'var(--text-muted)' }}>
-                {connectedDevice ?? 'No 3D mouse detected yet. Ensure driver is installed and browser input is permitted.'}
-              </div>
-              <div className="text-[10px] mt-1" style={{ color: 'var(--text-muted)' }}>
-                Note: some Bluetooth 3D mouse models may still work even if they do not appear in detected device status.
-              </div>
+          <div className="flex items-center gap-2 mb-2">
+            <Gamepad2 className="h-4 w-4" style={{ color: candidatePads.length > 0 ? 'var(--accent)' : 'var(--text-muted)' }} />
+            <div className="text-xs font-semibold" style={{ color: 'var(--text-strong)' }}>
+              Detected devices
             </div>
           </div>
+          {candidatePads.length === 0 ? (
+            <p className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+              No compatible input devices detected. Ensure your 3D mouse driver is installed.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              {candidatePads.map((pad) => {
+                const isNamed = NAMED_3D_MOUSE.test(pad.id);
+                const isBlocked = settings.blockedDeviceIds.includes(pad.id);
+                return (
+                  <div
+                    key={pad.id}
+                    className="flex items-start gap-2 rounded-md border p-2"
+                    style={{
+                      borderColor: isBlocked
+                        ? 'color-mix(in srgb, #f87171, var(--border-subtle) 60%)'
+                        : isNamed
+                          ? 'color-mix(in srgb, var(--accent), var(--border-subtle) 60%)'
+                          : 'color-mix(in srgb, #fb923c, var(--border-subtle) 60%)',
+                      background: isBlocked
+                        ? 'color-mix(in srgb, #f87171, var(--surface-1) 94%)'
+                        : 'var(--surface-1)',
+                    }}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-1.5">
+                        {isBlocked ? (
+                          <Ban className="h-3 w-3 flex-shrink-0" style={{ color: '#f87171' }} />
+                        ) : (
+                          <CheckCircle2 className="h-3 w-3 flex-shrink-0" style={{ color: isNamed ? 'var(--accent)' : '#fb923c' }} />
+                        )}
+                        <span className="text-[11px] font-semibold truncate" style={{ color: 'var(--text-strong)' }}>
+                          {pad.id}
+                        </span>
+                      </div>
+                      <div className="text-[10px] mt-0.5 pl-4.5" style={{ color: 'var(--text-muted)' }}>
+                        {pad.axes.length} axes ·{' '}
+                        {isBlocked ? 'blocked' : isNamed ? 'recognized 3D mouse' : 'unrecognized — used as fallback'}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const next = isBlocked
+                          ? settings.blockedDeviceIds.filter((id) => id !== pad.id)
+                          : [...settings.blockedDeviceIds, pad.id];
+                        onChange({ blockedDeviceIds: next });
+                      }}
+                      className="flex-shrink-0 rounded border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide transition-colors"
+                      style={isBlocked
+                        ? { borderColor: 'var(--border-subtle)', color: 'var(--text-muted)', background: 'var(--surface-2)' }
+                        : { borderColor: 'color-mix(in srgb, #f87171, var(--border-subtle) 50%)', color: '#f87171', background: 'color-mix(in srgb, #f87171, var(--surface-0) 92%)' }}
+                    >
+                      {isBlocked ? 'Unblock' : 'Block'}
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
 
         <div className="mt-2 rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>

--- a/src/components/settings/spacemousePreferences.ts
+++ b/src/components/settings/spacemousePreferences.ts
@@ -17,6 +17,7 @@ export type SpaceMouseSettings = {
   invertRx: boolean;
   invertRy: boolean;
   invertRz: boolean;
+  blockedDeviceIds: string[];
 };
 
 export const DEFAULT_SPACEMOUSE_SETTINGS: SpaceMouseSettings = {
@@ -33,6 +34,7 @@ export const DEFAULT_SPACEMOUSE_SETTINGS: SpaceMouseSettings = {
   invertRx: false,    // Pitch
   invertRy: true,     // Yaw
   invertRz: false,    // Roll
+  blockedDeviceIds: [],
 };
 
 let cachedRawSettings: string | null | undefined;
@@ -62,6 +64,9 @@ export function normalizeSpaceMouseSettings(value?: Partial<SpaceMouseSettings> 
     invertRx: !!merged.invertRx,
     invertRy: !!merged.invertRy,
     invertRz: !!merged.invertRz,
+    blockedDeviceIds: Array.isArray(merged.blockedDeviceIds)
+      ? merged.blockedDeviceIds.filter((id) => typeof id === 'string')
+      : [],
   };
 }
 


### PR DESCRIPTION
The SpaceMouse logic is not very solid, and there was no way of blocking individual devices if they're causing trouble (like a throttle in a flight controller being recognized as a valid axis).

- Added a list of all 6+-axes-recognized devices, and a checkbox to block them.
- Fallback exclusion list extended with flight-controller keywords
  (hotas, joystick, throttle, flight, rudder, pedal).
- Add logging to the entire SpaceMouse logic.

I added a manual toast for reporting a mouse hot-plugging event, because `showOperationError` is not really built for this.

Closes: #281