### PR TITLE
feat(arrange): allow negative arrange distances

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13542,9 +13542,11 @@ export default function Home() {
     const countY = Math.max(1, Math.round(arrangeArrayCountY));
     const countZ = Math.max(1, Math.round(arrangeArrayCountZ));
 
-    const gapX = Math.max(0, arrangeArrayGapX);
-    const gapY = Math.max(0, arrangeArrayGapY);
-    const gapZ = Math.max(0, arrangeArrayGapZ);
+    // Gaps may be negative (nested arrays); the steps below keep a small
+    // positive floor so the array still advances.
+    const gapX = arrangeArrayGapX;
+    const gapY = arrangeArrayGapY;
+    const gapZ = arrangeArrayGapZ;
 
     const baseDims = visibleModels.map((model) => {
       const t = modelTransformById.get(model.id) ?? model.transform;
@@ -13562,9 +13564,9 @@ export default function Home() {
     const maxDepth = Math.max(...baseDims.map((d) => d.depth));
     const maxHeight = Math.max(...baseDims.map((d) => d.height));
 
-    const stepX = maxWidth + gapX;
-    const stepY = maxDepth + gapY;
-    const stepZ = maxHeight + gapZ;
+    const stepX = Math.max(0.1, maxWidth + gapX);
+    const stepY = Math.max(0.1, maxDepth + gapY);
+    const stepZ = Math.max(0.1, maxHeight + gapZ);
 
     const rawMinX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
     const rawMaxX = rawMinX + scene.view3dSettings.widthMm;
@@ -14846,9 +14848,10 @@ export default function Home() {
       const countX = Math.max(1, Math.round(duplicateArrayCountX));
       const countY = Math.max(1, Math.round(duplicateArrayCountY));
       const countZ = Math.max(1, Math.round(duplicateArrayCountZ));
-      const stepX = width + Math.max(0, duplicateArrayGapX);
-      const stepY = depth + Math.max(0, duplicateArrayGapY);
-      const stepZ = height + Math.max(0, duplicateArrayGapZ);
+      // Gaps may be negative (nested arrays); floor the step so it advances.
+      const stepX = Math.max(0.1, width + duplicateArrayGapX);
+      const stepY = Math.max(0.1, depth + duplicateArrayGapY);
+      const stepZ = Math.max(0.1, height + duplicateArrayGapZ);
 
       const originOffsetX = ((countX - 1) * stepX) * 0.5;
       const originOffsetY = ((countY - 1) * stepY) * 0.5;
@@ -14867,7 +14870,8 @@ export default function Home() {
       }
     } else {
       const totalCount = Math.max(1, duplicateTotalCopies);
-      const spacing = Math.max(0, duplicateSpacingMm);
+      // Spacing may be negative (nesting); clamp so a step never collapses.
+      const spacing = Math.max(-Math.min(width, depth) + 0.1, duplicateSpacingMm);
 
       const rawDupMinX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
       const rawDupMaxX = rawDupMinX + scene.view3dSettings.widthMm;
@@ -15259,7 +15263,8 @@ export default function Home() {
     const sourceDims = getModelSupportAwareDimensionsMm(model, undefined, model.transform);
     const width = sourceDims.width;
     const depth = sourceDims.depth;
-    const spacing = Math.max(0, duplicateSpacingMm);
+    // Spacing may be negative (nesting); clamp so a step never collapses.
+    const spacing = Math.max(-Math.min(width, depth) + 0.1, duplicateSpacingMm);
 
     const rawFillMinX = scene.view3dSettings.originMode === 'front_left' ? 0 : -scene.view3dSettings.widthMm * 0.5;
     const rawFillMaxX = rawFillMinX + scene.view3dSettings.widthMm;

--- a/src/components/controls/ArrangePanel.tsx
+++ b/src/components/controls/ArrangePanel.tsx
@@ -144,11 +144,13 @@ export function ArrangePanel({
   const setClampedSpacing = React.useCallback((value: number) => {
     const next = sanitizeNumber(value, 0.5);
     const rounded = Number((Math.round(next * 10) / 10).toFixed(1));
-    onSpacingMmChange(Math.min(5, Math.max(0, rounded)));
+    // Allow negative spacing (down to -50mm) so parts can nest/interlock.
+    onSpacingMmChange(Math.min(5, Math.max(-50, rounded)));
   }, [onSpacingMmChange, sanitizeNumber]);
 
   const clampCount = React.useCallback((value: number) => Math.min(64, Math.max(1, Math.round(value))), []);
-  const clampGap = React.useCallback((value: number) => Math.min(120, Math.max(0, Math.round(value))), []);
+  // Negative gaps nest/overlap array copies (matches negative spacing above).
+  const clampGap = React.useCallback((value: number) => Math.min(120, Math.max(-120, Math.round(value))), []);
 
   return (
     <Card>
@@ -249,7 +251,7 @@ export function ArrangePanel({
               className="mt-1"
               value={spacingMm}
               onChange={setClampedSpacing}
-              min={0}
+              min={-50}
               max={5}
               step={0.1}
               unit="mm"
@@ -285,7 +287,7 @@ export function ArrangePanel({
                   <MiniStepperField
                     value={gapValue}
                     onChange={(next) => onGapChange(clampGap(next))}
-                    min={0}
+                    min={-120}
                     max={120}
                     disabled={isApplying}
                   />

--- a/src/components/controls/DuplicatePanel.tsx
+++ b/src/components/controls/DuplicatePanel.tsx
@@ -111,7 +111,8 @@ export function DuplicatePanel({
   const setClampedSpacing = React.useCallback((value: number) => {
     const next = sanitizeNumber(value, 0.5);
     const rounded = Number((Math.round(next * 10) / 10).toFixed(1));
-    onSpacingMmChange(Math.min(5, Math.max(0, rounded)));
+    // Negative spacing nests copies (matches Arrange/Fill Plate).
+    onSpacingMmChange(Math.min(5, Math.max(-5, rounded)));
   }, [onSpacingMmChange, sanitizeNumber]);
 
   const setClampedArrayCount = React.useCallback((setter: (value: number) => void, value: number) => {
@@ -121,7 +122,8 @@ export function DuplicatePanel({
 
   const setClampedArrayGap = React.useCallback((setter: (value: number) => void, value: number) => {
     const next = sanitizeNumber(value, 0);
-    setter(Math.min(120, Math.max(0, Math.round(next))));
+    // Negative gaps nest/overlap array copies.
+    setter(Math.min(120, Math.max(-120, Math.round(next))));
   }, [sanitizeNumber]);
 
   const displayTotalCopies = Math.max(1, layoutMode === 'array'
@@ -263,7 +265,7 @@ export function DuplicatePanel({
                   className="mt-1"
                   value={spacingMm}
                   onChange={setClampedSpacing}
-                  min={0}
+                  min={-5}
                   max={5}
                   step={0.1}
                   unit="mm"
@@ -303,7 +305,7 @@ export function DuplicatePanel({
                   <ScrollableNumberField
                     value={gapValue}
                     onChange={(next) => setClampedArrayGap(onGapChange, next)}
-                    min={0}
+                    min={-120}
                     max={120}
                     step={1}
                     unit="mm"

--- a/src/features/scene/arrange/highPrecisionArrange.ts
+++ b/src/features/scene/arrange/highPrecisionArrange.ts
@@ -108,7 +108,9 @@ export function computeHighPrecisionArrangeResult(input: HighPrecisionArrangeInp
 
   // Numerical tolerance guard used in spacing enforcement to avoid near-contact jitter.
   const SAT_EPS_MM = 0.05;
-  const spacing = Math.max(0, arrangeSpacingMm);
+  // Negative spacing is allowed (parts may nest/interlock tighter than contact);
+  // floored at -50mm to keep the SAT search well-conditioned.
+  const spacing = Math.max(-50, arrangeSpacingMm);
   const minSpacing = spacing + SAT_EPS_MM;
   const PERF_COMPLEX_SCENE = visibleModels.length >= 30;
 


### PR DESCRIPTION
## Summary

The layout tools (Arrange, Arrange Array, Duplicate, Fill Plate) all clamp their spacing/gap inputs to ≥ 0. This removes those clamps so parts can be placed closer than contact:

- **Arrange distance**: -50..5 mm (the high-precision SAT nester floors at -50)
- **Arrange array gaps** (X/Y/Z): -120..120 mm
- **Duplicate arrange distance**: -5..5 mm (auto and fill-plate modes)
- **Duplicate array gaps** (X/Y/Z): -120..120 mm

## Rationale

When parts carry large rafts or generous raft expansions, the raft footprints — not the parts — define the packing distance, and those footprints can often safely overlap or interlock. Negative distances let you pack such beds much tighter, and negative array gaps allow deliberately nested/interlocking arrays. The -50mm floor keeps the SAT search well-conditioned.

## Scope

Clamp changes only, in `ArrangePanel.tsx`, `DuplicatePanel.tsx`, `highPrecisionArrange.ts`, and the apply paths in `page.tsx`. Placement steps keep a small positive floor (0.1 mm; fill spacing floors at part size) so arrays and fill passes always advance even when the negative value exceeds the part size. Default behavior is unchanged — only the allowed input range grows.

## Validation

- The arrange-distance change is used in production on our filled beds with large raft expansions; the array/duplicate ranges are the same change we run daily in our fork.
- `npm run lint` / `npm run test` clean vs `main`.