### PR TITLE
fix: save dirty preset on Save button trigger in Support Studio

### DIFF
--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -209,6 +209,7 @@ export function SupportSidebar() {
     usePresetHotkeys();
     const settings = useSyncExternalStore(subscribeToSettings, getSettings, getSettings);
     const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'error'>('idle');
+    const [presetSaveTrigger, setPresetSaveTrigger] = useState(0);
     const [autoBraceStatus, setAutoBraceStatus] = useState<{ kind: 'success' | 'warning' | 'error'; message: string } | null>(null);
     const [defaultsAnimating, setDefaultsAnimating] = useState(false);
     const [expanded, setExpanded] = React.useState(true);
@@ -578,6 +579,11 @@ export function SupportSidebar() {
         try {
             saveSettingsToLocalStorage();
             localStorage.setItem(RAFT_STORAGE_KEY, JSON.stringify(getRaftSettings()));
+
+            // Trigger PresetSelector to save any dirty preset from within its
+            // own component scope, matching the context-menu "Save Changes" path.
+            setPresetSaveTrigger((n) => n + 1);
+
             setSaveStatus('saved');
         } catch (err) {
             console.error('[SupportSidebar] Failed to save settings:', err);
@@ -591,7 +597,7 @@ export function SupportSidebar() {
             setSaveStatus('idle');
             saveStatusTimeoutRef.current = null;
         }, 2000);
-    }, []);
+    }, [settings]);
 
     const handleRestoreDefaults = React.useCallback(() => {
         const RAFT_STORAGE_KEY = 'raft-settings';
@@ -1272,6 +1278,7 @@ export function SupportSidebar() {
                                                 <PresetSelector
                                                     selectedPresetIdOverride={effectivePresetIdOverride}
                                                     disableGlobalPresetActivation={Boolean(editableTarget)}
+                                                    saveTrigger={presetSaveTrigger}
                                                     onPresetSelected={(presetId) => {
                                                         const preset = getPresetById(presetId);
                                                         if (!preset) return;

--- a/src/supports/Settings/components/PresetSelector.tsx
+++ b/src/supports/Settings/components/PresetSelector.tsx
@@ -26,12 +26,16 @@ type PresetSelectorProps = {
     selectedPresetIdOverride?: string | null;
     onPresetSelected?: (presetId: string) => void;
     disableGlobalPresetActivation?: boolean;
+    /** Incremented externally to trigger a save of the currently-selected
+     *  dirty preset (e.g. from the Support Studio save button). */
+    saveTrigger?: number;
 };
 
 export function PresetSelector({
     selectedPresetIdOverride,
     onPresetSelected,
     disableGlobalPresetActivation = false,
+    saveTrigger,
 }: PresetSelectorProps) {
     const settings = useSyncExternalStore(subscribeToSettings, getSettings, getSettings);
     const [presets, setPresets] = useState(() => getPresetList());
@@ -87,6 +91,24 @@ export function PresetSelector({
     const hoveredPreset = hoveredPresetId ? presets.find((preset) => preset.id === hoveredPresetId) ?? null : null;
     const previewDescription = hoveredPreset?.description ?? selectedPreset?.description ?? '';
     const selectedPresetIsDirty = isPresetDirtyForSettings(effectiveSelectedPresetId, settings);
+
+    // Keep a ref so the save-trigger effect always reads the latest values
+    // without needing them as effect dependencies.
+    const effectiveSelectedPresetIdRef = useRef(effectiveSelectedPresetId);
+    effectiveSelectedPresetIdRef.current = effectiveSelectedPresetId;
+    const settingsRef = useRef(settings);
+    settingsRef.current = settings;
+
+    // When the parent save button triggers a save, persist any dirty preset
+    // changes from within the same component scope so the dirty indicator
+    // clears reliably.
+    useEffect(() => {
+        if (saveTrigger === undefined || saveTrigger === 0) return;
+        const presetId = effectiveSelectedPresetIdRef.current;
+        if (!presetId) return;
+        if (!isPresetDirtyForSettings(presetId, settingsRef.current)) return;
+        savePreset(presetId);
+    }, [saveTrigger]);
 
     useEffect(() => {
         if (!selectedPreset) {


### PR DESCRIPTION
This pull request improves how preset changes are saved in the settings UI, ensuring that dirty (unsaved) preset changes are reliably persisted when the main "Save" button is used. The main changes coordinate saving between the `SupportSidebar` and `PresetSelector` components by introducing a save trigger prop and effect.

**Preset saving coordination improvements:**

* [`SupportSidebar.tsx`](diffhunk://#diff-0e2afeb70a3e3909cf35966e3cde928ba81083fff06328f1afed281cb23b891bR212): Added a `presetSaveTrigger` state and increment it when the main save button is used, triggering the `PresetSelector` to save any dirty preset. [[1]](diffhunk://#diff-0e2afeb70a3e3909cf35966e3cde928ba81083fff06328f1afed281cb23b891bR212) [[2]](diffhunk://#diff-0e2afeb70a3e3909cf35966e3cde928ba81083fff06328f1afed281cb23b891bR582-R586) [[3]](diffhunk://#diff-0e2afeb70a3e3909cf35966e3cde928ba81083fff06328f1afed281cb23b891bR1281)
* [`PresetSelector.tsx`](diffhunk://#diff-8b49a5b4932286036d59437f098c238cc529f7aa0b40e5964c881c9b89f025bbR29-R38): Added a `saveTrigger` prop. When this prop changes, the component checks if the current preset is dirty and, if so, saves it. This ensures the dirty indicator clears and the preset state is consistent. [[1]](diffhunk://#diff-8b49a5b4932286036d59437f098c238cc529f7aa0b40e5964c881c9b89f025bbR29-R38) [[2]](diffhunk://#diff-8b49a5b4932286036d59437f098c238cc529f7aa0b40e5964c881c9b89f025bbR95-R112)

**Other improvements:**

* [`SupportSidebar.tsx`](diffhunk://#diff-0e2afeb70a3e3909cf35966e3cde928ba81083fff06328f1afed281cb23b891bL594-R600): Updated the effect that resets the save status to depend on `settings`, ensuring the UI reflects the latest state after saving.

Fixes #302 