### PR TITLE
fix(ci): allow manual dispatch of warm-rust-cache workflow

### DIFF
--- a/.github/workflows/warm-rust-cache.yml
+++ b/.github/workflows/warm-rust-cache.yml
@@ -9,6 +9,7 @@ on:
       - src-tauri/**
       - rust/**
       - rust-toolchain.toml
+  workflow_dispatch:
 
 concurrency:
   group: warm-rust-cache-${{ github.ref_name }}


### PR DESCRIPTION
When a warm run fails, the only way to retry was pushing another commit touching the Rust paths. `workflow_dispatch` allows re-running it manually against main or dev from the Actions UI.