### PR TITLE
fix: Twig shaft missing from STL export pipeline

### DIFF
--- a/src/features/export/logic/SupportGeometryGenerator.ts
+++ b/src/features/export/logic/SupportGeometryGenerator.ts
@@ -62,9 +62,21 @@ export class SupportGeometryGenerator {
     let currentStart = this.getStartPosition(data, raftSettings);
     
     data.segments.forEach((seg: Segment) => {
+      // Shaft start: prefer the segment's own bottomJoint so segments whose
+      // joints are not a simple forward chain are drawn at full length. Sticks
+      // are the case that matters: their body spans bottomJoint -> topJoint
+      // between the two contact-cone sockets, and the provided startPos equals
+      // one socket, so chaining from currentStart to topJoint collapsed the
+      // shaft to zero length (dropping the stem and detaching parented
+      // branches). For trunks/branches the bottomJoint coincides with the
+      // chained start, so this is a no-op there.
+      const segStart = seg.bottomJoint
+        ? new THREE.Vector3(seg.bottomJoint.pos.x, seg.bottomJoint.pos.y, seg.bottomJoint.pos.z)
+        : currentStart;
+
       // Calculate end point
       let endPoint: THREE.Vector3;
-      
+
       if (seg.topJoint) {
         endPoint = new THREE.Vector3(seg.topJoint.pos.x, seg.topJoint.pos.y, seg.topJoint.pos.z);
       } else if (data.contactCone) {
@@ -76,7 +88,7 @@ export class SupportGeometryGenerator {
       }
 
       // Generate Shaft
-      const shaftMesh = this.generateShaftMesh(currentStart, endPoint, seg.diameter);
+      const shaftMesh = this.generateShaftMesh(segStart, endPoint, seg.diameter);
       if (shaftMesh) group.add(shaftMesh);
 
       // Generate Joint (if present)

--- a/src/features/export/logic/SupportGeometryGenerator.ts
+++ b/src/features/export/logic/SupportGeometryGenerator.ts
@@ -60,7 +60,19 @@ export class SupportGeometryGenerator {
     // We need to track start position similar to SupportBuilder
     // Pass raftSettings to calculate correct start height (lifted by raft)
     let currentStart = this.getStartPosition(data, raftSettings);
-    
+
+    // Track joints already emitted so shared joints aren't drawn twice. Trunks
+    // and branches chain forward (each bottomJoint is the previous topJoint), so
+    // dedup keeps them unchanged; sticks have a distinct joint ("ball") at each
+    // socket, so this lets us draw both without duplicating shared ones.
+    const seenJointIds = new Set<string>();
+    const addJointSphere = (joint: Segment['topJoint']) => {
+      if (!joint || seenJointIds.has(joint.id)) return;
+      seenJointIds.add(joint.id);
+      const jointMesh = this.generateJointMesh(joint);
+      if (jointMesh) group.add(jointMesh);
+    };
+
     data.segments.forEach((seg: Segment) => {
       // Shaft start: prefer the segment's own bottomJoint so segments whose
       // joints are not a simple forward chain are drawn at full length. Sticks
@@ -91,11 +103,9 @@ export class SupportGeometryGenerator {
       const shaftMesh = this.generateShaftMesh(segStart, endPoint, seg.diameter);
       if (shaftMesh) group.add(shaftMesh);
 
-      // Generate Joint (if present)
-      if (seg.topJoint) {
-        const jointMesh = this.generateJointMesh(seg.topJoint);
-        if (jointMesh) group.add(jointMesh);
-      }
+      // Generate Joints ("balls") at both ends (deduplicated across segments)
+      addJointSphere(seg.bottomJoint);
+      addJointSphere(seg.topJoint);
 
       // Update start for next segment
       currentStart = endPoint;


### PR DESCRIPTION
## Problem
Stick supports (and any branch parented to a stick) came out broken in exported STL/3MF:
- The stick's connecting **stem was missing** entirely — only the two contact-cone tips survived.
- **Branches parented to the stick floated free**, detached from the structure running down to the plate.
- The **joint "ball" at one socket** of the stick was missing.

The raster/slicing pipeline was unaffected — this was specific to the mesh-export reconstruction.

## Root cause
`SupportGeometryGenerator.generateSupportGroup` builds each shaft from the chained `currentStart` to `seg.topJoint.pos`, and only emits a joint sphere for `seg.topJoint`.

A stick's body spans `bottomJoint → topJoint` between its two contact-cone sockets, and `buildStickGroup` passes a `startPos` equal to one socket. So the shaft was drawn `socket → same socket` = zero length → dropped (`bottomJoint`, the real far end, was never used), and only the `topJoint` ball was emitted. Branch knots sit on the missing stem, so they were left floating.

## Fix
In `generateSupportGroup`:
1. Start each shaft at `seg.bottomJoint?.pos ?? currentStart` (matches the raster path and `buildTwigGroup`) — robust to the stick builder's `swap` flag since it uses the segment's intrinsic joints rather than the cones.
2. Emit joint spheres at **both** ends, deduplicated by joint id.

No-op for trunks/branches: their first segment has no `bottomJoint`, and every later `bottomJoint` is exactly the previous segment's `topJoint` (verified 0.0000mm delta on a real scene), so dedup skips it — no new or duplicated geometry.

## Verification
Reconstructed the real failing `Knight_DF_Scene` from its `.voxl` and ran it through the export path:
- Stick stem restored (non-degenerate ~7.5mm shaft; mid-section triangles 0 → 35).
- Both previously-floating branches back on the stem axis at **0.000mm** — reconnected.
- Joint ball present at **both** stick sockets (bottom one was missing before).
- Trunk stem and joint count unchanged.
- Existing `supportExportReconstruction.test.ts` (5 tests) pass; `tsc --noEmit` clean.

resolves https://github.com/Open-Resin-Alliance/DragonFruit/issues/351