### PR TITLE
fix: reverse winding for mirrored models in raster staging

### DIFF
--- a/src/features/slicing/rasterLayerZipExport.ts
+++ b/src/features/slicing/rasterLayerZipExport.ts
@@ -576,14 +576,23 @@ function appendGeometryTriangles(
   const position = geometry.getAttribute('position');
   if (!position) return;
 
+  // A negative-determinant matrix (mirror / negative scale, e.g. a model
+  // matrix from a mirrored .lys import) reflects vertices without reordering
+  // them, inverting each triangle's winding. Swap b<->c to keep the baked
+  // geometry outward-wound for the rasterizer. Support/raft callers pass
+  // rotation-only matrices (determinant +1) or none, so they never flip. (#334)
+  const flipWinding = matrix ? matrix.determinant() < 0 : false;
+
   const v0 = new THREE.Vector3();
   const v1 = new THREE.Vector3();
   const v2 = new THREE.Vector3();
 
   const writeTri = (a: number, b: number, c: number) => {
+    const b2 = flipWinding ? c : b;
+    const c2 = flipWinding ? b : c;
     v0.set(position.getX(a), position.getY(a), position.getZ(a));
-    v1.set(position.getX(b), position.getY(b), position.getZ(b));
-    v2.set(position.getX(c), position.getY(c), position.getZ(c));
+    v1.set(position.getX(b2), position.getY(b2), position.getZ(b2));
+    v2.set(position.getX(c2), position.getY(c2), position.getZ(c2));
 
     if (matrix) {
       v0.applyMatrix4(matrix);
@@ -1376,6 +1385,10 @@ function buildTriangles(
 
   for (const model of models) {
     const matrix = composeModelMatrix(model.transform);
+    // A negative-determinant model transform (mirror / negative scale) reflects
+    // vertices without reordering them, inverting each triangle's winding. Swap
+    // b<->c so the baked model stays outward-wound for the rasterizer. (#334)
+    const flipWinding = matrix.determinant() < 0;
     const center = model.geometry.center;
     const geometry = model.geometry.geometry;
     const position = geometry.getAttribute('position');
@@ -1401,8 +1414,8 @@ function buildTriangles(
         const c = Number(idx[i + 2]);
 
         readVertex(a, v0);
-        readVertex(b, v1);
-        readVertex(c, v2);
+        readVertex(flipWinding ? c : b, v1);
+        readVertex(flipWinding ? b : c, v2);
 
         const zMin = Math.min(v0.z, v1.z, v2.z);
         const zMax = Math.max(v0.z, v1.z, v2.z);
@@ -1429,8 +1442,8 @@ function buildTriangles(
       const count = position.count;
       for (let i = 0; i < count; i += 3) {
         readVertex(i, v0);
-        readVertex(i + 1, v1);
-        readVertex(i + 2, v2);
+        readVertex(flipWinding ? i + 2 : i + 1, v1);
+        readVertex(flipWinding ? i + 1 : i + 2, v2);
 
         const zMin = Math.min(v0.z, v1.z, v2.z);
         const zMax = Math.max(v0.z, v1.z, v2.z);
@@ -1468,6 +1481,10 @@ function buildWorldTriangles(models: LoadedModel[]): WorldTriangle[] {
 
   for (const model of models) {
     const matrix = composeModelMatrix(model.transform);
+    // A negative-determinant model transform (mirror / negative scale) reflects
+    // vertices without reordering them, inverting each triangle's winding. Swap
+    // b<->c so the baked model stays outward-wound for the rasterizer. (#334)
+    const flipWinding = matrix.determinant() < 0;
     const center = model.geometry.center;
     const geometry = model.geometry.geometry;
     const position = geometry.getAttribute('position');
@@ -1493,8 +1510,8 @@ function buildWorldTriangles(models: LoadedModel[]): WorldTriangle[] {
         const c = Number(idx[i + 2]);
 
         readVertex(a, v0);
-        readVertex(b, v1);
-        readVertex(c, v2);
+        readVertex(flipWinding ? c : b, v1);
+        readVertex(flipWinding ? b : c, v2);
 
         const zMin = Math.min(v0.z, v1.z, v2.z);
         const zMax = Math.max(v0.z, v1.z, v2.z);
@@ -1517,8 +1534,8 @@ function buildWorldTriangles(models: LoadedModel[]): WorldTriangle[] {
       const count = position.count;
       for (let i = 0; i < count; i += 3) {
         readVertex(i, v0);
-        readVertex(i + 1, v1);
-        readVertex(i + 2, v2);
+        readVertex(flipWinding ? i + 2 : i + 1, v1);
+        readVertex(flipWinding ? i + 1 : i + 2, v2);
 
         const zMin = Math.min(v0.z, v1.z, v2.z);
         const zMax = Math.max(v0.z, v1.z, v2.z);
@@ -1557,6 +1574,14 @@ function appendModelTrianglesInRange(
   endTri: number,
 ): void {
   const matrix = composeModelMatrix(model.transform);
+  // A negative-determinant model transform (a mirror / negative scale, e.g.
+  // from a Lychee-mirrored .lys import or a transient live mirror preview)
+  // reflects the vertices without reordering them, which inverts every model
+  // triangle's winding. The rasterizer decides fill from face-normal X sign
+  // (geometry.rs: fill_wind), so an inside-out model overlapping the
+  // always-outward supports produces mixed-sign scanlines and dropped fill.
+  // Swap b<->c to keep the baked model consistently outward-wound. (#334)
+  const flipWinding = matrix.determinant() < 0;
   const center = model.geometry.center;
   const geometry = model.geometry.geometry;
   const position = geometry.getAttribute('position');
@@ -1577,6 +1602,11 @@ function appendModelTrianglesInRange(
     return target;
   };
 
+  const push = () =>
+    flipWinding
+      ? collector.pushTriangle(v0.x, v0.y, v0.z, v2.x, v2.y, v2.z, v1.x, v1.y, v1.z)
+      : collector.pushTriangle(v0.x, v0.y, v0.z, v1.x, v1.y, v1.z, v2.x, v2.y, v2.z);
+
   if (index) {
     const idx = index.array;
     const triStart = startTri * 3;
@@ -1585,7 +1615,7 @@ function appendModelTrianglesInRange(
       readVertex(Number(idx[i]), v0);
       readVertex(Number(idx[i + 1]), v1);
       readVertex(Number(idx[i + 2]), v2);
-      collector.pushTriangle(v0.x, v0.y, v0.z, v1.x, v1.y, v1.z, v2.x, v2.y, v2.z);
+      push();
     }
   } else {
     const triStart = startTri * 3;
@@ -1594,7 +1624,7 @@ function appendModelTrianglesInRange(
       readVertex(i, v0);
       readVertex(i + 1, v1);
       readVertex(i + 2, v2);
-      collector.pushTriangle(v0.x, v0.y, v0.z, v1.x, v1.y, v1.z, v2.x, v2.y, v2.z);
+      push();
     }
   }
 }


### PR DESCRIPTION
### Problem

Fixes https://github.com/Open-Resin-Alliance/DragonFruit/issues/334 — severe extending print artifacts that cluster around supports. Despite the issue title ("broken meshes"), the mesh is not broken: it's a **winding inconsistency between the model and its supports**.

The V3 rasterizer decides fill using non-zero winding, deriving each triangle's contribution purely from its face-normal X sign (`rust/dragonfruit-slicing-engine/src/geometry.rs:70`). A row is flagged defective and drops fill when it sees mixed-sign winding — `min_winding < 0 && max_winding > 0` (`rust/dragonfruit-slicing-engine/src/raster.rs:412`).

Supports are always re-tessellated fresh with outward winding. The model, however, bakes `composeModelMatrix(model.transform)` — including scale — via `applyMatrix4` **without ever reordering vertices**. When that transform has a **negative determinant** (a mirror / negative scale), the coordinates reflect but the vertex order doesn't, so every model triangle's normal flips and the model slices **inside-out relative to its supports**. Wherever they overlap → mixed-sign rows → dropped fill → the artifacts.

Two ways a negative-scale transform reaches slicing:

1. **LYS import** — `plugins/lys-import/fileTypeHandlers.ts:442` copies `rawObj.scale` verbatim; a Lychee-mirrored scene carries a negative axis and there's no bake/normalization step, so it persists for the whole session (the likely #334 case).
2. **Native mirror preview** — the transient negative-scale preview before `bakeMirrorIntoGeometry` (which *does* reverse winding on commit) finishes, or any reload of the un-baked transform.

### Fix

Detect `matrix.determinant() < 0` at the single slice-staging chokepoint and swap `b`↔`c`, keeping the baked model outward-wound — exactly what `bakeMirrorIntoGeometry` already does for the native mirror tool. Applied to all four bakers in `src/features/slicing/rasterLayerZipExport.ts`:

- `appendModelTrianglesInRange` (primary raster path)
- `buildTriangles`
- `buildWorldTriangles`
- `appendGeometryTriangles` (null-safe; support/raft callers pass rotation-only or no matrix and never flip)

### Scope / safety

- **No regression on non-mirrored models** — `determinant() >= 0` takes the unchanged branch (byte-identical output).
- **Supports and rafts are untouched** — they're never baked through `composeModelMatrix`, and their orientation matrices are pure rotations (determinant +1).
- The STL/3MF `ExportManager` path has the same class of bug but is **out of scope** — fixed on a separate branch.

### Testing

- `tsc --noEmit` passes (exit 0).
- **Manual repro:** import a `.lys` scene mirrored in Lychee (or mirror a native model and slice during the live preview), keep supports, slice through a support-to-model contact region → streaky dropouts appear before, solid fill after.
