### PR TITLE
fix: add permissions and config to store and share Rust caches

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -366,6 +366,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: ./src-tauri -> target
+          shared-key: tauri
 
       - name: Install frontend dependencies
         run: npm ci
@@ -497,6 +498,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: ./src-tauri -> target
+          shared-key: tauri
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -337,6 +337,9 @@ jobs:
             build_kind: flatpak
             artifact_name: dragonfruit-linux-flatpak-x64
     runs-on: ${{ matrix.platform }}
+    permissions:
+      actions: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -463,6 +466,9 @@ jobs:
       - derive
       - fetch-macos-artifacts
     runs-on: macos-latest
+    permissions:
+      actions: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -29,6 +29,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: write
+      contents: read
+      pages: write
+      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/plugin-registry-guardrails.yml
+++ b/.github/workflows/plugin-registry-guardrails.yml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   verify-generated-plugin-registry:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -16,6 +16,9 @@ jobs:
   macos-build:
     name: macOS compile check (Universal)
     runs-on: macos-latest
+    permissions:
+      actions: write
+      contents: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       commit_hash: ${{ steps.version.outputs.commit_hash }}

--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -69,6 +69,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: ./src-tauri -> target
+          shared-key: tauri
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,7 @@ jobs:
         uses: swatinem/rust-cache@v2
         with:
           workspaces: ./src-tauri -> target
+          shared-key: tauri
 
       - name: Install frontend dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,9 @@ jobs:
             build_kind: flatpak
             artifact_name: dragonfruit-linux-flatpak-x64
     runs-on: ${{ matrix.platform }}
+    permissions:
+      actions: write
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Several workflows were missing an `actions: write` permission, causing the post-compilation cache upload phase to fail with "_Cache reservation failed: cache write denied: token has no writable scopes_".  But even then, there was another problem.

Due to a new [security feature](https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/) rolled out by GitHub 10 days ago, untrusted trigger events (i.e. PRs) won't get a cache write token to avoid cache poisoning and escalation attacks.  This forces us to move the logic to `main` manually (if we want to generate, i.e. warm, a cache bundle valid for every macOS build before the 0.2.0 release) because a cache generated in the default branch will be used across `main`, `dev`and in any PR (thus making the time to generate a macOS build *really short* and not 16+ min because of the Rust modules compilation phase).  The idea is to push a merge commit including the involved commits to `main` and only then a manual `workflow_dispatch` on `build-nightly.yml` (which takes a branch input, defaulting to `dev` but you'd set it to `main`) to actually force the warming build.