### PR TITLE
fix(ci): build thumbnailer sidecars before cargo in warm workflow

### DIFF
--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -68,7 +68,9 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: ./src-tauri -> target
+          workspaces: |
+            ./src-tauri -> target
+            ./rust/dragonfruit-voxl-thumbnail -> target
           shared-key: tauri
 
       - name: Install frontend dependencies

--- a/.github/workflows/warm-rust-cache.yml
+++ b/.github/workflows/warm-rust-cache.yml
@@ -34,11 +34,18 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: ./src-tauri -> target
+          workspaces: |
+            ./src-tauri -> target
+            ./rust/dragonfruit-voxl-thumbnail -> target
           shared-key: tauri
 
       - name: Generate plugin registry
         run: node scripts/generate-plugin-registry.mjs
+
+      - name: Build thumbnail provider sidecars
+        env:
+          DF_BUILD_TARGET_TRIPLE: universal-apple-darwin
+        run: node scripts/build-thumbnail-providers.mjs
 
       - name: Compile Rust dependencies
         working-directory: src-tauri

--- a/.github/workflows/warm-rust-cache.yml
+++ b/.github/workflows/warm-rust-cache.yml
@@ -38,9 +38,21 @@ jobs:
             ./src-tauri -> target
             ./rust/dragonfruit-voxl-thumbnail -> target
           shared-key: tauri
+          # If a late compile step fails, still save everything built so far —
+          # the whole point of this workflow is warming the dependency cache.
+          cache-on-failure: true
 
       - name: Generate plugin registry
         run: node scripts/generate-plugin-registry.mjs
+
+      # tauri::generate_context!() embeds frontendDist assets when compiling
+      # dragonfruit-desktop and fails if the directory is missing. A stub is
+      # enough: desktop-crate artifacts are branch-specific and recompiled on
+      # every PR anyway; this workflow only warms the dependency cache.
+      - name: Stub frontend dist
+        run: |
+          mkdir -p src-tauri/frontend-dist
+          [ -f src-tauri/frontend-dist/index.html ] || echo '<!doctype html><title>warm-cache stub</title>' > src-tauri/frontend-dist/index.html
 
       - name: Build thumbnail provider sidecars
         env:


### PR DESCRIPTION
Add missing voxl thumbnailer sidecar binaries.

Run the script (with DF_BUILD_TARGET_TRIPLE=universal-apple-darwin so it
builds both arches and lipos them) before cargo build, and add the
thumbnailer crate to the rust-cache workspaces in BOTH workflows.

Create a frontend assets stub to make sure we don't create a full NextJs
cache just for Rust.  Also enable cache-on-failure so that if any future
step trips over yet another missing input, the dependencies compiled
up to that point are still saved instead of throwing the whole run away.