### PR TITLE
feat: add uniformation plugin submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "plugins/lys-import"]
 	path = plugins/lys-import
 	url = https://github.com/Open-Resin-Alliance/df-plugin-lys
+[submodule "plugins/uniformation"]
+	path = plugins/uniformation
+	url = ../df-plugin-uniformation.git

--- a/src/config/complex-plugin-allowlist.json
+++ b/src/config/complex-plugin-allowlist.json
@@ -18,6 +18,9 @@
     },
     {
       "id": "sdcp-v3"
+    },
+    {
+      "id": "uniformation"
     }
   ]
 }


### PR DESCRIPTION
This pull request adds the new `uniformation` plugin to the project as a git submodule and updates the plugin allowlist to include it. This enables the use of the `uniformation` plugin within the codebase.

**Plugin integration:**

* Added `plugins/uniformation` as a git submodule, referencing the `df-plugin-uniformation` repository. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R19-R21) [[2]](diffhunk://#diff-75948cebd9d2588bb3e95418495ceed1bc560402b6adeb11e177540abff86bc4R1)

**Configuration updates:**

* Updated `src/config/complex-plugin-allowlist.json` to include `uniformation` in the allowlist, permitting its use as a complex plugin.