### PR TITLE
fix: pin Rust to 1.97.0, modify workflows to warm cache

### DIFF
--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -1,7 +1,7 @@
 name: PR macOS Build Check
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize

--- a/.github/workflows/warm-rust-cache.yml
+++ b/.github/workflows/warm-rust-cache.yml
@@ -1,0 +1,46 @@
+name: Warm Rust cache
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+    paths:
+      - src-tauri/**
+      - rust/**
+      - rust-toolchain.toml
+
+concurrency:
+  group: warm-rust-cache-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  warm-macos:
+    name: Warm macOS Rust cache
+    runs-on: macos-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+          shared-key: tauri
+
+      - name: Compile Rust dependencies
+        working-directory: src-tauri
+        env:
+          CMAKE_OSX_ARCHITECTURES: "arm64;x86_64"
+          DF_BUILD_TARGET_TRIPLE: universal-apple-darwin
+        run: |
+          cargo build --release --target aarch64-apple-darwin
+          cargo build --release --target x86_64-apple-darwin

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+channel = "1.97.0"
+targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+  # iOS: add "aarch64-apple-ios-sim" (simulator) and/or "aarch64-apple-ios" (device)
+]


### PR DESCRIPTION
Every time Rust releases a new version, we get it and at the same time
invalidate our caches (because their hash depends on the version).

Also add a new workflow triggered on pushes to dev or main that creates
a cache to speed up things, and a tweak to pr-check-build to use the
pull-request branch instead of pull_request_target (`main`) for the caches.