### PR TITLE
fix: hollowing resource crashes performance fixes and VOXL mesh modifiers restoration

### DIFF
--- a/rust/dragonfruit-mesh-repair/src/hollowing.rs
+++ b/rust/dragonfruit-mesh-repair/src/hollowing.rs
@@ -643,7 +643,7 @@ pub fn hollow_voxel(mut mesh: IndexedMesh, options: &HollowOptions) -> HollowOut
         // The frontend will render spheres at removed_voxel_centers instead.
         (mesh.clone(), IndexedMesh::default())
     } else {
-        let (out, cavity) = build_hollow_output_mesh(
+        let (out, cavity, cavity_wall_score) = build_hollow_output_mesh(
             &mesh,
             &source_bbox,
             &grid,
@@ -654,6 +654,8 @@ pub fn hollow_voxel(mut mesh: IndexedMesh, options: &HollowOptions) -> HollowOut
             shell_voxels_f,
             smoothing_profile,
         );
+        #[cfg(not(feature = "manifold"))]
+        let _ = cavity_wall_score;
         #[cfg(feature = "manifold")]
         let (out, cavity) = finalize_hollow_output_mesh_for_manifold(
             &mesh,
@@ -667,6 +669,7 @@ pub fn hollow_voxel(mut mesh: IndexedMesh, options: &HollowOptions) -> HollowOut
             smoothing_profile,
             out,
             cavity,
+            cavity_wall_score,
         );
         (out, cavity)
     };
@@ -697,8 +700,8 @@ pub fn hollow_voxel(mut mesh: IndexedMesh, options: &HollowOptions) -> HollowOut
         };
     let mut removed_voxel_centers = collect_removed_voxel_centers(&grid, &solid, &keep);
     let removed_voxel_indices = collect_removed_voxel_indices(&grid, &solid, &keep);
-    let mut blocked_voxel_centers =
-        collect_blocked_voxel_centers(&grid, &options.blocked_voxel_indices);
+    let (mut blocked_voxel_centers, accepted_blocked_voxel_indices) =
+        collect_blocked_voxel_data(&grid, &solid, &options.blocked_voxel_indices);
 
     // Unrotate all outputs so DragonFruit's own (unrotated) geometry stays in
     // sync with what Rust produces.
@@ -743,12 +746,7 @@ pub fn hollow_voxel(mut mesh: IndexedMesh, options: &HollowOptions) -> HollowOut
         removed_voxel_centers,
         removed_voxel_indices,
         blocked_voxel_centers,
