### PR TITLE
fix: remove duplicated hotkey handlers, fix double paste

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8169,96 +8169,8 @@ export default function Home() {
   }, [isSelectAllModelsActive]);
 
 
-  const selectAllActive = useActionActive('CANVAS', 'SELECT_ALL');
-  const copyActive = useActionActive('CANVAS', 'COPY');
-  const pasteActive = useActionActive('CANVAS', 'PASTE');
-  const saveActive = useActionActive('GLOBAL', 'SAVE');
   const saveAsActive = useActionActive('GLOBAL', 'SAVE_AS');
-  const wasSelectAllActive = React.useRef(false);
-  const wasCopyActive = React.useRef(false);
-  const wasPasteActive = React.useRef(false);
-  const wasSaveActive = React.useRef(false);
   const wasSaveAsActive = React.useRef(false);
-
-  React.useEffect(() => {
-    if (!selectAllActive || wasSelectAllActive.current) {
-      wasSelectAllActive.current = selectAllActive;
-      return;
-    }
-    wasSelectAllActive.current = true;
-
-    if (scene.models.length === 0) return;
-    const visibleIds = scene.models.filter((model) => model.visible).map((model) => model.id);
-    if (visibleIds.length > 0) {
-      scene.setSelectedModelIds(visibleIds);
-      scene.setActiveModelId(visibleIds[0]);
-    }
-    setIsSelectAllModelsActive(true);
-  }, [selectAllActive, scene, setIsSelectAllModelsActive]);
-
-  React.useEffect(() => {
-    if (!copyActive || wasCopyActive.current) {
-      wasCopyActive.current = copyActive;
-      return;
-    }
-    wasCopyActive.current = true;
-
-    if (scene.mode !== 'prepare') return;
-    if (scene.selectedModelIds.length === 0 && !scene.activeModelId) return;
-    if (scene.selectedModelIds.length > 0) {
-      scene.copySelectedModels();
-    } else if (scene.activeModelId) {
-      scene.copyModel(scene.activeModelId);
-    }
-  }, [copyActive, scene]);
-
-  React.useEffect(() => {
-    if (!pasteActive || wasPasteActive.current) {
-      wasPasteActive.current = pasteActive;
-      return;
-    }
-    wasPasteActive.current = true;
-
-    if (scene.mode !== 'prepare') return;
-    if (!scene.canPasteModel) return;
-    const pastedIds = scene.pasteCopiedModelsAutoArrange(arrangeSpacingMm);
-    // Paste shares geometry with the source — add its cached volume directly
-    // instead of waiting for the async resin effect loop.
-    if (pastedIds.length > 0 && printingEstimatedResinMlRef.current != null) {
-      const pastedModel = scene.models.find((m) => pastedIds.includes(m.id));
-      if (pastedModel) {
-        const geom = pastedModel.geometry.geometry;
-        const pos = geom.getAttribute('position');
-        const idx = geom.getIndex();
-        const sourceKey = String(geom.userData?.resinVolumeSourceKey ?? geom.uuid);
-        const posVer = (pos as { version?: number; data?: { version?: number } }).version
-          ?? (pos as { version?: number; data?: { version?: number } }).data?.version ?? 0;
-        const idxVer = (idx as { version?: number } | null)?.version ?? 0;
-        const cacheKey = `${sourceKey}:${posVer}:${idxVer}`;
-        const cachedMl = printingBaseResinMlCacheRef.current.get(cacheKey) ?? null;
-        if (cachedMl != null) {
-          const sx = Math.abs(pastedModel.transform.scale.x || 1);
-          const sy = Math.abs(pastedModel.transform.scale.y || 1);
-          const sz = Math.abs(pastedModel.transform.scale.z || 1);
-          const addedMl = cachedMl * sx * sy * sz;
-          const nextTotal = (printingEstimatedResinMlRef.current - supportAndRaftResinMl) + addedMl + supportAndRaftResinMl;
-          printingEstimatedResinMlRef.current = nextTotal;
-          setPrintingEstimatedResinMl(nextTotal);
-        }
-      }
-    }
-  }, [pasteActive, scene, arrangeSpacingMm, printingEstimatedResinMlRef, supportAndRaftResinMl, printingBaseResinMlCacheRef, setPrintingEstimatedResinMl]);
-
-  React.useEffect(() => {
-    if (!saveActive || wasSaveActive.current) {
-      wasSaveActive.current = saveActive;
-      return;
-    }
-    wasSaveActive.current = true;
-
-    if (scene.models.length === 0) return;
-    void handleTopBarSaveScene();
-  }, [saveActive, scene.models.length, handleTopBarSaveScene]);
 
   React.useEffect(() => {
     if (!saveAsActive || wasSaveAsActive.current) {
@@ -8672,7 +8584,32 @@ export default function Home() {
 
       if (isVJustPressed && !active.has('alt')) {
         if (scene.mode === 'prepare' && scene.canPasteModel) {
-          scene.pasteCopiedModelsAutoArrange(arrangeSpacingMm);
+          const pastedIds = scene.pasteCopiedModelsAutoArrange(arrangeSpacingMm);
+          // Paste shares geometry with the source — add its cached volume directly
+          // instead of waiting for the async resin effect loop.
+          if (pastedIds.length > 0 && printingEstimatedResinMlRef.current != null) {
+            const pastedModel = scene.models.find((m) => pastedIds.includes(m.id));
+            if (pastedModel) {
+              const geom = pastedModel.geometry.geometry;
+              const pos = geom.getAttribute('position');
+              const idx = geom.getIndex();
+              const sourceKey = String(geom.userData?.resinVolumeSourceKey ?? geom.uuid);
+              const posVer = (pos as { version?: number; data?: { version?: number } }).version
+                ?? (pos as { version?: number; data?: { version?: number } }).data?.version ?? 0;
+              const idxVer = (idx as { version?: number } | null)?.version ?? 0;
+              const cacheKey = `${sourceKey}:${posVer}:${idxVer}`;
+              const cachedMl = printingBaseResinMlCacheRef.current.get(cacheKey) ?? null;
+              if (cachedMl != null) {
+                const sx = Math.abs(pastedModel.transform.scale.x || 1);
+                const sy = Math.abs(pastedModel.transform.scale.y || 1);
+                const sz = Math.abs(pastedModel.transform.scale.z || 1);
+                const addedMl = cachedMl * sx * sy * sz;
+                const nextTotal = (printingEstimatedResinMlRef.current - supportAndRaftResinMl) + addedMl + supportAndRaftResinMl;
+                printingEstimatedResinMlRef.current = nextTotal;
+                setPrintingEstimatedResinMl(nextTotal);
+              }
+            }
+          }
         }
       }
 
@@ -8695,7 +8632,11 @@ export default function Home() {
     activeHolePunchPlacements,
     syncHolePunchPanelFromSelection,
     arrangeSpacingMm,
-    handleTopBarSaveScene
+    handleTopBarSaveScene,
+    printingEstimatedResinMlRef,
+    supportAndRaftResinMl,
+    printingBaseResinMlCacheRef,
+    setPrintingEstimatedResinMl
   ]);
 
   // Relocated from the early state block: depends on hollowPreview which is now


### PR DESCRIPTION
Fix a double paste happening on every platform, caused by some leftovers from #297 (Hotkey refactor): SELECT_ALL, COPY, PASTE and SAVE were living outside the new is?JustPressed routines,
causing both handlers to fire and causing double effects (like the double
paste).  Also moved the resin calculation into the paste function.

Closes #368.