### PR TITLE
fix(ci): generate plugin registry before cargo in warm and PR workflows

### DIFF
--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -91,6 +91,9 @@ jobs:
           echo "APPLE_PASSWORD=$APPLE_PASSWORD" >> "$GITHUB_ENV"
           echo "APPLE_TEAM_ID=MHNF3GA2MM" >> "$GITHUB_ENV"
 
+      - name: Generate plugin registry
+        run: node scripts/generate-plugin-registry.mjs
+
       - name: Build Tauri universal macOS bundle
         uses: tauri-apps/tauri-action@v0
         env:

--- a/.github/workflows/warm-rust-cache.yml
+++ b/.github/workflows/warm-rust-cache.yml
@@ -36,6 +36,9 @@ jobs:
           workspaces: ./src-tauri -> target
           shared-key: tauri
 
+      - name: Generate plugin registry
+        run: node scripts/generate-plugin-registry.mjs
+
       - name: Compile Rust dependencies
         working-directory: src-tauri
         env:


### PR DESCRIPTION
Add another section to the workflows to force the compilation of the plugins before building the binary, so the cache warming doesn't crash.