### PR TITLE
fix: change polys to triangles

### DIFF
--- a/src/components/controls/ModelStatsCard.tsx
+++ b/src/components/controls/ModelStatsCard.tsx
@@ -565,7 +565,7 @@ export function ModelStatsCard({
               <span>STL size:</span>
               <span className="min-w-0 truncate" style={{ color: 'var(--text-strong)' }}>{model?.fileSizeBytes != null ? formatBytes(model.fileSizeBytes) : '-'}</span>
 
-              <span>Polygons:</span>
+              <span>Triangles:</span>
               <span className="min-w-0 truncate" style={{ color: 'var(--text-strong)' }}>{model ? formatPolygonCountCompact(model.polygonCount) : '-'}</span>
 
               <span>Shells:</span>

--- a/src/components/modals/DiagnosticsModal.tsx
+++ b/src/components/modals/DiagnosticsModal.tsx
@@ -649,8 +649,8 @@ export function DiagnosticsModal({
                 <div>Models: <span style={{ color: 'var(--text-strong)' }}>{modelCount}</span></div>
                 <div>Visible Models: <span style={{ color: 'var(--text-strong)' }}>{visibleModelCount}</span></div>
                 <div>Selected Models: <span style={{ color: 'var(--text-strong)' }}>{selectedModelCount}</span></div>
-                <div>Total Polygons: <span style={{ color: 'var(--text-strong)' }}>{totalPolygons.toLocaleString()}</span></div>
-                <div>Selected Polygons: <span style={{ color: 'var(--text-strong)' }}>{selectedPolygons.toLocaleString()}</span></div>
+                <div>Total Triangles: <span style={{ color: 'var(--text-strong)' }}>{totalPolygons.toLocaleString()}</span></div>
+                <div>Selected Triangles: <span style={{ color: 'var(--text-strong)' }}>{selectedPolygons.toLocaleString()}</span></div>
               </div>
             </div>
 

--- a/src/utils/meshStatsFormatting.ts
+++ b/src/utils/meshStatsFormatting.ts
@@ -25,10 +25,10 @@ export function formatPolygonCountCompact(count: number): string {
 
 /**
  * Formats stats for display in UI
- * e.g., "1.37M polys • 3 shells" or just "1.37M polys"
+ * e.g., "1.37M triangles • 3 shells" or just "1.37M triangles"
  */
 export function formatMeshStatsForDisplay(stats: MeshStats): string {
-  const polyText = `${formatPolygonCountCompact(stats.polygonCount)} polys`;
+  const polyText = `${formatPolygonCountCompact(stats.polygonCount)} triangles`;
   
   // Only show shell count if > 1 (single continuous shells are the desired result)
   if (stats.componentCount != null && stats.componentCount > 1) {


### PR DESCRIPTION
"Polys" in the UI should be called "triangles" (because they are) to avoid confusion.