### PR TITLE
fix: use a shared job-id so rust caches are shared

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -366,6 +366,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: ./src-tauri -> target
+          shared-key: tauri
 
       - name: Install frontend dependencies
         run: npm ci
@@ -497,6 +498,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: ./src-tauri -> target
+          shared-key: tauri
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -69,6 +69,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: ./src-tauri -> target
+          shared-key: tauri
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: ./src-tauri -> target
+          shared-key: tauri
 
       - name: Install frontend dependencies
         run: npm ci


### PR DESCRIPTION
The `swatinem/rust-cache` module uses the job-id to generate the cache
key, so caches for `macos-build` and `build-tauri` would be different.
We can use `shared-key` to replace the automatic per-job key component
with a fixed string across workflow files.
