### PR TITLE
fix(camera): perspective-switch fisheye and erratic focus hotkey

### DIFF
--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -6649,11 +6649,6 @@ export function SceneCanvas({
           <CameraFocusHotkeyController
             hoverPointRef={lastHoveredModelPointRef}
             setOrbitTargetFromPoint={setOrbitTargetFromPoint}
-            models={models}
-            activeModelId={activeModelId}
-            selectedModelIds={selectedModelIds ?? []}
-            hoveredModelId={hoveredModelId}
-            orbitTarget={orbitTarget}
             cameraRef={cameraRef}
             orbitControlsRef={orbitControlsRef as React.MutableRefObject<{ target: THREE.Vector3; update: () => void } | null>}
           />

--- a/src/components/scene/SceneCanvas/SceneCanvasCameraControllers.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvasCameraControllers.tsx
@@ -90,12 +90,6 @@ export function CameraProjectionController({ mode }: { mode: CameraProjectionMod
       // app load controls is null, so update() is never called — the camera stays
       // mis-oriented for every pick frame until the first gl.render().
       next.quaternion.copy(camera.quaternion);
-      next.position.copy(camera.position);
-      // Preserve view direction. Without copying quaternion, the new camera has identity
-      // rotation (looking down -Z) until OrbitControls.update() corrects it. At initial
-      // app load controls is null, so update() is never called — the camera stays
-      // mis-oriented for every pick frame until the first gl.render().
-      next.quaternion.copy(camera.quaternion);
       next.up.copy(camera.up);
 
       next.updateProjectionMatrix();
@@ -118,15 +112,15 @@ export function CameraProjectionController({ mode }: { mode: CameraProjectionMod
 
     if (camera instanceof THREE.OrthographicCamera) {
       const span = Math.max(1e-6, (camera.top - camera.bottom) / Math.max(1e-6, camera.zoom));
-      const distance = Math.max(0.001, span / 2);
-      
-      // When switching from ortho to perspective, calculate FOV to match
-      // the ortho zoom level so objects appear the same visual size.
-      // This prevents zoom-out/zoom-in when transitioning between projections.
-      const requiredHalfFov = Math.atan(span / (2 * distance));
-      const calculatedFov = THREE.MathUtils.radToDeg(2 * requiredHalfFov);
-      next.fov = THREE.MathUtils.clamp(calculatedFov, 5, 175);
-      
+      // Keep the natural default FOV and instead solve for the orbit distance
+      // at which that FOV shows the same vertical world span the ortho view
+      // did. This preserves the on-screen size of the model without the
+      // fisheye distortion a wide computed FOV would introduce, and it is the
+      // exact inverse of the perspective→ortho branch above
+      // (worldHalfH = tan(fov/2) · distance), so mode toggles round-trip.
+      const halfFov = THREE.MathUtils.degToRad(next.fov * 0.5);
+      const distance = Math.max(0.001, (span * 0.5) / Math.tan(halfFov));
+
       const direction = camera.position.clone().sub(target);
       if (direction.lengthSq() < 1e-10) direction.set(-1, -1, 1);
       direction.normalize();

--- a/src/components/scene/camera/CameraFocusHotkeyController.tsx
+++ b/src/components/scene/camera/CameraFocusHotkeyController.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import * as THREE from 'three';
-import { useFrame, useThree } from '@react-three/fiber';
+import { useFrame } from '@react-three/fiber';
 import { useCameraFocusHotkey } from '@/hotkeys/useCameraFocusHotkey';
-import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
-import { quaternionFromGlobalEuler } from '@/utils/rotation';
 
 type OrbitLikeControls = {
   target: THREE.Vector3;
@@ -21,80 +19,26 @@ function isOrbitLikeControls(value: unknown): value is OrbitLikeControls {
 type CameraFocusHotkeyControllerProps = {
   hoverPointRef: React.MutableRefObject<THREE.Vector3 | null>;
   setOrbitTargetFromPoint: (point: THREE.Vector3, options?: { animate?: boolean }) => void;
-  models: LoadedModel[];
-  activeModelId: string | null;
-  selectedModelIds: string[];
-  hoveredModelId: string | null;
-  orbitTarget: [number, number, number];
   cameraRef: React.MutableRefObject<THREE.Camera | null>;
   orbitControlsRef: React.MutableRefObject<{ target: THREE.Vector3; update: () => void } | null>;
 };
 
 type FocusTransition = {
   startPos: THREE.Vector3;
-  endPos: THREE.Vector3;
   startTarget: THREE.Vector3;
   endTarget: THREE.Vector3;
-  startZoom: number;
-  endZoom: number;
-  isOrthographic: boolean;
   startTime: number | null;
   durationMs: number;
   prevDamping: boolean | undefined;
   prevEnabled: boolean | undefined;
 };
 
-type FocusPointOptions = {
-  preserveCameraPosition?: boolean;
-};
-
-function computeModelWorldCenter(model: LoadedModel): THREE.Vector3 {
-  const localBounds = model.geometry.bbox.clone();
-  localBounds.translate(new THREE.Vector3(
-    -model.geometry.center.x,
-    -model.geometry.center.y,
-    -model.geometry.center.z,
-  ));
-
-  const worldMatrix = new THREE.Matrix4().compose(
-    model.transform.position,
-    quaternionFromGlobalEuler(model.transform.rotation),
-    model.transform.scale,
-  );
-  localBounds.applyMatrix4(worldMatrix);
-  return localBounds.getCenter(new THREE.Vector3());
-}
-
-function computeModelWorldBoundingSphere(model: LoadedModel): THREE.Sphere {
-  const localBounds = model.geometry.bbox.clone();
-  localBounds.translate(new THREE.Vector3(
-    -model.geometry.center.x,
-    -model.geometry.center.y,
-    -model.geometry.center.z,
-  ));
-  const worldMatrix = new THREE.Matrix4().compose(
-    model.transform.position,
-    quaternionFromGlobalEuler(model.transform.rotation),
-    model.transform.scale,
-  );
-  localBounds.applyMatrix4(worldMatrix);
-  return localBounds.getBoundingSphere(new THREE.Sphere());
-}
-
 export function CameraFocusHotkeyController({
   hoverPointRef,
   setOrbitTargetFromPoint,
-  models,
-  activeModelId,
-  selectedModelIds,
-  hoveredModelId,
-  orbitTarget,
   cameraRef,
   orbitControlsRef,
 }: CameraFocusHotkeyControllerProps) {
-  const { size } = useThree();
-  const sizeRef = React.useRef(size);
-  React.useEffect(() => { sizeRef.current = size; }, [size]);
   const transitionRef = React.useRef<FocusTransition | null>(null);
 
   useFrame(() => {
@@ -109,23 +53,15 @@ export function CameraFocusHotkeyController({
     const t = Math.min(1, (now - transition.startTime) / transition.durationMs);
     const eased = THREE.MathUtils.smootherstep(t, 0, 1);
 
-    camera.position.lerpVectors(transition.startPos, transition.endPos, eased);
+    // The camera stays where it is; only the orbit target moves. The
+    // controls.update() lookAt then re-orients the camera so the focused
+    // point glides to the screen centre with no zoom/distance change.
+    camera.position.copy(transition.startPos);
     controls.target.lerpVectors(transition.startTarget, transition.endTarget, eased);
-
-    if (transition.isOrthographic && camera instanceof THREE.OrthographicCamera) {
-      camera.zoom = THREE.MathUtils.lerp(transition.startZoom, transition.endZoom, eased);
-      camera.updateProjectionMatrix();
-    }
-
     controls.update();
 
     if (t >= 1) {
-      camera.position.copy(transition.endPos);
       controls.target.copy(transition.endTarget);
-      if (transition.isOrthographic && camera instanceof THREE.OrthographicCamera) {
-        camera.zoom = transition.endZoom;
-        camera.updateProjectionMatrix();
-      }
       controls.update();
 
       if (typeof transition.prevDamping === 'boolean') controls.enableDamping = transition.prevDamping;
@@ -134,20 +70,10 @@ export function CameraFocusHotkeyController({
     }
   }, -1);
 
-  const snapCameraToPoint = React.useCallback((
-    point: THREE.Vector3,
-    modelRadius?: number,
-    options?: FocusPointOptions,
-  ) => {
+  const focusCameraOnPoint = React.useCallback((point: THREE.Vector3) => {
     const camera = cameraRef.current;
     const controls = orbitControlsRef.current;
     if (!camera || !controls || !isOrbitLikeControls(controls)) {
-      // No orbit controls yet — just update the pivot state
-      setOrbitTargetFromPoint(point, { animate: false });
-      return;
-    }
-
-    if (!isOrbitLikeControls(controls)) {
       // No orbit controls yet — just update the pivot state
       setOrbitTargetFromPoint(point, { animate: false });
       return;
@@ -161,63 +87,16 @@ export function CameraFocusHotkeyController({
       transitionRef.current = null;
     }
 
-    const currentViewVector = camera.position.clone().sub(controls.target);
-    const hasValidView = currentViewVector.lengthSq() > 1e-8;
-    const viewDir = hasValidView
-      ? currentViewVector.normalize()
-      : new THREE.Vector3(-0.5, -0.7, 1).normalize();
-
-    // FOV-aware fit distance — identical formula to CameraIntroController prepare mode
-    let fitDistance = hasValidView ? currentViewVector.length() : 400;
-    let fitOrthoZoom: number | null = null;
-    if (modelRadius != null && modelRadius > 0) {
-      const isPerspective = camera instanceof THREE.PerspectiveCamera;
-      const vFov = isPerspective
-        ? THREE.MathUtils.degToRad((camera as THREE.PerspectiveCamera).fov)
-        : THREE.MathUtils.degToRad(50);
-      const { width, height } = sizeRef.current;
-      const aspect = width / Math.max(1, height);
-      const hFov = 2 * Math.atan(Math.tan(vFov * 0.5) * aspect);
-      const minFov = Math.max(0.0001, Math.min(vFov, hFov));
-      fitDistance = (modelRadius / Math.tan(minFov * 0.5)) * 1.05;
-
-      // Orthographic cameras must fit via zoom, not distance.
-      if (camera instanceof THREE.OrthographicCamera) {
-        const ortho = camera as THREE.OrthographicCamera;
-        const frustumHeight = Math.max(1e-6, ortho.top - ortho.bottom);
-        const requiredWorldHeight = (modelRadius * 2) * 1.08;
-        fitOrthoZoom = THREE.MathUtils.clamp(
-          frustumHeight / Math.max(1e-6, requiredWorldHeight),
-          0.0001,
-          200,
-        );
-      }
-    }
-
-    const endTarget = point.clone();
-    const preserveCameraPosition = !!options?.preserveCameraPosition;
-    const endPos = preserveCameraPosition
-      ? camera.position.clone()
-      : endTarget.clone().add(viewDir.clone().multiplyScalar(fitDistance));
-
     // Disable damping so no pending velocity is applied during update()
     const prevDamping = controls.enableDamping;
     const prevEnabled = controls.enabled;
     if (typeof prevDamping === 'boolean') controls.enableDamping = false;
     if (typeof prevEnabled === 'boolean') controls.enabled = false;
 
-    const isOrthographic = camera instanceof THREE.OrthographicCamera;
-    const startZoom = isOrthographic ? camera.zoom : 1;
-    const endZoom = fitOrthoZoom ?? startZoom;
-
     transitionRef.current = {
       startPos: camera.position.clone(),
-      endPos,
       startTarget: controls.target.clone(),
-      endTarget,
-      startZoom,
-      endZoom,
-      isOrthographic,
+      endTarget: point.clone(),
       startTime: null,
       durationMs: 260,
       prevDamping,
@@ -226,62 +105,13 @@ export function CameraFocusHotkeyController({
   }, [cameraRef, orbitControlsRef, setOrbitTargetFromPoint]);
 
   useCameraFocusHotkey(() => {
-    const visibleModels = models.filter((model) => model.visible);
-    const visibleById = new Map(visibleModels.map((model) => [model.id, model] as const));
+    // Focus is strictly hover-driven: re-pivot to the surface point under
+    // the cursor. When the cursor is not over a model there is no hover
+    // point and the hotkey does nothing — never fall back to framing a
+    // model, which used to fly the camera far out to fit it.
     const hoverPoint = hoverPointRef.current;
-
-    const hoveredSelectedModel = hoveredModelId
-      && (
-        hoveredModelId === activeModelId
-        || selectedModelIds.includes(hoveredModelId)
-      );
-
-    // Hovering a selected model: re-target the orbit pivot to the hovered
-    // surface point but keep the current zoom / camera position unchanged.
-    if (hoverPoint && hoveredSelectedModel) {
-      snapCameraToPoint(hoverPoint, undefined, { preserveCameraPosition: true });
-      return;
-    }
-
-    if (visibleModels.length === 0) {
-      if (hoverPoint) snapCameraToPoint(hoverPoint, undefined, { preserveCameraPosition: true });
-      return;
-    }
-
-    const preferredIds: string[] = [];
-    const seen = new Set<string>();
-    const pushPreferred = (id: string | null | undefined) => {
-      if (!id || seen.has(id) || !visibleById.has(id)) return;
-      seen.add(id);
-      preferredIds.push(id);
-    };
-
-    pushPreferred(activeModelId);
-    selectedModelIds.forEach((id) => pushPreferred(id));
-    pushPreferred(hoveredModelId);
-
-    const preferredModel = preferredIds.length > 0 ? visibleById.get(preferredIds[0]) ?? null : null;
-    if (preferredModel) {
-      const sphere = computeModelWorldBoundingSphere(preferredModel);
-      snapCameraToPoint(sphere.center, sphere.radius);
-      return;
-    }
-
-    const currentTarget = new THREE.Vector3(orbitTarget[0], orbitTarget[1], orbitTarget[2]);
-    let bestModel = visibleModels[0];
-    let bestDistanceSq = Number.POSITIVE_INFINITY;
-
-    for (const model of visibleModels) {
-      const center = computeModelWorldCenter(model);
-      const distanceSq = center.distanceToSquared(currentTarget);
-      if (distanceSq < bestDistanceSq) {
-        bestDistanceSq = distanceSq;
-        bestModel = model;
-      }
-    }
-
-    const bestSphere = computeModelWorldBoundingSphere(bestModel);
-    snapCameraToPoint(bestSphere.center, bestSphere.radius);
+    if (!hoverPoint) return;
+    focusCameraOnPoint(hoverPoint.clone());
   });
 
   return null;

--- a/src/hotkeys/hotkeyConfig.ts
+++ b/src/hotkeys/hotkeyConfig.ts
@@ -79,7 +79,7 @@ export const DEFAULT_KEYBINDINGS: HotkeyConfig = {
     CAMERA: {
         FOCUS_PICK: {
             key: 'f',
-            description: 'Press to focus hovered point on selected model, else snap to best visible model'
+            description: 'Press to center the camera on the model point under the cursor'
         },
         TOGGLE_PROJECTION: {
             key: 'o',


### PR DESCRIPTION
## Summary

Two camera interaction bug fixes.

### 1. Ortho → perspective switch produced a 90° fisheye lens (`189b44c6`)

The projection switch computed the perspective FOV from a distance it had just defined as `span / 2`, so `atan(span / (2 · distance))` was always `atan(1)` — every switch yielded exactly 90° FOV with the camera parked half a span from the target, giving a heavily distorted close-up view.

The switch now keeps the natural 50° default FOV and instead solves for the orbit distance that shows the same vertical world span the ortho view did (`distance = (span/2) / tan(fov/2)`). Visual size is preserved, and the math is the exact inverse of the perspective→ortho branch, so repeated mode toggles round-trip cleanly. Also removes an accidentally duplicated position/quaternion copy block in the ortho branch.

### 2. Focus hotkey (F) randomly flew the camera way out (`b700b995`)

The hotkey only honored the hovered surface point when the hovered model was active/selected. Hovering any other model — or empty space — silently fell through to a frame-whole-model fallback (active → selected → nearest model) that flew the camera out to a bounding-sphere fit distance. In practice the key felt random, since selection state isn't on your mind when pressing F.

Focus is now strictly hover-driven:
- Cursor on any model surface (selected or not): the orbit pivot glides to that point (260 ms) and the camera rotates in place to center it — zoom and distance untouched.
- Cursor not on a model: no-op.

The frame-whole-model fallback is removed entirely; the hotkey description in `hotkeyConfig.ts` is updated to match.

## Validation

- `npx tsc --noEmit` clean; eslint clean on changed lines (remaining SceneCanvas warnings are pre-existing).
- Manually verified in the app: ortho↔perspective toggling keeps model size with a natural lens; F centers the hovered point on selected and unselected models and does nothing off-model.