-        blocked_voxel_indices: options
-            .blocked_voxel_indices
-            .clone()
-            .into_iter()
-            .map(|i| i as u32)
-            .collect(),
+        blocked_voxel_indices: accepted_blocked_voxel_indices,
         report: HollowReport {
             mode: options.mode,
             voxel_resolution: options.voxel_resolution,
@@ -1003,15 +1001,19 @@ impl HollowSession {
         self.rotation_quat
     }
 
-    pub fn run(&self, options: &HollowOptions) -> HollowOutcome {
+    /// Recomputes the `keep` mask (which solid voxels remain material after
+    /// hollowing) for `options`, plus the count of voxels retained by the
+    /// initial shell-distance pass (`kept_shell`, reported as `shell_voxels`).
+    ///
+    /// This is the single source of truth for the keep mask: `run()` consumes
+    /// it to build the output mesh, and `select_removed_voxels_in_polygon`
+    /// consumes it so lasso selection sees the exact same cavity
+    /// (`removed = solid && !keep`) the preview was built from. Keeping one
+    /// implementation is what prevents projection/selection drift.
+    fn compute_keep_mask(&self, options: &HollowOptions) -> (Vec<bool>, usize) {
         let shell_voxels = (options.shell_thickness_mm.max(0.2) / self.grid.voxel_mm).ceil() as i32;
         let shell_voxels = shell_voxels.max(1);
         let shell_voxels_f = options.shell_thickness_mm.max(0.2) / self.grid.voxel_mm;
-        let smoothing_profile = effective_internal_cavity_smoothing_profile(
-            options.shell_thickness_mm,
-            options.smooth_internal_surfaces,
-            shell_voxels_f,
-        );
 
         let mut keep = vec![false; self.solid.len()];
         let mut kept_shell = 0usize;
@@ -1091,6 +1093,55 @@ impl HollowSession {
             }
         }
 
+        (keep, kept_shell)
+    }
+
+    /// Lasso selection over the FULL through-depth cavity, computed Rust-side
+    /// so it is immune to the boundary filter and viewport cap that narrow the
+    /// exported/rendered voxel subset. Returns the grid indices of every
+    /// removed (cavity) voxel whose projected screen point falls inside
+    /// `polygon` (container-pixel space). See the free `select_removed_voxels_in_polygon`
+    /// for the projection math, which is a 1:1 port of the frontend loop.
+    #[allow(clippy::too_many_arguments)]
+    pub fn select_removed_voxels_in_polygon(
+        &self,
+        options: &HollowOptions,
+        polygon: &[[f32; 2]],
+        view_proj: &[f32; 16],
+        rect_w: f32,
+        rect_h: f32,
+        geom_center: Vec3,
+        scale: Vec3,
+        model_quat: [f32; 4],
+        position: Vec3,
+    ) -> Vec<u32> {
+        let (keep, _kept_shell) = self.compute_keep_mask(options);
+        select_removed_voxels_in_polygon(
+            &self.grid,
+            &self.solid,
+            &keep,
+            self.rotation_quat,
+            polygon,
+            view_proj,
+            rect_w,
+            rect_h,
+            geom_center,
+            scale,
+            model_quat,
+            position,
+        )
+    }
+
+    pub fn run(&self, options: &HollowOptions) -> HollowOutcome {
+        let shell_voxels_f = options.shell_thickness_mm.max(0.2) / self.grid.voxel_mm;
+        let smoothing_profile = effective_internal_cavity_smoothing_profile(
+            options.shell_thickness_mm,
+            options.smooth_internal_surfaces,
+            shell_voxels_f,
+        );
+
+        let (keep, kept_shell) = self.compute_keep_mask(options);
+
         let removed_voxels = self
             .occupied_voxels
             .saturating_sub(keep.iter().filter(|v| **v).count());
@@ -1098,7 +1149,7 @@ impl HollowSession {
             // Sphere preview: skip the expensive mesh building entirely.
             (self.source_mesh.clone(), IndexedMesh::default())
         } else {
-            let (out, cavity) = build_hollow_output_mesh(
+            let (out, cavity, cavity_wall_score) = build_hollow_output_mesh(
                 &self.source_mesh,
                 &self.source_bbox,
                 &self.grid,
@@ -1109,6 +1160,8 @@ impl HollowSession {
                 shell_voxels_f,
                 smoothing_profile,
             );
+            #[cfg(not(feature = "manifold"))]
+            let _ = cavity_wall_score;
             #[cfg(feature = "manifold")]
             let (out, cavity) = finalize_hollow_output_mesh_for_manifold(
                 &self.source_mesh,
@@ -1122,6 +1175,7 @@ impl HollowSession {
                 smoothing_profile,
                 out,
                 cavity,
+                cavity_wall_score,
             );
             (out, cavity)
         };
@@ -1153,8 +1207,8 @@ impl HollowSession {
         let mut removed_voxel_centers =
             collect_removed_voxel_centers(&self.grid, &self.solid, &keep);
         let removed_voxel_indices = collect_removed_voxel_indices(&self.grid, &self.solid, &keep);
-        let mut blocked_voxel_centers =
-            collect_blocked_voxel_centers(&self.grid, &options.blocked_voxel_indices);
+        let (mut blocked_voxel_centers, accepted_blocked_voxel_indices) =
+            collect_blocked_voxel_data(&self.grid, &self.solid, &options.blocked_voxel_indices);
 
         // Unrotate all outputs so DragonFruit's own (unrotated) geometry
         // stays in sync with what Rust produces.
@@ -1202,12 +1256,7 @@ impl HollowSession {
             removed_voxel_centers,
             removed_voxel_indices,
             blocked_voxel_centers,
-            blocked_voxel_indices: options
-                .blocked_voxel_indices
-                .clone()
-                .into_iter()
-                .map(|i| i as u32)
-                .collect(),
+            blocked_voxel_indices: accepted_blocked_voxel_indices,
             report: HollowReport {
                 mode: options.mode,
                 voxel_resolution: self.voxel_resolution,
@@ -1224,19 +1273,50 @@ impl HollowSession {
     }
 }
 
+/// Returns true if the removed voxel at (x, y, z) is adjacent (6-connected)
+/// to at least one voxel that is not part of the removed cavity interior -
+/// i.e. it is kept material (shell) or genuinely outside the solid volume.
+/// Only these "boundary" removed voxels are ever visible in the rendered
+/// InstancedMesh preview, since interior removed voxels are fully occluded
+/// by the removed voxels surrounding them on all sides.
+#[inline]
+fn is_removed_voxel_boundary(
+    grid: &GridSpec,
+    solid: &[bool],
+    keep: &[bool],
+    x: usize,
+    y: usize,
+    z: usize,
+) -> bool {
+    for (dx, dy, dz) in N6 {
+        let (nx, ny, nz) = (x as isize + dx, y as isize + dy, z as isize + dz);
+        if !grid.in_bounds(nx, ny, nz) {
+            // Conservative: treat an out-of-grid neighbor as exposed too.
+            // Should not occur in practice given the 1-voxel construction
+            // margin, but never hides a genuinely exposed voxel if it did.
+            return true;
+        }
+        let n = grid.idx(nx as usize, ny as usize, nz as usize);
+        if !solid[n] || keep[n] {
+            // Neighbor is outside the solid mesh, or is kept (shell)
+            // material -> this removed voxel sits on the visible cavity wall.
+            return true;
+        }
+    }
+    false
+}
+
 fn collect_removed_voxel_centers(grid: &GridSpec, solid: &[bool], keep: &[bool]) -> Vec<f32> {
-    let removed_count = solid
-        .iter()
-        .zip(keep.iter())
-        .filter(|(is_solid, is_kept)| **is_solid && !**is_kept)
-        .count();
-    let mut centers = Vec::with_capacity(removed_count * 3);
+    let mut centers = Vec::new();
 
     for z in 0..grid.nz {
         for y in 0..grid.ny {
             for x in 0..grid.nx {
                 let index = grid.idx(x, y, z);
                 if !solid[index] || keep[index] {
+                    continue;
+                }
+                if !is_removed_voxel_boundary(grid, solid, keep, x, y, z) {
                     continue;
                 }
                 let center = grid.center_world(x, y, z);
@@ -1251,18 +1331,16 @@ fn collect_removed_voxel_centers(grid: &GridSpec, solid: &[bool], keep: &[bool])
 }
 
 fn collect_removed_voxel_indices(grid: &GridSpec, solid: &[bool], keep: &[bool]) -> Vec<u32> {
-    let removed_count = solid
-        .iter()
-        .zip(keep.iter())
-        .filter(|(is_solid, is_kept)| **is_solid && !**is_kept)
-        .count();
-    let mut indices = Vec::with_capacity(removed_count);
+    let mut indices = Vec::new();
 
     for z in 0..grid.nz {
         for y in 0..grid.ny {
             for x in 0..grid.nx {
                 let index = grid.idx(x, y, z);
                 if !solid[index] || keep[index] {
+                    continue;
+                }
+                if !is_removed_voxel_boundary(grid, solid, keep, x, y, z) {
                     continue;
                 }
                 indices.push(index as u32);
@@ -1273,24 +1351,183 @@ fn collect_removed_voxel_indices(grid: &GridSpec, solid: &[bool], keep: &[bool])
     indices
 }
 
-fn collect_blocked_voxel_centers(grid: &GridSpec, blocked_indices: &[usize]) -> Vec<f32> {
+/// Decodes committed blocked-voxel grid indices into world-space centers,
+/// mirroring the exact acceptance rule used when the blockers are applied to
+/// `keep` (`index` in bounds AND `solid[index]`). Returns centers and the
+/// accepted indices in lockstep - entry `i` of the centers always describes
+/// `accepted[i]` - so downstream positional mappings can never desync when a
+/// stale index is dropped.
+fn collect_blocked_voxel_data(
+    grid: &GridSpec,
+    solid: &[bool],
+    blocked_indices: &[usize],
+) -> (Vec<f32>, Vec<u32>) {
     let mut centers = Vec::with_capacity(blocked_indices.len() * 3);
+    let mut accepted = Vec::with_capacity(blocked_indices.len());
     for &index in blocked_indices {
-        let nz = grid.nz;
-        let ny = grid.ny;
-        let nx = grid.nx;
-        let z = index / (nx * ny);
-        let yz = index % (nx * ny);
-        let y = yz / nx;
-        let x = yz % nx;
-        if x < nx && y < ny && z < nz {
-            let c = grid.center_world(x, y, z);
-            centers.push(c.x);
-            centers.push(c.y);
-            centers.push(c.z);
+        if index >= solid.len() || !solid[index] {
+            continue;
+        }
+        let z = index / (grid.nx * grid.ny);
+        let yz = index % (grid.nx * grid.ny);
+        let y = yz / grid.nx;
+        let x = yz % grid.nx;
+        let c = grid.center_world(x, y, z);
+        centers.push(c.x);
+        centers.push(c.y);
+        centers.push(c.z);
+        accepted.push(index as u32);
+    }
+    (centers, accepted)
+}
+
+/// Ray-casting (even-odd) point-in-polygon test. A 1:1 port of the frontend
+/// `pointInPolygon` in `page.tsx` (the lasso resolver), including its
+/// `((yj - yi) || 1e-6)` zero-slope guard, so Rust selects exactly the voxels
+/// the polygon covers on screen.
+#[inline]
+fn point_in_polygon(polygon: &[[f32; 2]], x: f32, y: f32) -> bool {
+    let mut inside = false;
+    let n = polygon.len();
+    if n == 0 {
+        return false;
+    }
+    let mut j = n - 1;
+    for i in 0..n {
+        let xi = polygon[i][0];
+        let yi = polygon[i][1];
+        let xj = polygon[j][0];
+        let yj = polygon[j][1];
+        let denom = if (yj - yi) != 0.0 { yj - yi } else { 1e-6 };
+        let intersects =
+            ((yi > y) != (yj > y)) && (x < ((xj - xi) * (y - yi)) / denom + xi);
+        if intersects {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
+}
+
+/// Projects a world point to container-relative pixels, a 1:1 port of
+/// `projectWorldPoint`/`projectPointToCanvas` in `SceneCanvas.tsx`.
+///
+/// `view_proj` is a column-major 4x4 (`camera.projectionMatrix * matrixWorldInverse`,
+/// exactly what `Matrix4.toArray()` produces). The clip-space multiply mirrors
+/// THREE's `Vector3.applyMatrix4` (which divides by `w`), then the same
+/// NDC-finite / `z ∈ [-1, 1]` rejection and pixel mapping
+/// (`(ndc.x+1)*0.5*w`, `(1-ndc.y)*0.5*h`) the frontend uses. Returns `None`
+/// for any voxel the frontend would have dropped.
+#[inline]
+fn project_world_to_pixel(
+    view_proj: &[f32; 16],
+    v: Vec3,
+    rect_w: f32,
+    rect_h: f32,
+) -> Option<(f32, f32)> {
+    let m = view_proj;
+    // Column-major mat4 * vec4(v, 1): clip[row] = sum_col m[col*4 + row] * v[col].
+    let clip_x = m[0] * v.x + m[4] * v.y + m[8] * v.z + m[12];
+    let clip_y = m[1] * v.x + m[5] * v.y + m[9] * v.z + m[13];
+    let clip_z = m[2] * v.x + m[6] * v.y + m[10] * v.z + m[14];
+    let clip_w = m[3] * v.x + m[7] * v.y + m[11] * v.z + m[15];
+    if clip_w == 0.0 {
+        return None;
+    }
+    let ndc_x = clip_x / clip_w;
+    let ndc_y = clip_y / clip_w;
+    let ndc_z = clip_z / clip_w;
+    if !ndc_x.is_finite() || !ndc_y.is_finite() || !ndc_z.is_finite() {
+        return None;
+    }
+    if ndc_z < -1.0 || ndc_z > 1.0 {
+        return None;
+    }
+    let px = (ndc_x + 1.0) * 0.5 * rect_w;
+    let py = (1.0 - ndc_y) * 0.5 * rect_h;
+    Some((px, py))
+}
+
+/// Faithful 1:1 Rust port of the frontend lasso loop
+/// (`resolveBlockedHollowVoxelMarqueeSelection` in `page.tsx`, per voxel):
+///   1. `center` = exported (UNROTATED) voxel center — grid center rotated by
+///      `inv(session_rotation_quat)`, matching what the collectors export and
+///      what the frontend consumed.
+///   2. `local = (center - geom_center) * scale` (component-wise).
+///   3. `local = model_quat * local` (`quaternionFromGlobalEuler(rotation)`).
+///   4. `world = local + position`.
+///   5. project → container pixels, then even-odd point-in-polygon.
+///
+/// It iterates EVERY removed (cavity) voxel — `solid && !keep` — with NO
+/// boundary gate, so the full through-depth column is returned, not just the
+/// visible cavity-wall shell. That is the whole point: selection is decoupled
+/// from the boundary-filtered / cap-limited rendered subset.
+#[allow(clippy::too_many_arguments)]
+fn select_removed_voxels_in_polygon(
+    grid: &GridSpec,
+    solid: &[bool],
+    keep: &[bool],
+    session_rotation_quat: [f32; 4],
+    polygon: &[[f32; 2]],
+    view_proj: &[f32; 16],
+    rect_w: f32,
+    rect_h: f32,
+    geom_center: Vec3,
+    scale: Vec3,
+    model_quat: [f32; 4],
+    position: Vec3,
+) -> Vec<u32> {
+    if polygon.len() < 3 {
+        return Vec::new();
+    }
+
+    let inv_rotation_quat = [
+        -session_rotation_quat[0],
+        -session_rotation_quat[1],
+        -session_rotation_quat[2],
+        session_rotation_quat[3],
+    ];
+    let rotation_is_identity = session_rotation_quat[0] == 0.0
+        && session_rotation_quat[1] == 0.0
+        && session_rotation_quat[2] == 0.0;
+
+    let mut selected = Vec::new();
+    for z in 0..grid.nz {
+        for y in 0..grid.ny {
+            for x in 0..grid.nx {
+                let index = grid.idx(x, y, z);
+                if !solid[index] || keep[index] {
+                    continue;
+                }
+
+                // (1) Exported-space (unrotated) center, matching the collectors.
+                let mut center = grid.center_world(x, y, z);
+                if !rotation_is_identity {
+                    center = center.rotate_by_quat(inv_rotation_quat);
+                }
+                // (2) local = (center - geom_center) * scale (component-wise).
+                let local = Vec3::new(
+                    (center.x - geom_center.x) * scale.x,
+                    (center.y - geom_center.y) * scale.y,
+                    (center.z - geom_center.z) * scale.z,
+                );
+                // (3) local = model_quat * local.
+                let local = local.rotate_by_quat(model_quat);
+                // (4) world = local + position.
+                let world = local.add(position);
+                // (5) project + point-in-polygon.
+                let Some((px, py)) = project_world_to_pixel(view_proj, world, rect_w, rect_h)
+                else {
+                    continue;
+                };
+                if point_in_polygon(polygon, px, py) {
+                    selected.push(index as u32);
+                }
+            }
         }
     }
-    centers
+
+    selected
 }
 
 #[cfg(not(feature = "manifold"))]
@@ -1420,8 +1657,6 @@ fn organic_boundary_mesh(
     for z in 0..grid.nz.saturating_sub(1) {
         for y in 0..grid.ny.saturating_sub(1) {
             for x in 0..grid.nx.saturating_sub(1) {
-                let mut has_kept = false;
-                let mut has_carved = false;
                 let mut has_scalar_positive = false;
                 let mut has_scalar_negative = false;
 
@@ -1434,8 +1669,6 @@ fn organic_boundary_mesh(
                     corner_pos[corner_i] = grid.center_world(vx, vy, vz);
                     corner_kept[corner_i] = positive[vi];
                     corner_carved[corner_i] = negative[vi];
-                    has_kept |= corner_kept[corner_i];
-                    has_carved |= corner_carved[corner_i];
                     corner_scalar[corner_i] = scalar_field[vi];
                     if corner_kept[corner_i] || corner_carved[corner_i] {
                         if corner_scalar[corner_i] >= 0.0 {
@@ -1446,7 +1679,11 @@ fn organic_boundary_mesh(
                     }
                 }
 
-                if !(has_kept && has_carved) && !(has_scalar_positive && has_scalar_negative) {
+                // Scalar-sign-only gate: cubes whose classified corners all
+                // share one scalar sign contain no isosurface. (Cubes with
+                // only a hard-label crossing were exactly the shard
+                // generators removed by the 2026-07-12 audit fix.)
+                if !(has_scalar_positive && has_scalar_negative) {
                     continue;
                 }
 
@@ -1591,6 +1828,41 @@ fn build_smoothed_cavity_scalar_field(
         std::mem::swap(&mut field, &mut scratch);
     }
 
+    // Outer-skin guard: blur must never flip a kept voxel that sits on the
+    // model's outer surface (6-adjacent to non-solid space or the grid
+    // border) negative — a flip there lets the cavity isosurface exit
+    // through the model's outer skin at thin features. Clamp those voxels
+    // back to the same positive epsilon floor used at initialization.
+    let skin_floor = 0.05 * shell_voxels_f.max(0.2);
+    for z in 0..grid.nz {
+        for y in 0..grid.ny {
+            for x in 0..grid.nx {
+                let i = grid.idx(x, y, z);
+                if !keep[i] || !solid[i] {
+                    continue;
+                }
+                let mut touches_outside = false;
+                for (dx, dy, dz) in N6 {
+                    let nx_i = x as isize + dx;
+                    let ny_i = y as isize + dy;
+                    let nz_i = z as isize + dz;
+                    if !grid.in_bounds(nx_i, ny_i, nz_i) {
+                        touches_outside = true;
+                        break;
+                    }
+                    let ni = grid.idx(nx_i as usize, ny_i as usize, nz_i as usize);
+                    if !solid[ni] {
+                        touches_outside = true;
+                        break;
+                    }
+                }
+                if touches_outside {
+                    field[i] = field[i].max(skin_floor);
+                }
+            }
+        }
+    }
+
     field
 }
 
@@ -1604,8 +1876,8 @@ fn build_hollow_output_mesh(
     options: &HollowOptions,
     shell_voxels_f: f32,
     smoothing_profile: InternalCavitySmoothingProfile,
-) -> (IndexedMesh, IndexedMesh) {
-    let cavity_mesh = build_cavity_inner_mesh(
+) -> (IndexedMesh, IndexedMesh, usize) {
+    let (cavity_mesh, cavity_wall_score) = build_cavity_inner_mesh(
         source_bbox,
         grid,
         solid,
@@ -1623,7 +1895,11 @@ fn build_hollow_output_mesh(
         merge_meshes(&filtered_source, &cavity_mesh)
     };
 
-    (normalize_mesh_for_boolean(out_mesh), cavity_mesh)
+    (
+        normalize_mesh_for_boolean(out_mesh),
+        cavity_mesh,
+        cavity_wall_score,
+    )
 }
 
 /// Build only the internal cavity (+ infill) mesh without the outer shell.
@@ -1638,7 +1914,7 @@ fn build_cavity_inner_mesh(
     options: &HollowOptions,
     shell_voxels_f: f32,
     smoothing_profile: InternalCavitySmoothingProfile,
-) -> IndexedMesh {
+) -> (IndexedMesh, usize) {
     let cavity_positive = keep.to_vec();
     let cavity_negative: Vec<bool> = solid
         .iter()
@@ -1654,14 +1930,16 @@ fn build_cavity_inner_mesh(
         shell_voxels_f,
         smoothing_profile.scalar_field_blur_iterations,
     );
-    let cavity_mesh = stabilize_cavity_mesh_for_boolean(
-        smooth_cavity_mesh(
-            organic_boundary_mesh(grid, &cavity_positive, &cavity_negative, &cavity_scalar),
+    let (cavity_mesh, wall_defect_score) = drop_open_cavity_fragments(
+        stabilize_cavity_mesh_for_boolean(
+            smooth_cavity_mesh(
+                organic_boundary_mesh(grid, &cavity_positive, &cavity_negative, &cavity_scalar),
+                grid.voxel_mm,
+                smoothing_profile.taubin_iterations,
+                smoothing_profile.taubin_max_step_scale,
+            ),
             grid.voxel_mm,
-            smoothing_profile.taubin_iterations,
-            smoothing_profile.taubin_max_step_scale,
         ),
-        grid.voxel_mm,
     );
 
     let infill_mesh = if matches!(options.mode, HollowMode::Infill) {
@@ -1678,13 +1956,16 @@ fn build_cavity_inner_mesh(
         IndexedMesh::default()
     };
 
-    if infill_mesh.triangles.is_empty() {
+    // The infill lattice beams are closed tubes by construction; the cavity
+    // wall's defect score is the meaningful manifold-failure predictor.
+    let combined = if infill_mesh.triangles.is_empty() {
         cavity_mesh
     } else if cavity_mesh.triangles.is_empty() {
         infill_mesh
     } else {
         merge_meshes(&cavity_mesh, &infill_mesh)
-    }
+    };
+    (combined, wall_defect_score)
 }
 
 fn polygonize_cavity_tetrahedron(
@@ -1716,22 +1997,19 @@ fn polygonize_cavity_tetrahedron(
         }
     }
 
-    // Prefer the blurred scalar field for contouring. The previous extractor
-    // only crossed hard kept/carved voxel labels, which let smoothing slide
-    // vertices along a blocky voxel edge network but not escape that network.
-    // If the scalar field is locally degenerate, fall back to hard labels so a
-    // disabled or numerically flat field still produces a closed cavity wall.
-    let use_scalar_sides = scalar_positive_count > 0 && scalar_negative_count > 0;
-    if !use_scalar_sides {
-        for (local_i, &corner_i) in tet.iter().enumerate() {
-            side[local_i] = if kept[corner_i] {
-                Some(true)
-            } else if carved[corner_i] {
-                Some(false)
-            } else {
-                None
-            };
-        }
+    // Contour strictly by the scalar field's sign. The field is initialized
+    // with signed epsilon floors that exactly match the hard kept/carved
+    // labels (see build_smoothed_cavity_scalar_field), so with blur disabled
+    // this is identical to hard-label contouring. With blur enabled the
+    // isosurface legitimately migrates off the hard-label boundary; a tet
+    // whose classified corners are all one scalar sign simply contains no
+    // isosurface and must emit nothing. The previous per-tetrahedron
+    // fallback to hard labels in that case emitted detached midpoint "shard"
+    // triangles whose borders matched nothing (adjacent tets contoured by
+    // the scalar criterion), making the cavity non-manifold by construction
+    // and corrupting cross-section stencil parity (2026-07-12 audit).
+    if scalar_positive_count == 0 || scalar_negative_count == 0 {
+        return;
     }
 
     for (ea, eb) in tet_edges {
@@ -1753,7 +2031,7 @@ fn polygonize_cavity_tetrahedron(
         let va = scalar[ia];
         let vb = scalar[ib];
         let denom = va - vb;
-        let t = if !use_scalar_sides || denom.abs() <= 1e-6 {
+        let t = if denom.abs() <= 1e-6 {
             0.5
         } else {
             (va / denom).clamp(0.0, 1.0)
@@ -2179,6 +2457,169 @@ fn reduced_internal_cavity_smoothing_profile(
     }
 }
 
+/// Drops vertices not referenced by any triangle and remaps indices in
+/// place. O(V + T), no hashing. Replaces the previous full triangle-soup
+/// re-weld whose only observable effect was this same compaction (the
+/// manifold backend tolerates unreferenced vertices, but downstream code
+/// historically assumed none remain after normalization).
+fn compact_unreferenced_vertices(mesh: &mut IndexedMesh) {
+    let mut used = vec![false; mesh.positions.len()];
+    for tri in &mesh.triangles {
+        used[tri[0] as usize] = true;
+        used[tri[1] as usize] = true;
+        used[tri[2] as usize] = true;
+    }
+    if used.iter().all(|&u| u) {
+        return;
+    }
+    let mut remap = vec![u32::MAX; mesh.positions.len()];
+    let mut next = 0u32;
+    let mut new_positions = Vec::with_capacity(mesh.positions.len());
+    for (i, &is_used) in used.iter().enumerate() {
+        if is_used {
+            remap[i] = next;
+            new_positions.push(mesh.positions[i]);
+            next += 1;
+        }
+    }
+    for tri in &mut mesh.triangles {
+        tri[0] = remap[tri[0] as usize];
+        tri[1] = remap[tri[1] as usize];
+        tri[2] = remap[tri[2] as usize];
+    }
+    mesh.positions = new_positions;
+}
+
+/// Removes detached "shard" fragments from a generated cavity wall mesh:
+/// edge-connected components, other than the largest (always kept --
+/// ShellOpenFace/drain-hole modes legitimately produce an open main wall),
+/// that contain boundary edges. Such fragments arise where the smoothed
+/// scalar isosurface and the hard voxel labels disagree locally; they are
+/// visually occluded, but their open borders make manifold conversion
+/// structurally impossible and corrupt cross-section stencil parity.
+///
+/// Returns the cleaned mesh plus its residual defect score
+/// (`boundary_edges + 4 * non_manifold_edges`), which manifold
+/// stabilization uses to skip provably futile attempts.
+fn drop_open_cavity_fragments(mesh: IndexedMesh) -> (IndexedMesh, usize) {
+    if mesh.triangles.is_empty() {
+        return (mesh, 0);
+    }
+
+    let topo = crate::core::halfedge::Topology::build(&mesh);
+    let boundary_edges = topo.boundary_edges();
+    let non_manifold_count = topo.non_manifold_edges().len();
+    if boundary_edges.is_empty() {
+        return (mesh, non_manifold_count * 4);
+    }
+
+    fn find(parent: &mut [u32], mut i: u32) -> u32 {
+        while parent[i as usize] != i {
+            parent[i as usize] = parent[parent[i as usize] as usize];
+            i = parent[i as usize];
+        }
+        i
+    }
+
+    // Union-find over faces sharing an edge (any multiplicity, so
+    // non-manifold edges still connect their components).
+    let face_count = mesh.triangles.len();
+    let mut parent: Vec<u32> = (0..face_count as u32).collect();
+    for info in topo.edges.values() {
+        let mut faces = info.faces.iter();
+        if let Some(&first) = faces.next() {
+            let root = find(&mut parent, first);
+            for &other in faces {
+                let other_root = find(&mut parent, other);
+                parent[other_root as usize] = root;
+            }
+        }
+    }
+
+    let mut component_size = vec![0usize; face_count];
+    for face in 0..face_count as u32 {
+        let root = find(&mut parent, face);
+        component_size[root as usize] += 1;
+    }
+    let mut component_open = vec![false; face_count];
+    for key in &boundary_edges {
+        if let Some(info) = topo.edges.get(key) {
+            for &face in &info.faces {
+                let root = find(&mut parent, face);
+                component_open[root as usize] = true;
+            }
+        }
+    }
+    let largest_root = (0..face_count)
+        .max_by_key(|&i| component_size[i])
+        .unwrap_or(0) as u32;
+
+    let retained: Vec<[u32; 3]> = mesh
+        .triangles
+        .iter()
+        .enumerate()
+        .filter(|(face, _)| {
+            let root = find(&mut parent, *face as u32);
+            root == largest_root || !component_open[root as usize]
+        })
+        .map(|(_, tri)| *tri)
+        .collect();
+
+    if retained.len() == mesh.triangles.len() {
+        return (mesh, boundary_edges.len() + non_manifold_count * 4);
+    }
+
+    let dropped = mesh.triangles.len() - retained.len();
+    let mut cleaned = IndexedMesh {
+        positions: mesh.positions,
+        triangles: retained,
+    };
+    compact_unreferenced_vertices(&mut cleaned);
+
+    let cleaned_topo = crate::core::halfedge::Topology::build(&cleaned);
+    let score =
+        cleaned_topo.boundary_edges().len() + cleaned_topo.non_manifold_edges().len() * 4;
+    eprintln!(
+        "[dragonfruit-mesh-repair] cavity fragment cleanup: dropped {dropped} shard triangles, residual defect score {score}"
+    );
+    (cleaned, score)
+}
+
+/// Cheap topology-level defect summary: a single hash pass over the edges,
+/// with none of the BVH self-intersection work `crate::analysis::analyze`
+/// performs. Used to classify manifold-conversion failures before deciding
+/// whether retries can possibly help.
+#[cfg_attr(not(feature = "manifold"), allow(dead_code))]
+#[derive(Debug, Clone, Copy)]
+struct MeshDefectSummary {
+    boundary_edges: usize,
+    non_manifold_edges: usize,
+    inconsistent_edges: usize,
+}
+
+#[cfg_attr(not(feature = "manifold"), allow(dead_code))]
+fn summarize_mesh_defects(mesh: &IndexedMesh) -> MeshDefectSummary {
+    let topo = crate::core::halfedge::Topology::build(mesh);
+    MeshDefectSummary {
+        boundary_edges: topo.boundary_edges().len(),
+        non_manifold_edges: topo.non_manifold_edges().len(),
+        inconsistent_edges: topo.inconsistent_edges(),
+    }
+}
+
+/// Vertex welding can only close hairline cracks — boundary edges whose
+/// counterparts sit within the weld epsilon. It cannot repair edges shared
+/// by more than two faces, and it never changes winding, so retrying the
+/// weld ladder against those defect classes is provably futile
+/// (2026-07-12 audit: the ladder's absolute weld range is single-digit
+/// micrometres, five orders of magnitude below voxel-scale defects).
+#[cfg_attr(not(feature = "manifold"), allow(dead_code))]
+fn weld_retries_worthwhile(defects: &MeshDefectSummary) -> bool {
+    defects.non_manifold_edges == 0
+        && defects.inconsistent_edges == 0
+        && defects.boundary_edges > 0
+}
+
 fn normalize_mesh_for_boolean(mesh: IndexedMesh) -> IndexedMesh {
     normalize_mesh_for_boolean_with_weld(mesh, 1e-6)
 }
@@ -2200,7 +2641,12 @@ fn normalize_mesh_for_boolean_with_weld(mesh: IndexedMesh, weld_epsilon: f32) ->
     });
 
     if normalized.triangles.len() != mesh.triangles.len() {
-        normalized = IndexedMesh::from_triangle_soup(&normalized.to_triangle_soup(), weld_epsilon);
+        // Degenerate-triangle removal can orphan vertices. The previous full
+        // triangle-soup re-weld here cost another O(T) soup materialization
+        // plus ~3T serial hash interns per call, and its only observable
+        // effect was orphan compaction (re-welding at the same epsilon
+        // re-quantizes onto the same grid). Compact directly instead.
+        compact_unreferenced_vertices(&mut normalized);
     }
 
     normalized
@@ -2277,45 +2723,48 @@ fn stabilize_hollow_mesh_for_manifold(mesh: IndexedMesh) -> HollowManifoldStabil
         }
     }
 
-    for weld_epsilon in [2e-6_f32, 5e-6_f32, 1e-5_f32] {
-        let candidate = normalize_mesh_for_boolean_with_weld(mesh.clone(), weld_epsilon);
-        eprintln!(
-            "[dragonfruit-mesh-repair] hollow manifold stabilization: retry weld_epsilon={weld_epsilon:.1e} tris={} verts={}",
-            candidate.triangle_count(),
-            candidate.vertex_count()
-        );
-        match try_roundtrip_manifold_mesh(candidate) {
-            Ok(roundtripped) => {
-                eprintln!(
-                    "[dragonfruit-mesh-repair] hollow manifold stabilization: retry succeeded weld_epsilon={weld_epsilon:.1e} tris={} verts={}",
-                    roundtripped.triangle_count(),
-                    roundtripped.vertex_count()
-                );
-                return HollowManifoldStabilization::Stabilized(roundtripped);
-            }
-            Err(reason) => {
-                eprintln!(
-                    "[dragonfruit-mesh-repair] hollow manifold stabilization: retry failed weld_epsilon={weld_epsilon:.1e} ({reason})"
-                );
+    // Classify the failure once, cheaply, before deciding whether weld
+    // retries can possibly help. (Previously a full crate::analysis::analyze
+    // — including a BVH self-intersection pass over every triangle — ran
+    // after ALL retries failed, purely to print a log line.)
+    let defects = summarize_mesh_defects(&mesh);
+    eprintln!(
+        "[dragonfruit-mesh-repair] hollow manifold stabilization: defect summary boundary={} non_manifold={} inconsistent_winding={}",
+        defects.boundary_edges, defects.non_manifold_edges, defects.inconsistent_edges
+    );
+
+    if weld_retries_worthwhile(&defects) {
+        for weld_epsilon in [2e-6_f32, 5e-6_f32, 1e-5_f32] {
+            let candidate = normalize_mesh_for_boolean_with_weld(mesh.clone(), weld_epsilon);
+            eprintln!(
+                "[dragonfruit-mesh-repair] hollow manifold stabilization: retry weld_epsilon={weld_epsilon:.1e} tris={} verts={}",
+                candidate.triangle_count(),
+                candidate.vertex_count()
+            );
+            match try_roundtrip_manifold_mesh(candidate) {
+                Ok(roundtripped) => {
+                    eprintln!(
+                        "[dragonfruit-mesh-repair] hollow manifold stabilization: retry succeeded weld_epsilon={weld_epsilon:.1e} tris={} verts={}",
+                        roundtripped.triangle_count(),
+                        roundtripped.vertex_count()
+                    );
+                    return HollowManifoldStabilization::Stabilized(roundtripped);
+                }
+                Err(reason) => {
+                    eprintln!(
+                        "[dragonfruit-mesh-repair] hollow manifold stabilization: retry failed weld_epsilon={weld_epsilon:.1e} ({reason})"
+                    );
+                }
             }
         }
+        eprintln!(
+            "[dragonfruit-mesh-repair] hollow manifold stabilization: all weld retries failed, returning normalized non-manifold mesh"
+        );
+    } else {
+        eprintln!(
+            "[dragonfruit-mesh-repair] hollow manifold stabilization: skipping weld retries — defect class cannot be fixed by vertex welding"
+        );
     }
-
-    eprintln!(
-        "[dragonfruit-mesh-repair] hollow manifold stabilization: all retries failed, returning normalized non-manifold mesh"
-    );
-
-    let analysis = crate::analysis::analyze(&mesh);
-    eprintln!(
-        "[dragonfruit-mesh-repair] hollow manifold stabilization: failure summary nme={} nmv={} boundary={} loops={} inconsistent={} self_int={} comps={}",
-        analysis.non_manifold_edges,
-        analysis.non_manifold_vertices,
-        analysis.boundary_edges,
-        analysis.boundary_loops,
-        analysis.inconsistent_winding_edges,
-        analysis.self_intersection_triangles,
-        analysis.connected_components,
-    );
 
     HollowManifoldStabilization::Failed(mesh)
 }
@@ -2333,8 +2782,22 @@ fn finalize_hollow_output_mesh_for_manifold(
     smoothing_profile: InternalCavitySmoothingProfile,
     out_mesh: IndexedMesh,
     cavity_mesh: IndexedMesh,
+    cavity_wall_score: usize,
 ) -> (IndexedMesh, IndexedMesh) {
-    match stabilize_hollow_mesh_for_manifold(out_mesh) {
+    // A nonzero cavity wall defect score guarantees the merged mesh cannot
+    // pass manifold conversion: merging is pure concatenation, and every
+    // downstream weld epsilon is finer than the cavity-phase welds already
+    // attempted (2026-07-12 audit). Skip provably futile attempts outright.
+    let initial = if cavity_wall_score == 0 {
+        stabilize_hollow_mesh_for_manifold(out_mesh)
+    } else {
+        eprintln!(
+            "[dragonfruit-mesh-repair] hollow manifold stabilization: skipping initial attempt — cavity wall defect score {cavity_wall_score}"
+        );
+        HollowManifoldStabilization::Failed(out_mesh)
+    };
+
+    match initial {
         HollowManifoldStabilization::Stabilized(mesh) => (mesh, cavity_mesh),
         HollowManifoldStabilization::Failed(original_mesh) => {
             if smoothing_profile.is_disabled() {
@@ -2358,7 +2821,7 @@ fn finalize_hollow_output_mesh_for_manifold(
                 );
 
                 // Only rebuild the cavity mesh — the outer shell is cached.
-                let retry_cavity_mesh = build_cavity_inner_mesh(
+                let (retry_cavity_mesh, retry_score) = build_cavity_inner_mesh(
                     source_bbox,
                     grid,
                     solid,
@@ -2368,6 +2831,12 @@ fn finalize_hollow_output_mesh_for_manifold(
                     shell_voxels_f,
                     retry_profile,
                 );
+                if retry_score != 0 {
+                    eprintln!(
+                        "[dragonfruit-mesh-repair] hollow manifold stabilization: skipping retry — cavity wall defect score {retry_score}"
+                    );
+                    continue;
+                }
                 let retry_mesh =
                     normalize_mesh_for_boolean(merge_meshes(&filtered_source, &retry_cavity_mesh));
 
@@ -2383,7 +2852,7 @@ fn finalize_hollow_output_mesh_for_manifold(
                     "[dragonfruit-mesh-repair] hollow manifold stabilization: retrying hollow build without internal smoothing"
                 );
 
-                let retry_cavity_mesh = build_cavity_inner_mesh(
+                let (retry_cavity_mesh, retry_score) = build_cavity_inner_mesh(
                     source_bbox,
                     grid,
                     solid,
@@ -2393,6 +2862,12 @@ fn finalize_hollow_output_mesh_for_manifold(
                     shell_voxels_f,
                     smoothing_profile.disabled(),
                 );
+                if retry_score != 0 {
+                    eprintln!(
+                        "[dragonfruit-mesh-repair] hollow manifold stabilization: skipping final retry — cavity wall defect score {retry_score}"
+                    );
+                    return (original_mesh, cavity_mesh);
+                }
                 let retry_mesh =
                     normalize_mesh_for_boolean(merge_meshes(&filtered_source, &retry_cavity_mesh));
 
@@ -3896,6 +4371,359 @@ fn vec3_normalize(v: Vec3) -> Option<Vec3> {
 mod tests {
     use super::*;
 
+    /// Unit icosphere generator for cavity-quality integration tests
+    /// (methodology ported from the 2026-07-12 audit probe binary).
+    fn test_icosphere(radius: f32, subdivisions: u32) -> IndexedMesh {
+        let t = (1.0 + 5.0f32.sqrt()) / 2.0;
+        let mut verts: Vec<Vec3> = vec![
+            Vec3::new(-1.0, t, 0.0),
+            Vec3::new(1.0, t, 0.0),
+            Vec3::new(-1.0, -t, 0.0),
+            Vec3::new(1.0, -t, 0.0),
+            Vec3::new(0.0, -1.0, t),
+            Vec3::new(0.0, 1.0, t),
+            Vec3::new(0.0, -1.0, -t),
+            Vec3::new(0.0, 1.0, -t),
+            Vec3::new(t, 0.0, -1.0),
+            Vec3::new(t, 0.0, 1.0),
+            Vec3::new(-t, 0.0, -1.0),
+            Vec3::new(-t, 0.0, 1.0),
+        ];
+        let mut faces: Vec<[u32; 3]> = vec![
+            [0, 11, 5],
+            [0, 5, 1],
+            [0, 1, 7],
+            [0, 7, 10],
+            [0, 10, 11],
+            [1, 5, 9],
+            [5, 11, 4],
+            [11, 10, 2],
+            [10, 7, 6],
+            [7, 1, 8],
+            [3, 9, 4],
+            [3, 4, 2],
+            [3, 2, 6],
+            [3, 6, 8],
+            [3, 8, 9],
+            [4, 9, 5],
+            [2, 4, 11],
+            [6, 2, 10],
+            [8, 6, 7],
+            [9, 8, 1],
+        ];
+
+        for _ in 0..subdivisions {
+            let mut midpoint_cache: std::collections::HashMap<(u32, u32), u32> =
+                std::collections::HashMap::new();
+            let mut midpoint = |a: u32, b: u32, verts: &mut Vec<Vec3>| -> u32 {
+                let key = if a < b { (a, b) } else { (b, a) };
+                if let Some(&idx) = midpoint_cache.get(&key) {
+                    return idx;
+                }
+                let pa = verts[a as usize];
+                let pb = verts[b as usize];
+                let mid = Vec3::new(
+                    (pa.x + pb.x) * 0.5,
+                    (pa.y + pb.y) * 0.5,
+                    (pa.z + pb.z) * 0.5,
+                );
+                let idx = verts.len() as u32;
+                verts.push(mid);
+                midpoint_cache.insert(key, idx);
+                idx
+            };
+            let mut next_faces = Vec::with_capacity(faces.len() * 4);
+            for [a, b, c] in faces {
+                let ab = midpoint(a, b, &mut verts);
+                let bc = midpoint(b, c, &mut verts);
+                let ca = midpoint(c, a, &mut verts);
+                next_faces.push([a, ab, ca]);
+                next_faces.push([b, bc, ab]);
+                next_faces.push([c, ca, bc]);
+                next_faces.push([ab, bc, ca]);
+            }
+            faces = next_faces;
+        }
+
+        // Project all vertices onto the sphere.
+        for v in &mut verts {
+            let len = (v.x * v.x + v.y * v.y + v.z * v.z).sqrt().max(1e-9);
+            let s = radius / len;
+            *v = Vec3::new(v.x * s, v.y * s, v.z * s);
+        }
+
+        IndexedMesh {
+            positions: verts,
+            triangles: faces,
+        }
+    }
+
+    fn count_edge_connected_components(mesh: &IndexedMesh) -> usize {
+        let topo = crate::core::halfedge::Topology::build(mesh);
+        let n = mesh.triangles.len();
+        let mut parent: Vec<usize> = (0..n).collect();
+        fn find(parent: &mut Vec<usize>, mut i: usize) -> usize {
+            while parent[i] != i {
+                parent[i] = parent[parent[i]];
+                i = parent[i];
+            }
+            i
+        }
+        for info in topo.edges.values() {
+            let mut faces = info.faces.iter();
+            if let Some(&first) = faces.next() {
+                let root = find(&mut parent, first as usize);
+                for &other in faces {
+                    let other_root = find(&mut parent, other as usize);
+                    parent[other_root] = root;
+                }
+            }
+        }
+        let mut roots = std::collections::HashSet::new();
+        for i in 0..n {
+            let root = find(&mut parent, i);
+            roots.insert(root);
+        }
+        roots.len()
+    }
+
+    /// P0 integration regression test (audit fix #2/#3/#3b): a smoothed
+    /// cavity generated from a clean closed source mesh must itself be a
+    /// single watertight surface. Before the P0 fixes, the per-tetrahedron
+    /// hard-label fallback in the polygonizer emitted thousands of small
+    /// open "shard" fragments (measured in the 2026-07-12 audit), whose
+    /// boundary edges made manifold conversion structurally impossible and
+    /// corrupted cross-section stencil rendering.
+    #[test]
+    fn smoothed_cavity_from_sphere_is_single_watertight_component() {
+        let sphere = test_icosphere(20.0, 3);
+        let options = HollowOptions {
+            mode: HollowMode::Cavity,
+            voxel_resolution: 64,
+            shell_thickness_mm: 1.2,
+            smooth_internal_surfaces: true,
+            preview_cavity_only: true,
+            ..HollowOptions::default()
+        };
+
+        let outcome = hollow_voxel(sphere, &options);
+        let cavity = &outcome.mesh; // preview_cavity_only: out mesh IS the cavity
+        assert!(
+            cavity.triangle_count() > 1000,
+            "expected a substantial cavity mesh, got {} triangles",
+            cavity.triangle_count()
+        );
+
+        let topo = crate::core::halfedge::Topology::build(cavity);
+        let boundary = topo.boundary_edges().len();
+        let components = count_edge_connected_components(cavity);
+        assert_eq!(
+            boundary, 0,
+            "smoothed cavity has {boundary} boundary edges (open shard fragments)"
+        );
+        assert_eq!(
+            components, 1,
+            "smoothed cavity split into {components} edge-connected components"
+        );
+    }
+
+    /// P0 unit regression tests (audit fix #4): the weld-retry gate must
+    /// only allow retries for defect classes vertex welding can actually
+    /// fix (hairline boundary cracks), and must skip provably futile
+    /// retries (non-manifold edges, inconsistent winding, or no defect).
+    #[test]
+    fn weld_gate_classifies_defect_classes() {
+        // Closed tetrahedron with consistent outward winding: no defects.
+        let tet = IndexedMesh {
+            positions: vec![
+                Vec3::new(0.0, 0.0, 0.0),
+                Vec3::new(1.0, 0.0, 0.0),
+                Vec3::new(0.0, 1.0, 0.0),
+                Vec3::new(0.0, 0.0, 1.0),
+            ],
+            triangles: vec![[0, 2, 1], [0, 1, 3], [1, 2, 3], [0, 3, 2]],
+        };
+        let clean = summarize_mesh_defects(&tet);
+        assert_eq!(clean.boundary_edges, 0);
+        assert_eq!(clean.non_manifold_edges, 0);
+        assert_eq!(clean.inconsistent_edges, 0);
+        assert!(
+            !weld_retries_worthwhile(&clean),
+            "no defects -> nothing for welding to fix"
+        );
+
+        // Same tetrahedron with one face removed: boundary-only defect,
+        // the one class welding could conceivably repair.
+        let open = IndexedMesh {
+            positions: tet.positions.clone(),
+            triangles: vec![[0, 2, 1], [0, 1, 3], [1, 2, 3]],
+        };
+        let open_defects = summarize_mesh_defects(&open);
+        assert!(open_defects.boundary_edges > 0);
+        assert_eq!(open_defects.non_manifold_edges, 0);
+        assert!(
+            weld_retries_worthwhile(&open_defects),
+            "boundary-only defects are weld-worthy"
+        );
+
+        // Third face glued onto an existing edge: non-manifold edge —
+        // welding can never fix this, retries must be skipped.
+        let mut non_manifold = tet.clone();
+        non_manifold.positions.push(Vec3::new(1.0, 1.0, 1.0));
+        non_manifold.triangles.push([0, 1, 4]);
+        let nm_defects = summarize_mesh_defects(&non_manifold);
+        assert!(nm_defects.non_manifold_edges > 0);
+        assert!(
+            !weld_retries_worthwhile(&nm_defects),
+            "non-manifold edges are not fixable by welding"
+        );
+    }
+
+    /// P0 invariants guard (audit fix #5, behavior-preserving refactor):
+    /// after normalization removes degenerate triangles, the mesh must have
+    /// no unreferenced vertices, all indices in range, and all
+    /// non-degenerate input triangles preserved. Guards the replacement of
+    /// the second full triangle-soup re-weld with direct orphan compaction.
+    #[test]
+    fn normalize_with_weld_compacts_orphans_and_preserves_triangles() {
+        // Two well-separated valid triangles plus one degenerate (zero-area)
+        // triangle whose vertices appear nowhere else.
+        let positions = vec![
+            Vec3::new(0.0, 0.0, 0.0),
+            Vec3::new(10.0, 0.0, 0.0),
+            Vec3::new(0.0, 10.0, 0.0),
+            Vec3::new(0.0, 0.0, 20.0),
+            Vec3::new(10.0, 0.0, 20.0),
+            Vec3::new(0.0, 10.0, 20.0),
+            // Degenerate triangle: three collinear points far from the rest.
+            Vec3::new(50.0, 50.0, 50.0),
+            Vec3::new(51.0, 50.0, 50.0),
+            Vec3::new(52.0, 50.0, 50.0),
+        ];
+        let triangles = vec![[0u32, 1, 2], [3, 4, 5], [6, 7, 8]];
+        let mesh = IndexedMesh {
+            positions,
+            triangles,
+        };
+
+        let normalized = normalize_mesh_for_boolean_with_weld(mesh, 1e-6);
+
+        assert_eq!(
+            normalized.triangles.len(),
+            2,
+            "degenerate triangle should be removed"
+        );
+        let mut used = vec![false; normalized.positions.len()];
+        for tri in &normalized.triangles {
+            for &v in tri {
+                assert!(
+                    (v as usize) < normalized.positions.len(),
+                    "index {v} out of range after compaction"
+                );
+                used[v as usize] = true;
+            }
+        }
+        assert!(
+            used.iter().all(|&u| u),
+            "normalization left unreferenced vertices behind"
+        );
+    }
+
+    /// P0 unit regression test (audit fix #2): a tetrahedron whose corners
+    /// straddle the hard kept/carved labels but NOT the scalar field's sign
+    /// must emit nothing — the isosurface does not pass through it. Before
+    /// the fix, the per-tet fallback emitted midpoint triangles here,
+    /// producing detached shard fragments.
+    #[test]
+    fn polygonizer_emits_nothing_for_label_only_crossings() {
+        let grid = GridSpec {
+            nx: 2,
+            ny: 2,
+            nz: 2,
+            voxel_mm: 1.0,
+            min: Vec3::new(0.0, 0.0, 0.0),
+        };
+        // All 8 corners classified; hard labels split 4/4 along x, but the
+        // blurred scalar field is uniformly positive (crossing moved away).
+        let mut positive = vec![false; 8];
+        let mut negative = vec![false; 8];
+        let scalar = vec![0.5f32; 8];
+        for z in 0..2 {
+            for y in 0..2 {
+                for x in 0..2 {
+                    let i = grid.idx(x, y, z);
+                    if x == 0 {
+                        positive[i] = true;
+                    } else {
+                        negative[i] = true;
+                    }
+                }
+            }
+        }
+
+        let mesh = organic_boundary_mesh(&grid, &positive, &negative, &scalar);
+        assert_eq!(
+            mesh.triangle_count(),
+            0,
+            "label-only crossing emitted {} shard triangles",
+            mesh.triangle_count()
+        );
+    }
+
+    /// P0 unit regression test (audit fix #3b): blur must never flip the
+    /// scalar sign of a kept voxel on the model's outer skin (6-adjacent to
+    /// non-solid space) — a flip there lets the cavity isosurface exit
+    /// through the model's outer surface at thin features.
+    #[test]
+    fn scalar_field_blur_cannot_flip_outer_skin_voxels() {
+        // 5x5x5 grid: a 1-voxel-thick solid kept wall at x=1 (adjacent to
+        // empty space at x=0), backed by a large carved mass at x=2..=3
+        // whose strongly negative values would otherwise blur the thin
+        // wall negative.
+        let grid = GridSpec {
+            nx: 5,
+            ny: 5,
+            nz: 5,
+            voxel_mm: 1.0,
+            min: Vec3::new(0.0, 0.0, 0.0),
+        };
+        let n = grid.nx * grid.ny * grid.nz;
+        let mut solid = vec![false; n];
+        let mut keep = vec![false; n];
+        let mut dist = vec![0.0f32; n];
+        for z in 0..5 {
+            for y in 0..5 {
+                for x in 1..=3 {
+                    let i = grid.idx(x, y, z);
+                    solid[i] = true;
+                    if x == 1 {
+                        keep[i] = true;
+                        dist[i] = 0.0;
+                    } else {
+                        // Deep carved voxels: large dist makes shell_signed
+                        // strongly negative.
+                        dist[i] = 25.0;
+                    }
+                }
+            }
+        }
+
+        let shell_voxels_f = 1.0;
+        let field =
+            build_smoothed_cavity_scalar_field(&grid, &solid, &keep, &dist, shell_voxels_f, 9);
+
+        for z in 0..5 {
+            for y in 0..5 {
+                let i = grid.idx(1, y, z);
+                assert!(
+                    field[i] >= 0.0,
+                    "outer-skin kept voxel (1,{y},{z}) blurred negative: {}",
+                    field[i]
+                );
+            }
+        }
+    }
+
     #[test]
     fn parity_refinement_clears_enclosed_non_surface_cavity_component() {
         let grid = GridSpec {
@@ -3930,6 +4758,206 @@ mod tests {
             !solid[cavity_index],
             "parity refinement should clear the enclosed cavity center"
         );
+    }
+
+    #[test]
+    fn removed_voxel_collectors_emit_boundary_only_not_full_interior() {
+        // 7x7x7 grid; a 5x5x5 solid block occupies indices 1..=5 on every
+        // axis. Its outer 1-voxel-thick layer is "kept" (the shell), leaving
+        // an inner 3x3x3 sub-block (indices 2..=4) as the removed cavity.
+        // Of those 27 removed voxels, only the very center one (3,3,3) has
+        // no face-adjacent kept neighbor - the other 26 sit on the visible
+        // cavity wall and must still be emitted.
+        let grid = GridSpec {
+            nx: 7,
+            ny: 7,
+            nz: 7,
+            voxel_mm: 1.0,
+            min: Vec3::new(0.0, 0.0, 0.0),
+        };
+
+        let mut solid = vec![false; grid.nx * grid.ny * grid.nz];
+        let mut keep = vec![false; solid.len()];
+
+        for z in 1..=5 {
+            for y in 1..=5 {
+                for x in 1..=5 {
+                    let i = grid.idx(x, y, z);
+                    solid[i] = true;
+                    if x == 1 || x == 5 || y == 1 || y == 5 || z == 1 || z == 5 {
+                        keep[i] = true;
+                    }
+                }
+            }
+        }
+
+        let center_index = grid.idx(3, 3, 3);
+        let boundary_index = grid.idx(2, 2, 2);
+        assert!(solid[center_index] && !keep[center_index]);
+        assert!(solid[boundary_index] && !keep[boundary_index]);
+
+        let indices = collect_removed_voxel_indices(&grid, &solid, &keep);
+        assert_eq!(
+            indices.len(),
+            26,
+            "expected only the 26 shell-adjacent removed voxels, not the full 27-voxel interior"
+        );
+        assert!(
+            !indices.contains(&(center_index as u32)),
+            "fully-occluded interior voxel should be excluded"
+        );
+        assert!(
+            indices.contains(&(boundary_index as u32)),
+            "cavity-wall-adjacent voxel should still be included"
+        );
+
+        let centers = collect_removed_voxel_centers(&grid, &solid, &keep);
+        assert_eq!(centers.len(), 26 * 3);
+    }
+
+    #[test]
+    fn lasso_selection_returns_full_through_depth_cavity_column_not_just_boundary() {
+        // 5x5x5 solid block; the outer 1-voxel shell (any coord in {0, 4}) is
+        // kept, leaving the inner 3x3x3 (coords 1..=3) as the removed cavity.
+        // The dead-center voxel (2,2,2) is fully occluded (all 6 face
+        // neighbours are also removed), so the boundary filter drops it from
+        // the rendered/exported set — that is exactly the surface-peel
+        // regression this Rust selection restores.
+        let grid = GridSpec {
+            nx: 5,
+            ny: 5,
+            nz: 5,
+            voxel_mm: 1.0,
+            min: Vec3::new(0.0, 0.0, 0.0),
+        };
+
+        let mut solid = vec![false; grid.nx * grid.ny * grid.nz];
+        let mut keep = vec![false; solid.len()];
+        for z in 0..5 {
+            for y in 0..5 {
+                for x in 0..5 {
+                    let i = grid.idx(x, y, z);
+                    solid[i] = true;
+                    let is_shell = x == 0 || x == 4 || y == 0 || y == 4 || z == 0 || z == 4;
+                    if is_shell {
+                        keep[i] = true;
+                    }
+                }
+            }
+        }
+
+        // Analytic top-down orthographic view_proj (looking down -Z), so every
+        // Z layer projects to the SAME screen x/y — a through-depth column.
+        // ndc = world * 0.4 - 1  (world in [0,5] -> ndc in [-1,1]); w = 1.
+        // Column-major (as Matrix4.toArray produces), matching THREE:
+        //   clip.x = 0.4*wx - 1, clip.y = 0.4*wy - 1, clip.z = 0.4*wz - 1, w = 1.
+        let view_proj: [f32; 16] = [
+            0.4, 0.0, 0.0, 0.0, // col 0
+            0.0, 0.4, 0.0, 0.0, // col 1
+            0.0, 0.0, 0.4, 0.0, // col 2
+            -1.0, -1.0, -1.0, 1.0, // col 3 (translation)
+        ];
+        let rect_w = 100.0_f32;
+        let rect_h = 100.0_f32;
+        // Identity model transform so projection is purely the analytic view.
+        let identity_quat = [0.0_f32, 0.0, 0.0, 1.0];
+        let geom_center = Vec3::ZERO;
+        let scale = Vec3::new(1.0, 1.0, 1.0);
+        let position = Vec3::ZERO;
+
+        // A voxel center (cx, cy) projects to pixel:
+        //   px = ((0.4*cx - 1) + 1) * 0.5 * 100 = 0.4*cx*50 = 20*cx
+        //   py = (1 - (0.4*cy - 1)) * 0.5 * 100 = (2 - 0.4*cy)*50 = 100 - 20*cy
+        // Center column x=y=2 -> center (2.5,2.5) -> px=50, py=50.
+        // Corner column x=y=1 -> center (1.5,1.5) -> px=30, py=70.
+        // A tight polygon around (50,50) selects ONLY the x=y=2 column and
+        // excludes the (1,1,*) column at (30,70).
+        let polygon: Vec<[f32; 2]> = vec![[45.0, 45.0], [55.0, 45.0], [55.0, 55.0], [45.0, 55.0]];
+
+        let selected = select_removed_voxels_in_polygon(
+            &grid,
+            &solid,
+            &keep,
+            identity_quat,
+            &polygon,
+            &view_proj,
+            rect_w,
+            rect_h,
+            geom_center,
+            scale,
+            identity_quat,
+            position,
+        );
+
+        // The full through-depth center column (z = 1, 2, 3) must be selected,
+        // INCLUDING the fully-occluded interior voxel (2,2,2).
+        let center_deep = grid.idx(2, 2, 2);
+        let center_near = grid.idx(2, 2, 1);
+        let center_far = grid.idx(2, 2, 3);
+        assert!(
+            selected.contains(&(center_deep as u32)),
+            "the fully-occluded interior voxel (2,2,2) must be selected (through-depth)"
+        );
+        assert!(
+            selected.contains(&(center_near as u32)),
+            "near-layer center voxel (2,2,1) must be selected"
+        );
+        assert!(
+            selected.contains(&(center_far as u32)),
+            "far-layer center voxel (2,2,3) must be selected"
+        );
+
+        // Exactly the three cavity voxels of the center column — nothing else.
+        assert_eq!(
+            selected.len(),
+            3,
+            "only the x=y=2 cavity column (3 removed voxels) should be selected"
+        );
+
+        // A removed voxel that projects OUTSIDE the polygon must be excluded.
+        let outside = grid.idx(1, 1, 2); // projects to (30, 70)
+        assert!(
+            solid[outside] && !keep[outside],
+            "(1,1,2) is a removed cavity voxel"
+        );
+        assert!(
+            !selected.contains(&(outside as u32)),
+            "a cavity voxel projecting outside the polygon must be excluded"
+        );
+    }
+
+    #[test]
+    fn blocked_voxel_collector_drops_stale_indices_and_stays_positionally_aligned() {
+        let grid = GridSpec {
+            nx: 3,
+            ny: 3,
+            nz: 3,
+            voxel_mm: 1.0,
+            min: Vec3::new(0.0, 0.0, 0.0),
+        };
+
+        let mut solid = vec![false; grid.nx * grid.ny * grid.nz];
+        let first = grid.idx(1, 1, 1);
+        let second = grid.idx(2, 1, 1);
+        solid[first] = true;
+        solid[second] = true;
+
+        let not_solid = grid.idx(0, 0, 0);
+        let out_of_bounds = solid.len() + 4;
+        let blocked = vec![first, out_of_bounds, not_solid, second];
+
+        let (centers, accepted) = collect_blocked_voxel_data(&grid, &solid, &blocked);
+
+        // Acceptance must mirror the `keep[blocked_index] = true` rule
+        // exactly: in-bounds AND solid.
+        assert_eq!(accepted, vec![first as u32, second as u32]);
+        assert_eq!(centers.len(), accepted.len() * 3);
+
+        // Entry i of `centers` describes `accepted[i]` - after dropping the
+        // two stale entries the second center must be `second`'s, not
+        // `not_solid`'s.
+        let expected = grid.center_world(2, 1, 1);
+        assert_eq!(&centers[3..6], &[expected.x, expected.y, expected.z]);
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3385,6 +3385,8 @@ fn main() {
             mesh_repair::mesh_hollow_preview_read_removed_voxel_centers,
             mesh_repair::mesh_hollow_preview_read_removed_voxel_indices,
             mesh_repair::mesh_hollow_preview_read_blocked_voxel_centers,
+            mesh_repair::mesh_hollow_preview_read_blocked_voxel_indices,
+            mesh_repair::mesh_hollow_preview_select_removed_voxels_in_polygon,
             mesh_repair::mesh_hollow_preview_read_cavity_positions,
             mesh_repair::mesh_hollow_staged_read_cavity_positions,
             mesh_repair::mesh_punch_staged,

--- a/src-tauri/src/mesh_repair.rs
+++ b/src-tauri/src/mesh_repair.rs
@@ -38,6 +38,7 @@ static HOLLOW_PREVIEW_REMOVED_VOXEL_CENTER_BYTES: OnceLock<Mutex<Option<Vec<u8>>
 static HOLLOW_PREVIEW_REMOVED_VOXEL_INDEX_BYTES: OnceLock<Mutex<Option<Vec<u8>>>> = OnceLock::new();
 static HOLLOW_PREVIEW_BLOCKED_VOXEL_CENTER_BYTES: OnceLock<Mutex<Option<Vec<u8>>>> =
     OnceLock::new();
+static HOLLOW_PREVIEW_BLOCKED_VOXEL_INDEX_BYTES: OnceLock<Mutex<Option<Vec<u8>>>> = OnceLock::new();
 /// Cavity interior mesh from the staged hollow path.
 static HOLLOW_STAGED_CAVITY_RESULT_BYTES: OnceLock<Mutex<Option<Vec<u8>>>> = OnceLock::new();
 /// Cavity interior mesh from the preview hollow path.
@@ -73,6 +74,10 @@ fn hollow_preview_blocked_voxel_center_bytes() -> &'static Mutex<Option<Vec<u8>>
     HOLLOW_PREVIEW_BLOCKED_VOXEL_CENTER_BYTES.get_or_init(|| Mutex::new(None))
 }
 
+fn hollow_preview_blocked_voxel_index_bytes() -> &'static Mutex<Option<Vec<u8>>> {
+    HOLLOW_PREVIEW_BLOCKED_VOXEL_INDEX_BYTES.get_or_init(|| Mutex::new(None))
+}
+
 fn hollow_staged_cavity_result_bytes() -> &'static Mutex<Option<Vec<u8>>> {
     HOLLOW_STAGED_CAVITY_RESULT_BYTES.get_or_init(|| Mutex::new(None))
 }
@@ -87,6 +92,45 @@ fn punch_source_bytes() -> &'static Mutex<Option<Vec<u8>>> {
 
 fn punch_result_bytes() -> &'static Mutex<Option<Vec<u8>>> {
     PUNCH_RESULT_BYTES.get_or_init(|| Mutex::new(None))
+}
+
+/// Clears every hollow-preview buffer derived from the captured source mesh
+/// (session cache, all result/removed/blocked/cavity byte buffers). Called
+/// whenever a new source mesh is captured so stale data from a previous
+/// model/session can never be served alongside a fresh one.
+fn reset_hollow_preview_derived_state() -> Result<(), String> {
+    *hollow_preview_session()
+        .lock()
+        .map_err(|e| format!("hollow preview session lock poisoned: {e}"))? = None;
+    *hollow_preview_result_bytes()
+        .lock()
+        .map_err(|e| format!("hollow preview result lock poisoned: {e}"))? = None;
+    *hollow_preview_infill_result_bytes()
+        .lock()
+        .map_err(|e| format!("hollow preview infill result lock poisoned: {e}"))? = None;
+    *hollow_preview_removed_voxel_center_bytes()
+        .lock()
+        .map_err(|e| format!("hollow preview removed voxel center result lock poisoned: {e}"))? =
+        None;
+    *hollow_preview_removed_voxel_index_bytes()
+        .lock()
+        .map_err(|e| format!("hollow preview removed voxel index result lock poisoned: {e}"))? =
+        None;
+    *hollow_preview_blocked_voxel_center_bytes()
+        .lock()
+        .map_err(|e| format!("hollow preview blocked voxel center result lock poisoned: {e}"))? =
+        None;
+    *hollow_preview_blocked_voxel_index_bytes()
+        .lock()
+        .map_err(|e| format!("hollow preview blocked voxel index result lock poisoned: {e}"))? =
+        None;
+    *hollow_preview_cavity_result_bytes()
+        .lock()
+        .map_err(|e| format!("hollow preview cavity result lock poisoned: {e}"))? = None;
+    *hollow_staged_cavity_result_bytes()
+        .lock()
+        .map_err(|e| format!("hollow staged cavity result lock poisoned: {e}"))? = None;
+    Ok(())
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -132,29 +176,29 @@ impl From<RepairOptionsDto> for RepairOptions {
     }
 }
 
-fn parse_options(options_json: &str) -> RepairOptions {
+fn parse_options(options_json: &str) -> Result<RepairOptions, String> {
     if options_json.trim().is_empty() {
-        return RepairOptions::default();
+        return Ok(RepairOptions::default());
     }
     serde_json::from_str::<RepairOptionsDto>(options_json)
-        .unwrap_or_default()
-        .into()
+        .map(RepairOptions::from)
+        .map_err(|e| format!("invalid repair options JSON: {e}"))
 }
 
-fn parse_hollow_options(options_json: &str) -> HollowOptions {
+fn parse_hollow_options(options_json: &str) -> Result<HollowOptions, String> {
     if options_json.trim().is_empty() {
-        return HollowOptions::default();
+        return Ok(HollowOptions::default());
     }
-
-    serde_json::from_str::<HollowOptions>(options_json).unwrap_or_default()
+    serde_json::from_str::<HollowOptions>(options_json)
+        .map_err(|e| format!("invalid hollow options JSON: {e}"))
 }
 
-fn parse_hole_punch_options(options_json: &str) -> HolePunchOptions {
+fn parse_hole_punch_options(options_json: &str) -> Result<HolePunchOptions, String> {
     if options_json.trim().is_empty() {
-        return HolePunchOptions::default();
+        return Ok(HolePunchOptions::default());
     }
-
-    serde_json::from_str::<HolePunchOptions>(options_json).unwrap_or_default()
+    serde_json::from_str::<HolePunchOptions>(options_json)
+        .map_err(|e| format!("invalid hole punch options JSON: {e}"))
 }
 
 #[tauri::command]
@@ -187,7 +231,7 @@ pub async fn mesh_repair_from_path(
             path.display()
         ));
     }
-    let options = parse_options(&options_json);
+    let options = parse_options(&options_json)?;
     let source_path = file_path.clone();
     let (mesh, mut report) = tauri::async_runtime::spawn_blocking(move || {
         let mesh = io::load_mesh_from_path(&path).map_err(|e| e.to_string())?;
@@ -203,7 +247,7 @@ pub async fn mesh_repair_from_path(
 
 #[tauri::command]
 pub async fn mesh_repair_staged(options_json: String) -> Result<String, String> {
-    let options = parse_options(&options_json);
+    let options = parse_options(&options_json)?;
     let bytes = read_staging_bytes()?;
     let (mesh, report) = tauri::async_runtime::spawn_blocking(move || {
         let mesh = io::staged::load_positions_le(&bytes).map_err(|e| e.to_string())?;
@@ -251,7 +295,7 @@ pub async fn mesh_analyze_staged() -> Result<String, String> {
 /// Replaces staged positions with the hollowed result and returns a JSON report.
 #[tauri::command]
 pub async fn mesh_hollow_staged(options_json: String) -> Result<String, String> {
-    let options = parse_hollow_options(&options_json);
+    let options = parse_hollow_options(&options_json)?;
     let bytes = read_staging_bytes()?;
     let (mesh, cavity_bytes, report) = tauri::async_runtime::spawn_blocking(move || {
         let mesh = io::staged::load_positions_le(&bytes).map_err(|e| e.to_string())?;
@@ -288,23 +332,7 @@ pub async fn mesh_hollow_preview_capture_staged_source() -> Result<(), String> {
         .lock()
         .map_err(|e| format!("hollow preview source lock poisoned: {e}"))? =
         Some(Arc::new(source_mesh));
-    *hollow_preview_session()
-        .lock()
-        .map_err(|e| format!("hollow preview session lock poisoned: {e}"))? = None;
-    *hollow_preview_result_bytes()
-        .lock()
-        .map_err(|e| format!("hollow preview result lock poisoned: {e}"))? = None;
-    *hollow_preview_infill_result_bytes()
-        .lock()
-        .map_err(|e| format!("hollow preview infill result lock poisoned: {e}"))? = None;
-    *hollow_preview_removed_voxel_center_bytes()
-        .lock()
-        .map_err(|e| format!("hollow preview removed voxel center result lock poisoned: {e}"))? =
-        None;
-    *hollow_preview_removed_voxel_index_bytes()
-        .lock()
-        .map_err(|e| format!("hollow preview removed voxel index result lock poisoned: {e}"))? =
-        None;
+    reset_hollow_preview_derived_state()?;
     Ok(())
 }
 
@@ -314,7 +342,7 @@ pub async fn mesh_hollow_preview_capture_staged_source() -> Result<(), String> {
 pub async fn mesh_hollow_preview_from_captured_source(
     options_json: String,
 ) -> Result<String, String> {
-    let options = parse_hollow_options(&options_json);
+    let options = parse_hollow_options(&options_json)?;
     let source_mesh = hollow_preview_source_mesh()
         .lock()
         .map_err(|e| format!("hollow preview source lock poisoned: {e}"))?
@@ -380,6 +408,7 @@ pub async fn mesh_hollow_preview_from_captured_source(
         removed_voxel_center_bytes,
         removed_voxel_index_bytes,
         blocked_voxel_center_bytes,
+        blocked_voxel_index_bytes,
         report,
     ) = tauri::async_runtime::spawn_blocking(move || {
         let outcome = session.run(&options);
@@ -399,6 +428,8 @@ pub async fn mesh_hollow_preview_from_captured_source(
             bytemuck::cast_slice::<u32, u8>(&outcome.removed_voxel_indices).to_vec();
         let blocked_voxel_center_bytes =
             bytemuck::cast_slice::<f32, u8>(&outcome.blocked_voxel_centers).to_vec();
+        let blocked_voxel_index_bytes =
+            bytemuck::cast_slice::<u32, u8>(&outcome.blocked_voxel_indices).to_vec();
         Ok::<_, String>((
             bytes,
             cavity_bytes,
@@ -406,6 +437,7 @@ pub async fn mesh_hollow_preview_from_captured_source(
             removed_voxel_center_bytes,
             removed_voxel_index_bytes,
             blocked_voxel_center_bytes,
+            blocked_voxel_index_bytes,
             outcome.report,
         ))
     })
@@ -415,11 +447,9 @@ pub async fn mesh_hollow_preview_from_captured_source(
     *hollow_preview_result_bytes()
         .lock()
         .map_err(|e| format!("hollow preview result lock poisoned: {e}"))? = Some(positions_bytes);
-    if let Some(cb) = cavity_bytes {
-        *hollow_preview_cavity_result_bytes()
-            .lock()
-            .map_err(|e| format!("hollow preview cavity result lock poisoned: {e}"))? = Some(cb);
-    }
+    *hollow_preview_cavity_result_bytes()
+        .lock()
+        .map_err(|e| format!("hollow preview cavity result lock poisoned: {e}"))? = cavity_bytes;
     *hollow_preview_infill_result_bytes()
         .lock()
         .map_err(|e| format!("hollow preview infill result lock poisoned: {e}"))? =
@@ -436,6 +466,10 @@ pub async fn mesh_hollow_preview_from_captured_source(
         .lock()
         .map_err(|e| format!("hollow preview blocked voxel center result lock poisoned: {e}"))? =
         Some(blocked_voxel_center_bytes);
+    *hollow_preview_blocked_voxel_index_bytes()
+        .lock()
+        .map_err(|e| format!("hollow preview blocked voxel index result lock poisoned: {e}"))? =
+        Some(blocked_voxel_index_bytes);
 
     serde_json::to_string(&report).map_err(|e| format!("serialize hollow preview report: {e}"))
 }
@@ -444,7 +478,7 @@ pub async fn mesh_hollow_preview_from_captured_source(
 pub async fn mesh_hollow_apply_from_captured_source(
     options_json: String,
 ) -> Result<String, String> {
-    let options = parse_hollow_options(&options_json);
+    let options = parse_hollow_options(&options_json)?;
     let source_mesh = hollow_preview_source_mesh()
         .lock()
         .map_err(|e| format!("hollow preview source lock poisoned: {e}"))?
@@ -589,6 +623,85 @@ pub async fn mesh_hollow_preview_read_blocked_voxel_centers() -> Result<Response
     Ok(Response::new(bytes))
 }
 
+#[tauri::command]
+pub async fn mesh_hollow_preview_read_blocked_voxel_indices() -> Result<Response, String> {
+    let bytes = hollow_preview_blocked_voxel_index_bytes()
+        .lock()
+        .map_err(|e| format!("hollow preview blocked voxel index result lock poisoned: {e}"))?
+        .clone()
+        .ok_or_else(|| {
+            "No hollow preview blocked voxel index result — call mesh_hollow_preview_from_captured_source first"
+                .to_string()
+        })?;
+    Ok(Response::new(bytes))
+}
+
+/// Request payload for `mesh_hollow_preview_select_removed_voxels_in_polygon`.
+/// All fields are in the same spaces the frontend lasso resolver used before
+/// the projection moved to Rust: `polygon` in container pixels, `view_proj` a
+/// column-major `projectionMatrix * matrixWorldInverse`, and the model
+/// transform (`geometry_center`/`scale`/`rotation_quat`/`position`) matching
+/// `resolveBlockedHollowVoxelMarqueeSelection`.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SelectRemovedVoxelsRequest {
+    polygon: Vec<[f32; 2]>,
+    view_proj: [f32; 16],
+    rect_width: f32,
+    rect_height: f32,
+    geometry_center: [f32; 3],
+    scale: [f32; 3],
+    rotation_quat: [f32; 4],
+    position: [f32; 3],
+    options: HollowOptions,
+}
+
+/// Selects the full through-depth set of removed (cavity) voxels whose
+/// projected screen point falls inside the lasso polygon, operating on the
+/// cached hollow-preview session so the result is immune to the boundary
+/// filter and viewport cap that narrow the rendered/exported voxel subset.
+/// Returns the grid indices as raw little-endian `u32` bytes.
+#[tauri::command]
+pub async fn mesh_hollow_preview_select_removed_voxels_in_polygon(
+    request_json: String,
+) -> Result<Response, String> {
+    let request: SelectRemovedVoxelsRequest = serde_json::from_str(&request_json)
+        .map_err(|e| format!("invalid select-removed-voxels request JSON: {e}"))?;
+
+    let session = hollow_preview_session()
+        .lock()
+        .map_err(|e| format!("hollow preview session lock poisoned: {e}"))?
+        .clone()
+        .ok_or_else(|| {
+            "No hollow preview session — call mesh_hollow_preview_from_captured_source first"
+                .to_string()
+        })?;
+
+    let indices = tauri::async_runtime::spawn_blocking(move || {
+        let selected = session.select_removed_voxels_in_polygon(
+            &request.options,
+            &request.polygon,
+            &request.view_proj,
+            request.rect_width,
+            request.rect_height,
+            Vec3::new(
+                request.geometry_center[0],
+                request.geometry_center[1],
+                request.geometry_center[2],
+            ),
+            Vec3::new(request.scale[0], request.scale[1], request.scale[2]),
+            request.rotation_quat,
+            Vec3::new(request.position[0], request.position[1], request.position[2]),
+        );
+        Ok::<Vec<u32>, String>(selected)
+    })
+    .await
+    .map_err(|e| format!("hollow select task panicked: {e}"))??;
+
+    let bytes = bytemuck::cast_slice::<u32, u8>(&indices).to_vec();
+    Ok(Response::new(bytes))
+}
+
 /// Reads the cavity interior mesh positions from the last preview hollow operation.
 #[tauri::command]
 pub async fn mesh_hollow_preview_read_cavity_positions() -> Result<Response, String> {
@@ -619,7 +732,7 @@ pub async fn mesh_hollow_staged_read_cavity_positions() -> Result<Response, Stri
 /// Applies manual cylindrical hole punches to the current staged mesh.
 #[tauri::command]
 pub async fn mesh_punch_staged(options_json: String) -> Result<String, String> {
-    let options = parse_hole_punch_options(&options_json);
+    let options = parse_hole_punch_options(&options_json)?;
     let bytes = read_staging_bytes()?;
     let (mesh, report) = tauri::async_runtime::spawn_blocking(move || {
         let mesh = io::staged::load_positions_le(&bytes).map_err(|e| e.to_string())?;
@@ -651,7 +764,7 @@ pub async fn mesh_punch_capture_staged_source() -> Result<(), String> {
 /// regular staged mesh buffer.
 #[tauri::command]
 pub async fn mesh_punch_from_captured_source(options_json: String) -> Result<String, String> {
-    let options = parse_hole_punch_options(&options_json);
+    let options = parse_hole_punch_options(&options_json)?;
     let source_bytes = punch_source_bytes()
         .lock()
         .map_err(|e| format!("punch source lock poisoned: {e}"))?
@@ -1194,4 +1307,35 @@ fn replace_staging_with_mesh(mesh: &IndexedMesh) -> Result<(), String> {
         .lock()
         .map_err(|e| format!("staged mesh lock poisoned: {e}"))? = Some(bytes);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hollow_options_parsing_rejects_malformed_json_instead_of_defaulting() {
+        // Wrong type: previously produced HollowOptions::default() (resolution
+        // 64, 2mm shell) and the destructive hollow ran anyway.
+        assert!(parse_hollow_options(r#"{"voxelResolution": "192"}"#).is_err());
+        // Truncated JSON.
+        assert!(parse_hollow_options(r#"{"voxelResolution": 192"#).is_err());
+    }
+
+    #[test]
+    fn hollow_options_parsing_accepts_empty_and_valid_input() {
+        let defaults = parse_hollow_options("").expect("empty input falls back to defaults");
+        assert_eq!(defaults.voxel_resolution, HollowOptions::default().voxel_resolution);
+
+        let parsed = parse_hollow_options(r#"{"voxelResolution": 128, "shellThicknessMm": 1.5}"#)
+            .expect("well-formed JSON parses");
+        assert_eq!(parsed.voxel_resolution, 128);
+        assert!((parsed.shell_thickness_mm - 1.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn repair_and_punch_options_parsing_reject_malformed_json() {
+        assert!(parse_options(r#"{"weldEpsilon": "tiny"}"#).is_err());
+        assert!(parse_hole_punch_options(r#"{"punches": {}}"#).is_err());
+    }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,6 +30,7 @@ import { useArrangeManager } from '@/features/scene/arrange/useArrangeManager';
 import { useHolePunchManager } from '@/features/hole-punching/useHolePunchManager';
 import { useHollowingManager } from '@/features/hollowing/useHollowingManager';
 import type { HollowingManagerDeps } from '@/features/hollowing/useHollowingManager';
+import { useModifierApplyOverlay } from '@/features/hollowing/useModifierApplyOverlay';
 import { useImportExportManager } from '@/features/import-export/useImportExportManager';
 import type { ImportExportManagerDeps } from '@/features/import-export/useImportExportManager';
 import { GlobalUpdateIndicator } from '@/features/updater/GlobalUpdateIndicator';
@@ -133,7 +134,6 @@ import {
   serializeSingleHolePunchPlacement,
 } from '@/features/hole-punching/holePunchPersistence';
 import {
-  buildGeometryVersionKey,
   createGeometryFromPreviewPositions,
   disposeHollowPreviewCacheEntry,
   disposeHollowPreviewGeometryIfUncached,
@@ -330,7 +330,6 @@ import {
   hollowFromGeometry,
   hollowPreviewFromCapturedSource,
   stageHollowPreviewSource,
-  type HollowOptions,
   type HollowReport,
 } from '@/utils/meshHollowing';
 import {
@@ -386,12 +385,6 @@ const HOLE_PUNCH_DEPTH_OFFSET_FROM_SHELL_MM = 1;
 const HOLE_PUNCH_AUTO_DEPTH_RAY_START_OFFSET_MM = 0.3;
 const HOLE_PUNCH_AUTO_DEPTH_MIN_INSIDE_MM = 1;
 const HOLLOW_PREVIEW_DEBOUNCE_MS = 90;
-const HOLLOW_PREVIEW_THICKNESS_QUANTUM_MM = 0.2;
-
-function quantizePreviewShellThicknessMm(valueMm: number): number {
-  const clamped = Math.max(0.1, valueMm);
-  return Number((Math.round(clamped / HOLLOW_PREVIEW_THICKNESS_QUANTUM_MM) * HOLLOW_PREVIEW_THICKNESS_QUANTUM_MM).toFixed(3));
-}
 
 function getDefaultHolePunchDepthMm(shellThicknessMm: number): number {
   return Number(
@@ -525,6 +518,9 @@ export default function Home() {
   const hollowingDepsRef = React.useRef<HollowingManagerDeps>({
     showOperationError: () => {},
     setShowDamagedModelDialog: () => {},
+    beginFinalizing: () => {},
+    clearFinalizing: () => {},
+    nextPaint: async () => {},
     persistActiveModelModifiers: () => {},
     setPendingModifierResetAction: () => {},
     setInteriorView: () => {},
@@ -599,8 +595,6 @@ export default function Home() {
     requestResetHollowing,
     requestClearAppliedHollowing,
     clearPendingHollowPreviewDebounce,
-    resolveHollowPreviewSourceGeometry,
-    buildHollowingOptions,
     buildHollowPreviewRequest,
     cacheHollowPreviewResult,
     materializeHollowPreviewCacheEntry,
@@ -839,6 +833,18 @@ export default function Home() {
   const [holePunchHoverPlacement, setHolePunchHoverPlacement] = React.useState<HolePunchPlacementState | null>(null);
   const [isApplyingHolePunch, setIsApplyingHolePunch] = React.useState(false);
   const [pendingHolePunchAutoApplyModelId, setPendingHolePunchAutoApplyModelId] = React.useState<string | null>(null);
+  const {
+    isFinalizing,
+    beginFinalizing,
+    clearFinalizing,
+    finalizingOverlayContent,
+    nextPaint,
+  } = useModifierApplyOverlay({
+    hasPendingBackgroundGeometryWork: scene.hasPendingBackgroundGeometryWork,
+    isApplyingHollowing,
+    isApplyingHolePunch,
+    pendingHolePunchAutoApplyModelId,
+  });
   const [pendingModifierResetAction, setPendingModifierResetAction] = React.useState<PendingModifierResetAction | null>(null);
   const [pendingBlockerResetState, setPendingBlockerResetState] = React.useState<HollowingPanelState | null>(null);
   const [debugPrimitivesPanelVisible, setDebugPrimitivesPanelVisible] = React.useState<boolean>(false);
@@ -1264,7 +1270,7 @@ export default function Home() {
   } = importExport;
 
   const [isExporting, setIsExporting] = React.useState(false);
-  const showModifierApplyBlockingOverlay = isApplyingHollowing || isApplyingHolePunch || isApplyingBlockersHollowing || pendingHolePunchAutoApplyModelId !== null;
+  const showModifierApplyBlockingOverlay = isApplyingHollowing || isApplyingHolePunch || isApplyingBlockersHollowing || pendingHolePunchAutoApplyModelId !== null || isFinalizing;
   const [modifierApplyOverlayElapsedSec, setModifierApplyOverlayElapsedSec] = React.useState(0);
 
 
@@ -1278,6 +1284,8 @@ export default function Home() {
         ],
       };
     }
+
+    if (finalizingOverlayContent) return finalizingOverlayContent;
 
     if (isApplyingHollowing) {
       return {
@@ -1316,7 +1324,7 @@ export default function Home() {
         'Please wait a moment.',
       ],
     };
-  }, [isApplyingBlockersHollowing, isApplyingHolePunch, isApplyingHollowing, pendingHolePunchAutoApplyModelId]);
+  }, [finalizingOverlayContent, isApplyingBlockersHollowing, isApplyingHolePunch, isApplyingHollowing, pendingHolePunchAutoApplyModelId]);
 
 
   React.useEffect(() => {
@@ -8565,6 +8573,9 @@ export default function Home() {
     setHolePunchHoverPlacement,
     showOperationError,
     setShowDamagedModelDialog,
+    beginFinalizing,
+    clearFinalizing,
+    nextPaint,
   });
   const {
     holePunchState,
@@ -8710,6 +8721,9 @@ export default function Home() {
   hollowingDepsRef.current = {
     showOperationError,
     setShowDamagedModelDialog,
+    beginFinalizing,
+    clearFinalizing,
+    nextPaint,
     persistActiveModelModifiers,
     setPendingModifierResetAction,
     setInteriorView,
@@ -8764,6 +8778,7 @@ export default function Home() {
         enabled: true,
         bakedIntoGeometry: false,
         blockedVoxelIndices,
+        blockedVoxelRotationQuat: undefined,
         mode: next.mode,
         voxelSizeMm: next.voxelSizeMm,
         shellThicknessMm: next.shellThicknessMm,
@@ -8974,26 +8989,19 @@ export default function Home() {
       return;
     }
 
-    const previewShellThicknessMm = quantizePreviewShellThicknessMm(hollowingState.shellThicknessMm);
-    const sourceGeometry = resolveHollowPreviewSourceGeometry(activeModel);
-    const sourceGeometryKey = buildGeometryVersionKey(sourceGeometry);
-    const bbox = sourceGeometry.boundingBox ?? new THREE.Box3().setFromBufferAttribute(
-      sourceGeometry.getAttribute('position') as THREE.BufferAttribute,
-    );
-    const bboxSize = bbox.getSize(new THREE.Vector3());
-    const maxExtent = Math.max(bboxSize.x, bboxSize.y, bboxSize.z);
-
-    const debounceQuat = new THREE.Quaternion().setFromEuler(activeModel.transform.rotation);
-    const options: HollowOptions = {
-      ...buildHollowingOptions(activeModel.transform.scale, maxExtent, {
-        preview: true,
-        previewShellThicknessMm,
-      }),
-      previewCavityOnly: true,
-      rotationQuat: [debounceQuat.x, debounceQuat.y, debounceQuat.z, debounceQuat.w],
-    };
-    const optionsKey = JSON.stringify(options);
-    const previewKey = `${activeModel.id}::${sourceGeometryKey}::${optionsKey}`;
+    // Single source of truth for preview options and cache keys, shared with
+    // the toolbar-hover warmup path. Building options inline here previously
+    // omitted `previewVoxelSpheres: true` (and `drainHoles: []`), which made
+    // every debounced parameter change run the full cavity-mesh build — and,
+    // on manifold failure, the entire stabilization retry cascade — for a
+    // result the preview never renders, while also splitting the cache keys
+    // so warmup-primed entries could never serve the live preview.
+    const {
+      sourceGeometry,
+      sourceGeometryKey,
+      options,
+      previewKey,
+    } = buildHollowPreviewRequest(activeModel);
 
     if (hollowPreview && hollowPreview.modelId === activeModel.id && hollowPreview.previewKey === previewKey) {
       return;
@@ -9015,7 +9023,7 @@ export default function Home() {
       clearPendingHollowPreviewDebounce();
     };
   }, [
-    buildHollowingOptions,
+    buildHollowPreviewRequest,
     clearHollowPreview,
     clearPendingHollowPreviewDebounce,
     hollowPreview,
@@ -9023,7 +9031,6 @@ export default function Home() {
     isHollowingDirty,
     isApplyingHollowing,
     isShellFaceSelectionPending,
-    resolveHollowPreviewSourceGeometry,
     runHollowPreview,
     scene.activeModel,
     scene.mode,

--- a/src/components/organisms/scene/SceneOverlays.tsx
+++ b/src/components/organisms/scene/SceneOverlays.tsx
@@ -4,7 +4,6 @@ import { HolePunchPreviewCylinder } from '@/features/hole-punching/HolePunchPrev
 import { HolePunchGizmo } from '@/features/hole-punching/HolePunchGizmo';
 import { HollowVoxelEditOverlay } from '@/components/scene/HollowVoxelEditOverlay';
 import { HollowVoxelPreview } from '@/components/scene/HollowVoxelPreview';
-import { quaternionFromGlobalEuler } from '@/utils/rotation';
 import type { HolePunchPlacementState } from '@/features/hole-punching/holePunchGeometry';
 import type { HolePunchPanelState } from '@/features/hole-punching/HolePunchPanel';
 import type { HollowPreviewState } from '@/features/hollowing/hollowingPreviewTypes';
@@ -322,7 +321,7 @@ export function SceneOverlays({
           blockedVoxelIndexSet={blockedPreviewVoxelInstanceIdSet}
           modelTransform={{
             position: previewModel.transform.position,
-            quaternion: quaternionFromGlobalEuler(previewModel.transform.rotation),
+            quaternion: new THREE.Quaternion().setFromEuler(previewModel.transform.rotation),
             scale: previewModel.transform.scale,
           }}
           geometryCenter={previewModel.geometry.center}
@@ -338,7 +337,7 @@ export function SceneOverlays({
               voxelSizeMm={hollowPreview.report.voxelSizeMm}
               modelTransform={{
                 position: previewModel.transform.position,
-                quaternion: quaternionFromGlobalEuler(previewModel.transform.rotation),
+                quaternion: new THREE.Quaternion().setFromEuler(previewModel.transform.rotation),
                 scale: previewModel.transform.scale,
               }}
               geometryCenter={previewModel.geometry.center}
@@ -346,7 +345,7 @@ export function SceneOverlays({
           )}
           <group
             position={previewModel.transform.position}
-            quaternion={quaternionFromGlobalEuler(previewModel.transform.rotation)}
+            quaternion={new THREE.Quaternion().setFromEuler(previewModel.transform.rotation)}
             scale={previewModel.transform.scale}
           >
             {!hollowPreview.previewVoxelSpheres && (

--- a/src/components/organisms/scene/SceneOverlays.tsx
+++ b/src/components/organisms/scene/SceneOverlays.tsx
@@ -4,6 +4,7 @@ import { HolePunchPreviewCylinder } from '@/features/hole-punching/HolePunchPrev
 import { HolePunchGizmo } from '@/features/hole-punching/HolePunchGizmo';
 import { HollowVoxelEditOverlay } from '@/components/scene/HollowVoxelEditOverlay';
 import { HollowVoxelPreview } from '@/components/scene/HollowVoxelPreview';
+import { getUniformScaleFactorForThickness } from '@/utils/geometryScaling';
 import type { HolePunchPlacementState } from '@/features/hole-punching/holePunchGeometry';
 import type { HolePunchPanelState } from '@/features/hole-punching/HolePunchPanel';
 import type { HollowPreviewState } from '@/features/hollowing/hollowingPreviewTypes';
@@ -64,10 +65,14 @@ function WorldSpaceVoxelPreview({
     () => transformVoxelCentersToWorld(voxelCenters, geometryCenter, scale, quaternion, position),
     [voxelCenters, geometryCenter, scale, quaternion, position],
   );
+  // report.voxelSizeMm is the grid's LOCAL voxel size (worldSize / scale);
+  // the centers above are world-space, so the render size must be world-space
+  // too or scaled models draw voxels 1/scale of their spacing.
+  const worldVoxelSizeMm = voxelSizeMm * getUniformScaleFactorForThickness(scale);
   return (
     <HollowVoxelPreview
       voxelCenters={worldCenters}
-      voxelSizeMm={voxelSizeMm}
+      voxelSizeMm={worldVoxelSizeMm}
       meshOffset={new THREE.Vector3(0, 0, 0)}
     />
   );
@@ -103,11 +108,13 @@ function WorldSpaceVoxelEditOverlay({
       : undefined,
     [blockedVoxelCenters, geometryCenter, scale, quaternion, position],
   );
+  // Same local→world size conversion as WorldSpaceVoxelPreview above.
+  const worldVoxelRadiusMm = voxelRadiusMm * getUniformScaleFactorForThickness(scale);
   return (
     <HollowVoxelEditOverlay
       voxelCenters={worldCenters}
       blockedVoxelCenters={worldBlockedCenters}
-      voxelRadiusMm={voxelRadiusMm}
+      voxelRadiusMm={worldVoxelRadiusMm}
       blockedVoxelIndexSet={blockedVoxelIndexSet}
       meshOffset={new THREE.Vector3(0, 0, 0)}
       onToggleVoxel={onToggleVoxel}

--- a/src/components/scene/HollowVoxelEditOverlay.tsx
+++ b/src/components/scene/HollowVoxelEditOverlay.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import * as THREE from 'three';
+import { getVoxelPreviewBudget, tryAllocateFloat32Array, warnOnce } from './hollowVoxelPreviewLimits';
+import { INSTANCED_EDGE_FRAGMENT_SHADER, INSTANCED_EDGE_VERTEX_SHADER } from './instancedEdgeShader';
 
 type HollowVoxelEditOverlayProps = {
   voxelCenters: Float32Array;
@@ -13,6 +15,13 @@ type HollowVoxelEditOverlayProps = {
 const UNBLOCKED = new THREE.Color('#66ecff');
 const BLOCKED = new THREE.Color('#ffd928');
 const EDGE_COLOR = '#1a3340';
+const EDGE_OPACITY = 0.45;
+// Stable reference so the shaderMaterial's `uniforms` prop doesn't get a
+// fresh object (and re-upload to the GPU) on every render.
+const EDGE_UNIFORMS = {
+  uColor: { value: new THREE.Color(EDGE_COLOR) },
+  uOpacity: { value: EDGE_OPACITY },
+};
 
 /** 12 edges of a unit cube centred at origin, as 24 vertex positions. */
 const CUBE_EDGE_VERTICES = new Float32Array([
@@ -30,41 +39,20 @@ const CUBE_EDGE_VERTICES = new Float32Array([
   -0.5,  0.5, -0.5, -0.5,  0.5,  0.5,
 ]);
 
-function buildEdgePositions(
-  voxelCenters: Float32Array,
-  blockedVoxelCenters: Float32Array | undefined,
-  voxelSizeMm: number,
-  offsetX: number,
-  offsetY: number,
-  offsetZ: number,
-): Float32Array {
-  const removedCount = Math.floor(voxelCenters.length / 3);
-  const blockedCount = blockedVoxelCenters
-    ? Math.floor(blockedVoxelCenters.length / 3)
-    : 0;
-  const total = removedCount + blockedCount;
-  const out = new Float32Array(total * 72);
-
-  const writeEdges = (i: number, cx: number, cy: number, cz: number) => {
-    const vo = i * 72;
-    for (let v = 0; v < 72; v += 3) {
-      out[vo + v]     = cx + CUBE_EDGE_VERTICES[v]     * voxelSizeMm;
-      out[vo + v + 1] = cy + CUBE_EDGE_VERTICES[v + 1] * voxelSizeMm;
-      out[vo + v + 2] = cz + CUBE_EDGE_VERTICES[v + 2] * voxelSizeMm;
-    }
-  };
-
-  for (let i = 0; i < removedCount; i += 1) {
-    const base = i * 3;
-    writeEdges(i, voxelCenters[base] + offsetX, voxelCenters[base + 1] + offsetY, voxelCenters[base + 2] + offsetZ);
-  }
-  if (blockedVoxelCenters) {
-    for (let i = 0; i < blockedCount; i += 1) {
-      const base = i * 3;
-      writeEdges(removedCount + i, blockedVoxelCenters[base] + offsetX, blockedVoxelCenters[base + 1] + offsetY, blockedVoxelCenters[base + 2] + offsetZ);
-    }
-  }
-  return out;
+/**
+ * Builds the GPU-instanced edge-wireframe geometry: a shared, non-instanced
+ * 24-vertex cube-edge template plus a per-instance transform attribute that
+ * reuses the exact same matrix buffer already built for the cube
+ * InstancedMesh (`instanceData.matrices` from `buildInstanceData`) -- zero
+ * additional per-voxel memory, unlike the previous fully-expanded
+ * world-space buffer.
+ */
+function buildInstancedEdgeGeometry(matrices: Float32Array): THREE.InstancedBufferGeometry {
+  const geom = new THREE.InstancedBufferGeometry();
+  geom.setAttribute('position', new THREE.BufferAttribute(CUBE_EDGE_VERTICES, 3));
+  geom.setAttribute('instanceTransform', new THREE.InstancedBufferAttribute(matrices, 16));
+  geom.instanceCount = Math.floor(matrices.length / 16);
+  return geom;
 }
 
 function buildInstanceData(
@@ -75,14 +63,15 @@ function buildInstanceData(
   offsetY: number,
   offsetZ: number,
   blockedVoxelIndexSet: Set<number>,
-): { matrices: Float32Array; colors: Float32Array } {
+): { matrices: Float32Array; colors: Float32Array } | null {
   const removedCount = Math.floor(voxelCenters.length / 3);
   const blockedCount = blockedVoxelCenters
     ? Math.floor(blockedVoxelCenters.length / 3)
     : 0;
   const total = removedCount + blockedCount;
-  const matrices = new Float32Array(total * 16);
-  const colors = new Float32Array(total * 3);
+  const matrices = tryAllocateFloat32Array(total * 16);
+  const colors = matrices ? tryAllocateFloat32Array(total * 3) : null;
+  if (!matrices || !colors) return null;
   const scale = voxelSizeMm;
 
   const writeInstance = (i: number, cx: number, cy: number, cz: number, isBlocked: boolean) => {
@@ -151,8 +140,34 @@ export function HollowVoxelEditOverlay({
     : 0;
   const totalCount = removedCount + blockedCount;
 
-  const { matrices, colors } = React.useMemo(
-    () => buildInstanceData(
+  const budget = getVoxelPreviewBudget();
+  // Edges degrade gracefully (skipped above budget, cheap to re-enable once
+  // the voxel count drops back down). The cube InstancedMesh itself has a
+  // much higher ceiling (64 bytes/voxel), and truncating it isn't safe here
+  // without also renumbering blockedVoxelIndexSet (computed by the caller
+  // against the *full*, untruncated removed/blocked counts) -- so on the
+  // rare chance even that generous ceiling is exceeded, skip rendering this
+  // overlay entirely rather than risk misaligned voxel-toggle indices.
+  const showEdges = totalCount <= budget.maxEdgeInstances;
+  const overCubeBudget = totalCount > budget.maxCubeInstances;
+
+  React.useEffect(() => {
+    if (overCubeBudget) {
+      warnOnce(
+        'hollow-voxel-edit-overlay-cube-cap',
+        `[HollowVoxelEditOverlay] voxel count ${totalCount} exceeds render budget (${budget.maxCubeInstances}); hiding the edit overlay to avoid an out-of-memory crash.`,
+      );
+    } else if (!showEdges) {
+      warnOnce(
+        'hollow-voxel-edit-overlay-edge-cap',
+        `[HollowVoxelEditOverlay] voxel count ${totalCount} exceeds edge-render budget (${budget.maxEdgeInstances}); showing cubes without edge outlines.`,
+      );
+    }
+  }, [totalCount, overCubeBudget, showEdges, budget.maxCubeInstances, budget.maxEdgeInstances]);
+
+  const instanceData = React.useMemo(() => {
+    if (overCubeBudget) return null;
+    return buildInstanceData(
       voxelCenters,
       blockedVoxelCenters,
       voxelRadiusMm,
@@ -160,27 +175,28 @@ export function HollowVoxelEditOverlay({
       meshOffset.y,
       meshOffset.z,
       blockedVoxelIndexSet,
-    ),
-    [voxelCenters, blockedVoxelCenters, voxelRadiusMm, meshOffset.x, meshOffset.y, meshOffset.z, blockedVoxelIndexSet],
-  );
-
-  const edgeGeometry = React.useMemo(() => {
-    const edgePos = buildEdgePositions(
-      voxelCenters,
-      blockedVoxelCenters,
-      voxelRadiusMm,
-      meshOffset.x,
-      meshOffset.y,
-      meshOffset.z,
     );
-    const geom = new THREE.BufferGeometry();
-    geom.setAttribute('position', new THREE.BufferAttribute(edgePos, 3));
-    return geom;
-  }, [voxelCenters, blockedVoxelCenters, voxelRadiusMm, meshOffset.x, meshOffset.y, meshOffset.z]);
+  }, [voxelCenters, blockedVoxelCenters, voxelRadiusMm, meshOffset.x, meshOffset.y, meshOffset.z, blockedVoxelIndexSet, overCubeBudget]);
+
+  // Edge geometry: GPU-instanced, reusing the same per-voxel matrices
+  // already built for the cube InstancedMesh above (instanceData.matrices).
+  const edgeGeometry = React.useMemo(() => {
+    if (!showEdges || !instanceData) return null;
+    return buildInstancedEdgeGeometry(instanceData.matrices);
+  }, [instanceData, showEdges]);
+
+  // R3F only auto-disposes attached geometry on unmount. In edit mode
+  // instanceData changes on every blocker click, so without this the old
+  // edge geometry's GL buffers leak on each click (~64 bytes per voxel).
+  React.useEffect(() => {
+    if (!edgeGeometry) return;
+    return () => edgeGeometry.dispose();
+  }, [edgeGeometry]);
 
   React.useEffect(() => {
     const mesh = meshRef.current;
-    if (!mesh) return;
+    if (!mesh || !instanceData) return;
+    const { matrices, colors } = instanceData;
     const dummy = new THREE.Object3D();
     for (let i = 0; i < totalCount; i += 1) {
       const base = i * 16;
@@ -193,9 +209,9 @@ export function HollowVoxelEditOverlay({
     }
     mesh.instanceMatrix.needsUpdate = true;
     if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
-  }, [matrices, colors, totalCount]);
+  }, [instanceData, totalCount]);
 
-  if (totalCount === 0) return null;
+  if (totalCount === 0 || !instanceData) return null;
 
   return (
     <group>
@@ -218,19 +234,23 @@ export function HollowVoxelEditOverlay({
           depthWrite={true}
         />
       </instancedMesh>
-      <lineSegments
-        geometry={edgeGeometry}
-        renderOrder={30002}
-        raycast={() => null}
-      >
-        <lineBasicMaterial
-          color={EDGE_COLOR}
-          transparent
-          opacity={0.45}
-          depthTest
-          depthWrite={false}
-        />
-      </lineSegments>
+      {edgeGeometry && (
+        <lineSegments
+          geometry={edgeGeometry}
+          renderOrder={30002}
+          frustumCulled={false}
+          raycast={() => null}
+        >
+          <shaderMaterial
+            transparent
+            depthTest
+            depthWrite={false}
+            uniforms={EDGE_UNIFORMS}
+            vertexShader={INSTANCED_EDGE_VERTEX_SHADER}
+            fragmentShader={INSTANCED_EDGE_FRAGMENT_SHADER}
+          />
+        </lineSegments>
+      )}
     </group>
   );
 }

--- a/src/components/scene/HollowVoxelPreview.tsx
+++ b/src/components/scene/HollowVoxelPreview.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import * as THREE from 'three';
+import { getVoxelPreviewBudget, tryAllocateFloat32Array, warnOnce } from './hollowVoxelPreviewLimits';
+import { INSTANCED_EDGE_FRAGMENT_SHADER, INSTANCED_EDGE_VERTEX_SHADER } from './instancedEdgeShader';
 
 type HollowVoxelPreviewProps = {
   voxelCenters: Float32Array;
@@ -9,6 +11,13 @@ type HollowVoxelPreviewProps = {
 
 const CAVITY_COLOR = '#66ecff';
 const EDGE_COLOR = '#000000';
+const EDGE_OPACITY = 0.45;
+// Stable references so the shaderMaterial's `uniforms` prop doesn't get a
+// fresh object (and re-upload to the GPU) on every render.
+const EDGE_UNIFORMS = {
+  uColor: { value: new THREE.Color(EDGE_COLOR) },
+  uOpacity: { value: EDGE_OPACITY },
+};
 
 /** 12 edges of a unit cube centred at origin, as 24 vertex positions. */
 const CUBE_EDGE_VERTICES = new Float32Array([
@@ -37,9 +46,10 @@ function buildInstanceMatrices(
   offsetZ: number,
 ): Float32Array {
   const count = Math.floor(voxelCenters.length / 3);
-  const matrices = new Float32Array(count * 16);
+  const matrices = tryAllocateFloat32Array(count * 16) ?? new Float32Array(0);
+  const usableCount = Math.floor(matrices.length / 16);
   const scale = voxelSizeMm;
-  for (let i = 0; i < count; i += 1) {
+  for (let i = 0; i < usableCount; i += 1) {
     const base = i * 3;
     const cx = voxelCenters[base] + offsetX;
     const cy = voxelCenters[base + 1] + offsetY;
@@ -65,29 +75,19 @@ function buildInstanceMatrices(
   return matrices;
 }
 
-function buildEdgePositions(
-  voxelCenters: Float32Array,
-  voxelSizeMm: number,
-  offsetX: number,
-  offsetY: number,
-  offsetZ: number,
-): Float32Array {
-  const count = Math.floor(voxelCenters.length / 3);
-  const half = voxelSizeMm * 0.5;
-  const out = new Float32Array(count * 24 * 3); // 24 vertices per cube
-  for (let i = 0; i < count; i += 1) {
-    const base = i * 3;
-    const cx = voxelCenters[base] + offsetX;
-    const cy = voxelCenters[base + 1] + offsetY;
-    const cz = voxelCenters[base + 2] + offsetZ;
-    const vo = i * 72;
-    for (let v = 0; v < 72; v += 3) {
-      out[vo + v]     = cx + CUBE_EDGE_VERTICES[v]     * voxelSizeMm;
-      out[vo + v + 1] = cy + CUBE_EDGE_VERTICES[v + 1] * voxelSizeMm;
-      out[vo + v + 2] = cz + CUBE_EDGE_VERTICES[v + 2] * voxelSizeMm;
-    }
-  }
-  return out;
+/**
+ * Builds the GPU-instanced edge-wireframe geometry: a shared, non-instanced
+ * 24-vertex cube-edge template plus a per-instance transform attribute that
+ * reuses the exact same matrix buffer already built for the cube
+ * InstancedMesh (`matrices` from `buildInstanceMatrices`) -- zero additional
+ * per-voxel memory, unlike the previous fully-expanded world-space buffer.
+ */
+function buildInstancedEdgeGeometry(matrices: Float32Array): THREE.InstancedBufferGeometry {
+  const geom = new THREE.InstancedBufferGeometry();
+  geom.setAttribute('position', new THREE.BufferAttribute(CUBE_EDGE_VERTICES, 3));
+  geom.setAttribute('instanceTransform', new THREE.InstancedBufferAttribute(matrices, 16));
+  geom.instanceCount = Math.floor(matrices.length / 16);
+  return geom;
 }
 
 /**
@@ -101,31 +101,62 @@ export function HollowVoxelPreview({
 }: HollowVoxelPreviewProps) {
   const meshRef = React.useRef<THREE.InstancedMesh>(null);
   const edgeRef = React.useRef<THREE.LineSegments>(null);
-  const count = Math.floor(voxelCenters.length / 3);
+  const fullCount = Math.floor(voxelCenters.length / 3);
+
+  const budget = getVoxelPreviewBudget();
+  const clampedCount = Math.min(fullCount, budget.maxCubeInstances);
+  const showEdges = fullCount <= budget.maxEdgeInstances;
+
+  // Cheap: subarray is a view over the same buffer, not a copy.
+  const clampedVoxelCenters = React.useMemo(
+    () => (clampedCount === fullCount ? voxelCenters : voxelCenters.subarray(0, clampedCount * 3)),
+    [voxelCenters, clampedCount, fullCount],
+  );
+
+  React.useEffect(() => {
+    if (fullCount > clampedCount) {
+      warnOnce(
+        'hollow-voxel-preview-cube-cap',
+        `[HollowVoxelPreview] voxel count ${fullCount} exceeds render budget (${budget.maxCubeInstances}); showing first ${clampedCount} voxels only.`,
+      );
+    } else if (!showEdges) {
+      warnOnce(
+        'hollow-voxel-preview-edge-cap',
+        `[HollowVoxelPreview] voxel count ${fullCount} exceeds edge-render budget (${budget.maxEdgeInstances}); showing cubes without edge outlines.`,
+      );
+    }
+  }, [fullCount, clampedCount, showEdges, budget.maxCubeInstances, budget.maxEdgeInstances]);
 
   const matrices = React.useMemo(() => {
     return buildInstanceMatrices(
-      voxelCenters,
+      clampedVoxelCenters,
       voxelSizeMm,
       meshOffset.x,
       meshOffset.y,
       meshOffset.z,
     );
-  }, [voxelCenters, voxelSizeMm, meshOffset.x, meshOffset.y, meshOffset.z]);
+  }, [clampedVoxelCenters, voxelSizeMm, meshOffset.x, meshOffset.y, meshOffset.z]);
 
-  // Edge geometry: single LineSegments with all cube edges baked in world space.
+  // Actual usable instance count -- derived from the built buffer itself
+  // rather than trusting clampedCount blindly, in case the (already
+  // budget-limited) allocation still failed for some other reason.
+  const count = Math.floor(matrices.length / 16);
+
+  // Edge geometry: GPU-instanced, reusing the same per-voxel matrices
+  // already built for the cube InstancedMesh above -- see
+  // buildInstancedEdgeGeometry. Skipped only if there are no cubes to draw.
   const edgeGeometry = React.useMemo(() => {
-    const edgePos = buildEdgePositions(
-      voxelCenters,
-      voxelSizeMm,
-      meshOffset.x,
-      meshOffset.y,
-      meshOffset.z,
-    );
-    const geom = new THREE.BufferGeometry();
-    geom.setAttribute('position', new THREE.BufferAttribute(edgePos, 3));
-    return geom;
-  }, [voxelCenters, voxelSizeMm, meshOffset.x, meshOffset.y, meshOffset.z]);
+    if (!showEdges || count === 0) return null;
+    return buildInstancedEdgeGeometry(matrices);
+  }, [matrices, count, showEdges]);
+
+  // R3F only auto-disposes attached geometry on unmount. When the memo swaps
+  // in a fresh edge geometry mid-life (every preview update), the previous
+  // one's GL buffers would otherwise leak (~64 bytes per voxel per swap).
+  React.useEffect(() => {
+    if (!edgeGeometry) return;
+    return () => edgeGeometry.dispose();
+  }, [edgeGeometry]);
 
   // Push instance matrices into the InstancedMesh on every change.
   React.useEffect(() => {
@@ -163,20 +194,24 @@ export function HollowVoxelPreview({
           depthWrite={true}
         />
       </instancedMesh>
+      {edgeGeometry && (
       <lineSegments
         ref={edgeRef}
         geometry={edgeGeometry}
         renderOrder={8}
+        frustumCulled={false}
         raycast={() => null}
       >
-        <lineBasicMaterial
-          color={EDGE_COLOR}
+        <shaderMaterial
           transparent
-          opacity={0.45}
           depthTest
           depthWrite={false}
+          uniforms={EDGE_UNIFORMS}
+          vertexShader={INSTANCED_EDGE_VERTEX_SHADER}
+          fragmentShader={INSTANCED_EDGE_FRAGMENT_SHADER}
         />
       </lineSegments>
+      )}
     </group>
   );
 }

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -544,8 +544,15 @@ export function SceneCanvas({
       polygon: Array<{ x: number; y: number }>,
       helpers: {
         projectWorldPoint: (point: THREE.Vector3) => { x: number; y: number; z: number } | null;
+        /** Snapshot of the camera projection + container size at pointer-up,
+         *  so a resolver can hand projection off to a backend (e.g. Rust-side
+         *  voxel selection) instead of projecting per-voxel on the client.
+         *  viewProj is column-major projectionMatrix * matrixWorldInverse. */
+        getCameraProjection: () =>
+          | { viewProj: number[]; rectWidth: number; rectHeight: number }
+          | null;
       },
-    ) => string[];
+    ) => string[] | Promise<string[]>;
     /** altKey is true when the Alt modifier was held at pointer-up. */
     onSelectionChange: (ids: string[], altKey?: boolean) => void;
   };
@@ -2885,12 +2892,38 @@ export function SceneCanvas({
       // ignore release failures
     }
 
-    customPrepareLassoSelection.onSelectionChange(
+    // Snapshot altKey now — the resolver may be async (Rust round-trip on
+    // release) and the pointer event must not be read after it settles.
+    const altKey = e.altKey;
+    const getCameraProjection = () => {
+      const projectionRect = containerRef.current?.getBoundingClientRect();
+      const projectionCamera = cameraRef.current;
+      if (!projectionRect || !projectionCamera) return null;
+      projectionCamera.updateMatrixWorld();
+      const viewProj = projectionCamera.projectionMatrix
+        .clone()
+        .multiply(projectionCamera.matrixWorldInverse)
+        .toArray();
+      return {
+        viewProj,
+        rectWidth: projectionRect.width,
+        rectHeight: projectionRect.height,
+      };
+    };
+
+    Promise.resolve(
       customPrepareLassoSelection.resolveSelection(path, {
         projectWorldPoint: projectPointToCanvas,
+        getCameraProjection,
       }),
-      e.altKey,
-    );
+    )
+      .then((ids) => {
+        customPrepareLassoSelection.onSelectionChange(ids, altKey);
+      })
+      .catch(() => {
+        // Selection resolution failed (e.g. backend unavailable); leave the
+        // blocked set unchanged rather than throwing from a pointer handler.
+      });
 
     suppressNextCanvasClickRef.current = true;
     e.preventDefault();

--- a/src/components/scene/hollowVoxelPreviewLimits.ts
+++ b/src/components/scene/hollowVoxelPreviewLimits.ts
@@ -1,0 +1,89 @@
+/**
+ * Resource-aware safety limits for the hollow-voxel preview renderers
+ * (`HollowVoxelPreview.tsx`, `HollowVoxelEditOverlay.tsx`).
+ *
+ * The cube bodies are a shared `InstancedMesh`, 64 bytes/voxel for the
+ * instance matrix. The cube-edge wireframe used to be a separate, fully
+ * expanded `LineSegments` position buffer at 288 bytes/voxel (24 vertices x
+ * 3 floats) -- on a large part with a fine voxel size (or after repeated
+ * lasso-blocking re-exposes more of the cavity interior as boundary), voxel
+ * counts could reach into the millions, and an unbounded
+ * `new Float32Array(voxelCount * 72)` could throw
+ * `RangeError: Array buffer allocation failed` and crash the render tree.
+ *
+ * The edges are now GPU-instanced too (see `instancedEdgeShader.ts` /
+ * `buildInstancedEdgeGeometry` in both renderer files), reusing the exact
+ * same per-voxel matrix buffer already built for the cubes -- there is no
+ * longer any O(voxel count) allocation for edges at all, just one shared
+ * 288-byte template built once. So `maxEdgeInstances` is now simply equal
+ * to `maxCubeInstances`; it's kept as a distinct field (rather than removed)
+ * so neither renderer file needs to change its cap-checking logic, and so a
+ * future change to either cost model doesn't require touching call sites.
+ *
+ * The budget itself is sized from `performance.memory.jsHeapSizeLimit` when
+ * available (Chromium/WebView2) so the cap scales with the actual runtime
+ * rather than a single fixed number picked for one machine.
+ */
+
+const BUDGET_FRACTION_OF_HEAP_LIMIT = 0.12;
+const FALLBACK_BUDGET_BYTES = 150 * 1024 * 1024;
+const BYTES_PER_CUBE_INSTANCE = 64; // 4x4 f32 instance matrix -- the only real per-voxel cost left
+
+export type VoxelPreviewBudget = {
+  maxCubeInstances: number;
+  maxEdgeInstances: number;
+};
+
+function readMemoryBudgetBytes(): number {
+  const memory = (performance as Performance & { memory?: { jsHeapSizeLimit?: number } }).memory;
+  if (memory && typeof memory.jsHeapSizeLimit === 'number' && memory.jsHeapSizeLimit > 0) {
+    return memory.jsHeapSizeLimit * BUDGET_FRACTION_OF_HEAP_LIMIT;
+  }
+  return FALLBACK_BUDGET_BYTES;
+}
+
+let cachedBudget: VoxelPreviewBudget | null = null;
+
+/**
+ * Returns the current voxel-instance ceilings. Cached for the page's
+ * lifetime -- `jsHeapSizeLimit` is a fixed property of the running engine,
+ * not something that changes moment to moment.
+ */
+export function getVoxelPreviewBudget(): VoxelPreviewBudget {
+  if (!cachedBudget) {
+    const budgetBytes = readMemoryBudgetBytes();
+    const maxCubeInstances = Math.max(1, Math.floor(budgetBytes / BYTES_PER_CUBE_INSTANCE));
+    cachedBudget = {
+      maxCubeInstances,
+      maxEdgeInstances: maxCubeInstances,
+    };
+  }
+  return cachedBudget;
+}
+
+const warnedKeys = new Set<string>();
+
+/** Logs a console warning at most once per unique key for the page's lifetime. */
+export function warnOnce(key: string, message: string): void {
+  if (warnedKeys.has(key)) return;
+  warnedKeys.add(key);
+  console.warn(message);
+}
+
+/**
+ * Allocates a Float32Array, returning `null` instead of throwing if the
+ * engine can't satisfy the request. Defense-in-depth alongside the
+ * resource-aware budget above, which should normally prevent this from
+ * ever being hit -- guards against the heuristic underestimating real
+ * available memory (fragmentation, other processes, etc.).
+ */
+export function tryAllocateFloat32Array(length: number): Float32Array | null {
+  try {
+    return new Float32Array(length);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/src/components/scene/instancedEdgeShader.ts
+++ b/src/components/scene/instancedEdgeShader.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared GPU-instanced shader source for the hollow-voxel cube-edge
+ * wireframe overlay (`HollowVoxelPreview.tsx`, `HollowVoxelEditOverlay.tsx`).
+ *
+ * `instanceTransform` is fed the exact same per-voxel matrix buffer already
+ * built for the cube `InstancedMesh` in each file -- reusing that buffer
+ * directly means the edge overlay costs zero additional per-voxel memory
+ * beyond the shared 24-vertex cube-edge template, instead of the previous
+ * fully-expanded 288-bytes/voxel world-space position buffer.
+ *
+ * Deliberately named `instanceTransform`, not `instanceMatrix`: three.js
+ * only auto-injects its reserved `instanceMatrix` attribute handling for
+ * objects with `isInstancedMesh === true` (see `WebGLPrograms.js`), which a
+ * `THREE.LineSegments` never is. The actual instanced-draw machinery
+ * (vertexAttribDivisor, mat4-attribute location splitting) is keyed on the
+ * geometry side (`InstancedBufferGeometry`/`InstancedBufferAttribute`), not
+ * the object type, so a self-contained attribute name here is correct and
+ * avoids any ambiguity with three's built-in instancing path.
+ *
+ * `toneMapping()`/`linearToOutputTexel()` and the `TONE_MAPPING` define are
+ * auto-provided by the renderer for any non-RawShaderMaterial with tone
+ * mapping enabled (verified against `WebGLProgram.js` in this three.js
+ * version) -- they must be called here for the edge color to visually match
+ * the rest of the tonemapped/color-managed scene, but nothing else needs to
+ * be declared for them to exist.
+ */
+
+export const INSTANCED_EDGE_VERTEX_SHADER = /* glsl */ `
+attribute mat4 instanceTransform;
+
+void main() {
+  vec4 localPos = instanceTransform * vec4(position, 1.0);
+  vec4 mvPosition = modelViewMatrix * localPos;
+  gl_Position = projectionMatrix * mvPosition;
+}
+`;
+
+export const INSTANCED_EDGE_FRAGMENT_SHADER = /* glsl */ `
+uniform vec3 uColor;
+uniform float uOpacity;
+
+void main() {
+  gl_FragColor = vec4(uColor, uOpacity);
+  #if defined( TONE_MAPPING )
+    gl_FragColor.rgb = toneMapping( gl_FragColor.rgb );
+  #endif
+  gl_FragColor = linearToOutputTexel( gl_FragColor );
+}
+`;

--- a/src/features/export/logic/ExportManager.ts
+++ b/src/features/export/logic/ExportManager.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { STLExporter } from 'three-stdlib';
 import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import type { ModelMeshModifiers } from '@/features/mesh-modifiers/types';
+import { resolveModelMeshModifiers } from '@/features/mesh-modifiers/meshModifierStore';
 import { KNOWN_SOURCE_EXTENSION_STRIP_RE } from '@/features/plugins/pluginFileTypeExtensions';
 import { buildSupportExportFromStores, serializeVoxlDocumentV2 } from '@/features/scene/voxl';
 import { buildScopedSupportExportDocument, buildScopedSupportGeometryGroup } from '@/features/export/logic/supportExportReconstruction';
@@ -1194,7 +1195,11 @@ export class ExportManager {
                   z: model.transform.scale.z,
                 },
               },
-              meshModifiers: model.meshModifiers,
+              // Model objects in React state carry meshModifiers: undefined
+              // by design (externalized store) — resolve through the store or
+              // every saved VOXL silently loses hollowing/hole-punch
+              // re-editability (voxl-format-spec.md V2.1 requirement).
+              meshModifiers: resolveModelMeshModifiers(model),
               mesh: {
                 mode: 'embedded-file',
                 fileName: `${this.normalizeExportFilenameBase(model.name || 'model')}.stl`,

--- a/src/features/hole-punching/useHolePunchManager.ts
+++ b/src/features/hole-punching/useHolePunchManager.ts
@@ -76,6 +76,10 @@ export type UseHolePunchManagerOptions = {
   // Misc shared sinks.
   showOperationError: (message: string) => void;
   setShowDamagedModelDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  // Modifier-apply overlay finalizing controls (useModifierApplyOverlay in Home).
+  beginFinalizing: (kind: 'hollowing' | 'holePunch') => void;
+  clearFinalizing: () => void;
+  nextPaint: () => Promise<void>;
 };
 
 export function useHolePunchManager({
@@ -106,6 +110,9 @@ export function useHolePunchManager({
   setHolePunchHoverPlacement,
   showOperationError,
   setShowDamagedModelDialog,
+  beginFinalizing,
+  clearFinalizing,
+  nextPaint,
 }: UseHolePunchManagerOptions) {
   const [holePunchState, setHolePunchState] = React.useState<HolePunchPanelState>({
     radiusMm: 2.0,
@@ -1196,6 +1203,12 @@ export function useHolePunchManager({
           return;
         }
 
+        // Backend work is done — switch the blocking overlay to the
+        // "loading mesh" message and let it paint before the heavy
+        // synchronous finalization below (see handleApplyHollowing).
+        beginFinalizing('holePunch');
+        await nextPaint();
+
         const nextGeometry = new THREE.BufferGeometry();
         nextGeometry.setAttribute('position', new THREE.BufferAttribute(result.positions, 3));
         nextGeometry.computeVertexNormals();
@@ -1212,6 +1225,7 @@ export function useHolePunchManager({
             sourceGeometry.dispose();
           }
           nextGeometry.dispose();
+          clearFinalizing();
           return;
         }
 
@@ -1235,11 +1249,12 @@ export function useHolePunchManager({
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         showOperationError(`Hole punching failed: ${message}`);
+        clearFinalizing();
       } finally {
         setIsApplyingHolePunch(false);
       }
     })();
-  }, [activeHolePunchPlacements, persistActiveModelModifiers, scene, sleep]);
+  }, [activeHolePunchPlacements, beginFinalizing, clearFinalizing, nextPaint, persistActiveModelModifiers, scene, sleep]);
 
   React.useEffect(() => {
     if (!pendingHolePunchAutoApplyModelId) return;

--- a/src/features/hollowing/__tests__/cavityCentering.test.ts
+++ b/src/features/hollowing/__tests__/cavityCentering.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as THREE from 'three';
+import { centerCavityPositions } from '../cavityCentering';
+
+// Regression guard for the VOXL cavity-alignment bug: the persisted cavity must
+// be recentered by the SAME `−model.geometry.center` that ExportManager bakes
+// into the model STL. The old code encoded the cavity RAW (an identity
+// transform), which these assertions would reject.
+
+test('centerCavityPositions translates every triple by −center', () => {
+  const positions = new Float32Array([
+    1, 2, 3,
+    4, 5, 6,
+    -7, -8, -9,
+  ]);
+  const center = { x: 10, y: 20, z: 30 };
+
+  const out = centerCavityPositions(positions, center);
+
+  assert.deepEqual(Array.from(out), [
+    1 - 10, 2 - 20, 3 - 30,
+    4 - 10, 5 - 20, 6 - 30,
+    -7 - 10, -8 - 20, -9 - 30,
+  ]);
+});
+
+test('centerCavityPositions does not mutate the input (in-session cavity is shared)', () => {
+  const positions = new Float32Array([1, 2, 3, 4, 5, 6]);
+  const snapshot = Array.from(positions);
+  const center = { x: 1, y: 1, z: 1 };
+
+  const out = centerCavityPositions(positions, center);
+
+  assert.deepEqual(Array.from(positions), snapshot, 'input array must be untouched');
+  assert.notStrictEqual(out, positions, 'must return a new array');
+  assert.equal(out.length, positions.length);
+});
+
+test('recentering by the model center aligns the cavity frame with the model STL', () => {
+  // Model + cavity in the same raw in-session frame, offset from origin.
+  const modelPositions = new Float32Array([
+    0, 0, 0,
+    20, 0, 0,
+    20, 40, 0,
+    0, 40, 0,
+  ]);
+  const cavityPositions = new Float32Array([
+    5, 5, 0,
+    15, 5, 0,
+    15, 35, 0,
+    5, 35, 0,
+  ]);
+
+  // C = the model bbox center — exactly what ExportManager bakes into the STL.
+  const modelBbox = new THREE.Box3().setFromArray(modelPositions);
+  const modelCenter = modelBbox.getCenter(new THREE.Vector3());
+
+  // Model STL is exported translated by −C (ExportManager behavior).
+  const exportedModelBbox = modelBbox.clone().translate(modelCenter.clone().negate());
+  // Cavity is persisted via the helper (translated by −C).
+  const exportedCavity = centerCavityPositions(cavityPositions, modelCenter);
+  const exportedCavityBbox = new THREE.Box3().setFromArray(exportedCavity);
+
+  // The cavity's offset from the model center is preserved after recentering,
+  // so on reload the verbatim cavity sits in the same frame as the model.
+  const exportedModelCenter = exportedModelBbox.getCenter(new THREE.Vector3());
+  const exportedCavityCenter = exportedCavityBbox.getCenter(new THREE.Vector3());
+  // Model+cavity are concentric here, so both land at the origin.
+  assert.ok(exportedModelCenter.length() < 1e-6, 'centered model sits at origin');
+  assert.ok(exportedCavityCenter.length() < 1e-6, 'recentered cavity sits at origin');
+});

--- a/src/features/hollowing/cavityCentering.ts
+++ b/src/features/hollowing/cavityCentering.ts
@@ -1,0 +1,31 @@
+/**
+ * Recentering helper for the persisted (on-disk) hollowing cavity.
+ *
+ * When a VOXL is saved, the model STL is exported RE-CENTERED: ExportManager
+ * bakes `mesh.position = −model.geometry.center` into the vertices
+ * (`exportModelAsEmbeddedBinaryStlBytes`). The cavity, however, is persisted as
+ * `cavityPositionsBase64` and rebuilt verbatim on reload. To keep the reloaded
+ * cavity aligned with the reloaded (already-centered) model, the on-disk cavity
+ * must live in the SAME centered frame — i.e. translated by the same `−center`.
+ *
+ * This returns a NEW Float32Array; the input is never mutated because the
+ * in-session cavity geometry references the original `result.cavityPositions`
+ * array directly and must stay in the raw (uncentered) in-session frame.
+ *
+ * @param positions xyz-triple vertex positions (length is a multiple of 3).
+ * @param center the model geometry bbox center that the model STL is centered
+ *   by on export (= `model.geometry.center` post-`replaceModelGeometry`).
+ */
+export function centerCavityPositions(
+  positions: Float32Array,
+  center: { readonly x: number; readonly y: number; readonly z: number },
+): Float32Array {
+  const { x: cx, y: cy, z: cz } = center;
+  const out = new Float32Array(positions.length);
+  for (let i = 0; i + 2 < positions.length; i += 3) {
+    out[i] = positions[i] - cx;
+    out[i + 1] = positions[i + 1] - cy;
+    out[i + 2] = positions[i + 2] - cz;
+  }
+  return out;
+}

--- a/src/features/hollowing/hollowingPreviewTypes.ts
+++ b/src/features/hollowing/hollowingPreviewTypes.ts
@@ -8,6 +8,13 @@ export type HollowPreviewState = {
   removedVoxelCenters: Float32Array;
   removedVoxelIndices: Uint32Array;
   blockedVoxelCenters?: Float32Array;
+  /** Grid indices Rust actually accepted for the blocked centers, in lockstep
+   *  with blockedVoxelCenters. Downstream positional mappings consume this
+   *  instead of the committed array, so a stale/dropped index never desyncs. */
+  blockedVoxelIndices?: Uint32Array;
+  /** The committed blocked set this preview was computed FROM — used to gate
+   *  the quiet resync so a newer in-flight request can't be clobbered. */
+  requestedBlockedVoxelIndices?: readonly number[];
   report: HollowReport;
   previewKey: string;
   /** When true, the geometry is the original source mesh and the cavity
@@ -23,6 +30,8 @@ export type HollowPreviewCacheEntry = {
   removedVoxelCenters?: Float32Array;
   removedVoxelIndices?: Uint32Array;
   blockedVoxelCenters?: Float32Array;
+  blockedVoxelIndices?: Uint32Array;
+  requestedBlockedVoxelIndices?: readonly number[];
   previewGeometry?: THREE.BufferGeometry | null;
   infillGeometry?: THREE.BufferGeometry | null;
 };

--- a/src/features/hollowing/index.ts
+++ b/src/features/hollowing/index.ts
@@ -1,2 +1,5 @@
 export { HollowingPanel } from './HollowingPanel';
 export type { HollowingPanelState } from './HollowingPanel';
+export { useModifierApplyOverlay } from './useModifierApplyOverlay';
+export type { ModifierApplyOverlayApi, ModifierApplyOverlayArgs } from './useModifierApplyOverlay';
+export { centerCavityPositions } from './cavityCentering';

--- a/src/features/hollowing/useHollowingManager.ts
+++ b/src/features/hollowing/useHollowingManager.ts
@@ -78,6 +78,10 @@ function quantizePreviewShellThicknessMm(valueMm: number): number {
 export type HollowingManagerDeps = {
   showOperationError: (message: string) => void;
   setShowDamagedModelDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  /** Modifier-apply overlay finalizing controls (useModifierApplyOverlay in Home). */
+  beginFinalizing: (kind: 'hollowing' | 'holePunch') => void;
+  clearFinalizing: () => void;
+  nextPaint: () => Promise<void>;
   persistActiveModelModifiers: (next: ModelMeshModifiers | undefined) => void;
   setPendingModifierResetAction: React.Dispatch<React.SetStateAction<'hollowing' | 'hole_punch' | 'clear_hollowing' | null>>;
   setInteriorView: React.Dispatch<React.SetStateAction<boolean>>;
@@ -240,6 +244,14 @@ export function useHollowingManager({
           return;
         }
 
+        // Backend work is done — everything below is main-thread mesh
+        // finalization. Switch the blocking overlay to the "loading mesh"
+        // message and give it one frame to paint before the heavy
+        // synchronous block starts; the drain-watcher effect clears the
+        // flag once the swap and its deferred work have settled.
+        deps.current.beginFinalizing('hollowing');
+        await deps.current.nextPaint();
+
         const nextGeometry = new THREE.BufferGeometry();
         nextGeometry.setAttribute('position', new THREE.BufferAttribute(result.positions, 3));
         nextGeometry.computeVertexNormals();
@@ -278,6 +290,7 @@ export function useHollowingManager({
         );
         if (!replaced) {
           nextGeometry.dispose();
+          deps.current.clearFinalizing();
           return;
         }
 
@@ -384,6 +397,7 @@ export function useHollowingManager({
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         deps.current.showOperationError(`Hollowing failed: ${message}`);
+        deps.current.clearFinalizing();
       } finally {
         setIsApplyingHollowing(false);
         setIsApplyingBlockersHollowing(false);

--- a/src/features/hollowing/useHollowingManager.ts
+++ b/src/features/hollowing/useHollowingManager.ts
@@ -8,7 +8,6 @@ import type { ModelMeshModifiers } from '@/features/mesh-modifiers/types';
 import type { MeshShaderType } from '@/features/shaders/mesh';
 import type { HolePunchPanelState } from '@/features/hole-punching/HolePunchPanel';
 import type { HolePunchPlacementState } from '@/features/hole-punching/holePunchGeometry';
-import { quaternionFromGlobalEuler } from '@/utils/rotation';
 import { snapshotGeometryPositions, geometryFromSnapshot } from '@/utils/geometrySnapshot';
 import { bytesToBase64, base64ToBytes } from '@/utils/base64';
 import {
@@ -20,10 +19,13 @@ import {
   hollowApplyFromCapturedSource,
   hollowFromGeometry,
   hollowPreviewFromCapturedSource,
+  selectRemovedVoxelsInPolygon,
   stageHollowPreviewSource,
   type HollowOptions,
   type HollowReport,
 } from '@/utils/meshHollowing';
+import { centerCavityPositions } from '@/features/hollowing/cavityCentering';
+import { getRotationQuatTuple } from '@/features/mesh-modifiers/hollowingGrid';
 import { toPersistedHolePunchPlacements } from '@/features/hole-punching/holePunchPersistence';
 import type { GeometryWithBounds } from '@/hooks/useStlGeometry';
 import { serializeHollowingModifier } from '@/features/hollowing/hollowingSerialize';
@@ -288,10 +290,21 @@ export function useHollowingManager({
         let cavityPositionsBase64: string | undefined;
         let cavityPositionCount: number | undefined;
         if (result.cavityPositions) {
+          // Recenter the PERSISTED cavity by the same −center ExportManager
+          // bakes into the model STL on save (model.geometry.center, which
+          // replaceModelGeometry derives from nextGeometry's bounding box).
+          // On reload the cavity is rebuilt verbatim, so the on-disk cavity
+          // must share the model's centered frame or it renders displaced by
+          // ~half the model height. The in-session cavity geometry (built above
+          // from the raw result.cavityPositions) is intentionally left untouched.
+          if (!nextGeometry.boundingBox) nextGeometry.computeBoundingBox();
+          const modelCenter = new THREE.Vector3();
+          nextGeometry.boundingBox?.getCenter(modelCenter);
+          const centeredCavity = centerCavityPositions(result.cavityPositions, modelCenter);
           const cavityBytes = new Uint8Array(
-            result.cavityPositions.buffer,
-            result.cavityPositions.byteOffset,
-            result.cavityPositions.byteLength,
+            centeredCavity.buffer,
+            centeredCavity.byteOffset,
+            centeredCavity.byteLength,
           );
           cavityPositionsBase64 = bytesToBase64(cavityBytes);
           cavityPositionCount = result.cavityPositions.length / 3;
@@ -340,6 +353,9 @@ export function useHollowingManager({
             cavityPositionsBase64,
             cavityPositionCount,
             blockedVoxelIndices: blockedHollowVoxelIndices,
+            blockedVoxelRotationQuat: blockedHollowVoxelIndices.length > 0
+              ? getRotationQuatTuple(activeModel.transform.rotation)
+              : undefined,
             mode: effectiveHollowMode,
             voxelSizeMm: hollowingState.voxelSizeMm,
             shellThicknessMm: hollowingState.shellThicknessMm,
@@ -420,6 +436,7 @@ export function useHollowingManager({
         sourcePositionsBase64: undefined,
         sourcePositionCount: undefined,
         blockedVoxelIndices: [],
+        blockedVoxelRotationQuat: undefined,
         mode: defaultHollowingState.mode,
         voxelSizeMm: defaultHollowingState.voxelSizeMm,
         shellThicknessMm: defaultHollowingState.shellThicknessMm,
@@ -480,6 +497,7 @@ export function useHollowingManager({
         sourcePositionsBase64: undefined,
         sourcePositionCount: undefined,
         blockedVoxelIndices: [],
+        blockedVoxelRotationQuat: undefined,
         // Keep current settings — don't reset to defaults.
         mode: hollowingState.mode,
         voxelSizeMm: hollowingState.voxelSizeMm,
@@ -739,7 +757,9 @@ export function useHollowingManager({
     if (preview.blockedVoxelCenters) {
       const blockedCount = Math.floor(preview.blockedVoxelCenters.length / 3);
       for (let blockedIndex = 0; blockedIndex < blockedCount; blockedIndex += 1) {
-        const gridIndex = blockedHollowVoxelIndices[blockedIndex];
+        const gridIndex = preview.blockedVoxelIndices
+          ? preview.blockedVoxelIndices[blockedIndex]
+          : blockedHollowVoxelIndices[blockedIndex];
         if (activeBlockedIndexSet.has(gridIndex)) {
           next.add(preview.removedVoxelIndices.length + blockedIndex);
         }
@@ -762,6 +782,9 @@ export function useHollowingManager({
         sourcePositionsBase64: activeModel.meshModifiers?.hollowing?.sourcePositionsBase64,
         sourcePositionCount: activeModel.meshModifiers?.hollowing?.sourcePositionCount,
         blockedVoxelIndices: nextIndices,
+        blockedVoxelRotationQuat: nextIndices.length > 0
+          ? getRotationQuatTuple(activeModel.transform.rotation)
+          : undefined,
         mode: hollowingState.mode,
         voxelSizeMm: hollowingState.voxelSizeMm,
         shellThicknessMm: hollowingState.shellThicknessMm,
@@ -787,10 +810,13 @@ export function useHollowingManager({
       // Instance in the removed voxel array — look up grid index directly.
       gridVoxelIndex = currentPreview.removedVoxelIndices[voxelIndex];
     } else {
-      // Instance in the appended blocked-only array — look up via
-      // blockedHollowVoxelIndices (committed set, same order as blocked centers).
+      // Instance in the appended blocked-only array — look up via the echoed
+      // accepted indices (in lockstep with the blocked centers), falling back
+      // to the committed set when the echo is unavailable.
       const blockedOffset = voxelIndex - removedCount;
-      gridVoxelIndex = blockedHollowVoxelIndices[blockedOffset];
+      gridVoxelIndex = currentPreview.blockedVoxelIndices
+        ? currentPreview.blockedVoxelIndices[blockedOffset]
+        : blockedHollowVoxelIndices[blockedOffset];
     }
 
     if (!Number.isFinite(gridVoxelIndex)) return;
@@ -945,6 +971,8 @@ export function useHollowingManager({
     removedVoxelCenters: Float32Array | undefined,
     removedVoxelIndices: Uint32Array | undefined,
     blockedVoxelCenters: Float32Array | undefined,
+    blockedVoxelIndices: Uint32Array | undefined,
+    requestedBlockedVoxelIndices: number[],
     previewKey: string,
   ) => {
     const cachedPositions = new Float32Array(positions.length);
@@ -958,6 +986,9 @@ export function useHollowingManager({
     const cachedBlockedVoxelCenters = blockedVoxelCenters
       ? new Float32Array(blockedVoxelCenters)
       : undefined;
+    const cachedBlockedVoxelIndices = blockedVoxelIndices
+      ? new Uint32Array(blockedVoxelIndices)
+      : undefined;
 
     hollowPreviewResultCacheRef.current.set(previewKey, {
       modelId: activeModelId,
@@ -967,6 +998,8 @@ export function useHollowingManager({
       removedVoxelCenters: cachedRemovedVoxelCenters,
       removedVoxelIndices: cachedRemovedVoxelIndices,
       blockedVoxelCenters: cachedBlockedVoxelCenters,
+      blockedVoxelIndices: cachedBlockedVoxelIndices,
+      requestedBlockedVoxelIndices: [...requestedBlockedVoxelIndices],
       previewGeometry: null,
       infillGeometry: null,
     });
@@ -1033,6 +1066,8 @@ export function useHollowingManager({
         result.removedVoxelCenters,
         result.removedVoxelIndices,
         result.blockedVoxelCenters,
+        result.blockedVoxelIndices,
+        options.blockedVoxelIndices ?? [],
         previewKey,
       );
 
@@ -1100,6 +1135,8 @@ export function useHollowingManager({
             removedVoxelCenters: cached.removedVoxelCenters ?? new Float32Array(0),
             removedVoxelIndices: cached.removedVoxelIndices ?? new Uint32Array(0),
             blockedVoxelCenters: cached.blockedVoxelCenters,
+            blockedVoxelIndices: cached.blockedVoxelIndices,
+            requestedBlockedVoxelIndices: cached.requestedBlockedVoxelIndices,
             report: cached.report,
             previewKey,
             previewVoxelSpheres: true,
@@ -1135,6 +1172,8 @@ export function useHollowingManager({
         result.removedVoxelCenters,
         result.removedVoxelIndices,
         result.blockedVoxelCenters,
+        result.blockedVoxelIndices,
+        options.blockedVoxelIndices ?? [],
         previewKey,
       );
       const materialized = materializeHollowPreviewCacheEntry(previewKey);
@@ -1164,6 +1203,8 @@ export function useHollowingManager({
           removedVoxelCenters: result.removedVoxelCenters ?? new Float32Array(0),
           removedVoxelIndices: result.removedVoxelIndices ?? new Uint32Array(0),
           blockedVoxelCenters: result.blockedVoxelCenters,
+          blockedVoxelIndices: result.blockedVoxelIndices,
+          requestedBlockedVoxelIndices: options.blockedVoxelIndices ?? [],
           report: result.report,
           previewKey,
           previewVoxelSpheres: true,
@@ -1200,8 +1241,14 @@ export function useHollowingManager({
   React.useEffect(() => {
     return () => {
       if (hollowPreview) {
-        hollowPreview.geometry.dispose();
-        hollowPreview.infillGeometry?.dispose();
+        disposeHollowPreviewGeometryIfUncached(
+          hollowPreview.geometry,
+          hollowPreviewResultCacheRef.current.values(),
+        );
+        disposeHollowPreviewGeometryIfUncached(
+          hollowPreview.infillGeometry ?? null,
+          hollowPreviewResultCacheRef.current.values(),
+        );
       }
     };
   }, [hollowPreview]);
@@ -1310,12 +1357,13 @@ export function useHollowingManager({
     setEditingBlockedHollowVoxelIndices(blockedHollowVoxelIndices);
   }, [blockedHollowVoxelIndices, scene.mode, transformMgr.transformMode]);
 
-  const resolveBlockedHollowVoxelMarqueeSelection = React.useCallback((
+  const resolveBlockedHollowVoxelMarqueeSelection = React.useCallback(async (
     polygon: Array<{ x: number; y: number }>,
     helpers: {
       projectWorldPoint: (point: THREE.Vector3) => { x: number; y: number; z: number } | null;
+      getCameraProjection?: () => { viewProj: number[]; rectWidth: number; rectHeight: number } | null;
     },
-  ) => {
+  ): Promise<string[]> => {
     const preview = hollowPreview;
     const activeModel = scene.activeModel;
     if (!preview || !activeModel || polygon.length < 3) return [] as string[];
@@ -1334,26 +1382,61 @@ export function useHollowingManager({
       return inside;
     };
 
-    const modelQuaternion = quaternionFromGlobalEuler(activeModel.transform.rotation);
+    const modelQuaternion = new THREE.Quaternion().setFromEuler(activeModel.transform.rotation);
     const selected: string[] = [];
 
-    for (let instanceIndex = 0; instanceIndex < preview.removedVoxelIndices.length; instanceIndex += 1) {
-      const offset = instanceIndex * 3;
-      const localPoint = new THREE.Vector3(
-        preview.removedVoxelCenters[offset] - activeModel.geometry.center.x,
-        preview.removedVoxelCenters[offset + 1] - activeModel.geometry.center.y,
-        preview.removedVoxelCenters[offset + 2] - activeModel.geometry.center.z,
-      );
-      localPoint.multiply(activeModel.transform.scale);
-      localPoint.applyQuaternion(modelQuaternion);
-      localPoint.add(activeModel.transform.position);
-      const projected = helpers.projectWorldPoint(localPoint);
-      if (!projected) continue;
-      if (!pointInPolygon(projected.x, projected.y)) continue;
-      selected.push(String(preview.removedVoxelIndices[instanceIndex]));
+    // Removed/cavity voxels are resolved in Rust against the full grid, so the
+    // whole through-depth column under the lasso is selected — not just the
+    // boundary-filtered / cap-limited shell that `preview.removedVoxelCenters`
+    // now holds after the 90a15d3d rendering filter. Rust reproduces this
+    // exact projection (unrotated center -> model transform -> viewProj ->
+    // container pixels -> point-in-polygon); see meshHollowing.ts / hollowing.rs.
+    const cameraProjection = helpers.getCameraProjection?.();
+    if (cameraProjection) {
+      const { options } = buildHollowPreviewRequest(activeModel);
+      try {
+        const removedIndices = await selectRemovedVoxelsInPolygon({
+          polygon: polygon.map((point) => [point.x, point.y] as [number, number]),
+          viewProj: cameraProjection.viewProj,
+          rectWidth: cameraProjection.rectWidth,
+          rectHeight: cameraProjection.rectHeight,
+          geometryCenter: [
+            activeModel.geometry.center.x,
+            activeModel.geometry.center.y,
+            activeModel.geometry.center.z,
+          ],
+          scale: [
+            activeModel.transform.scale.x,
+            activeModel.transform.scale.y,
+            activeModel.transform.scale.z,
+          ],
+          rotationQuat: [
+            modelQuaternion.x,
+            modelQuaternion.y,
+            modelQuaternion.z,
+            modelQuaternion.w,
+          ],
+          position: [
+            activeModel.transform.position.x,
+            activeModel.transform.position.y,
+            activeModel.transform.position.z,
+          ],
+          options,
+        });
+        if (removedIndices) {
+          for (let i = 0; i < removedIndices.length; i += 1) {
+            selected.push(String(removedIndices[i]));
+          }
+        }
+      } catch {
+        // Backend selection unavailable/failed: fall through with the blocked
+        // set only rather than throwing out of the lasso release handler.
+      }
     }
 
-    // Also test blocked-only voxel centers so lassoing over them works.
+    // Already-blocked voxels stay client-side: that center set is
+    // user-selection-bounded (never boundary-filtered), and Alt+lasso needs it
+    // to un-block. This loop is unchanged from the pre-regression resolver.
     if (preview.blockedVoxelCenters) {
       const blockedCount = Math.floor(preview.blockedVoxelCenters.length / 3);
       for (let blockedIndex = 0; blockedIndex < blockedCount; blockedIndex += 1) {
@@ -1369,12 +1452,14 @@ export function useHollowingManager({
         const projected = helpers.projectWorldPoint(localPoint);
         if (!projected) continue;
         if (!pointInPolygon(projected.x, projected.y)) continue;
-        selected.push(String(blockedHollowVoxelIndices[blockedIndex]));
+        selected.push(String(preview.blockedVoxelIndices
+          ? preview.blockedVoxelIndices[blockedIndex]
+          : blockedHollowVoxelIndices[blockedIndex]));
       }
     }
 
     return selected;
-  }, [hollowPreview, scene.activeModel, blockedHollowVoxelIndices]);
+  }, [hollowPreview, scene.activeModel, blockedHollowVoxelIndices, buildHollowPreviewRequest]);
 
   const handleBlockedHollowVoxelMarqueeSelection = React.useCallback((ids: string[], altKey?: boolean) => {
     if (ids.length === 0) return;

--- a/src/features/hollowing/useHollowingManager.ts
+++ b/src/features/hollowing/useHollowingManager.ts
@@ -25,7 +25,7 @@ import {
   type HollowReport,
 } from '@/utils/meshHollowing';
 import { centerCavityPositions } from '@/features/hollowing/cavityCentering';
-import { getRotationQuatTuple } from '@/features/mesh-modifiers/hollowingGrid';
+import { getRotationQuatTuple, resolveBlockedVoxelValidity } from '@/features/mesh-modifiers/hollowingGrid';
 import { toPersistedHolePunchPlacements } from '@/features/hole-punching/holePunchPersistence';
 import type { GeometryWithBounds } from '@/hooks/useStlGeometry';
 import { serializeHollowingModifier } from '@/features/hollowing/hollowingSerialize';
@@ -1333,6 +1333,76 @@ export function useHollowingManager({
       cavityGeometryByModelIdRef.current.set(model.id, { geometry: cavityGeometry });
     }
   }, [scene.models]);
+
+  // Rust echoes back which committed blockers it actually accepted (stale
+  // indices that fell off the grid or landed on non-solid voxels are
+  // dropped, preserving order). If the echo differs from the committed set,
+  // adopt it so the persisted modifier stays in lockstep with the preview.
+  React.useEffect(() => {
+    const preview = hollowPreview;
+    const echoed = preview?.blockedVoxelIndices;
+    const requested = preview?.requestedBlockedVoxelIndices;
+    if (!preview || !echoed || !requested) return;
+    // Only resync when this preview was computed FROM the current committed
+    // set — otherwise a newer request is already in flight and comparing
+    // against it would clobber fresh state.
+    if (requested.length !== blockedHollowVoxelIndices.length
+      || requested.some((value, i) => value !== blockedHollowVoxelIndices[i])) {
+      return;
+    }
+    // The accepted list is an order-preserving subsequence of the request:
+    // equal length means identical content.
+    if (echoed.length === blockedHollowVoxelIndices.length) return;
+    commitBlockedHollowVoxelIndices(Array.from(echoed));
+  }, [blockedHollowVoxelIndices, commitBlockedHollowVoxelIndices, hollowPreview]);
+
+  // Committed blockers index the rotation-aligned voxel grid. If the model is
+  // rotated after they were painted, the same linear indices land on entirely
+  // different voxels (or off the grid), so Rust would either silently ignore
+  // them or pin the wrong voxels (hollowing.rs keep-application). Clear them
+  // instead, mirroring the resolution-change invalidation in
+  // handleHollowingStateChange and the legacy-format clear above.
+  // NOTE: models in React state carry meshModifiers: undefined by design —
+  // modifiers must be read through the externalized store (getModelMeshModifiers),
+  // matching the cavity-restore effect above.
+  React.useEffect(() => {
+    for (const model of scene.models) {
+      const modifiers = scene.getModelMeshModifiers(model.id);
+      const hollowing = modifiers?.hollowing;
+      if (!hollowing?.enabled || hollowing.bakedIntoGeometry) continue;
+      if (!hollowing.blockedVoxelIndices?.length) continue;
+      const currentQuat = getRotationQuatTuple(model.transform.rotation);
+      const validity = resolveBlockedVoxelValidity(hollowing, currentQuat);
+      if (validity === 'valid') continue;
+
+      if (validity === 'stamp-legacy') {
+        // Blockers persisted before the rotation stamp existed: adopt the
+        // current rotation instead of destroying the user's selection on
+        // first launch after this change.
+        scene.setModelMeshModifiers(model.id, {
+          ...(modifiers ?? {}),
+          hollowing: { ...hollowing, blockedVoxelRotationQuat: currentQuat },
+        });
+        continue;
+      }
+
+      console.warn(
+        '[Hollowing] Cleared blocked voxels: model rotation changed since they were painted.',
+      );
+      scene.setModelMeshModifiers(model.id, {
+        ...(modifiers ?? {}),
+        hollowing: {
+          ...hollowing,
+          blockedVoxelIndices: [],
+          blockedVoxelRotationQuat: undefined,
+        },
+      });
+      if (model.id === scene.activeModelId) {
+        setBlockedHollowVoxelIndices([]);
+        setEditingBlockedHollowVoxelIndices([]);
+      }
+    }
+  }, [scene.models, scene.getModelMeshModifiers, scene.setModelMeshModifiers, scene.activeModelId, setBlockedHollowVoxelIndices, setEditingBlockedHollowVoxelIndices]);
 
   React.useEffect(() => {
     return () => {

--- a/src/features/hollowing/useModifierApplyOverlay.ts
+++ b/src/features/hollowing/useModifierApplyOverlay.ts
@@ -1,0 +1,134 @@
+import * as React from 'react';
+
+export interface ModifierApplyOverlayArgs {
+  /** scene.hasPendingBackgroundGeometryWork — polled by the drain-watcher. */
+  hasPendingBackgroundGeometryWork: () => boolean;
+  /** Cross-domain apply flags, needed only to gate the two finalizing content
+   *  branches so they yield to in-flight applies exactly as today. */
+  isApplyingHollowing: boolean;
+  isApplyingHolePunch: boolean;
+  pendingHolePunchAutoApplyModelId: string | null;
+}
+
+export interface ModifierApplyOverlayContent {
+  title: string;
+  detailLines: string[];
+}
+
+export interface ModifierApplyOverlayApi {
+  /** finalizingModifierApply !== null */
+  isFinalizing: boolean;
+  beginFinalizing: (kind: 'hollowing' | 'holePunch') => void;
+  clearFinalizing: () => void;
+  /** The "…complete — loading mesh…" content, or null when a plain apply
+   *  message should win. Consumed by a 1-line guard in modifierApplyOverlayContent. */
+  finalizingOverlayContent: ModifierApplyOverlayContent | null;
+  /** Pure double-rAF; resolves after the next presented frame. */
+  nextPaint: () => Promise<void>;
+}
+
+export function useModifierApplyOverlay(
+  args: ModifierApplyOverlayArgs,
+): ModifierApplyOverlayApi {
+  const {
+    hasPendingBackgroundGeometryWork,
+    isApplyingHollowing,
+    isApplyingHolePunch,
+    pendingHolePunchAutoApplyModelId,
+  } = args;
+
+  // Set when a modifier apply's BACKEND work has finished but the UI-side
+  // finalization (geometry build, React commit, GPU upload, deferred BVH /
+  // flattening-plane work) is still in flight. Keeps the blocking overlay up
+  // with a "loading mesh" message until the app is genuinely responsive —
+  // previously the overlay vanished at the end of the async handler while
+  // the main thread stayed frozen for seconds afterwards.
+  const [finalizingModifierApply, setFinalizingModifierApply] =
+    React.useState<null | 'hollowing' | 'holePunch'>(null);
+
+  // Resolves after the NEXT presented frame: the first rAF fires after the
+  // pending React commit but before paint, the second after that frame has
+  // actually been shown. Used to let an overlay message paint before a heavy
+  // synchronous main-thread block starts.
+  const nextPaint = React.useCallback(() => new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve());
+    });
+  }), []);
+
+  const finalizingOverlayContent = React.useMemo<ModifierApplyOverlayContent | null>(() => {
+    // Backend finished; the UI is loading the new mesh (geometry build, GPU
+    // upload, pick-acceleration rebuild). Wins over the "Applying..." copy
+    // for the same operation, but yields to a queued hole-punch auto-apply
+    // chain, whose combined/punch messages stay accurate.
+    if (
+      finalizingModifierApply === 'hollowing'
+      && !isApplyingHolePunch
+      && pendingHolePunchAutoApplyModelId === null
+    ) {
+      return {
+        title: 'Hollowing complete — loading mesh…',
+        detailLines: [
+          'Uploading the new geometry to the viewport and rebuilding pick acceleration.',
+          'The app may pause briefly.',
+        ],
+      };
+    }
+
+    if (finalizingModifierApply === 'holePunch' && !isApplyingHollowing) {
+      return {
+        title: 'Hole punches complete — loading mesh…',
+        detailLines: [
+          'Uploading the new geometry to the viewport and rebuilding pick acceleration.',
+          'The app may pause briefly.',
+        ],
+      };
+    }
+
+    return null;
+  }, [finalizingModifierApply, isApplyingHollowing, isApplyingHolePunch, pendingHolePunchAutoApplyModelId]);
+
+  // Clears the "finalizing" overlay state once the post-apply mesh swap has
+  // genuinely settled: two consecutive presented frames with the deferred
+  // geometry work (BVH builds, disposals, flattening planes) drained. rAF
+  // only fires between presented frames, so this inherently waits out the
+  // heavy commit + GPU-upload frame as well. A 20s cap prevents a wedged
+  // queue from pinning the overlay forever.
+  React.useEffect(() => {
+    if (finalizingModifierApply === null) return;
+    let cancelled = false;
+    let rafId = 0;
+    const startedAt = performance.now();
+    let idleFrames = 0;
+    const tick = () => {
+      if (cancelled) return;
+      const busy = hasPendingBackgroundGeometryWork();
+      idleFrames = busy ? 0 : idleFrames + 1;
+      if (idleFrames >= 2 || performance.now() - startedAt > 20_000) {
+        setFinalizingModifierApply(null);
+        return;
+      }
+      rafId = requestAnimationFrame(tick);
+    };
+    rafId = requestAnimationFrame(tick);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(rafId);
+    };
+  }, [finalizingModifierApply, hasPendingBackgroundGeometryWork]);
+
+  const beginFinalizing = React.useCallback((kind: 'hollowing' | 'holePunch') => {
+    setFinalizingModifierApply(kind);
+  }, []);
+  const clearFinalizing = React.useCallback(() => {
+    setFinalizingModifierApply(null);
+  }, []);
+
+  return {
+    isFinalizing: finalizingModifierApply !== null,
+    beginFinalizing,
+    clearFinalizing,
+    finalizingOverlayContent,
+    nextPaint,
+  };
+}

--- a/src/features/mesh-modifiers/__tests__/hollowingGrid.test.ts
+++ b/src/features/mesh-modifiers/__tests__/hollowingGrid.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as THREE from 'three';
+import {
+  getRotationQuatTuple,
+  hashBlockedVoxelIndices,
+  resolveBlockedVoxelValidity,
+  rotationQuatTuplesMatch,
+} from '../hollowingGrid';
+
+test('resolveBlockedVoxelValidity decision table', () => {
+  const identity = getRotationQuatTuple(new THREE.Euler(0, 0, 0));
+  const rotated = getRotationQuatTuple(new THREE.Euler(0, 0, Math.PI / 2));
+
+  // No blockers: always valid, regardless of stamps.
+  assert.equal(resolveBlockedVoxelValidity(undefined, identity), 'valid');
+  assert.equal(
+    resolveBlockedVoxelValidity({ blockedVoxelIndices: [] }, rotated),
+    'valid',
+  );
+
+  // Legacy data (no stamp): adopt, do not destroy.
+  assert.equal(
+    resolveBlockedVoxelValidity({ blockedVoxelIndices: [1, 2] }, rotated),
+    'stamp-legacy',
+  );
+
+  // Matching stamp: valid.
+  assert.equal(
+    resolveBlockedVoxelValidity(
+      { blockedVoxelIndices: [1, 2], blockedVoxelRotationQuat: identity },
+      identity,
+    ),
+    'valid',
+  );
+
+  // Rotation changed since commit: stale.
+  assert.equal(
+    resolveBlockedVoxelValidity(
+      { blockedVoxelIndices: [1, 2], blockedVoxelRotationQuat: identity },
+      rotated,
+    ),
+    'stale',
+  );
+});
+
+test('rotationQuatTuplesMatch treats q and -q as the same rotation', () => {
+  const q = getRotationQuatTuple(new THREE.Euler(0.3, -0.7, 1.1));
+  const negated: typeof q = [-q[0], -q[1], -q[2], -q[3]];
+  assert.ok(rotationQuatTuplesMatch(q, negated));
+  const other = getRotationQuatTuple(new THREE.Euler(0.3, -0.7, 1.2));
+  assert.ok(!rotationQuatTuplesMatch(q, other));
+});
+
+test('hashBlockedVoxelIndices is order-sensitive and length-prefixed', () => {
+  assert.equal(hashBlockedVoxelIndices([1, 2, 3]), hashBlockedVoxelIndices([1, 2, 3]));
+  assert.notEqual(hashBlockedVoxelIndices([1, 2, 3]), hashBlockedVoxelIndices([3, 2, 1]));
+  assert.notEqual(hashBlockedVoxelIndices([]), hashBlockedVoxelIndices([0]));
+});

--- a/src/features/mesh-modifiers/__tests__/meshModifierStore.test.ts
+++ b/src/features/mesh-modifiers/__tests__/meshModifierStore.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as THREE from 'three';
+import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
+import type { ModelMeshModifiers } from '../types';
+import {
+  deleteStoredMeshModifiers,
+  getStoredMeshModifiers,
+  resolveModelMeshModifiers,
+  storeModelMeshModifiers,
+} from '../meshModifierStore';
+import { prepareModelGeometryForOutput } from '../prepareModelGeometry';
+
+const HOLLOWING_MODIFIERS: ModelMeshModifiers = {
+  hollowing: {
+    enabled: true,
+    bakedIntoGeometry: false,
+    mode: 'cavity',
+    voxelSizeMm: 0.65,
+    shellThicknessMm: 1.2,
+    openFace: 'z_max',
+  },
+};
+
+function makeStrippedModel(id: string): LoadedModel {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute(
+    'position',
+    new THREE.Float32BufferAttribute([0, 0, 0, 10, 0, 0, 0, 10, 0], 3),
+  );
+  geometry.computeBoundingBox();
+  const bbox = geometry.boundingBox?.clone() ?? new THREE.Box3();
+  const center = bbox.getCenter(new THREE.Vector3());
+  const size = bbox.getSize(new THREE.Vector3());
+  return {
+    id,
+    name: `${id}.stl`,
+    visible: true,
+    polygonCount: 1,
+    // Models in React state carry meshModifiers: undefined by design — the
+    // externalized store is the source of truth.
+    meshModifiers: undefined,
+    geometry: {
+      geometry,
+      bbox,
+      center,
+      size,
+      flatteningPlanes: [],
+    },
+    transform: {
+      position: new THREE.Vector3(),
+      rotation: new THREE.Euler(),
+      scale: new THREE.Vector3(1, 1, 1),
+    },
+  } as unknown as LoadedModel;
+}
+
+test('store round-trip and resolve precedence', () => {
+  const id = 'store-roundtrip-model';
+  try {
+    assert.equal(getStoredMeshModifiers(id), undefined);
+    storeModelMeshModifiers(id, HOLLOWING_MODIFIERS);
+    assert.equal(getStoredMeshModifiers(id), HOLLOWING_MODIFIERS);
+
+    // Stripped model resolves from the store.
+    assert.equal(
+      resolveModelMeshModifiers({ id, meshModifiers: undefined }),
+      HOLLOWING_MODIFIERS,
+    );
+
+    // A copy still attached to the model object wins over the store.
+    const attached: ModelMeshModifiers = { hollowing: null };
+    assert.equal(
+      resolveModelMeshModifiers({ id, meshModifiers: attached }),
+      attached,
+    );
+
+    // Storing null clears; delete is idempotent.
+    storeModelMeshModifiers(id, null);
+    assert.equal(getStoredMeshModifiers(id), undefined);
+    deleteStoredMeshModifiers(id);
+  } finally {
+    deleteStoredMeshModifiers(id);
+  }
+});
+
+// Regression test for the June 2026 externalization regression (`ecaa9186`):
+// model objects carry meshModifiers: undefined, so any output path reading
+// `model.meshModifiers` directly silently skips unbaked hollowing (and saved
+// VOXLs lose re-editability). With modifiers resolved through the store,
+// prepareModelGeometryForOutput must ATTEMPT hollowing — outside the Tauri
+// desktop runtime that attempt rejects with the "DragonFruit Desktop" error,
+// which is exactly the observable proof the modifiers were seen.
+test('output preparation resolves unbaked hollowing from the external store', async () => {
+  const id = 'stripped-hollow-model';
+  const model = makeStrippedModel(id);
+  try {
+    storeModelMeshModifiers(id, HOLLOWING_MODIFIERS);
+    await assert.rejects(
+      () => prepareModelGeometryForOutput(model),
+      /DragonFruit Desktop/,
+      'stored (externalized) hollowing modifiers were not resolved at output time',
+    );
+  } finally {
+    deleteStoredMeshModifiers(id);
+    model.geometry.geometry.dispose();
+  }
+});
+
+test('output preparation leaves unmodified models untouched', async () => {
+  const id = 'plain-model';
+  const model = makeStrippedModel(id);
+  try {
+    const prepared = await prepareModelGeometryForOutput(model);
+    assert.equal(prepared.geometry, model.geometry.geometry);
+    assert.equal(prepared.disposeAfterUse, false);
+  } finally {
+    deleteStoredMeshModifiers(id);
+    model.geometry.geometry.dispose();
+  }
+});

--- a/src/features/mesh-modifiers/__tests__/prepareModelGeometryHollowing.test.ts
+++ b/src/features/mesh-modifiers/__tests__/prepareModelGeometryHollowing.test.ts
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as THREE from 'three';
+import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
+import { prepareModelGeometryForOutput } from '../prepareModelGeometry';
+
+type InvokeCall = { cmd: string; args: unknown };
+
+// Installs a fake Tauri IPC boundary. `@tauri-apps/api/core`'s `invoke` reads
+// `window.__TAURI_INTERNALS__.invoke(cmd, args, options)` at call time
+// (node_modules/@tauri-apps/api/core.js:202), and meshHollowing.ts's
+// isTauriRuntime()/loadTauriCore() check lazily at call time, so re-installing
+// the window per test is sufficient even though loadTauriCore module-caches its
+// promise. Command names mirror the real hollowFromGeometry sequence
+// (meshHollowing.ts:199-212).
+function installFakeTauri(): InvokeCall[] {
+  const calls: InvokeCall[] = [];
+  const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  const invoke = async (cmd: string, args?: unknown) => {
+    calls.push({ cmd, args });
+    switch (cmd) {
+      case 'stage_mesh_binary_set':
+        return undefined;
+      case 'mesh_hollow_staged':
+        return JSON.stringify({ removedVoxels: 10 });
+      case 'mesh_repair_read_positions':
+        return new Uint8Array(positions.buffer.slice(0));
+      case 'mesh_hollow_staged_read_cavity_positions':
+        return new Uint8Array(0);
+      default:
+        throw new Error(`unexpected command: ${cmd}`);
+    }
+  };
+  (globalThis as { window?: unknown }).window = { __TAURI_INTERNALS__: { invoke } };
+  return calls;
+}
+
+function buildHollowedModel(
+  rotation: THREE.Euler,
+  blockedVoxelIndices: number[],
+  scale: THREE.Vector3 = new THREE.Vector3(1, 1, 1),
+): LoadedModel {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute([
+    0, 0, 0, 2, 0, 0, 0, 2, 0,
+  ], 3));
+  geometry.computeBoundingBox();
+  const bbox = geometry.boundingBox?.clone() ?? new THREE.Box3();
+  return {
+    id: 'hollow-model',
+    name: 'hollow-model.stl',
+    visible: true,
+    polygonCount: 1,
+    geometry: {
+      geometry,
+      bbox,
+      center: bbox.getCenter(new THREE.Vector3()),
+      size: bbox.getSize(new THREE.Vector3()),
+      flatteningPlanes: [],
+    },
+    transform: {
+      position: new THREE.Vector3(),
+      rotation,
+      scale,
+    },
+    meshModifiers: {
+      hollowing: {
+        enabled: true,
+        bakedIntoGeometry: false,
+        blockedVoxelIndices,
+        mode: 'cavity',
+        voxelSizeMm: 0.5,
+        shellThicknessMm: 2,
+        openFace: 'z_max',
+      },
+    },
+  } as unknown as LoadedModel;
+}
+
+test('slice-time hollowing forwards painted blocked voxel indices', async () => {
+  const calls = installFakeTauri();
+  try {
+    const model = buildHollowedModel(new THREE.Euler(0, 0, 0), [3, 5, 8]);
+    await prepareModelGeometryForOutput(model);
+
+    const hollowCall = calls.find((call) => call.cmd === 'mesh_hollow_staged');
+    assert.ok(hollowCall, 'expected mesh_hollow_staged to be invoked');
+    const options = JSON.parse(
+      (hollowCall.args as { optionsJson: string }).optionsJson,
+    ) as { blockedVoxelIndices?: number[] };
+    assert.deepEqual(
+      options.blockedVoxelIndices,
+      [3, 5, 8],
+      'painted blockers must reach the slice-time hollow, not be silently dropped',
+    );
+  } finally {
+    delete (globalThis as { window?: unknown }).window;
+  }
+});
+
+test('slice-time hollow cache misses when the model rotation changes', async () => {
+  const calls = installFakeTauri();
+  try {
+    const modelA = buildHollowedModel(new THREE.Euler(0, 0, 0), []);
+    await prepareModelGeometryForOutput(modelA);
+
+    // Same geometry object (same uuid/versions), different rotation — today
+    // this is a cache HIT and the stale-orientation cavity is served.
+    const modelB = {
+      ...modelA,
+      transform: {
+        ...modelA.transform,
+        rotation: new THREE.Euler(0, 0, Math.PI / 2),
+      },
+    } as LoadedModel;
+    await prepareModelGeometryForOutput(modelB);
+
+    const hollowCalls = calls.filter((call) => call.cmd === 'mesh_hollow_staged');
+    assert.equal(
+      hollowCalls.length,
+      2,
+      'rotating the model must invalidate the prepared-geometry cache',
+    );
+    const optionsB = JSON.parse(
+      (hollowCalls[1].args as { optionsJson: string }).optionsJson,
+    ) as { rotationQuat?: number[] };
+    assert.ok(
+      Math.abs((optionsB.rotationQuat?.[2] ?? 0) - Math.sin(Math.PI / 4)) < 1e-6,
+      'second hollow must be computed at the new rotation',
+    );
+  } finally {
+    delete (globalThis as { window?: unknown }).window;
+  }
+});
+
+test('slice-time hollow cache misses when the painted blockers change', async () => {
+  const calls = installFakeTauri();
+  try {
+    const modelA = buildHollowedModel(new THREE.Euler(0, 0, 0), [1, 2]);
+    await prepareModelGeometryForOutput(modelA);
+
+    // Same geometry object + rotation, different painted blockers. Today the
+    // signature ignores blockedVoxelIndices → cache HIT → the previous cavity
+    // (computed without the new blockers) is served.
+    const modelB = {
+      ...modelA,
+      meshModifiers: {
+        hollowing: {
+          ...(modelA.meshModifiers?.hollowing ?? {}),
+          blockedVoxelIndices: [1, 2, 3],
+        },
+      },
+    } as LoadedModel;
+    await prepareModelGeometryForOutput(modelB);
+
+    const hollowCalls = calls.filter((call) => call.cmd === 'mesh_hollow_staged');
+    assert.equal(
+      hollowCalls.length,
+      2,
+      'changing painted blockers must invalidate the prepared-geometry cache',
+    );
+    const optionsB = JSON.parse(
+      (hollowCalls[1].args as { optionsJson: string }).optionsJson,
+    ) as { blockedVoxelIndices?: number[] };
+    assert.deepEqual(optionsB.blockedVoxelIndices, [1, 2, 3]);
+  } finally {
+    delete (globalThis as { window?: unknown }).window;
+  }
+});
+
+test('slice-time hollow converts world-mm params to local-mm on scaled models', async () => {
+  const calls = installFakeTauri();
+  try {
+    // Uniform scale ×2: the voxel grid lives in local space, so a 2 mm world
+    // shell must be forwarded as a 1 mm local shell — the same conversion the
+    // preview and Apply paths already apply. Today the raw world value leaks
+    // through, painting blockers onto a mismatched grid on scaled models.
+    const model = buildHollowedModel(
+      new THREE.Euler(0, 0, 0),
+      [],
+      new THREE.Vector3(2, 2, 2),
+    );
+    await prepareModelGeometryForOutput(model);
+
+    const hollowCall = calls.find((call) => call.cmd === 'mesh_hollow_staged');
+    assert.ok(hollowCall, 'expected mesh_hollow_staged to be invoked');
+    const options = JSON.parse(
+      (hollowCall.args as { optionsJson: string }).optionsJson,
+    ) as { shellThicknessMm?: number };
+    assert.ok(
+      Math.abs((options.shellThicknessMm ?? 0) - 1) < 1e-9,
+      `scaled-model shell must be world→local converted (expected 1, got ${options.shellThicknessMm})`,
+    );
+  } finally {
+    delete (globalThis as { window?: unknown }).window;
+  }
+});

--- a/src/features/mesh-modifiers/hollowingGrid.ts
+++ b/src/features/mesh-modifiers/hollowingGrid.ts
@@ -1,0 +1,80 @@
+import * as THREE from 'three';
+import type { ModelHollowingModifier } from './types';
+
+// The world↔local scaling helpers live in utils/geometryScaling (shared with
+// the hollowing manager and other transform consumers); re-exported here so
+// hollowing-grid callers keep a single import site for grid math.
+export {
+  getUniformScaleFactorForThickness,
+  worldMmToLocalMm,
+  computeVoxelResolution,
+} from '@/utils/geometryScaling';
+
+export type RotationQuatTuple = [number, number, number, number];
+
+/** Order-sensitive FNV-1a hash over blocked voxel indices. Used in cache
+ *  signatures instead of JSON.stringify (a large lasso selection would
+ *  otherwise serialize to tens of MB of key string — see audit item #23). */
+export function hashBlockedVoxelIndices(indices: readonly number[]): string {
+  let hash = 0x811c9dc5;
+  for (const value of indices) {
+    hash ^= value & 0xffff;
+    hash = Math.imul(hash, 0x01000193);
+    hash ^= (value >>> 16) & 0xffff;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${indices.length}:${(hash >>> 0).toString(16)}`;
+}
+
+export function getRotationQuatTuple(rotation: THREE.Euler): RotationQuatTuple {
+  const quat = new THREE.Quaternion().setFromEuler(rotation);
+  return [quat.x, quat.y, quat.z, quat.w];
+}
+
+/** True when two quaternions encode the same rotation. q and -q are the same
+ *  rotation (double cover), so compare via |dot| instead of componentwise. */
+export function rotationQuatTuplesMatch(
+  a: RotationQuatTuple,
+  b: RotationQuatTuple,
+  epsilon = 1e-6,
+): boolean {
+  const dot = a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3];
+  return Math.abs(dot) >= 1 - epsilon;
+}
+
+/** Rotation folded into cache signatures: quantized to 1e-5 so float noise
+ *  below the harmless-drift threshold (see audit "Verified-OK": quaternion
+ *  round-trip drift ~1e-5 mm) cannot thrash keys, and sign-canonicalized so
+ *  q and -q agree. */
+export function buildRotationSignature(rotation: THREE.Euler): string {
+  const quat = new THREE.Quaternion().setFromEuler(rotation);
+  const sign = quat.w < 0 ? -1 : 1;
+  const q = (v: number) => Math.round(sign * v * 1e5) / 1e5;
+  return `${q(quat.x)},${q(quat.y)},${q(quat.z)},${q(quat.w)}`;
+}
+
+export type BlockedVoxelValidity = 'valid' | 'stamp-legacy' | 'stale';
+
+/** Decides what to do with a model's committed blocked voxels given its
+ *  current scene rotation:
+ *  - 'valid':        rotation still matches the commit-time stamp (or there
+ *                    are no blockers);
+ *  - 'stamp-legacy': blockers predate the rotation stamp (data persisted
+ *                    before this change) — adopt the current rotation as the
+ *                    stamp rather than destroying the user's selection;
+ *  - 'stale':        rotation changed since commit — the linear indices
+ *                    address a different rotation-aligned grid and must be
+ *                    cleared. */
+export function resolveBlockedVoxelValidity(
+  hollowing:
+    | Pick<ModelHollowingModifier, 'blockedVoxelIndices' | 'blockedVoxelRotationQuat'>
+    | null
+    | undefined,
+  currentQuat: RotationQuatTuple,
+): BlockedVoxelValidity {
+  if (!hollowing?.blockedVoxelIndices?.length) return 'valid';
+  if (!hollowing.blockedVoxelRotationQuat) return 'stamp-legacy';
+  return rotationQuatTuplesMatch(hollowing.blockedVoxelRotationQuat, currentQuat)
+    ? 'valid'
+    : 'stale';
+}

--- a/src/features/mesh-modifiers/meshModifierStore.ts
+++ b/src/features/mesh-modifiers/meshModifierStore.ts
@@ -1,0 +1,50 @@
+import type { ModelMeshModifiers } from './types';
+
+// Mesh modifiers (which can carry very large payloads, e.g. hollowing
+// sourcePositionsBase64 from LYS imports) are kept in this module-level Map
+// instead of on model objects. This prevents React's state reconciliation
+// from churning on large payloads during selection, copy, paste, and
+// duplicate operations.
+//
+// IMPORTANT for anything that persists or exports models: model objects in
+// React state carry `meshModifiers: undefined` by design. Any code that
+// serializes models (VOXL save, autosave, scene export) or applies modifiers
+// at output time (slicing) must resolve modifiers through this store — use
+// `resolveModelMeshModifiers` — or it will silently persist nothing. That
+// exact omission shipped in the June 2026 externalization refactor and made
+// every VOXL saved afterward lose hollowing/hole-punch re-editability.
+const meshModifierStoreRef: { current: Map<string, ModelMeshModifiers> } = {
+  current: new Map(),
+};
+
+export function storeModelMeshModifiers(
+  modelId: string,
+  modifiers: ModelMeshModifiers | undefined | null,
+): void {
+  if (modifiers) {
+    meshModifierStoreRef.current.set(modelId, modifiers);
+  } else {
+    meshModifierStoreRef.current.delete(modelId);
+  }
+}
+
+export function getStoredMeshModifiers(modelId: string): ModelMeshModifiers | undefined {
+  return meshModifierStoreRef.current.get(modelId);
+}
+
+export function deleteStoredMeshModifiers(modelId: string): void {
+  meshModifierStoreRef.current.delete(modelId);
+}
+
+/**
+ * Resolves a model's mesh modifiers, preferring any copy still attached to
+ * the model object (pre-externalization data, tests) and falling back to
+ * the external store. Every save/export/slice boundary must use this
+ * instead of reading `model.meshModifiers` directly.
+ */
+export function resolveModelMeshModifiers(model: {
+  id: string;
+  meshModifiers?: ModelMeshModifiers;
+}): ModelMeshModifiers | undefined {
+  return model.meshModifiers ?? getStoredMeshModifiers(model.id);
+}

--- a/src/features/mesh-modifiers/prepareModelGeometry.ts
+++ b/src/features/mesh-modifiers/prepareModelGeometry.ts
@@ -1,6 +1,16 @@
 import * as THREE from 'three';
 import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
-import type { ModelHolePunchPlacement } from './types';
+import type { ModelHolePunchPlacement, ModelHollowingModifier } from './types';
+import { resolveModelMeshModifiers } from './meshModifierStore';
+import {
+  buildRotationSignature,
+  computeVoxelResolution,
+  getRotationQuatTuple,
+  getUniformScaleFactorForThickness,
+  hashBlockedVoxelIndices,
+  resolveBlockedVoxelValidity,
+  worldMmToLocalMm,
+} from './hollowingGrid';
 import { hollowFromGeometry, type HollowOptions } from '@/utils/meshHollowing';
 import { punchFromGeometry, type PunchOptions } from '@/utils/meshPunching';
 import { splitClassifiedSupportGeometry } from '@/features/scene/splitClassifiedSupports';
@@ -31,8 +41,27 @@ function computeGeometrySignature(geometry: THREE.BufferGeometry): string {
   return `${geometry.uuid}:${vertexCount}:${positionVersion}:${indexVersion}`;
 }
 
+// The blocked voxels forwarded to slice-time hollowing (and folded into the
+// cache signature) must be the same list. Item #7's invalidation effect clears
+// stale blockers in the UI; if a stale set still reaches slice time (rotation
+// changed in the same frame, or the effect never ran), dropping them beats
+// hollowing against a mismatched grid. Callers pass the store-resolved
+// `hollowing`, never `model.meshModifiers?.hollowing` directly.
+function getEffectiveBlockedVoxelIndices(
+  model: LoadedModel,
+  hollowing: ModelHollowingModifier,
+): number[] {
+  const blocked = hollowing.blockedVoxelIndices ?? [];
+  if (blocked.length === 0) return blocked;
+  const currentQuat = getRotationQuatTuple(model.transform.rotation);
+  if (resolveBlockedVoxelValidity(hollowing, currentQuat) === 'stale') {
+    return [];
+  }
+  return blocked;
+}
+
 function buildModifierSignature(model: LoadedModel): string | null {
-  const modifiers = model.meshModifiers;
+  const modifiers = resolveModelMeshModifiers(model);
   const hollowing = modifiers?.hollowing?.enabled && !modifiers.hollowing.bakedIntoGeometry
     ? modifiers.hollowing
     : null;
@@ -54,6 +83,20 @@ function buildModifierSignature(model: LoadedModel): string | null {
       infillCellMm: hollowing.infillCellMm ?? 4.2426,
       infillBeamRadiusMm: hollowing.infillBeamRadiusMm ?? 0.35,
       openFace: hollowing.openFace,
+      // Rotation and scale change the Rust voxel grid; the blocker hash changes
+      // the keep mask. Geometry version does not change on transform (rotation
+      // is a transform, geometry is local-space), so without these the cache
+      // would serve a cavity computed at a stale rotation/scale/blocker set.
+      // Hash (not the raw array) keeps the key O(1)-sized for large lasso
+      // selections (audit #23); it covers the *effective* (validity-filtered)
+      // list so the signature matches what is actually forwarded.
+      rotation: buildRotationSignature(model.transform.rotation),
+      scaleFactor: Number(
+        getUniformScaleFactorForThickness(model.transform.scale).toFixed(6),
+      ),
+      blockedVoxelIndicesHash: hashBlockedVoxelIndices(
+        getEffectiveBlockedVoxelIndices(model, hollowing),
+      ),
     } : null,
     holePunches: punches.map((placement) => ({
       centerNorm: placement.centerNorm,
@@ -205,7 +248,10 @@ export async function prepareModelGeometryForOutput(model: LoadedModel): Promise
     }
   }
 
-  const modifiers = model.meshModifiers;
+  // Model objects in React state deliberately carry meshModifiers: undefined
+  // (externalized store) — resolve through the store or unbaked hollowing is
+  // silently skipped at slice/export time.
+  const modifiers = resolveModelMeshModifiers(model);
   const hollowing = modifiers?.hollowing;
   const shouldApplyHollowing = Boolean(hollowing?.enabled && !hollowing.bakedIntoGeometry);
   // Hole punches are never auto-applied during slice/export — the user must
@@ -232,15 +278,27 @@ export async function prepareModelGeometryForOutput(model: LoadedModel): Promise
 
   if (shouldApplyHollowing && hollowing) {
     const maxExtent = Math.max(sourceBounds.size.x, sourceBounds.size.y, sourceBounds.size.z);
-    const voxelResolution = Math.min(192, Math.max(24, Math.round(maxExtent / Math.max(0.05, hollowing.voxelSizeMm))));
+    // The voxel grid lives in the model's local space, so world-space mm params
+    // (voxel size, shell thickness, infill dims) must be converted to local mm
+    // before hollowing — the same conversion the preview (buildHollowingOptions)
+    // and Apply paths already apply. For unscaled models this is an exact no-op
+    // (worldMmToLocalMm(v, 1) === max(1e-4, v)); scaled models now slice against
+    // the same grid the preview showed, so forwarded blockers land on the right
+    // voxels.
+    const scaleFactor = getUniformScaleFactorForThickness(model.transform.scale);
+    const voxelResolution = computeVoxelResolution(
+      worldMmToLocalMm(hollowing.voxelSizeMm, scaleFactor),
+      maxExtent,
+    );
     const quat = new THREE.Quaternion().setFromEuler(model.transform.rotation);
     const hollowOptions: HollowOptions = {
       mode: hollowing.mode,
       voxelResolution,
-      shellThicknessMm: hollowing.shellThicknessMm,
+      shellThicknessMm: worldMmToLocalMm(hollowing.shellThicknessMm, scaleFactor),
+      blockedVoxelIndices: getEffectiveBlockedVoxelIndices(model, hollowing),
       infillMode: hollowing.infillMode ?? 'lattice',
-      infillCellMm: hollowing.infillCellMm ?? 4.2426,
-      infillBeamRadiusMm: hollowing.infillBeamRadiusMm ?? 0.35,
+      infillCellMm: worldMmToLocalMm(hollowing.infillCellMm ?? 4.2426, scaleFactor),
+      infillBeamRadiusMm: worldMmToLocalMm(hollowing.infillBeamRadiusMm ?? 0.35, scaleFactor),
       openFace: hollowing.openFace,
       drainHoles: [],
       previewCavityOnly: false,

--- a/src/features/mesh-modifiers/types.ts
+++ b/src/features/mesh-modifiers/types.ts
@@ -12,6 +12,11 @@ export type ModelHollowingModifier = {
   /** Number of vertices in the cavity mesh (count × 3 = float count). */
   cavityPositionCount?: number;
   blockedVoxelIndices?: number[];
+  /** Scene rotation (unit quaternion [x, y, z, w]) captured when
+   *  blockedVoxelIndices were committed. Blocker indices address the
+   *  rotation-aligned voxel grid, so they are only meaningful while the
+   *  model's rotation still matches this stamp. */
+  blockedVoxelRotationQuat?: [number, number, number, number];
   mode: MeshModifierHollowMode;
   voxelSizeMm: number;
   shellThicknessMm: number;

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -38,6 +38,11 @@ import {
   subscribeToProfileStore,
 } from '@/features/profiles/profileStore';
 import type { ModelMeshModifiers } from '@/features/mesh-modifiers/types';
+import {
+  deleteStoredMeshModifiers,
+  getStoredMeshModifiers,
+  storeModelMeshModifiers,
+} from '@/features/mesh-modifiers/meshModifierStore';
 import { splitClassifiedSupportGeometry } from '@/features/scene/splitClassifiedSupports';
 
 type PersistedMeshAppearance = {
@@ -89,6 +94,11 @@ const RECENT_FILES_DB_VERSION = 1;
 const RECENT_FILES_STORE_NAME = 'files';
 const SCENE_MODELS_SNAPSHOT_APPLY = 'scene_models_snapshot_apply';
 const SCENE_HISTORY_MAX_SNAPSHOTS = 200;
+// Belt-and-suspenders alongside the count cap above: a handful of
+// full-resolution geometry swaps (e.g. repeated hollowing on a large model)
+// can retain far more memory per snapshot than typical small edits, so the
+// flat count cap alone can leave a lot of stale geometry pinned alive.
+const SCENE_HISTORY_MAX_ESTIMATED_GEOMETRY_BYTES = 300 * 1024 * 1024;
 
 type SceneSnapshotPayload = { key: string };
 
@@ -172,29 +182,13 @@ function cloneMeshModifiersShallow(modifiers: ModelMeshModifiers): ModelMeshModi
 // ── External Mesh Modifier Store ─────────────────────────────────────────
 //
 // Model mesh modifiers (especially the MB-scale cavityPositionsBase64 /
-// sourcePositionsBase64 from LYS imports) are kept in this module-level Map
-// instead of on model objects. This prevents React's state reconciliation
-// from churning on large payloads during selection, copy, paste, and
-// duplicate operations.
-const meshModifierStoreRef: { current: Map<string, ModelMeshModifiers> } = {
-  current: new Map(),
-};
-
-function storeModelMeshModifiers(modelId: string, modifiers: ModelMeshModifiers | undefined | null): void {
-  if (modifiers) {
-    meshModifierStoreRef.current.set(modelId, modifiers);
-  } else {
-    meshModifierStoreRef.current.delete(modelId);
-  }
-}
-
-function getStoredMeshModifiers(modelId: string): ModelMeshModifiers | undefined {
-  return meshModifierStoreRef.current.get(modelId);
-}
-
-function deleteStoredMeshModifiers(modelId: string): void {
-  meshModifierStoreRef.current.delete(modelId);
-}
+// sourcePositionsBase64 from LYS imports) are kept in a module-level Map in
+// features/mesh-modifiers/meshModifierStore.ts instead of on model objects.
+// This prevents React's state reconciliation from churning on large payloads
+// during selection, copy, paste, and duplicate operations. Save/export/slice
+// boundaries must resolve modifiers through that store (see
+// resolveModelMeshModifiers) — model objects carry meshModifiers: undefined
+// by design.
 
 function schedulePostPaint(callback: () => void): void {
   if (typeof window === 'undefined') {
@@ -254,12 +248,53 @@ function hasSupportsOrKickstandsForModel(
   return Object.values(kickstandState.kickstands).some((kickstand) => kickstand.modelId === modelId);
 }
 
+function estimateGeometryBytes(geometry: THREE.BufferGeometry): number {
+  let total = 0;
+  for (const key in geometry.attributes) {
+    const attribute = geometry.attributes[key];
+    if (attribute?.array) {
+      total += (attribute.array as ArrayBufferView).byteLength;
+    }
+  }
+  if (geometry.index?.array) {
+    total += (geometry.index.array as ArrayBufferView).byteLength;
+  }
+  return total;
+}
+
+// Deliberately not deduplicated across snapshots/models: many pairs will
+// reference the same unchanged geometry, so this over-counts rather than
+// under-counts. That's the right direction for a safety cap -- it can only
+// make eviction more eager than strictly necessary, never less.
+function estimateSceneSnapshotRegistryBytes(): number {
+  let total = 0;
+  for (const pair of sceneSnapshotRegistry.values()) {
+    for (const model of pair.before.models) {
+      total += estimateGeometryBytes(model.geometry.geometry);
+    }
+    for (const model of pair.after.models) {
+      total += estimateGeometryBytes(model.geometry.geometry);
+    }
+  }
+  return total;
+}
+
 function storeSceneSnapshotPair(pair: SceneSnapshotPair): string {
   const key = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
   sceneSnapshotRegistry.set(key, pair);
   sceneSnapshotOrder.push(key);
 
   while (sceneSnapshotOrder.length > SCENE_HISTORY_MAX_SNAPSHOTS) {
+    const removed = sceneSnapshotOrder.shift();
+    if (removed) sceneSnapshotRegistry.delete(removed);
+  }
+
+  // Always keep at least one snapshot so undo of the most recent action
+  // still works, even if it alone exceeds the byte budget.
+  while (
+    sceneSnapshotOrder.length > 1
+    && estimateSceneSnapshotRegistryBytes() > SCENE_HISTORY_MAX_ESTIMATED_GEOMETRY_BYTES
+  ) {
     const removed = sceneSnapshotOrder.shift();
     if (removed) sceneSnapshotRegistry.delete(removed);
   }
@@ -1028,6 +1063,9 @@ export function useSceneCollectionManager() {
   const deferredAccelerationPausedRef = useRef(false);
   const deferredDisposalQueueRef = useRef<THREE.BufferGeometry[]>([]);
   const deferredDisposalProcessingRef = useRef(false);
+  // Count of scheduled-but-unfinished flattening-plane computations (idle
+  // callbacks after geometry swaps). Part of hasPendingBackgroundGeometryWork.
+  const pendingFlatteningPlanesRef = useRef(0);
   const trackedGeometriesRef = useRef<Set<THREE.BufferGeometry>>(new Set());
 
   const tryRevokeObjectUrl = useCallback((url: string) => {
@@ -1792,6 +1830,21 @@ export function useSceneCollectionManager() {
     }
   }, [processDeferredAccelerationQueue]);
 
+  /**
+   * True while deferred post-swap geometry work (BVH acceleration builds,
+   * deferred geometry disposals, flattening-plane computation) is queued or
+   * running. Lets the UI keep a blocking "finalizing" indicator visible
+   * until the app is genuinely responsive again after a large geometry swap
+   * — the swap itself resolves long before this work drains.
+   */
+  const hasPendingBackgroundGeometryWork = useCallback(() => (
+    deferredAccelerationQueueRef.current.length > 0
+    || deferredAccelerationProcessingRef.current
+    || deferredDisposalQueueRef.current.length > 0
+    || deferredDisposalProcessingRef.current
+    || pendingFlatteningPlanesRef.current > 0
+  ), []);
+
   const processDeferredDisposalQueue = useCallback(() => {
     if (deferredDisposalProcessingRef.current) return;
     if (deferredDisposalQueueRef.current.length === 0) return;
@@ -2524,14 +2577,19 @@ export function useSceneCollectionManager() {
           setTimeout(cb, 16);
         }
       };
+      pendingFlatteningPlanesRef.current += 1;
       scheduleIdle(() => {
-        const planes = computeFlatteningPlanes(nextBufferGeometry);
-        nextGeometry.flatteningPlanes = planes;
-        setModels((prev) => prev.map((m) => (
-          m.id === id && m.geometry.geometry === nextBufferGeometry
-            ? { ...m, geometry: { ...m.geometry, flatteningPlanes: planes } }
-            : m
-        )));
+        try {
+          const planes = computeFlatteningPlanes(nextBufferGeometry);
+          nextGeometry.flatteningPlanes = planes;
+          setModels((prev) => prev.map((m) => (
+            m.id === id && m.geometry.geometry === nextBufferGeometry
+              ? { ...m, geometry: { ...m.geometry, flatteningPlanes: planes } }
+              : m
+          )));
+        } finally {
+          pendingFlatteningPlanesRef.current = Math.max(0, pendingFlatteningPlanesRef.current - 1);
+        }
       });
     }
 
@@ -2578,13 +2636,18 @@ export function useSceneCollectionManager() {
         setTimeout(cb, 16);
       }
     };
+    pendingFlatteningPlanesRef.current += 1;
     scheduleIdle(() => {
-      const planes = computeFlatteningPlanes(geom);
-      setModels((prev) => prev.map((m) => (
-        m.id === id && m.geometry.geometry === geom
-          ? { ...m, geometry: { ...m.geometry, flatteningPlanes: planes } }
-          : m
-      )));
+      try {
+        const planes = computeFlatteningPlanes(geom);
+        setModels((prev) => prev.map((m) => (
+          m.id === id && m.geometry.geometry === geom
+            ? { ...m, geometry: { ...m.geometry, flatteningPlanes: planes } }
+            : m
+        )));
+      } finally {
+        pendingFlatteningPlanesRef.current = Math.max(0, pendingFlatteningPlanesRef.current - 1);
+      }
     });
   }, [deferAccelerateGeometry]);
 
@@ -4788,6 +4851,7 @@ export function useSceneCollectionManager() {
     pasteCopiedModelsAutoArrange,
     duplicateModelWithTransforms,
     setBackgroundGeometryWorkPaused,
+    hasPendingBackgroundGeometryWork,
     canPasteModel: modelClipboard.length > 0,
 
     // Scene settings

--- a/src/utils/meshHollowing.ts
+++ b/src/utils/meshHollowing.ts
@@ -65,6 +65,25 @@ export interface HollowResult {
   removedVoxelCenters?: Float32Array;
   removedVoxelIndices?: Uint32Array;
   blockedVoxelCenters?: Float32Array;
+  blockedVoxelIndices?: Uint32Array;
+}
+
+/** Request for the Rust-side lasso voxel selection. Mirrors the model
+ *  transform + camera projection the frontend lasso resolver used before the
+ *  per-voxel projection moved into Rust. */
+export interface SelectRemovedVoxelsInPolygonRequest {
+  /** Lasso polygon in container-pixel space (same space as the resolver's
+   *  projectWorldPoint output): [[px, py], ...]. */
+  polygon: Array<[number, number]>;
+  /** Column-major camera.projectionMatrix * matrixWorldInverse (16 floats). */
+  viewProj: number[];
+  rectWidth: number;
+  rectHeight: number;
+  geometryCenter: [number, number, number];
+  scale: [number, number, number];
+  rotationQuat: [number, number, number, number];
+  position: [number, number, number];
+  options: HollowOptions;
 }
 
 export function isTauriRuntime(): boolean {
@@ -145,7 +164,9 @@ async function readPositionsFromCommand(
 
 async function readUint32FromCommand(
   invoke: TauriInvoke,
-  command: 'mesh_hollow_preview_read_removed_voxel_indices',
+  command:
+    | 'mesh_hollow_preview_read_removed_voxel_indices'
+    | 'mesh_hollow_preview_read_blocked_voxel_indices',
 ): Promise<Uint32Array> {
   const bytes = await invoke<ArrayBuffer | Uint8Array | number[]>(command);
   let u8: Uint8Array;
@@ -268,7 +289,13 @@ export async function hollowPreviewFromCapturedSource(
   } catch {
     blockedVoxelCenters = undefined;
   }
-  return { report, positions, cavityPositions, infillPositions, removedVoxelCenters, removedVoxelIndices, blockedVoxelCenters };
+  let blockedVoxelIndices: Uint32Array | undefined;
+  try {
+    blockedVoxelIndices = await readUint32FromCommand(core.invoke, 'mesh_hollow_preview_read_blocked_voxel_indices');
+  } catch {
+    blockedVoxelIndices = undefined;
+  }
+  return { report, positions, cavityPositions, infillPositions, removedVoxelCenters, removedVoxelIndices, blockedVoxelCenters, blockedVoxelIndices };
 }
 
 export async function hollowApplyFromCapturedSource(
@@ -288,6 +315,37 @@ export async function hollowApplyFromCapturedSource(
     cavityPositions = undefined;
   }
   return { report, positions, cavityPositions };
+}
+
+/** Rust-side lasso selection of the FULL through-depth cavity voxel column
+ *  under the polygon. Returns the selected grid indices, or null outside the
+ *  Tauri runtime. Decoupled from the boundary-filtered / capped rendered set,
+ *  which is why selection can no longer only reach the surface layer. */
+export async function selectRemovedVoxelsInPolygon(
+  request: SelectRemovedVoxelsInPolygonRequest,
+): Promise<Uint32Array | null> {
+  const core = await loadTauriCore();
+  if (!core) return null;
+
+  const requestJson = JSON.stringify(request);
+  const bytes = await core.invoke<ArrayBuffer | Uint8Array | number[]>(
+    'mesh_hollow_preview_select_removed_voxels_in_polygon',
+    { requestJson },
+  );
+  let u8: Uint8Array;
+  if (bytes instanceof ArrayBuffer) {
+    u8 = new Uint8Array(bytes);
+  } else if (bytes instanceof Uint8Array) {
+    u8 = bytes;
+  } else if (Array.isArray(bytes)) {
+    u8 = new Uint8Array(bytes);
+  } else {
+    throw new Error('mesh_hollow_preview_select_removed_voxels_in_polygon returned unexpected type');
+  }
+
+  const copy = new Uint8Array(u8.byteLength);
+  copy.set(u8);
+  return new Uint32Array(copy.buffer);
 }
 
 export function applyHollowedPositions(geometry: THREE.BufferGeometry, positions: Float32Array): void {


### PR DESCRIPTION
This comprises several fixes and improvements for voxel hollowing.  
Key issues addressed: 

- #349 Results in partial and full browser crash on the UI side while Rust hollowing is still running in the background.  Test case is physically large and/or high poly (>1M) models. 
- #356 VOXL saving misses mesh-modifier data making hollowing un-editable between sessions. Likely regression source ecaa9186.
- #357 Visual corruption in the hollowing mesh.