### PR TITLE
fix: add permissions to allow Rust cache be stored

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -337,6 +337,9 @@ jobs:
             build_kind: flatpak
             artifact_name: dragonfruit-linux-flatpak-x64
     runs-on: ${{ matrix.platform }}
+    permissions:
+      actions: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -463,6 +466,9 @@ jobs:
       - derive
       - fetch-macos-artifacts
     runs-on: macos-latest
+    permissions:
+      actions: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -29,6 +29,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: write
+      contents: read
+      pages: write
+      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/plugin-registry-guardrails.yml
+++ b/.github/workflows/plugin-registry-guardrails.yml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   verify-generated-plugin-registry:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -16,6 +16,9 @@ jobs:
   macos-build:
     name: macOS compile check (Universal)
     runs-on: macos-latest
+    permissions:
+      actions: write
+      contents: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       commit_hash: ${{ steps.version.outputs.commit_hash }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,9 @@ jobs:
             build_kind: flatpak
             artifact_name: dragonfruit-linux-flatpak-x64
     runs-on: ${{ matrix.platform }}
+    permissions:
+      actions: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Add a write permission for both contents and actions only inside the build-tauri job.

In GitHub Actions, once you declare any explicit `permissions: block`, every scope you don't list gets set to none, instead of its default. We added `contents: write` at the workflow level, but that left the built-tauri job scope without *any* permissions at all, silently failing with "token has no writable scopes" messages.

The first run after this lands will still be a cold build (nothing to restore yet), but every run after that should hit the cache.