### PR TITLE
ci: bump GitHub Actions to latest safe major versions

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - name: Check commenter has write access
         id: check_access
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           COMMENT_USER: ${{ github.event.comment.user.login }}
         with:
@@ -108,7 +108,7 @@ jobs:
       - name: Fetch PR branch info
         id: pr_info
         if: steps.check_access.outputs.result == 'granted'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PR: ${{ github.event.issue.number }}
         with:
@@ -127,7 +127,7 @@ jobs:
       - name: Extract custom release name from comment
         id: extract_name
         if: steps.check_access.outputs.result == 'granted'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           result-encoding: string
           script: |
@@ -204,7 +204,7 @@ jobs:
 
       - name: Determine checkout ref
         id: checkout_ref
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
           BRANCH: ${{ steps.branch.outputs.branch }}
@@ -222,7 +222,7 @@ jobs:
             }
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.checkout_ref.outputs.ref }}
           submodules: recursive
@@ -290,7 +290,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download macOS DMG from PR check
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: macos-artifacts
           run-id: ${{ inputs.pr_run_id }}
@@ -314,7 +314,7 @@ jobs:
           fi
 
       - name: Upload renamed DMG
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dragonfruit-macos-universal
           path: macos-artifacts/*_DragonFruit_nightly.dmg
@@ -342,7 +342,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.derive.outputs.checkout_ref }}
           submodules: recursive
@@ -354,7 +354,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev librsvg2-dev patchelf libfuse2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.23.1"
           cache: npm
@@ -445,7 +445,7 @@ jobs:
 
       - name: Upload Windows installer
         if: matrix.build_kind == 'tauri'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: src-tauri/target/*/release/bundle/nsis/*_DragonFruit_nightly.exe
@@ -453,7 +453,7 @@ jobs:
 
       - name: Upload flatpak artifact
         if: matrix.build_kind == 'flatpak'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: src-tauri/target/release/bundle/flatpak/*_DragonFruit_nightly.flatpak
@@ -472,13 +472,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.derive.outputs.checkout_ref }}
           submodules: recursive
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.23.1"
           cache: npm
@@ -489,7 +489,7 @@ jobs:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Install Apple Certificate
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@v7
         with:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASS }}
@@ -536,7 +536,7 @@ jobs:
           done
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dragonfruit-macos-universal
           path: src-tauri/target/*/release/bundle/dmg/*_DragonFruit_nightly.dmg
@@ -554,12 +554,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: release-assets
 
       - name: Remove old nightly release if exists
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           TAG: ${{ needs.derive.outputs.release_tag }}
         with:
@@ -589,7 +589,7 @@ jobs:
             }
 
       - name: Create tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           TAG_NAME: ${{ needs.derive.outputs.release_tag }}
           COMMIT_SHA: ${{ needs.derive.outputs.commit_sha }}
@@ -608,7 +608,7 @@ jobs:
             });
 
       - name: Publish nightly prerelease
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.derive.outputs.release_tag }}
           name: ${{ needs.derive.outputs.release_name }}

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -53,13 +53,13 @@ jobs:
         run: node scripts/materialize-doc-placeholder-assets.mjs
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build docs site
         run: mkdocs build --strict --site-dir site
 
       - name: Inject updater JSONs into site
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -101,10 +101,10 @@ jobs:
             }
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/plugin-registry-guardrails.yml
+++ b/.github/workflows/plugin-registry-guardrails.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.23.1"
           cache: npm

--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -24,13 +24,13 @@ jobs:
       commit_hash: ${{ steps.version.outputs.commit_hash }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.23.1"
           cache: npm
@@ -41,7 +41,7 @@ jobs:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Install Apple Certificate
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@v7
         with:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASS }}
@@ -123,7 +123,7 @@ jobs:
           done
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-dmg
           path: src-tauri/target/*/release/bundle/dmg/*_DragonFruit_nightly.dmg
@@ -137,7 +137,7 @@ jobs:
     if: always()
     steps:
       - name: Upsert PR status comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           BUILD_RESULT: ${{ needs.macos-build.result }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       updater_json: ${{ steps.version.outputs.updater_json }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 
@@ -120,7 +120,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -131,7 +131,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libappindicator3-dev librsvg2-dev patchelf libfuse2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.23.1"
           cache: npm
@@ -143,7 +143,7 @@ jobs:
 
       - name: Install Apple Certificate
         if: matrix.platform == 'macos-latest'
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@v7
         with:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASS }}
@@ -219,7 +219,7 @@ jobs:
 
       - name: Upload macOS installer + updater artifacts
         if: matrix.build_kind == 'tauri' && matrix.platform == 'macos-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: |
@@ -230,7 +230,7 @@ jobs:
 
       - name: Upload Windows installer + updater artifacts
         if: matrix.build_kind == 'tauri' && matrix.platform == 'windows-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: src-tauri/target/*/release/bundle/nsis/*
@@ -238,7 +238,7 @@ jobs:
 
       - name: Upload flatpak artifact
         if: matrix.build_kind == 'flatpak'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: src-tauri/target/release/bundle/flatpak/*.flatpak
@@ -253,12 +253,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: release-assets
 
       - name: Generate updater JSON
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           VERSION: ${{ needs.detect-version-bump.outputs.version }}
           TAG_NAME: ${{ needs.detect-version-bump.outputs.tag_name }}
@@ -305,7 +305,7 @@ jobs:
             core.info(`Generated ${jsonFile}:\n${JSON.stringify(json, null, 2)}`);
 
       - name: Create tag if needed
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           TAG_NAME: ${{ needs.detect-version-bump.outputs.tag_name }}
         with:
@@ -325,7 +325,7 @@ jobs:
       - name: Resolve release notes from matching dev prerelease
         id: release_notes
         if: needs.detect-version-bump.outputs.is_prerelease == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           VERSION: ${{ needs.detect-version-bump.outputs.version }}
           FALLBACK_BODY: ${{ needs.detect-version-bump.outputs.release_body }}
@@ -356,7 +356,7 @@ jobs:
             core.setOutput("body", body);
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.detect-version-bump.outputs.tag_name }}
           name: ${{ needs.detect-version-bump.outputs.release_name }}


### PR DESCRIPTION
Update all actions where major version bumps were Node.js runtime
upgrades only, with no breaking changes to inputs/outputs:

```
- actions/checkout              v4 -> v7
- actions/configure-pages       v5 -> v6
- actions/deploy-pages          v4 -> v5
- actions/download-artifact     v4 -> v8
- actions/github-script         v7 -> v9
- actions/setup-node            v4 -> v6
- actions/setup-python          v5 -> v6
- actions/upload-artifact       v4 -> v7
- actions/upload-pages-artifact v3 -> v5
- apple-actions/import-codesign-certs v3 -> v7
- softprops/action-gh-release   v2 -> v3
```
`tauri-apps/tauri-action` is not updated on purpose, because v0 -> v1
has a breaking change in .app.tar.gz naming that may affect the updater
pipeline and I need to check it more carefully.