### PR TITLE
fix: kitchen-sink of annoying little bugs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { execSync } from "child_process";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 
@@ -7,6 +8,25 @@ const { version: packageVersion, buildChannel: packageBuildChannel } = JSON.pars
 ) as { version: string; buildChannel?: string };
 
 const buildChannel = (packageBuildChannel ?? 'mainline').trim().toLowerCase();
+
+// Git build fingerprint, baked in at build time so About can tell apart
+// binaries that all report the same package version. Empty when git is
+// unavailable (e.g. building from a source tarball).
+const git = (command: string): string => {
+  try {
+    return execSync(command, { cwd: __dirname, stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {
+    return "";
+  }
+};
+const gitCommit = git("git rev-parse --short=9 HEAD");
+const gitDirty = gitCommit && git("git status --porcelain") !== "" ? "-dirty" : "";
+// Exact tag wins over branch name; detached HEAD (CI checkouts) reports "HEAD",
+// which is meaningless to users, so drop it.
+const gitBranch = git("git rev-parse --abbrev-ref HEAD").replace(/^HEAD$/, "");
+const gitRef = git("git describe --tags --exact-match") || gitBranch;
 
 const nextConfig: NextConfig = {
   turbopack: {},
@@ -18,6 +38,8 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_APP_VERSION: packageVersion,
     NEXT_PUBLIC_BUILD_CHANNEL: buildChannel,
+    NEXT_PUBLIC_GIT_COMMIT: gitCommit ? `${gitCommit}${gitDirty}` : "",
+    NEXT_PUBLIC_GIT_REF: gitRef,
   },
   reactCompiler: true,
   allowedDevOrigins: ['127.0.0.1', '::1'],

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -60,6 +60,7 @@ fn default_dither_device_gamma() -> f64 {
 }
 
 mod plugin_registry;
+mod window_state;
 
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use serde::Deserialize;
@@ -2722,12 +2723,11 @@ async fn focus_main_window_command(app: DragonFruitAppHandle) -> Result<(), Stri
 async fn reveal_main_window_command(app: DragonFruitAppHandle) -> Result<(), String> {
     // Show the main window first so there is no gap between splash close and
     // main window appearance (which would expose the desktop for a frame).
-    // Maximize before show so the window is already at full size when it
-    // becomes visible — avoids a two-step resize flash on Windows.
+    // Geometry (restored session state or first-launch maximize) was already
+    // applied at window creation, so showing here causes no resize flash.
     if let Some(window) = app.get_webview_window("main") {
         let is_visible = window.is_visible().unwrap_or(true);
         if !is_visible {
-            let _ = window.maximize();
             // Re-enable taskbar entry just before we make the window visible.
             #[cfg(target_os = "windows")]
             let _ = window.set_skip_taskbar(false);
@@ -3234,6 +3234,8 @@ fn main() {
     let builder = builder.setup(|app| {
         let app_handle = app.handle().clone();
 
+        app.manage(window_state::WindowStateTracker::default());
+
         // Defer main window creation to an async task so the splashscreen's
         // WebView2 instance fully initialises before the main window's does.
         // On Windows, simultaneous WebView2 init produces a brief window flash
@@ -3272,12 +3274,22 @@ fn main() {
             let builder = builder.skip_taskbar(true);
 
             match builder.build() {
-                Ok(_window) => {
+                Ok(window) => {
+                    // Restore the previous session's geometry while the window
+                    // is still hidden; first launch keeps the maximized default.
+                    match window_state::load(&app_handle) {
+                        Some(state) => window_state::restore(&window, &state),
+                        None => {
+                            let _ = window.maximize();
+                        }
+                    }
+                    window_state::track(&window);
+
                     // On macOS, reveal immediately so a frontend startup hiccup
                     // can't leave the app invisible when created as hidden.
                     #[cfg(target_os = "macos")]
                     {
-                        if let Err(error) = _window.show() {
+                        if let Err(error) = window.show() {
                             log::warn!("Failed to show main window during setup: {error}");
                         }
                     }
@@ -3402,6 +3414,16 @@ fn main() {
             updater_channel::get_saved_update_channel,
             updater_channel::save_update_channel
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running DragonFruit desktop app");
+        .build(tauri::generate_context!())
+        .expect("error while running DragonFruit desktop app")
+        .run(|app_handle, event| {
+            // CloseRequested does not fire on macOS Cmd+Q, so also flush the
+            // tracked window state when the app itself is quitting.
+            if matches!(
+                event,
+                tauri::RunEvent::ExitRequested { .. } | tauri::RunEvent::Exit
+            ) {
+                window_state::save(app_handle);
+            }
+        });
 }

--- a/src-tauri/src/window_state.rs
+++ b/src-tauri/src/window_state.rs
@@ -1,0 +1,156 @@
+//! Persists the main window's size, position and maximized flag across
+//! launches. Hand-rolled instead of `tauri-plugin-window-state` because the
+//! pinned tauri fork (feat/cef) makes external plugin resolution fragile —
+//! see the dependency comments in Cargo.toml.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Mutex;
+use tauri::{AppHandle, Manager, PhysicalPosition, PhysicalSize, Runtime, WebviewWindow};
+
+const STATE_FILE: &str = "window-state.json";
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct WindowState {
+    pub width: u32,
+    pub height: u32,
+    pub x: i32,
+    pub y: i32,
+    pub maximized: bool,
+}
+
+/// Last known geometry of the main window, refreshed from window events.
+/// Kept in memory (not written per-event) and flushed to disk on close/exit.
+/// Geometry is only overwritten while the window is in the normal state, so
+/// the pre-maximize size survives (a maximized window reports the full work
+/// area as its size).
+#[derive(Default)]
+pub struct WindowStateTracker(Mutex<Option<WindowState>>);
+
+fn state_file_path<R: Runtime>(app: &AppHandle<R>) -> Option<PathBuf> {
+    app.path()
+        .app_config_dir()
+        .ok()
+        .map(|dir| dir.join(STATE_FILE))
+}
+
+pub fn load<R: Runtime>(app: &AppHandle<R>) -> Option<WindowState> {
+    let raw = std::fs::read_to_string(state_file_path(app)?).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Applies saved geometry to the freshly created (still hidden) window.
+/// The saved position is ignored when it no longer intersects any monitor,
+/// e.g. after unplugging an external display.
+pub fn restore<R: Runtime>(window: &WebviewWindow<R>, state: &WindowState) {
+    let position_on_screen = window
+        .available_monitors()
+        .map(|monitors| {
+            monitors.iter().any(|monitor| {
+                let mon_pos = monitor.position();
+                let mon_size = monitor.size();
+                let overlaps_x = state.x + (state.width as i32) > mon_pos.x
+                    && state.x < mon_pos.x + mon_size.width as i32;
+                let overlaps_y =
+                    state.y >= mon_pos.y - 8 && state.y < mon_pos.y + mon_size.height as i32;
+                overlaps_x && overlaps_y
+            })
+        })
+        .unwrap_or(false);
+
+    let _ = window.set_size(PhysicalSize::new(state.width, state.height));
+    if position_on_screen {
+        let _ = window.set_position(PhysicalPosition::new(state.x, state.y));
+    } else {
+        let _ = window.center();
+    }
+    if state.maximized {
+        let _ = window.maximize();
+    }
+}
+
+/// Subscribes to the window's move/resize/close events to keep the tracker
+/// current and flush it to disk when the window closes.
+pub fn track<R: Runtime>(window: &WebviewWindow<R>) {
+    let app = window.app_handle().clone();
+    let tracked = window.clone();
+    window.on_window_event(move |event| match event {
+        tauri::WindowEvent::Resized(_) | tauri::WindowEvent::Moved(_) => {
+            update_tracker(&app, &tracked);
+        }
+        tauri::WindowEvent::CloseRequested { .. } => save(&app),
+        _ => {}
+    });
+    // Seed the tracker so an exit without any move/resize still persists state.
+    // Dispatched onto the main thread rather than called inline: `track()` runs
+    // during startup from a background thread (main window creation is deferred
+    // off-thread, see main.rs), and `update_tracker` locks the tracker mutex
+    // before making a synchronous cross-thread query for the window's geometry.
+    // If the main thread was concurrently handling a Resized/Moved event for
+    // this same window via the handler above — which the `restore()` call just
+    // before `track()` reliably triggers — it would block on that same mutex,
+    // while this thread blocks waiting for the main thread: a deadlock that
+    // hung the app on every launch.
+    let app = window.app_handle().clone();
+    let seed_window = window.clone();
+    let _ = window.run_on_main_thread(move || update_tracker(&app, &seed_window));
+}
+
+fn update_tracker<R: Runtime>(app: &AppHandle<R>, window: &WebviewWindow<R>) {
+    let Some(tracker) = app.try_state::<WindowStateTracker>() else {
+        return;
+    };
+    let Ok(mut guard) = tracker.0.lock() else {
+        return;
+    };
+
+    if window.is_minimized().unwrap_or(false) {
+        return;
+    }
+    let maximized = window.is_maximized().unwrap_or(false);
+    if (maximized || window.is_fullscreen().unwrap_or(false)) && guard.is_some() {
+        // Keep the last normal-state geometry; only record the flag.
+        if let Some(state) = guard.as_mut() {
+            state.maximized = maximized;
+        }
+        return;
+    }
+
+    let (Ok(size), Ok(position)) = (window.inner_size(), window.outer_position()) else {
+        return;
+    };
+    if size.width == 0 || size.height == 0 {
+        return;
+    }
+    *guard = Some(WindowState {
+        width: size.width,
+        height: size.height,
+        x: position.x,
+        y: position.y,
+        maximized,
+    });
+}
+
+/// Writes the tracked state to disk. Called on window close and app exit.
+pub fn save<R: Runtime>(app: &AppHandle<R>) {
+    let Some(tracker) = app.try_state::<WindowStateTracker>() else {
+        return;
+    };
+    let Some(state) = tracker.0.lock().ok().and_then(|guard| *guard) else {
+        return;
+    };
+    let Some(path) = state_file_path(app) else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match serde_json::to_string_pretty(&state) {
+        Ok(json) => {
+            if let Err(error) = std::fs::write(&path, json) {
+                log::warn!("[window-state] Failed to write {}: {error}", path.display());
+            }
+        }
+        Err(error) => log::warn!("[window-state] Failed to serialize state: {error}"),
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -75,7 +75,7 @@
         "height": 800,
         "minWidth": 960,
         "minHeight": 600,
-        "maximized": true,
+        "maximized": false,
         "resizable": true,
         "decorations": true,
         "hiddenTitle": true,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { HotkeyProvider } from "@/hotkeys/HotkeyContext";
 import { HotkeyRegistryManager } from "@/hotkeys/HotkeyRegistryManager";
 import { RendererCrashDiagnostics } from "@/components/debug/RendererCrashDiagnostics";
+import { DevIndicatorPosition } from "@/components/debug/DevIndicatorPosition";
 import { AppLogger } from "@/components/AppLogger";
 import { I18nClientProvider } from "@/components/I18nClientProvider";
 
@@ -49,6 +50,7 @@ export default function RootLayout({
             <HotkeyRegistryManager />
             <AppLogger />
             <RendererCrashDiagnostics />
+            <DevIndicatorPosition />
             {children}
           </HotkeyProvider>
         </I18nClientProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5332,7 +5332,9 @@ export default function Home() {
     const gesture = rightClickGestureRef.current;
     const moved = Boolean(gesture?.moved);
     const shouldSuppress = performance.now() < suppressEditorContextMenuUntilRef.current;
-    if (!moved && !shouldSuppress) {
+    // No editor menu on the empty-scene welcome screen — there is nothing to act
+    // on (unless the clipboard holds a cut/copied model that could be pasted).
+    if (!moved && !shouldSuppress && (scene.models.length > 0 || scene.canPasteModel)) {
       if (scene.mode === 'support' && supportShaftHoverDebug.segmentId && supportShaftHoverDebug.point) {
         setEditorContextMenuSupportTarget({
           segmentId: supportShaftHoverDebug.segmentId,
@@ -5348,7 +5350,7 @@ export default function Home() {
     window.setTimeout(() => {
       rightClickGestureRef.current = null;
     }, 0);
-  }, [scene.mode, supportShaftHoverDebug.point, supportShaftHoverDebug.segmentId]);
+  }, [scene.mode, scene.models.length, scene.canPasteModel, supportShaftHoverDebug.point, supportShaftHoverDebug.segmentId]);
 
   React.useEffect(() => {
     const markSuppressed = (durationMs: number) => {

--- a/src/components/controls/LayerSlider.tsx
+++ b/src/components/controls/LayerSlider.tsx
@@ -1,6 +1,7 @@
 ﻿"use client";
 
 import React from 'react';
+import { Tooltip } from '@/components/ui/Tooltip';
 
 type LayerSliderProps = {
   min: number;
@@ -615,6 +616,7 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
       : '';
     return `Layer ${value} • ${mmLabel} • Right-click a handle to type an exact value${modeHint}${toggleHint}`;
   }, [crossSectionEnabled, crossSectionMode, currentHeightMm, formatMm, onCrossSectionModeChange, onToggleCrossSection, value]);
+  const railClassName = `relative mx-auto ${embedded ? (expandToContainer ? 'flex-1 h-full min-h-[300px]' : 'h-[46vh]') : 'h-[56vh]'} ${embedded ? (isMinimalRail ? (isCompactMinimalRail ? 'w-4' : 'w-5') : 'w-7') : 'w-10'} cursor-pointer`;
 
   return (
     <div
@@ -675,9 +677,13 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
           </div>
         )}
 
+        <Tooltip
+          content={isMinimalRail ? <span className="whitespace-pre-line">{minimalRailTitle}</span> : undefined}
+          wrapperClassName={railClassName}
+        >
         <div
           data-no-drag="true"
-          className={`relative mx-auto ${embedded ? (expandToContainer ? (isMinimalRail ? 'flex-1 h-full min-h-[300px]' : 'flex-1 h-full min-h-[300px]') : 'h-[46vh]') : 'h-[56vh]'} ${embedded ? (isMinimalRail ? (isCompactMinimalRail ? 'w-4' : 'w-5') : 'w-7') : 'w-10'} cursor-pointer`}
+          className={railClassName}
           onMouseDown={onPointerDown}
           onDoubleClick={(e) => {
             if (!onToggleCrossSection) return;
@@ -693,9 +699,6 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
           }}
           tabIndex={0}
           onKeyDown={onKeyDown}
-          title={isMinimalRail
-            ? minimalRailTitle
-            : undefined}
         >
           {!isMinimalRail && (
             <div
@@ -1036,6 +1039,7 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
             </div>
           </div>
         </div>
+        </Tooltip>
 
         {!isMinimalRail && (
           <div className="mt-1 text-center text-[10px] tabular-nums" style={{ color: 'var(--text-muted)' }}>
@@ -1052,13 +1056,14 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
               {min}
             </div>
             {showModeIndicator && (
-              <div
-                className={minimalRailBadgeClass}
-                style={railBadgeStyle}
-                title={`Current cross-section mode: ${crossSectionMode}. Right-click slider to toggle.`}
-              >
-                {crossSectionMode === 'smooth' ? 'S' : 'R'}
-              </div>
+              <Tooltip content={`Current cross-section mode: ${crossSectionMode}. Right-click slider to toggle.`}>
+                <div
+                  className={minimalRailBadgeClass}
+                  style={railBadgeStyle}
+                >
+                  {crossSectionMode === 'smooth' ? 'S' : 'R'}
+                </div>
+              </Tooltip>
             )}
           </div>
         )}

--- a/src/components/controls/LayerSlider.tsx
+++ b/src/components/controls/LayerSlider.tsx
@@ -50,6 +50,7 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
 
   // Thumb click-to-edit state
   const [editingThumb, setEditingThumb] = React.useState<'upper' | 'lower' | null>(null);
+  const [editPopoverSide, setEditPopoverSide] = React.useState<'left' | 'right'>('left');
   const [editMode, setEditMode] = React.useState<'layer' | 'mm'>('layer');
   const [editRawValue, setEditRawValue] = React.useState('');
   const editInputRef = React.useRef<HTMLInputElement>(null);
@@ -200,6 +201,14 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
 
   const openThumbEdit = React.useCallback((thumb: 'upper' | 'lower') => {
     const currentLayer = thumb === 'upper' ? valueRef.current : lowerValueRef.current;
+    // Open the popover towards whichever side of the rail actually has room —
+    // sliders docked at the right screen edge would otherwise clip it off-screen.
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (rect) {
+      const popoverSpace = 156; // min-width 136px + 10px offset + margin
+      const spaceRight = window.innerWidth - rect.right;
+      setEditPopoverSide(spaceRight >= popoverSpace || spaceRight >= rect.left ? 'right' : 'left');
+    }
     setEditMode('layer');
     setEditRawValue(String(Math.round(currentLayer)));
     setEditingThumb(thumb);
@@ -590,19 +599,22 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
     ? 'inline-flex items-center rounded-md border px-0.5 py-0 text-[8px] font-semibold tabular-nums'
     : railBadgeClass;
   const shouldPlaceCurrentBadgeBelowThumb = isMinimalRail && percent >= 96;
-  const thumbEditPopoverClassName = isCompactMinimalRail
+  const thumbEditPopoverClassName = editPopoverSide === 'right'
     ? 'absolute left-full top-1/2 -translate-y-1/2 z-[200] flex flex-col gap-1.5 rounded-lg border p-2'
     : 'absolute right-full top-1/2 -translate-y-1/2 z-[200] flex flex-col gap-1.5 rounded-lg border p-2';
-  const thumbEditPopoverOffsetStyle: React.CSSProperties = isCompactMinimalRail
+  const thumbEditPopoverOffsetStyle: React.CSSProperties = editPopoverSide === 'right'
     ? { marginLeft: '10px' }
     : { marginRight: '10px' };
   const minimalRailTitle = React.useMemo(() => {
-    const mmLabel = typeof currentHeightMm === 'number' ? `${formatMm(currentHeightMm)} mm` : 'ΓÇö';
-    const rightClickAction = onCrossSectionModeChange
-      ? `Right-click to toggle ${crossSectionMode === 'smooth' ? 'rasterized' : 'smooth'}`
-      : 'Right-click thumb to edit';
-    return `Layer ${value} ΓÇó ${mmLabel} ΓÇó ${rightClickAction}`;
-  }, [crossSectionMode, currentHeightMm, formatMm, onCrossSectionModeChange, value]);
+    const mmLabel = typeof currentHeightMm === 'number' ? `${formatMm(currentHeightMm)} mm` : '—';
+    const modeHint = onCrossSectionModeChange
+      ? ` • Right-click track to switch to ${crossSectionMode === 'smooth' ? 'rasterized' : 'smooth'} cross-section`
+      : '';
+    const toggleHint = onToggleCrossSection
+      ? ` • Double-click to turn the cross-section ${crossSectionEnabled ? 'off' : 'back on'}`
+      : '';
+    return `Layer ${value} • ${mmLabel} • Right-click a handle to type an exact value${modeHint}${toggleHint}`;
+  }, [crossSectionEnabled, crossSectionMode, currentHeightMm, formatMm, onCrossSectionModeChange, onToggleCrossSection, value]);
 
   return (
     <div
@@ -645,7 +657,7 @@ export function LayerSlider({ min, max, step, value, onChange, onScrubStart, onS
                 background: 'color-mix(in srgb, var(--surface-1), transparent 12%)',
               }}
             >
-              {typeof currentHeightMm === 'number' ? `${formatMm(currentHeightMm)} mm` : 'ΓÇö'}
+              {typeof currentHeightMm === 'number' ? `${formatMm(currentHeightMm)} mm` : '—'}
             </div>
             {typeof maxHeightMm === 'number' && !embedded && (
               <div className="text-[10px] tabular-nums" style={{ color: 'var(--text-muted)' }}>

--- a/src/components/controls/ModelManagerPanel.tsx
+++ b/src/components/controls/ModelManagerPanel.tsx
@@ -22,6 +22,7 @@ import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import { Card, CardHeader, IconButton } from '@/components/atoms';
 import { formatMeshStatsForDisplay } from '@/utils/meshStatsFormatting';
 import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
+import { Tooltip } from '@/components/ui/Tooltip';
 
 type SelectMode = 'single' | 'toggle' | 'add';
 
@@ -605,9 +606,11 @@ export function ModelManagerPanel({
                                 )}
                               </div>
                             ) : (
-                              <div className="text-xs font-medium truncate" style={{ color: 'var(--text-strong)' }}>
-                                {model.name}
-                              </div>
+                              <Tooltip content={model.name} fullWidth>
+                                <div className="min-w-0 text-xs font-medium truncate" style={{ color: 'var(--text-strong)' }}>
+                                  {model.name}
+                                </div>
+                              </Tooltip>
                             )}
                             <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
                               {formatMeshStatsForDisplay({

--- a/src/components/controls/ViewTypeDropdown.tsx
+++ b/src/components/controls/ViewTypeDropdown.tsx
@@ -91,11 +91,12 @@ export function ViewTypeDropdown({
         title={title ?? (iconOnly ? `Camera view mode: ${currentLabel}` : 'View type')}
         options={dropdownOptions}
         className="space-y-0"
-        selectClassName={`${iconOnly ? '!h-8 !w-8 !p-2 justify-center' : '!h-8 !px-2 !py-1.5 text-xs'} ${fullWidth ? 'w-full' : ''}`}
+        selectClassName={`${iconOnly ? '!h-8 !w-[52px] !p-0' : '!h-8 !px-2 !py-1.5 text-xs'} ${fullWidth ? 'w-full' : ''}`}
+        chevronClassName={iconOnly ? 'right-1.5' : undefined}
         menuAlign="right"
         menuClassName="!w-64"
         hideSelectedText={iconOnly}
-        selectedDisplayAlignment={iconOnly ? 'center' : 'left'}
+        selectedDisplayAlignment="left"
         selectedDisplay={iconOnly ? <Camera className="h-4 w-4" style={{ color: 'var(--text-strong)' }} /> : undefined}
         leadingDisplay={iconOnly ? undefined : <span style={{ color: 'var(--accent)' }}>{getViewTypeIcon(value)}</span>}
       />

--- a/src/components/controls/ViewTypeDropdown.tsx
+++ b/src/components/controls/ViewTypeDropdown.tsx
@@ -91,12 +91,12 @@ export function ViewTypeDropdown({
         title={title ?? (iconOnly ? `Camera view mode: ${currentLabel}` : 'View type')}
         options={dropdownOptions}
         className="space-y-0"
-        selectClassName={`${iconOnly ? '!h-8 !w-[52px] !p-0' : '!h-8 !px-2 !py-1.5 text-xs'} ${fullWidth ? 'w-full' : ''}`}
-        chevronClassName={iconOnly ? 'right-1.5' : undefined}
+        selectClassName={`${iconOnly ? '!h-8 !w-8 !p-0' : '!h-8 !px-2 !py-1.5 text-xs'} ${fullWidth ? 'w-full' : ''}`}
+        hideChevron={iconOnly}
         menuAlign="right"
         menuClassName="!w-64"
         hideSelectedText={iconOnly}
-        selectedDisplayAlignment="left"
+        selectedDisplayAlignment={iconOnly ? 'center' : 'left'}
         selectedDisplay={iconOnly ? <Camera className="h-4 w-4" style={{ color: 'var(--text-strong)' }} /> : undefined}
         leadingDisplay={iconOnly ? undefined : <span style={{ color: 'var(--accent)' }}>{getViewTypeIcon(value)}</span>}
       />

--- a/src/components/debug/DevIndicatorPosition.tsx
+++ b/src/components/debug/DevIndicatorPosition.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from 'react';
+
+// Horizontal offset for the Next.js dev tools indicator ("N" badge). At its
+// default top-right spot it sits on top of the app's Settings gear in the top
+// bar; 160px further left it lands in the free gap between the Print stage
+// button and the camera controls.
+const INDICATOR_RIGHT_PX = 180; // default 20px + 160px shift
+
+/**
+ * Moves the Next.js dev tools indicator out of the top bar's action cluster.
+ *
+ * `devIndicators.position` only supports the four corners, so this reaches
+ * into the indicator's shadow root and pins `right` with !important, which
+ * wins over the inline style Next re-applies on badge state changes. Renders
+ * nothing and does nothing in production builds, where the indicator does
+ * not exist.
+ */
+export function DevIndicatorPosition() {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'development') return;
+
+    const inject = () => {
+      const shadowRoot = document.querySelector('nextjs-portal')?.shadowRoot;
+      if (!shadowRoot || shadowRoot.querySelector('[data-dragonfruit-indicator-offset]')) return;
+      const style = document.createElement('style');
+      style.setAttribute('data-dragonfruit-indicator-offset', 'true');
+      style.textContent = `#devtools-indicator { right: ${INDICATOR_RIGHT_PX}px !important; }`;
+      shadowRoot.appendChild(style);
+    };
+
+    // The portal may not exist yet on mount, and dev overlays can recreate
+    // it, so re-inject whenever the top-level DOM changes.
+    inject();
+    const observer = new MutationObserver(inject);
+    observer.observe(document.body, { childList: true });
+    return () => observer.disconnect();
+  }, []);
+
+  return null;
+}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1132,7 +1132,7 @@ export function TopBar({
             onChange={onViewTypeOverrideChange}
             iconOnly
             title={_(msg`View mode`)}
-            className="[&>button]:!h-8 [&>button]:!w-[52px] [&>button]:!p-0"
+            className="[&>button]:!h-8 [&>button]:!w-8 [&>button]:!p-0"
           />
           <Button
             type="button"

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1132,7 +1132,7 @@ export function TopBar({
             onChange={onViewTypeOverrideChange}
             iconOnly
             title={_(msg`View mode`)}
-            className="[&>button]:!h-8 [&>button]:!w-8 [&>button]:!p-0"
+            className="[&>button]:!h-8 [&>button]:!w-[52px] [&>button]:!p-0"
           />
           <Button
             type="button"

--- a/src/components/scene/CrossSectionStencilCap.tsx
+++ b/src/components/scene/CrossSectionStencilCap.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import React from 'react';
+import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { ModelTransform } from '@/hooks/useModelTransform';
 import { quaternionFromGlobalEuler } from '@/utils/rotation';
+
+/** Per-model transforms mutated imperatively while a gizmo drag is active.
+ *  The stencil passes follow these per-frame (like the meshes themselves do)
+ *  so the cap doesn't lag behind until the drag commits through React. */
+export type CrossSectionLiveTransforms = ReadonlyMap<string, ModelTransform>;
 
 export type CrossSectionStencilCapEntry = {
   id: string;
@@ -16,6 +22,9 @@ export type CrossSectionStencilCapEntry = {
 
 type CrossSectionStencilCapProps = {
   entries: CrossSectionStencilCapEntry[];
+  /** Live per-model transforms during gizmo drags; stencil passes follow them
+   *  per-frame so the cap moves with the mesh instead of snapping on release. */
+  liveTransformsRef?: React.RefObject<CrossSectionLiveTransforms | null>;
   sourceObject?: THREE.Object3D | null;
   sourceObjectVersion?: unknown;
   skipSourceZBounds?: boolean;
@@ -171,20 +180,43 @@ StaticInstancedStencilPassMemo.displayName = 'StaticInstancedStencilPassMemo';
 
 function ModelStencilPass({
   entry,
+  liveTransformsRef,
   backMaterial,
   frontMaterial,
   backRenderOrder,
   frontRenderOrder,
 }: {
   entry: ModelStencilPassEntry;
+  liveTransformsRef?: React.RefObject<CrossSectionLiveTransforms | null>;
   backMaterial: THREE.Material;
   frontMaterial: THREE.Material;
   backRenderOrder: number;
   frontRenderOrder: number;
 }) {
+  const groupRef = React.useRef<THREE.Group>(null);
+  const followingLiveRef = React.useRef(false);
+
+  // Gizmo drags move meshes imperatively without React renders, so the
+  // committed entry.matrix goes stale mid-drag. Follow the live transform
+  // per-frame, and restore the committed matrix once the drag ends.
+  useFrame(() => {
+    const group = groupRef.current;
+    if (!group) return;
+    const live = liveTransformsRef?.current?.get(entry.id) ?? null;
+    if (live) {
+      group.matrix.compose(live.position, quaternionFromGlobalEuler(live.rotation), live.scale);
+      group.matrixWorldNeedsUpdate = true;
+      followingLiveRef.current = true;
+    } else if (followingLiveRef.current) {
+      group.matrix.copy(entry.matrix);
+      group.matrixWorldNeedsUpdate = true;
+      followingLiveRef.current = false;
+    }
+  });
+
   return (
     <group key={`stencil-cap-${entry.id}`}>
-      <group matrix={entry.matrix} matrixAutoUpdate={false}>
+      <group ref={groupRef} matrix={entry.matrix} matrixAutoUpdate={false}>
         <mesh
           geometry={entry.geometry}
           position={entry.offset}
@@ -210,6 +242,7 @@ const ModelStencilPassMemo = React.memo(
   ModelStencilPass,
   (prev, next) => (
     prev.entry === next.entry
+    && prev.liveTransformsRef === next.liveTransformsRef
     && prev.backMaterial === next.backMaterial
     && prev.frontMaterial === next.frontMaterial
     && prev.backRenderOrder === next.backRenderOrder
@@ -330,6 +363,7 @@ const STENCIL_CAP_ORDER = STENCIL_RENDER_ORDER_BASE + 0.45;
 
 function CrossSectionStencilCapInner({
   entries,
+  liveTransformsRef,
   sourceObject,
   sourceObjectVersion,
   skipSourceZBounds = false,
@@ -820,13 +854,14 @@ function CrossSectionStencilCapInner({
       <ModelStencilPassMemo
         key={`stencil-cap-${entry.id}`}
         entry={entry}
+        liveTransformsRef={liveTransformsRef}
         backMaterial={stencilBack}
         frontMaterial={stencilFront}
         backRenderOrder={MODEL_BACK_ORDER}
         frontRenderOrder={MODEL_FRONT_ORDER}
       />
     ));
-  }, [stencilBack, stencilFront, visibleModelStencilEntries, MODEL_BACK_ORDER, MODEL_FRONT_ORDER]);
+  }, [liveTransformsRef, stencilBack, stencilFront, visibleModelStencilEntries, MODEL_BACK_ORDER, MODEL_FRONT_ORDER]);
 
   const staticSingleStencilPassNodes = React.useMemo(() => {
     return visibleStaticSingleEntries.map((entry) => (
@@ -909,6 +944,7 @@ const areCrossSectionStencilCapPropsEqual = (
 ) => {
   return (
     prev.entries === next.entries
+    && prev.liveTransformsRef === next.liveTransformsRef
     && prev.sourceObject === next.sourceObject
     && prev.sourceObjectVersion === next.sourceObjectVersion
     && prev.skipSourceZBounds === next.skipSourceZBounds

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -1033,13 +1033,24 @@ export function SceneCanvas({
     }, 180);
   }, [cancelPendingSupportDragResets, resetSupportDragGroupNow]);
 
+  // Live transforms consumed per-frame by the cross-section stencil caps so
+  // the cut surface follows the mesh during gizmo drags instead of snapping
+  // into place on release. Mirrors liveDragTransformRef (active model) plus
+  // the multi-selection preview transforms.
+  const crossSectionLiveTransformsRef = React.useRef<Map<string, ModelTransform>>(new Map());
+
   const queueLiveDragTransform = React.useCallback((next: ModelTransform | null) => {
     liveDragTransformRef.current = next;
+    if (next && activeModelId) {
+      crossSectionLiveTransformsRef.current.set(activeModelId, next);
+    } else if (!next) {
+      crossSectionLiveTransformsRef.current.clear();
+    }
     // During active drag, avoid per-frame React rerenders; scene objects are
     // moved imperatively and this ref remains the source of truth.
     if (isGizmoDragging) return;
     setLiveDragTransformVersion((value) => value + 1);
-  }, [isGizmoDragging]);
+  }, [activeModelId, isGizmoDragging]);
 
   const {
     effectiveHoldSupportDragDelta,
@@ -1085,6 +1096,7 @@ export function SceneCanvas({
     // This prevents stale live transforms from the previous model from being
     // reused after delete/import/undo flows.
     liveDragTransformRef.current = null;
+    crossSectionLiveTransformsRef.current.clear();
     setLiveDragTransformVersion((value) => value + 1);
     setIsGizmoDragging(false);
     setIsGizmoRetargeting(false);
@@ -1100,6 +1112,7 @@ export function SceneCanvas({
     // Clear all transient gizmo/live state so rendering falls back to store data.
     cancelPendingSupportDragResets();
     liveDragTransformRef.current = null;
+    crossSectionLiveTransformsRef.current.clear();
     setLiveDragTransformVersion((value) => value + 1);
     gizmoTransformStartSnapshotRef.current = null;
     setActiveGizmoDragDescriptor(null);
@@ -1114,8 +1127,10 @@ export function SceneCanvas({
   ]);
 
   React.useEffect(() => {
+    const liveTransforms = crossSectionLiveTransformsRef.current;
     return () => {
       liveDragTransformRef.current = null;
+      liveTransforms.clear();
     };
   }, []);
 
@@ -2478,6 +2493,9 @@ export function SceneCanvas({
   ) => {
     for (const [modelId, preview] of Object.entries(previewByModelId)) {
       if (modelId === snapshot.activeModelId) continue;
+
+      // Keep the cross-section caps following the previewed models too.
+      crossSectionLiveTransformsRef.current.set(modelId, preview);
 
       const meshGroup = meshRefs.current[modelId];
       if (meshGroup) {
@@ -5842,6 +5860,7 @@ export function SceneCanvas({
                 <CrossSectionStencilCap
                   key="cross-section-cap-top"
                   entries={crossSectionCapEntries}
+                  liveTransformsRef={crossSectionLiveTransformsRef}
                   sourceObject={supportDragGroupRef?.current ?? null}
                   sourceObjectVersion={clipUpper != null ? crossSectionStencilSourceVersion : undefined}
                   // During slider scrubbing, avoid expensive source z-bound
@@ -5867,6 +5886,7 @@ export function SceneCanvas({
                 <CrossSectionStencilCap
                   key="cross-section-cap-bottom"
                   entries={crossSectionCapEntries}
+                  liveTransformsRef={crossSectionLiveTransformsRef}
                   sourceObject={supportDragGroupRef?.current ?? null}
                   sourceObjectVersion={crossSectionStencilSourceVersion}
                   skipSourceZBounds={isLayerScrubbing}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -4470,7 +4470,7 @@ export function SceneCanvas({
       }
 
       benchmarkRunIdRef.current = requestId;
-      dispatchProgress({ requestId, status: 'started', message: `Preparing ${stressProfile} 3D orbit sweepsΓÇª` });
+      dispatchProgress({ requestId, status: 'started', message: `Preparing ${stressProfile} 3D orbit sweeps…` });
 
       const startedAt = performance.now();
       const startedAtIso = new Date().toISOString();
@@ -6736,7 +6736,7 @@ export function SceneCanvas({
           }}
         >
           <div className="rounded border border-neutral-700 bg-neutral-900/70 px-3 py-2 text-sm text-neutral-100">
-            Loading brushΓÇª
+            Loading brush…
           </div>
         </div>
       )}
@@ -6753,7 +6753,7 @@ export function SceneCanvas({
           }}
         >
           <div className="rounded border border-neutral-700 bg-neutral-900/70 px-3 py-2 text-sm text-neutral-100">
-            SmoothingΓÇª {Math.round((smoothingProcessing.progress ?? 0) * 100)}%
+            Smoothing… {Math.round((smoothingProcessing.progress ?? 0) * 100)}%
           </div>
         </div>
       )}

--- a/src/components/settings/HotkeysSettingsTab.tsx
+++ b/src/components/settings/HotkeysSettingsTab.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import React, { useMemo, useState, useEffect } from 'react';
-import { Keyboard, Lock, RotateCcw } from 'lucide-react';
+import { Keyboard, RotateCcw } from 'lucide-react';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
-import { HotkeyBinding, UNIVERSAL_HOTKEYS } from '@/hotkeys/hotkeyConfig';
+import { HotkeyBinding } from '@/hotkeys/hotkeyConfig';
 
 const PINNED_SLOT_LABELS: Record<string, string> = {
   SLOT_1: 'Slot 1',
@@ -15,11 +15,12 @@ const PINNED_SLOT_LABELS: Record<string, string> = {
 };
 
 const CATEGORY_LABELS: Record<string, string> = {
+  GLOBAL: 'General',
   CAMERA: 'Camera',
+  ROTATION: 'Rotation',
   CANVAS: 'Canvas Tools',
   SUPPORTS: 'Supports',
   PRESETS: 'Presets',
-  ROTATION: 'Rotation',
 };
 
 const SECTION_GROUPS: Array<{
@@ -31,8 +32,8 @@ const SECTION_GROUPS: Array<{
   {
     id: 'global',
     title: 'Global',
-    description: 'Camera, focus, and viewport shortcuts available across all workspaces.',
-    categories: ['CAMERA'],
+    description: 'General, camera, and rotation shortcuts available across all workspaces.',
+    categories: ['GLOBAL', 'CAMERA', 'ROTATION'],
   },
   {
     id: 'scene',
@@ -51,12 +52,6 @@ const SECTION_GROUPS: Array<{
     title: 'Support Presets',
     description: 'Quick-apply support preset shortcuts.',
     categories: ['PRESETS'],
-  },
-  {
-    id: 'rotation',
-    title: 'Rotation Helpers',
-    description: 'Modifier-assisted snapping during rotation drag.',
-    categories: ['ROTATION'],
   },
 ];
 
@@ -210,48 +205,16 @@ export function HotkeysSettingsTab() {
     }).filter((section) => section.categories.some((category) => category.entries.length > 0));
   }, [config]);
 
-  const universalRows = useMemo(() => {
-    return Object.entries(UNIVERSAL_HOTKEYS).map(([action, binding]) => {
-      if ('keys' in binding) {
-        return {
-          action,
-          label: binding.description,
-          tokenGroups: binding.keys.map((key) => [toKeyLabel(key)]),
-        };
-      }
-
-      const modifierTokens = binding.modifier
-        ? binding.modifier.split('+').map(toModifierLabel)
-        : [];
-
-      return {
-        action,
-        label: binding.description,
-        tokenGroups: [[...modifierTokens, toKeyLabel(binding.key)]],
-      };
-    });
-  }, []);
-
-  const rotationSection = useMemo(
-    () => configurableSections.find((section) => section.id === 'rotation') ?? null,
-    [configurableSections],
-  );
-
-  const nonRotationSections = useMemo(
-    () => configurableSections.filter((section) => section.id !== 'rotation'),
-    [configurableSections],
-  );
-
   const sectionRows = useMemo(() => {
-    const rows: Array<[typeof nonRotationSections[number] | null, typeof nonRotationSections[number] | null]> = [];
-    for (let index = 0; index < nonRotationSections.length; index += 2) {
+    const rows: Array<[typeof configurableSections[number] | null, typeof configurableSections[number] | null]> = [];
+    for (let index = 0; index < configurableSections.length; index += 2) {
       rows.push([
-        nonRotationSections[index] ?? null,
-        nonRotationSections[index + 1] ?? null,
+        configurableSections[index] ?? null,
+        configurableSections[index + 1] ?? null,
       ]);
     }
     return rows;
-  }, [nonRotationSections]);
+  }, [configurableSections]);
 
   const renderConfigSection = (section: {
     id: string;
@@ -323,10 +286,6 @@ export function HotkeysSettingsTab() {
 
   return (
     <div className="h-full min-h-0 flex flex-col gap-2">
-      <div className="px-0.5 text-[11px]" style={{ color: 'var(--text-muted)' }}>
-        Click a shortcut chip to record a new key combo. Press <strong>Esc</strong> while recording to cancel.
-      </div>
-
       <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar pr-1">
         <div className="space-y-2.5">
           {sectionRows.map(([leftSection, rightSection], index) => (
@@ -335,68 +294,6 @@ export function HotkeysSettingsTab() {
               {rightSection ? renderConfigSection(rightSection) : <div />}
             </div>
           ))}
-
-          <div className="grid gap-2.5 lg:grid-cols-2">
-            {rotationSection ? renderConfigSection(rotationSection) : <div />}
-
-            <section
-              className="rounded-lg border p-2.5 h-full"
-              style={{
-                borderColor: 'var(--border-subtle)',
-                background: 'var(--surface-1)',
-              }}
-            >
-              <div className="flex items-start gap-2">
-                <span
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-md border shrink-0"
-                  style={{
-                    borderColor: 'var(--border-subtle)',
-                    background: 'color-mix(in srgb, var(--surface-2), transparent 8%)',
-                  }}
-                >
-                  <Lock className="h-4 w-4" style={{ color: 'var(--text-muted)' }} />
-                </span>
-                <div className="min-w-0 flex-1">
-                  <h4 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
-                    System Standard
-                  </h4>
-                  <p className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
-                    Fixed shortcuts shared across all configurations.
-                  </p>
-                </div>
-              </div>
-
-              <div className="mt-1.5 space-y-1">
-                {universalRows.map((row) => (
-                  <div
-                    key={row.action}
-                    className="flex items-center justify-between gap-2 rounded-md border px-2 py-1.5"
-                    style={{
-                      borderColor: 'var(--border-subtle)',
-                      background: 'color-mix(in srgb, var(--surface-2), transparent 8%)',
-                    }}
-                    title="System standard shortcut"
-                  >
-                    <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
-                      {row.label}
-                    </span>
-                    <div className="flex items-center gap-1.5">
-                      {row.tokenGroups.map((group, groupIndex) => (
-                        <React.Fragment key={`${row.action}-${groupIndex}`}>
-                          {group.map((token) => (
-                            <KbdToken key={`${row.action}-${groupIndex}-${token}`}>{token}</KbdToken>
-                          ))}
-                          {groupIndex < row.tokenGroups.length - 1 && (
-                            <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>or</span>
-                          )}
-                        </React.Fragment>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </section>
-          </div>
         </div>
       </div>
 
@@ -473,56 +370,50 @@ function HotkeyRow({ label, binding, isRecording, onRecord, onCancel }: {
   const tokens = getBindingTokens(binding);
 
   return (
-    <div
-      className="flex items-center justify-between gap-2 rounded-md border px-2 py-1.5 transition-colors"
-      style={{
-        borderColor: 'var(--border-subtle)',
-        background: 'color-mix(in srgb, var(--surface-2), transparent 10%)',
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        if (isRecording) {
+          onCancel();
+        } else {
+          onRecord();
+        }
       }}
+      className="flex w-full items-center justify-between gap-2 rounded-md border px-2 py-1.5 transition-colors"
+      style={isRecording
+        ? {
+          borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 35%)',
+          background: 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)',
+          color: 'var(--text-strong)',
+        }
+        : {
+          borderColor: 'var(--border-subtle)',
+          background: 'color-mix(in srgb, var(--surface-2), transparent 10%)',
+          color: 'var(--text-strong)',
+        }}
     >
       <span className="min-w-0 text-[11px] truncate" style={{ color: 'var(--text-strong)' }} title={label}>
         {label}
       </span>
 
-      <button
-        type="button"
-        onClick={(event) => {
-          event.stopPropagation();
-          if (isRecording) {
-            onCancel();
-          } else {
-            onRecord();
-          }
-        }}
-        className="inline-flex min-w-[108px] items-center justify-center gap-1 rounded-md border px-1.5 py-1 text-[10px] transition-all"
-        style={isRecording
-          ? {
-            borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 35%)',
-            background: 'color-mix(in srgb, var(--accent), var(--surface-1) 84%)',
-            color: 'var(--text-strong)',
-          }
-          : {
-            borderColor: 'var(--border-subtle)',
-            background: 'var(--surface-1)',
-            color: 'var(--text-muted)',
-          }}
-      >
+      <span className="inline-flex min-w-[108px] items-center justify-center gap-1">
         {isRecording ? (
-          <span className="font-medium">Press keys…</span>
+          <span className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Press keys…</span>
         ) : (
           tokens.map((token) => <KbdToken key={`${binding.description}-${token}`}>{token}</KbdToken>)
         )}
-      </button>
-    </div>
+      </span>
+    </button>
   );
 }
 
 function KbdToken({ children }: { children: React.ReactNode }) {
   return (
     <kbd
-      className="inline-flex min-w-[20px] items-center justify-center rounded border px-1 py-0.5 font-mono text-[10px]"
+      className="inline-flex min-w-[20px] items-center justify-center rounded border px-1 py-1 font-mono text-[10px]"
       style={{
-        borderColor: 'var(--border-subtle)',
+        borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 50%)',
         background: 'color-mix(in srgb, var(--surface-2), transparent 4%)',
         color: 'var(--text-strong)',
       }}

--- a/src/components/settings/PluginsSettingsTab.tsx
+++ b/src/components/settings/PluginsSettingsTab.tsx
@@ -357,9 +357,11 @@ export function PluginsSettingsTab() {
             </p>
           </div>
         </div>
-        <p className="mt-1 text-[11px]" style={{ color: 'var(--text-muted)' }}>
-          Debug URLs: <code>df://debug_plugin_official</code> and <code>df://debug_plugin_3rd</code>
-        </p>
+        {isDevRuntime && (
+          <p className="mt-1 text-[11px]" style={{ color: 'var(--text-muted)' }}>
+            Debug URLs: <code>df://debug_plugin_official</code> and <code>df://debug_plugin_3rd</code>
+          </p>
+        )}
 
         <div className="mt-2.5 grid grid-cols-[1fr_auto] gap-2">
           <input

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -45,6 +45,7 @@ import {
   type SavedCustomThemeProfile,
 } from '@/components/settings/themeCustomizations';
 import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
+import { Tooltip } from '@/components/ui/Tooltip';
 import {
   DEFAULT_SPACEMOUSE_SETTINGS,
   getSavedSpaceMouseSettings,
@@ -1523,23 +1524,30 @@ export function SettingsModal({
 
                         <div className="mt-3 flex flex-col items-center gap-2">
                           <div className="flex flex-wrap items-center justify-center gap-2.5">
-                            <span
-                              role="button"
-                              tabIndex={0}
-                              onClick={handleCopyBuildInfo}
-                              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleCopyBuildInfo(); } }}
-                              className="inline-flex cursor-pointer items-center rounded-full border px-2.5 py-0.5 text-[12px] font-semibold tabular-nums transition-colors"
-                              style={{
-                                color: copied ? '#2d8a4e' : 'var(--text-strong)',
-                                borderColor: copied ? '#2d8a4e' : 'color-mix(in srgb, var(--border-subtle), white 8%)',
-                                background: copied
-                                  ? 'rgba(45,138,78,0.1)'
-                                  : 'color-mix(in srgb, var(--surface-1), transparent 8%)',
-                              }}
-                              title={DRAGONFRUIT_GIT_BUILD_LABEL ? `Copy build info\n${DRAGONFRUIT_GIT_BUILD_LABEL}` : undefined}
+                            <Tooltip
+                              content={
+                                <span className="whitespace-pre-line">
+                                  Click to copy build info{DRAGONFRUIT_GIT_BUILD_LABEL ? `\n${DRAGONFRUIT_GIT_BUILD_LABEL}` : ''}
+                                </span>
+                              }
                             >
-                              {copied ? '✓ Copied!' : `Version ${DRAGONFRUIT_VERSION}`}
-                            </span>
+                              <span
+                                role="button"
+                                tabIndex={0}
+                                onClick={handleCopyBuildInfo}
+                                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleCopyBuildInfo(); } }}
+                                className="inline-flex cursor-pointer items-center rounded-full border px-2.5 py-0.5 text-[12px] font-semibold tabular-nums transition-colors"
+                                style={{
+                                  color: copied ? '#2d8a4e' : 'var(--text-strong)',
+                                  borderColor: copied ? '#2d8a4e' : 'color-mix(in srgb, var(--border-subtle), white 8%)',
+                                  background: copied
+                                    ? 'rgba(45,138,78,0.1)'
+                                    : 'color-mix(in srgb, var(--surface-1), transparent 8%)',
+                                }}
+                              >
+                                {copied ? '✓ Copied!' : `Version ${DRAGONFRUIT_VERSION}`}
+                              </span>
+                            </Tooltip>
                             <span
                               className="inline-flex rounded-full border px-2.5 py-0.5 text-[11px] font-semibold"
                               style={buildStatusStyle}

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -17,7 +17,7 @@ import { UpdatesSettingsTab } from '@/features/updater/UpdatesSettingsTab';
 import { getUpdateChannel, type UpdateChannel } from '@/features/updater/updateBridge';
 import { WorkspacesSettingsTab } from '@/components/settings/WorkspacesSettingsTab';
 import { PerformanceSettingsTab, type SlicingThumbnailRenderSettings } from '@/components/settings/PerformanceSettingsTab';
-import { AlertTriangle, Check, CloudDownload, Edit3, ExternalLink, Gamepad2, Github, HardDrive, Info, Keyboard, MonitorCog, Palette, Plug, RotateCcw, Save, Settings2, Trash2, X, Camera, Grid3x3, ArchiveRestore, ScrollText } from 'lucide-react';
+import { AlertTriangle, Check, ClipboardCopy, CloudDownload, Edit3, ExternalLink, Gamepad2, Github, HardDrive, Info, Keyboard, MonitorCog, Palette, Plug, RotateCcw, Save, Settings2, Trash2, X, Camera, Grid3x3, ArchiveRestore, ScrollText } from 'lucide-react';
 import type { MatcapVariant, MeshShaderType } from '@/features/shaders/mesh';
 import {
   applyThemeCustomColors,
@@ -131,6 +131,12 @@ const DEFAULT_HOVER_TINT_STRENGTH = 0.5;
 const DEFAULT_SELECTED_TINT_STRENGTH = 0.75;
 const DRAGONFRUIT_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? '0.0.0';
 const DRAGONFRUIT_BUILD_CHANNEL = (process.env.NEXT_PUBLIC_BUILD_CHANNEL ?? 'mainline').trim().toLowerCase();
+const DRAGONFRUIT_GIT_COMMIT = process.env.NEXT_PUBLIC_GIT_COMMIT ?? '';
+const DRAGONFRUIT_GIT_REF = process.env.NEXT_PUBLIC_GIT_REF ?? '';
+// e.g. "dev @ 62e80c79b" — identifies the exact build behind a version number.
+const DRAGONFRUIT_GIT_BUILD_LABEL = DRAGONFRUIT_GIT_COMMIT
+  ? `${DRAGONFRUIT_GIT_REF ? `${DRAGONFRUIT_GIT_REF} @ ` : ''}${DRAGONFRUIT_GIT_COMMIT}`
+  : '';
 const ORA_LOGO_DARK_URL = '/dragonfruit_assets/branding/open_resin_alliance_logo_darkmode.png';
 const DRAGONFRUIT_REPO_URL = 'https://github.com/Open-Resin-Alliance/DragonFruit';
 const DEFAULT_SLICING_THUMBNAIL_RENDER_SETTINGS: SlicingThumbnailRenderSettings = {
@@ -237,6 +243,17 @@ export function SettingsModal({
   initialTab,
 }: SettingsModalProps) {
   const [activeTab, setActiveTab] = useState<SettingsTabKey>(initialTab ?? 'general');
+
+  const [buildInfoCopied, setBuildInfoCopied] = useState(false);
+  const handleCopyBuildInfo = React.useCallback(async () => {
+    // Full build identity in one string — what a bug report needs.
+    const buildInfo = `DragonFruit ${DRAGONFRUIT_VERSION} (${DRAGONFRUIT_BUILD_CHANNEL})${DRAGONFRUIT_GIT_BUILD_LABEL ? ` — ${DRAGONFRUIT_GIT_BUILD_LABEL}` : ''}`;
+    try {
+      await navigator.clipboard.writeText(buildInfo);
+      setBuildInfoCopied(true);
+      setTimeout(() => setBuildInfoCopied(false), 2000);
+    } catch { /* clipboard unavailable */ }
+  }, []);
 
   // Language is a draft like every other setting: changing the switcher only
   // updates draftLocale; the actual loadLocale happens in handleApply.
@@ -1504,23 +1521,43 @@ export function SettingsModal({
                           </span>
                         </div>
 
-                        <div className="mt-3 flex flex-wrap items-center justify-center gap-2.5">
-                          <span
-                            className="inline-flex rounded-full border px-2.5 py-0.5 text-[12px] font-semibold tabular-nums"
-                            style={{
-                              color: 'var(--text-strong)',
-                              borderColor: 'color-mix(in srgb, var(--border-subtle), white 8%)',
-                              background: 'color-mix(in srgb, var(--surface-1), transparent 8%)',
-                            }}
-                          >
-                            Version {DRAGONFRUIT_VERSION}
-                          </span>
-                          <span
-                            className="inline-flex rounded-full border px-2.5 py-0.5 text-[11px] font-semibold"
-                            style={buildStatusStyle}
-                          >
-                            {buildStatusLabel}
-                          </span>
+                        <div className="mt-3 flex flex-col items-center gap-2">
+                          <div className="flex flex-wrap items-center justify-center gap-2.5">
+                            <span
+                              className="inline-flex rounded-full border px-2.5 py-0.5 text-[12px] font-semibold tabular-nums"
+                              style={{
+                                color: 'var(--text-strong)',
+                                borderColor: 'color-mix(in srgb, var(--border-subtle), white 8%)',
+                                background: 'color-mix(in srgb, var(--surface-1), transparent 8%)',
+                              }}
+                            >
+                              Version {DRAGONFRUIT_VERSION}
+                            </span>
+                            <span
+                              className="inline-flex rounded-full border px-2.5 py-0.5 text-[11px] font-semibold"
+                              style={buildStatusStyle}
+                            >
+                              {buildStatusLabel}
+                            </span>
+                          </div>
+                          {DRAGONFRUIT_GIT_BUILD_LABEL && (
+                            <button
+                              type="button"
+                              onClick={handleCopyBuildInfo}
+                              className="inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-2.5 py-0.5 font-mono text-[11px] tabular-nums transition-colors"
+                              style={{
+                                color: buildInfoCopied ? 'var(--accent)' : 'var(--text-muted)',
+                                borderColor: 'color-mix(in srgb, var(--border-subtle), white 8%)',
+                                background: 'color-mix(in srgb, var(--surface-1), transparent 8%)',
+                              }}
+                              title="Copy build info (version, channel and git commit)"
+                            >
+                              <span className="select-text">{DRAGONFRUIT_GIT_BUILD_LABEL}</span>
+                              {buildInfoCopied
+                                ? <Check className="h-3 w-3 shrink-0" />
+                                : <ClipboardCopy className="h-3 w-3 shrink-0" />}
+                            </button>
+                          )}
                         </div>
                       </div>
 

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1229,7 +1229,7 @@ export function SettingsModal({
             }}
           >
             <div className="h-full min-h-0 overflow-y-auto custom-scrollbar pr-1 flex flex-col">
-              <div className="space-y-1.5">
+              <div className="space-y-1">
                 {sidebarTopTabs.map((tab) => {
                   const meta = tabMeta[tab];
                   const Icon = meta.icon;
@@ -1241,7 +1241,7 @@ export function SettingsModal({
                       key={tab}
                       type="button"
                       onClick={() => setActiveTab(tab)}
-                      className="w-full rounded-lg border px-3 py-2.5 text-left transition-all duration-150"
+                      className="w-full rounded-lg border px-3 py-2 text-left transition-all duration-150"
                       style={active
                         ? {
                           borderColor: `color-mix(in srgb, ${tabColor}, var(--border-subtle) 35%)`,
@@ -1253,9 +1253,9 @@ export function SettingsModal({
                           background: 'var(--surface-1)',
                         }}
                     >
-                      <div className="flex items-start gap-2.5">
+                      <div className="flex items-center gap-2">
                         <span
-                          className="inline-flex h-7 w-7 items-center justify-center rounded-md border"
+                          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border"
                           style={{
                             borderColor: active
                               ? `color-mix(in srgb, ${tabColor}, var(--border-subtle) 30%)`
@@ -1281,7 +1281,7 @@ export function SettingsModal({
                 })}
               </div>
 
-              <div className="mt-auto space-y-1.5 pt-3">
+              <div className="mt-auto space-y-1 pt-3">
                 {sidebarBottomTabs.map((tab) => {
                   const meta = tabMeta[tab];
                   const Icon = meta.icon;
@@ -1294,7 +1294,7 @@ export function SettingsModal({
                       type="button"
                       aria-disabled={false}
                       onClick={() => setActiveTab(tab)}
-                      className="w-full rounded-lg border px-3 py-2.5 text-left transition-all duration-150"
+                      className="w-full rounded-lg border px-3 py-2 text-left transition-all duration-150"
                       style={{
                         ...(active
                           ? {
@@ -1308,9 +1308,9 @@ export function SettingsModal({
                           }),
                       }}
                     >
-                      <div className="flex items-start gap-2.5">
+                      <div className="flex items-center gap-2">
                         <span
-                          className="inline-flex h-7 w-7 items-center justify-center rounded-md border"
+                          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-md border"
                           style={{
                             borderColor: active
                               ? `color-mix(in srgb, ${tabColor}, var(--border-subtle) 30%)`
@@ -1339,15 +1339,6 @@ export function SettingsModal({
           </div>
 
           <div className={usesInternalTabScrollLayout ? 'flex-1 min-h-0 flex flex-col p-4' : 'flex-1 min-h-0 overflow-y-auto custom-scrollbar p-4'}>
-            {activeTab !== 'about' && activeTab !== 'updates' && (
-              <div className="mb-3 rounded-lg border px-3 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-1), transparent 8%)' }}>
-                <div className="flex items-center gap-2">
-                  <ActiveTabIcon className="h-4 w-4" style={{ color: activeTabColor }} />
-                  <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>{tabMeta[activeTab].label}</h3>
-                </div>
-                <p className="mt-0.5 text-[11px]" style={{ color: 'var(--text-muted)' }}>{tabMeta[activeTab].description}</p>
-              </div>
-            )}
 
             <div key={activeTab} className={usesInternalTabScrollLayout ? 'animate-[settingsTabIn_180ms_ease-out] flex-1 min-h-0 flex flex-col' : 'animate-[settingsTabIn_180ms_ease-out]'}>
               {activeTab === 'general' && (

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -17,7 +17,7 @@ import { UpdatesSettingsTab } from '@/features/updater/UpdatesSettingsTab';
 import { getUpdateChannel, type UpdateChannel } from '@/features/updater/updateBridge';
 import { WorkspacesSettingsTab } from '@/components/settings/WorkspacesSettingsTab';
 import { PerformanceSettingsTab, type SlicingThumbnailRenderSettings } from '@/components/settings/PerformanceSettingsTab';
-import { AlertTriangle, Check, ClipboardCopy, CloudDownload, Edit3, ExternalLink, Gamepad2, Github, HardDrive, Info, Keyboard, MonitorCog, Palette, Plug, RotateCcw, Save, Settings2, Trash2, X, Camera, Grid3x3, ArchiveRestore, ScrollText } from 'lucide-react';
+import { AlertTriangle, Check, CloudDownload, Edit3, ExternalLink, Gamepad2, Github, HardDrive, Info, Keyboard, MonitorCog, Palette, Plug, RotateCcw, Save, Settings2, Trash2, X, Camera, Grid3x3, ArchiveRestore, ScrollText } from 'lucide-react';
 import type { MatcapVariant, MeshShaderType } from '@/features/shaders/mesh';
 import {
   applyThemeCustomColors,
@@ -244,14 +244,14 @@ export function SettingsModal({
 }: SettingsModalProps) {
   const [activeTab, setActiveTab] = useState<SettingsTabKey>(initialTab ?? 'general');
 
-  const [buildInfoCopied, setBuildInfoCopied] = useState(false);
+  const [copied, setCopied] = useState(false);
   const handleCopyBuildInfo = React.useCallback(async () => {
     // Full build identity in one string — what a bug report needs.
     const buildInfo = `DragonFruit ${DRAGONFRUIT_VERSION} (${DRAGONFRUIT_BUILD_CHANNEL})${DRAGONFRUIT_GIT_BUILD_LABEL ? ` — ${DRAGONFRUIT_GIT_BUILD_LABEL}` : ''}`;
     try {
       await navigator.clipboard.writeText(buildInfo);
-      setBuildInfoCopied(true);
-      setTimeout(() => setBuildInfoCopied(false), 2000);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     } catch { /* clipboard unavailable */ }
   }, []);
 
@@ -1524,14 +1524,21 @@ export function SettingsModal({
                         <div className="mt-3 flex flex-col items-center gap-2">
                           <div className="flex flex-wrap items-center justify-center gap-2.5">
                             <span
-                              className="inline-flex rounded-full border px-2.5 py-0.5 text-[12px] font-semibold tabular-nums"
+                              role="button"
+                              tabIndex={0}
+                              onClick={handleCopyBuildInfo}
+                              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleCopyBuildInfo(); } }}
+                              className="inline-flex cursor-pointer items-center rounded-full border px-2.5 py-0.5 text-[12px] font-semibold tabular-nums transition-colors"
                               style={{
-                                color: 'var(--text-strong)',
-                                borderColor: 'color-mix(in srgb, var(--border-subtle), white 8%)',
-                                background: 'color-mix(in srgb, var(--surface-1), transparent 8%)',
+                                color: copied ? '#2d8a4e' : 'var(--text-strong)',
+                                borderColor: copied ? '#2d8a4e' : 'color-mix(in srgb, var(--border-subtle), white 8%)',
+                                background: copied
+                                  ? 'rgba(45,138,78,0.1)'
+                                  : 'color-mix(in srgb, var(--surface-1), transparent 8%)',
                               }}
+                              title={DRAGONFRUIT_GIT_BUILD_LABEL ? `Copy build info\n${DRAGONFRUIT_GIT_BUILD_LABEL}` : undefined}
                             >
-                              Version {DRAGONFRUIT_VERSION}
+                              {copied ? '✓ Copied!' : `Version ${DRAGONFRUIT_VERSION}`}
                             </span>
                             <span
                               className="inline-flex rounded-full border px-2.5 py-0.5 text-[11px] font-semibold"
@@ -1540,24 +1547,6 @@ export function SettingsModal({
                               {buildStatusLabel}
                             </span>
                           </div>
-                          {DRAGONFRUIT_GIT_BUILD_LABEL && (
-                            <button
-                              type="button"
-                              onClick={handleCopyBuildInfo}
-                              className="inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-2.5 py-0.5 font-mono text-[11px] tabular-nums transition-colors"
-                              style={{
-                                color: buildInfoCopied ? 'var(--accent)' : 'var(--text-muted)',
-                                borderColor: 'color-mix(in srgb, var(--border-subtle), white 8%)',
-                                background: 'color-mix(in srgb, var(--surface-1), transparent 8%)',
-                              }}
-                              title="Copy build info (version, channel and git commit)"
-                            >
-                              <span className="select-text">{DRAGONFRUIT_GIT_BUILD_LABEL}</span>
-                              {buildInfoCopied
-                                ? <Check className="h-3 w-3 shrink-0" />
-                                : <ClipboardCopy className="h-3 w-3 shrink-0" />}
-                            </button>
-                          )}
                         </div>
                       </div>
 

--- a/src/components/ui/SelectDropdown.tsx
+++ b/src/components/ui/SelectDropdown.tsx
@@ -36,6 +36,9 @@ export type SelectDropdownProps<T extends string | number = string> = {
   selectedDisplayOffsetX?: number;
   menuClassName?: string;
   menuAlign?: 'left' | 'right';
+  /** Positioning class for the chevron, e.g. 'right-1.5' for narrow icon-only
+   *  triggers where the default gap reads as wasted space. */
+  chevronClassName?: string;
   optionClassName?: string;
   menuFooterAction?: {
     label: string;
@@ -74,6 +77,7 @@ export function SelectDropdown<T extends string | number = string>({
   selectedDisplayOffsetX = 0,
   menuClassName = '',
   menuAlign = 'left',
+  chevronClassName = 'right-3',
   optionClassName = '',
   menuFooterAction,
   menuFooterDivider = true,
@@ -138,14 +142,19 @@ export function SelectDropdown<T extends string | number = string>({
     const margin = 8;
     const gap = 6;
 
-    // The menu is always forced to the trigger's width (minWidth/width below),
-    // so position from rect.width directly. Measuring offsetWidth instead was
-    // wrong on the first pass — before the width style applied — which left the
-    // menu mispositioned until a later pass corrected it (the visible reflow).
-    const measuredMenuWidth = rect.width;
-    const measuredMenuHeight = measureMenu && menuRef.current
-      ? menuRef.current.offsetHeight
-      : 0;
+    // The menu is normally forced to the trigger's width (minWidth/width
+    // below), but menuClassName can override it with !important (e.g. !w-64).
+    // Apply the trigger width before measuring so the measurement reflects
+    // exactly what will render: the override if present, rect.width otherwise.
+    // Measuring without the inline width was wrong on the first pass — the
+    // content-sized menu left align-right menus mispositioned/clipped.
+    let measuredMenuWidth = rect.width;
+    let measuredMenuHeight = 0;
+    if (measureMenu && menuRef.current) {
+      menuRef.current.style.width = `${rect.width}px`;
+      measuredMenuWidth = menuRef.current.offsetWidth;
+      measuredMenuHeight = menuRef.current.offsetHeight;
+    }
 
     let left = rect.left;
     if (menuAlign === 'right') {
@@ -297,7 +306,7 @@ export function SelectDropdown<T extends string | number = string>({
           </span>
         )}
         <ChevronDown
-          className={`pointer-events-none absolute right-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          className={`pointer-events-none absolute ${chevronClassName} top-1/2 h-3.5 w-3.5 -translate-y-1/2 transition-transform ${isOpen ? 'rotate-180' : ''}`}
           style={{ color: disabled ? 'var(--text-muted)' : 'var(--text-muted)' }}
         />
 

--- a/src/components/ui/SelectDropdown.tsx
+++ b/src/components/ui/SelectDropdown.tsx
@@ -39,6 +39,9 @@ export type SelectDropdownProps<T extends string | number = string> = {
   /** Positioning class for the chevron, e.g. 'right-1.5' for narrow icon-only
    *  triggers where the default gap reads as wasted space. */
   chevronClassName?: string;
+  /** When true the chevron icon is not rendered. Useful for icon-only triggers
+   *  where the arrow wastes horizontal space. */
+  hideChevron?: boolean;
   optionClassName?: string;
   menuFooterAction?: {
     label: string;
@@ -78,6 +81,7 @@ export function SelectDropdown<T extends string | number = string>({
   menuClassName = '',
   menuAlign = 'left',
   chevronClassName = 'right-3',
+  hideChevron = false,
   optionClassName = '',
   menuFooterAction,
   menuFooterDivider = true,
@@ -305,10 +309,12 @@ export function SelectDropdown<T extends string | number = string>({
             {endAdornment}
           </span>
         )}
-        <ChevronDown
-          className={`pointer-events-none absolute ${chevronClassName} top-1/2 h-3.5 w-3.5 -translate-y-1/2 transition-transform ${isOpen ? 'rotate-180' : ''}`}
-          style={{ color: disabled ? 'var(--text-muted)' : 'var(--text-muted)' }}
-        />
+        {!hideChevron && (
+          <ChevronDown
+            className={`pointer-events-none absolute ${chevronClassName} top-1/2 h-3.5 w-3.5 -translate-y-1/2 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+            style={{ color: disabled ? 'var(--text-muted)' : 'var(--text-muted)' }}
+          />
+        )}
 
         </button>
 

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useState } from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 
 interface TooltipProps {
   /** Content to show inside the tooltip popover. Falsy content skips the tooltip entirely (children render unwrapped). */
@@ -40,11 +40,16 @@ interface TooltipProps {
 export function Tooltip({ content, offsetY = 28, maxWidth = 260, wrapperClassName, fullWidth, children }: TooltipProps) {
   const [hovered, setHovered] = useState(false);
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+  // Real position, filled in once the popover has been measured. Kept separate from
+  // `pos` (raw cursor position) so the very first mount can stay hidden instead of
+  // flashing at a guessed spot before snapping to its centered, clamped position.
+  const [coords, setCoords] = useState<{ left: number; top: number } | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
 
   const handleMouseEnter = (e: React.MouseEvent) => {
     setHovered(true);
     setPos({ x: e.clientX, y: e.clientY });
+    setCoords(null);
   };
 
   const handleMouseMove = (e: React.MouseEvent) => {
@@ -55,33 +60,40 @@ export function Tooltip({ content, offsetY = 28, maxWidth = 260, wrapperClassNam
   const handleMouseLeave = () => {
     setHovered(false);
     setPos(null);
+    setCoords(null);
   };
-
-  if (!content) return children;
 
   const show = hovered && pos;
 
-  // Compute clamped position (only after ref is available)
+  // Runs synchronously after DOM mutation but before the browser paints, so the
+  // guessed-position frame below is never actually shown on screen.
+  useLayoutEffect(() => {
+    if (!show || !pos) return;
+    const el = popoverRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const halfW = rect.width / 2;
+    // Horizontal clamping: prefer centered under cursor, but keep on-screen
+    const left = Math.max(4, Math.min(window.innerWidth - rect.width - 4, pos.x - halfW));
+    let top = pos.y + offsetY;
+    // Vertical clamping: if below viewport, flip above cursor
+    if (top + rect.height > window.innerHeight - 4) {
+      top = pos.y - offsetY - rect.height;
+    }
+    // If still off-screen top, clamp to 4px from top
+    if (top < 4) top = 4;
+    setCoords({ left, top });
+  }, [show, pos, offsetY, content]);
+
+  if (!content) return children;
+
+  // Before the first measurement, fall back to a raw guess; the popover stays
+  // invisible until `coords` is set, so this guess is never actually painted.
   let left = 0;
   let top = 0;
   if (show) {
-    // Before the popover has ever measured itself, assume worst-case (maxWidth) so it
-    // can't render past the right edge on the first frame of a hover near the edge.
-    left = Math.max(4, Math.min(window.innerWidth - maxWidth - 4, pos.x));
-    top = pos.y + offsetY;
-    const el = popoverRef.current;
-    if (el) {
-      const rect = el.getBoundingClientRect();
-      // Horizontal clamping: prefer centered under cursor, but keep on-screen
-      const halfW = rect.width / 2;
-      left = Math.max(4, Math.min(window.innerWidth - rect.width - 4, pos.x - halfW));
-      // Vertical clamping: if below viewport, flip above cursor
-      if (top + rect.height > window.innerHeight - 4) {
-        top = pos.y - offsetY - rect.height;
-      }
-      // If still off-screen top, clamp to 4px from top
-      if (top < 4) top = 4;
-    }
+    left = coords ? coords.left : pos.x;
+    top = coords ? coords.top : pos.y + offsetY;
   }
 
   return (
@@ -103,6 +115,7 @@ export function Tooltip({ content, offsetY = 28, maxWidth = 260, wrapperClassNam
           style={{
             left,
             top,
+            visibility: coords ? 'visible' : 'hidden',
             background: 'rgba(24, 24, 24, 0.98)',
             color: 'var(--text-strong, #e0e0e0)',
             border: '1px solid var(--accent, #baf72e)',

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -11,6 +11,13 @@ interface TooltipProps {
   maxWidth?: number;
   /** Extra classes for the wrapping span, e.g. to pass through flex sizing (flex-1, h-full) from the trigger. */
   wrapperClassName?: string;
+  /**
+   * Make the wrapping span a block-level, full-width flex container instead of the
+   * default shrink-to-fit inline-flex. Needed when the trigger is a truncating text
+   * row: an inline-flex wrapper sizes to the trigger's untruncated content width,
+   * which defeats `truncate`. The trigger still needs its own `min-w-0` to shrink.
+   */
+  fullWidth?: boolean;
   /** Children must be a single React element (the trigger). */
   children: React.ReactElement;
 }
@@ -30,7 +37,7 @@ interface TooltipProps {
  *     <button>Label</button>
  *   </Tooltip>
  */
-export function Tooltip({ content, offsetY = 28, maxWidth = 260, wrapperClassName, children }: TooltipProps) {
+export function Tooltip({ content, offsetY = 28, maxWidth = 260, wrapperClassName, fullWidth, children }: TooltipProps) {
   const [hovered, setHovered] = useState(false);
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -80,6 +87,7 @@ export function Tooltip({ content, offsetY = 28, maxWidth = 260, wrapperClassNam
   return (
     <span
       className={wrapperClassName ? `inline-flex ${wrapperClassName}` : 'inline-flex'}
+      style={fullWidth ? { display: 'flex', width: '100%', minWidth: 0 } : undefined}
       onMouseEnter={handleMouseEnter}
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -3,12 +3,14 @@
 import React, { useRef, useState } from 'react';
 
 interface TooltipProps {
-  /** Content to show inside the tooltip popover. */
+  /** Content to show inside the tooltip popover. Falsy content skips the tooltip entirely (children render unwrapped). */
   content: React.ReactNode;
   /** Vertical offset from the cursor (default 28). */
   offsetY?: number;
   /** Max width of the tooltip box (default 260). */
   maxWidth?: number;
+  /** Extra classes for the wrapping span, e.g. to pass through flex sizing (flex-1, h-full) from the trigger. */
+  wrapperClassName?: string;
   /** Children must be a single React element (the trigger). */
   children: React.ReactElement;
 }
@@ -28,7 +30,7 @@ interface TooltipProps {
  *     <button>Label</button>
  *   </Tooltip>
  */
-export function Tooltip({ content, offsetY = 28, maxWidth = 260, children }: TooltipProps) {
+export function Tooltip({ content, offsetY = 28, maxWidth = 260, wrapperClassName, children }: TooltipProps) {
   const [hovered, setHovered] = useState(false);
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -48,13 +50,17 @@ export function Tooltip({ content, offsetY = 28, maxWidth = 260, children }: Too
     setPos(null);
   };
 
+  if (!content) return children;
+
   const show = hovered && pos;
 
   // Compute clamped position (only after ref is available)
   let left = 0;
   let top = 0;
   if (show) {
-    left = pos.x;
+    // Before the popover has ever measured itself, assume worst-case (maxWidth) so it
+    // can't render past the right edge on the first frame of a hover near the edge.
+    left = Math.max(4, Math.min(window.innerWidth - maxWidth - 4, pos.x));
     top = pos.y + offsetY;
     const el = popoverRef.current;
     if (el) {
@@ -73,7 +79,7 @@ export function Tooltip({ content, offsetY = 28, maxWidth = 260, children }: Too
 
   return (
     <span
-      className="inline-flex"
+      className={wrapperClassName ? `inline-flex ${wrapperClassName}` : 'inline-flex'}
       onMouseEnter={handleMouseEnter}
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
@@ -92,6 +98,7 @@ export function Tooltip({ content, offsetY = 28, maxWidth = 260, children }: Too
             background: 'rgba(24, 24, 24, 0.98)',
             color: 'var(--text-strong, #e0e0e0)',
             border: '1px solid var(--accent, #baf72e)',
+            width: 'max-content',
             maxWidth,
             whiteSpace: 'normal',
             textAlign: 'left',

--- a/src/features/updater/UpdateCheckerSection.tsx
+++ b/src/features/updater/UpdateCheckerSection.tsx
@@ -50,27 +50,27 @@ function IdleState({ onCheck }: { onCheck: () => void }) {
     <button
       type="button"
       onClick={onCheck}
-      className="w-full rounded-lg border px-3 py-2.5 text-left transition-all duration-150 hover:brightness-110"
+      className="w-full rounded-md border p-2.5 text-left transition-all duration-150 hover:brightness-110"
       style={{
         borderColor: 'var(--border-subtle)',
-        background: 'color-mix(in srgb, var(--surface-1), transparent 8%)',
+        background: 'var(--surface-0)',
       }}
     >
       <div className="flex items-center gap-2.5">
         <span
-          className="inline-flex h-7 w-7 items-center justify-center rounded-md border"
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
           style={{
             borderColor: 'var(--border-subtle)',
-            background: 'var(--surface-2)',
+            background: 'color-mix(in srgb, var(--surface-2), transparent 8%)',
           }}
         >
-          <CloudDownload className="h-3.5 w-3.5" style={{ color: 'var(--text-muted)' }} />
+          <CloudDownload className="h-4 w-4" style={{ color: 'var(--accent)' }} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
             Check for Updates
           </span>
-          <span className="block text-[11px]" style={{ color: 'var(--text-muted)' }}>
+          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
             See if a newer version of DragonFruit is available
           </span>
         </span>
@@ -82,27 +82,27 @@ function IdleState({ onCheck }: { onCheck: () => void }) {
 function CheckingState() {
   return (
     <div
-      className="w-full rounded-lg border px-3 py-2.5"
+      className="w-full rounded-md border p-2.5"
       style={{
         borderColor: 'var(--border-subtle)',
-        background: 'color-mix(in srgb, var(--surface-1), transparent 8%)',
+        background: 'var(--surface-0)',
       }}
     >
       <div className="flex items-center gap-2.5">
         <span
-          className="inline-flex h-7 w-7 items-center justify-center rounded-md border"
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
           style={{
             borderColor: 'var(--border-subtle)',
-            background: 'var(--surface-2)',
+            background: 'color-mix(in srgb, var(--surface-2), transparent 8%)',
           }}
         >
-          <Loader2 className="h-3.5 w-3.5 animate-spin" style={{ color: 'var(--accent)' }} />
+          <Loader2 className="h-4 w-4 animate-spin" style={{ color: 'var(--accent)' }} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
             Checking for updates…
           </span>
-          <span className="block text-[11px]" style={{ color: 'var(--text-muted)' }}>
+          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
             Querying GitHub releases
           </span>
         </span>
@@ -114,7 +114,7 @@ function CheckingState() {
 function UpToDateState({ onCheck }: { onCheck: () => void }) {
   return (
     <div
-      className="w-full rounded-lg border px-3 py-2.5"
+      className="w-full rounded-md border p-2.5"
       style={{
         borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 50%)',
         background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-0) 92%)',
@@ -122,33 +122,33 @@ function UpToDateState({ onCheck }: { onCheck: () => void }) {
     >
       <div className="flex items-center gap-2.5">
         <span
-          className="inline-flex h-7 w-7 items-center justify-center rounded-md border"
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
           style={{
             borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 38%)',
             background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 85%)',
           }}
         >
-          <Check className="h-3.5 w-3.5" style={{ color: 'var(--accent-secondary)' }} />
+          <Check className="h-4 w-4" style={{ color: 'var(--accent-secondary)' }} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
             Up To Date!
           </span>
-          <span className="block text-[11px]" style={{ color: 'var(--text-muted)' }}>
+          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
             You're running the latest version of DragonFruit.
           </span>
         </span>
         <button
           type="button"
           onClick={onCheck}
-          className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] transition-all duration-150"
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-all duration-150"
           style={{
-            color: 'var(--text-muted)',
-            borderColor: 'var(--border-subtle)',
-            background: 'var(--surface-2)',
+            color: 'var(--accent-secondary-action-color)',
+            borderColor: 'var(--accent-secondary-action-border)',
+            background: 'var(--accent-secondary-action-bg-92)',
           }}
         >
-          <RotateCcw className="h-3 w-3" />
+          <RotateCcw className="h-3.5 w-3.5" />
           Check Again
         </button>
       </div>
@@ -169,28 +169,28 @@ function AvailableState({
 
   return (
     <div
-      className="w-full rounded-lg border overflow-hidden"
+      className="w-full rounded-md border overflow-hidden"
       style={{
         borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)',
         background: 'color-mix(in srgb, var(--accent), var(--surface-0) 90%)',
       }}
     >
       {/* Header */}
-      <div className="flex items-center gap-2.5 px-3 py-2.5">
+      <div className="flex items-center gap-2.5 p-2.5">
         <span
-          className="inline-flex h-7 w-7 items-center justify-center rounded-md border"
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
           style={{
             borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
             background: 'color-mix(in srgb, var(--accent), var(--surface-1) 82%)',
           }}
         >
-          <Download className="h-3.5 w-3.5" style={{ color: 'var(--accent)' }} />
+          <Download className="h-4 w-4" style={{ color: 'var(--accent)' }} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
             Update Available
           </span>
-          <span className="block text-[11px]" style={{ color: 'var(--text-muted)' }}>
+          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
             DragonFruit v{info.version} is available (you have v{info.currentVersion})
           </span>
         </span>
@@ -199,7 +199,7 @@ function AvailableState({
       {/* Release notes */}
       {info.body && (
         <div
-          className="mx-3 mb-2 max-h-28 overflow-y-auto custom-scrollbar rounded-md border px-2.5 py-2 text-[11px] leading-relaxed"
+          className="mx-0 mb-2 max-h-28 overflow-y-auto custom-scrollbar rounded-md border px-2.5 py-2 text-[11px] leading-relaxed"
           style={{
             borderColor: 'var(--border-subtle)',
             background: 'color-mix(in srgb, var(--surface-1), transparent 30%)',
@@ -213,7 +213,7 @@ function AvailableState({
       )}
 
       {/* Actions — single "Download & Install" button using the plugin */}
-      <div className="flex items-center gap-2 px-3 pb-2.5">
+      <div className="flex items-center gap-2 px-0 pb-0">
         <button
           type="button"
           onClick={onDownload}
@@ -279,7 +279,7 @@ function DownloadingState({
 
   return (
     <div
-      className="w-full rounded-lg border px-3 py-2.5"
+      className="w-full rounded-md border p-2.5"
       style={{
         borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)',
         background: 'color-mix(in srgb, var(--accent), var(--surface-0) 90%)',
@@ -287,19 +287,19 @@ function DownloadingState({
     >
       <div className="flex items-center gap-2.5 mb-2">
         <span
-          className="inline-flex h-7 w-7 items-center justify-center rounded-md border"
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
           style={{
             borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
             background: 'color-mix(in srgb, var(--accent), var(--surface-1) 82%)',
           }}
         >
-          <Loader2 className="h-3.5 w-3.5 animate-spin" style={{ color: 'var(--accent)' }} />
+          <Loader2 className="h-4 w-4 animate-spin" style={{ color: 'var(--accent)' }} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
             Downloading Update
           </span>
-          <span className="block text-[11px]" style={{ color: 'var(--text-muted)' }}>
+          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
             {formatBytes(downloaded)} / {formatBytes(contentLength)} ({pct}%)
           </span>
         </span>
@@ -312,7 +312,7 @@ function DownloadingState({
 function InstallingState() {
   return (
     <div
-      className="w-full rounded-lg border px-3 py-2.5"
+      className="w-full rounded-md border p-2.5"
       style={{
         borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)',
         background: 'color-mix(in srgb, var(--accent), var(--surface-0) 90%)',
@@ -320,19 +320,19 @@ function InstallingState() {
     >
       <div className="flex items-center gap-2.5">
         <span
-          className="inline-flex h-7 w-7 items-center justify-center rounded-md border"
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
           style={{
             borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
             background: 'color-mix(in srgb, var(--accent), var(--surface-1) 82%)',
           }}
         >
-          <Loader2 className="h-3.5 w-3.5 animate-spin" style={{ color: 'var(--accent)' }} />
+          <Loader2 className="h-4 w-4 animate-spin" style={{ color: 'var(--accent)' }} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
             Installing Update…
           </span>
-          <span className="block text-[11px]" style={{ color: 'var(--text-muted)' }}>
+          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
             The update is being installed. DragonFruit will restart automatically.
           </span>
         </span>
@@ -344,7 +344,7 @@ function InstallingState() {
 function InstalledState() {
   return (
     <div
-      className="w-full rounded-lg border px-3 py-2.5"
+      className="w-full rounded-md border p-2.5"
       style={{
         borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 50%)',
         background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-0) 92%)',
@@ -352,13 +352,13 @@ function InstalledState() {
     >
       <div className="flex items-center gap-2.5">
         <span
-          className="inline-flex h-7 w-7 items-center justify-center rounded-md border"
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
           style={{
             borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 38%)',
             background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 85%)',
           }}
         >
-          <CloudOff className="h-3.5 w-3.5" style={{ color: 'var(--accent-secondary)' }} />
+          <CloudOff className="h-4 w-4" style={{ color: 'var(--accent-secondary)' }} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
@@ -379,7 +379,7 @@ function ErrorState({
 }) {
   return (
     <div
-      className="w-full rounded-lg border px-3 py-2.5"
+      className="w-full rounded-md border p-2.5"
       style={{
         borderColor: 'color-mix(in srgb, #b91c1c, var(--border-subtle) 50%)',
         background: 'color-mix(in srgb, #b91c1c, var(--surface-0) 92%)',
@@ -387,19 +387,19 @@ function ErrorState({
     >
       <div className="flex items-center gap-2.5">
         <span
-          className="inline-flex h-7 w-7 items-center justify-center rounded-md border"
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
           style={{
             borderColor: 'color-mix(in srgb, #b91c1c, var(--border-subtle) 38%)',
             background: 'color-mix(in srgb, #b91c1c, var(--surface-1) 85%)',
           }}
         >
-          <CloudOff className="h-3.5 w-3.5" style={{ color: '#ef4444' }} />
+          <CloudOff className="h-4 w-4" style={{ color: '#ef4444' }} />
         </span>
         <span className="min-w-0 flex-1">
           <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
             Update Failed
           </span>
-          <span className="block text-[11px]" style={{ color: 'var(--text-muted)' }}>
+          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
             {message}
           </span>
         </span>

--- a/src/features/updater/UpdatesSettingsTab.tsx
+++ b/src/features/updater/UpdatesSettingsTab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import { GitBranch } from 'lucide-react';
+import { CloudDownload, GitBranch } from 'lucide-react';
 import { UpdateCheckerSection } from '@/features/updater/UpdateCheckerSection';
 import { setUpdateChannel } from '@/features/updater/updateBridge';
 import type { UpdateChannel } from '@/features/updater/updateBridge';
@@ -25,89 +25,109 @@ export function UpdatesSettingsTab({
 
   return (
     <div className="space-y-3">
-      {/* Release channel selector */}
-      <div
+      {/* Release Channel */}
+      <section
         className="rounded-lg border p-3"
-        style={{
-          borderColor: 'var(--border-subtle)',
-          background: 'var(--surface-1)',
-        }}
+        style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
       >
-        <div className="flex items-center gap-2 mb-2.5">
+        <div className="flex items-start gap-2.5">
           <span
-            className="inline-flex h-7 w-7 items-center justify-center rounded-md border"
-            style={{
-              borderColor: 'var(--border-subtle)',
-              background: 'var(--surface-2)',
-            }}
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
+            style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-2), transparent 8%)' }}
           >
-            <GitBranch className="h-3.5 w-3.5" style={{ color: 'var(--text-muted)' }} />
+            <GitBranch className="h-4 w-4" style={{ color: 'var(--accent)' }} />
           </span>
-          <div>
-            <div className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
+          <div className="min-w-0 flex-1">
+            <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
               Release Channel
-            </div>
-            <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
-              Choose which update feed to check
-            </div>
+            </h3>
+            <p className="mt-0.5 text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+              Choose which update feed to check for new versions.
+            </p>
           </div>
         </div>
 
-        <div className="flex gap-2">
-          <button
-            type="button"
-            onClick={() => handleChannelSelect('stable')}
-            className="flex-1 rounded-lg border px-3 py-2 text-left transition-all duration-150"
-            style={
-              channel === 'stable'
-                ? {
-                    borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 35%)',
-                    background: 'color-mix(in srgb, var(--accent), var(--surface-0) 84%)',
-                    boxShadow: '0 0 0 1px color-mix(in srgb, var(--accent), transparent 76%) inset',
-                  }
-                : {
-                    borderColor: 'var(--border-subtle)',
-                    background: 'var(--surface-2)',
-                  }
-            }
-          >
-            <div className="text-sm font-semibold" style={{ color: channel === 'stable' ? 'var(--accent)' : 'var(--text-strong)' }}>
-              Stable
-            </div>
-            <div className="text-[10px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
-              Production releases only. Recommended for most users.
-            </div>
-          </button>
+        <div className="mt-2 rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => handleChannelSelect('stable')}
+              className="flex-1 rounded-md border px-3 py-2 text-left transition-all duration-150"
+              style={
+                channel === 'stable'
+                  ? {
+                      borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 35%)',
+                      background: 'color-mix(in srgb, var(--accent), var(--surface-0) 84%)',
+                      boxShadow: '0 0 0 1px color-mix(in srgb, var(--accent), transparent 76%) inset',
+                    }
+                  : {
+                      borderColor: 'var(--border-subtle)',
+                      background: 'var(--surface-1)',
+                    }
+              }
+            >
+              <div className="text-sm font-semibold" style={{ color: channel === 'stable' ? 'var(--accent)' : 'var(--text-strong)' }}>
+                Stable
+              </div>
+              <div className="mt-0.5 text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                Production releases only. Recommended for most users.
+              </div>
+            </button>
 
-          <button
-            type="button"
-            onClick={() => handleChannelSelect('dev')}
-            className="flex-1 rounded-lg border px-3 py-2 text-left transition-all duration-150"
-            style={
-              channel === 'dev'
-                ? {
-                    borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 35%)',
-                    background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-0) 84%)',
-                    boxShadow: '0 0 0 1px color-mix(in srgb, var(--accent-secondary), transparent 76%) inset',
-                  }
-                : {
-                    borderColor: 'var(--border-subtle)',
-                    background: 'var(--surface-2)',
-                  }
-            }
-          >
-            <div className="text-sm font-semibold" style={{ color: channel === 'dev' ? 'var(--accent-secondary)' : 'var(--text-strong)' }}>
-              Dev
-            </div>
-            <div className="text-[10px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
-              Pre-release builds from the dev branch. May be unstable.
-            </div>
-          </button>
+            <button
+              type="button"
+              onClick={() => handleChannelSelect('dev')}
+              className="flex-1 rounded-md border px-3 py-2 text-left transition-all duration-150"
+              style={
+                channel === 'dev'
+                  ? {
+                      borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 35%)',
+                      background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-0) 84%)',
+                      boxShadow: '0 0 0 1px color-mix(in srgb, var(--accent-secondary), transparent 76%) inset',
+                    }
+                  : {
+                      borderColor: 'var(--border-subtle)',
+                      background: 'var(--surface-1)',
+                    }
+              }
+            >
+              <div className="text-sm font-semibold" style={{ color: channel === 'dev' ? 'var(--accent-secondary)' : 'var(--text-strong)' }}>
+                Dev
+              </div>
+              <div className="mt-0.5 text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                Pre-release builds from the dev branch. May be unstable.
+              </div>
+            </button>
+          </div>
         </div>
-      </div>
+      </section>
 
-      {/* Update checker */}
-      <UpdateCheckerSection />
+      {/* Update Checker */}
+      <section
+        className="rounded-lg border p-3"
+        style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+      >
+        <div className="flex items-start gap-2.5">
+          <span
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
+            style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-2), transparent 8%)' }}
+          >
+            <CloudDownload className="h-4 w-4" style={{ color: 'var(--accent)' }} />
+          </span>
+          <div className="min-w-0 flex-1">
+            <h3 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
+              Updates
+            </h3>
+            <p className="mt-0.5 text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+              Check for and install new versions of DragonFruit.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-2">
+          <UpdateCheckerSection />
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/hotkeys/hotkeyConfig.ts
+++ b/src/hotkeys/hotkeyConfig.ts
@@ -157,15 +157,29 @@ export const DEFAULT_KEYBINDINGS: HotkeyConfig = {
         SNAP_COARSE: {
             key: 'drag',
             modifier: 'meta',
-            description: 'Snap rotation to 45° increments (Cmd/Ctrl + drag)'
+            description: 'Rotation Snap (45°)'
         },
         SNAP_FINE: {
             key: 'drag',
             modifier: 'meta+shift',
-            description: 'Snap rotation to 15° increments (Cmd/Ctrl + Shift + drag)'
+            description: 'Rotation Snap (15°)'
         }
     },
     GLOBAL: {
+        DELETE: {
+            key: 'Delete',
+            description: 'Delete selected item'
+        },
+        UNDO: {
+            key: 'z',
+            modifier: 'ctrl',
+            description: 'Undo last action'
+        },
+        REDO: {
+            key: 'z',
+            modifier: 'ctrl+shift',
+            description: 'Redo last action'
+        },
         SAVE: {
             key: 's',
             modifier: 'ctrl',


### PR DESCRIPTION
* feat(about): Show the Git build fingerprint (commit hash and branch/tag) in Settings → About, with one-click copy for bug reports and graceful fallback when Git metadata is unavailable. Closes #364.
* fix(editor): Prevent the editor context menu from opening on the empty-scene screen, while still allowing paste when the clipboard contains a model. Closes #365.
* fix(layer-slider): Keep the layer-slider thumb edit popover on-screen, fix mojibake in tooltips/strings, and update the tooltip to document all supported interactions. Closes #366.
* feat(window): Persist the main window's size, position, and maximized state across sessions, restoring it safely without visual flicker and handling disconnected displays. Closes #363.
* chore(dev): Reposition the Next.js development indicator so it no longer overlaps the Settings button in development builds. Closes #367.
* fix(topbar): Remove the chevron in the view-mode dropdown. Closes #370.
* fix(cross-section): Keep cross-section stencil caps synchronized with live gizmo drags without introducing extra React renders. Closes #369.
* update submodule `modules/lys-import` to [09c7980](https://github.com/Open-Resin-Alliance/df-plugin-lys/compare/7484a7f3113b85eff8613e54a3f4304f7c432b22...09c798025fe229b5bbc8d5cb43a3d343d8ba4cc6)
* refactor(hotkeys): consolidate rotation helpers into global section.
* Several fixes of styling in Settings and sidebar.
* Replace several native titles with Tooltip.
* Fix several issues with Tooltip, and added some functionality.
* fix(models): show a tooltip for truncated model names.