### PR TITLE
fix(supports): cannot attach a branch to a curved segment while that segment is selected

### DIFF
--- a/src/components/organisms/SystemNotificationStack.tsx
+++ b/src/components/organisms/SystemNotificationStack.tsx
@@ -98,27 +98,115 @@ function ActionButton({ action, onClose }: { action: SystemNotificationAction; o
   );
 }
 
+const EXIT_MS = 200;
+
 export function SystemNotificationStack() {
-  const notifications = useSyncExternalStore(
+  const storeNotifications = useSyncExternalStore(
     subscribeSystemNotifications,
     getSystemNotificationsSnapshot,
     getSystemNotificationsSnapshot,
   );
 
-  if (notifications.length === 0) return null;
+  // Displayed list preserves exiting items for slide-out animation.
+  const [displayed, setDisplayed] = React.useState<SystemNotification[]>(storeNotifications);
+  const [exitingIds, setExitingIds] = React.useState<Set<string>>(() => new Set());
+  const timersRef = React.useRef<Map<string, number>>(new Map());
+
+  // Sync displayed with store: add newcomers, keep exiting
+  React.useEffect(() => {
+    setDisplayed((prev) => {
+      const storeIds = new Set(storeNotifications.map((n) => n.id));
+      const prevIds = new Set(prev.map((n) => n.id));
+      const storeMap = new Map(storeNotifications.map((n) => [n.id, n] as const));
+
+      // Keep exiting items that are still animating (removed from store but in exitingIds)
+      const next: SystemNotification[] = [];
+      for (const n of prev) {
+        if (storeIds.has(n.id) || exitingIds.has(n.id)) {
+          // Update with fresh store version if still present
+          next.push(storeMap.get(n.id) ?? n);
+        }
+      }
+      for (const n of storeNotifications) {
+        if (!prevIds.has(n.id) && !exitingIds.has(n.id)) next.push(n);
+      }
+      // If store reordered (unlikely), respect store order for non-exiting
+      // Keep exiting items at their previous indices; new items appended per above is fine.
+      return next;
+    });
+  }, [storeNotifications, exitingIds]);
+
+  // Handle external removals (expiry, GlobalUpdateIndicator) that bypass handleDismiss:
+  // if store removed an id that is still in displayed but not already exiting, animate it.
+  React.useEffect(() => {
+    const storeIds = new Set(storeNotifications.map((n) => n.id));
+    const toExit = displayed.filter((n) => !storeIds.has(n.id) && !exitingIds.has(n.id));
+    if (toExit.length === 0) return;
+    setExitingIds((prev) => {
+      const next = new Set(prev);
+      for (const n of toExit) {
+        next.add(n.id);
+        const t = window.setTimeout(() => {
+          setDisplayed((d) => d.filter((x) => x.id !== n.id));
+          setExitingIds((p) => {
+            const np = new Set(p);
+            np.delete(n.id);
+            return np;
+          });
+          timersRef.current.delete(n.id);
+        }, EXIT_MS);
+        timersRef.current.set(n.id, t);
+      }
+      return next;
+    });
+  }, [displayed, storeNotifications, exitingIds]);
+
+  React.useEffect(() => {
+    return () => {
+      for (const t of timersRef.current.values()) window.clearTimeout(t);
+      timersRef.current.clear();
+    };
+  }, []);
+
+  const handleDismiss = React.useCallback((n: SystemNotification) => {
+    if (exitingIds.has(n.id)) return;
+    setExitingIds((prev) => {
+      const next = new Set(prev);
+      next.add(n.id);
+      return next;
+    });
+    // Ensure displayed contains the item (it already does)
+    const t = window.setTimeout(() => {
+      dismissSystemNotification(n.id);
+      n.onClose?.();
+      // Remove from displayed/exiting after store update will also trigger,
+      // but clean locally as well in case store already removed
+      setDisplayed((d) => d.filter((x) => x.id !== n.id));
+      setExitingIds((p) => {
+        const np = new Set(p);
+        np.delete(n.id);
+        return np;
+      });
+      timersRef.current.delete(n.id);
+    }, EXIT_MS);
+    timersRef.current.set(n.id, t);
+  }, [exitingIds]);
+
+  if (displayed.length === 0) return null;
 
   return (
     <>
-      <style>{`@keyframes df-system-expiry { from { transform: scaleX(1); } to { transform: scaleX(0); } } @keyframes df-fly-in-right { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }`}</style>
+      <style>{`@keyframes df-system-expiry { from { transform: scaleX(1); } to { transform: scaleX(0); } } @keyframes df-fly-in-right { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } } @keyframes df-fly-out-right { from { transform: translateX(0); opacity: 1; } to { transform: translateX(100%); opacity: 0; } }`}</style>
       <div className="fixed bottom-6 right-6 z-[130] flex flex-col gap-3 pointer-events-none">
-        {notifications.map((n) => {
+        {displayed.map((n) => {
           const tone = toneStyles(n.tone);
           const showExpiry = !!n.expiryMs && n.expiryMs > 0;
+          const isExiting = exitingIds.has(n.id);
           return (
             <div
               key={n.id}
               className="pointer-events-auto w-[22rem]"
-              style={{ animation: 'df-fly-in-right 0.2s ease-out forwards' } as React.CSSProperties}
+              style={{ animation: isExiting ? `df-fly-out-right ${EXIT_MS}ms ease-in forwards` : 'df-fly-in-right 0.2s ease-out forwards' } as React.CSSProperties}
             >
               <div
                 className="relative overflow-hidden rounded-xl border shadow-2xl backdrop-blur-2xl"
@@ -186,15 +274,12 @@ export function SystemNotificationStack() {
                     </div>
                   )}
                   {n.actions?.map((a, idx) => (
-                    <ActionButton key={idx} action={a} onClose={() => dismissSystemNotification(n.id)} />
+                    <ActionButton key={idx} action={a} onClose={() => handleDismiss(n)} />
                   ))}
                   {(!n.actions || n.actions.length === 0) && n.dismissible !== false && (
                     <button
                       type="button"
-                      onClick={() => {
-                        dismissSystemNotification(n.id);
-                        n.onClose?.();
-                      }}
+                      onClick={() => handleDismiss(n)}
                       className="flex-1 ui-button ui-button-secondary !h-9 px-4 text-sm"
                     >
                       Dismiss

--- a/src/features/export/logic/SupportGeometryGenerator.ts
+++ b/src/features/export/logic/SupportGeometryGenerator.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { Roots, Segment, Joint, Vec3 } from '@/supports/types';
+import { bezierToLineSegments } from '@/supports/Curves/BezierUtils';
 import { SupportData } from '@/supports/rendering/SupportBuilder';
 import { getFinalSocketPosition } from '@/supports/SupportPrimitives/ContactCone';
 import { getConeQuaternion } from '@/supports/SupportPrimitives/ContactCone/contactConeUtils';
@@ -99,9 +100,10 @@ export class SupportGeometryGenerator {
         endPoint = currentStart.clone().add(new THREE.Vector3(0, 0, 10));
       }
 
-      // Generate Shaft
-      const shaftMesh = this.generateShaftMesh(segStart, endPoint, seg.diameter);
-      if (shaftMesh) group.add(shaftMesh);
+      // Generate Shaft (curved segments tessellate into piecewise cylinders)
+      for (const shaftMesh of this.generateSegmentShaftMeshes(seg, segStart, endPoint)) {
+        group.add(shaftMesh);
+      }
 
       // Generate Joints ("balls") at both ends (deduplicated across segments)
       addJointSphere(seg.bottomJoint);
@@ -189,6 +191,36 @@ export class SupportGeometryGenerator {
     group.add(sphereMesh);
 
     return group;
+  }
+
+  /**
+   * Generates the shaft mesh(es) for a segment: one cylinder for a straight
+   * segment, or a piecewise-cylinder approximation of the curve for a bezier
+   * segment (matching the live renderers and the raster slicing path).
+   */
+  public static generateSegmentShaftMeshes(segment: Segment, start: THREE.Vector3, end: THREE.Vector3): THREE.Mesh[] {
+    if (segment.type === 'bezier') {
+      const points = bezierToLineSegments(
+        { x: start.x, y: start.y, z: start.z },
+        segment.controlPoint1,
+        segment.controlPoint2,
+        { x: end.x, y: end.y, z: end.z },
+        segment.resolution,
+      );
+      const meshes: THREE.Mesh[] = [];
+      for (let i = 0; i < points.length - 1; i += 1) {
+        const mesh = this.generateShaftMesh(
+          new THREE.Vector3(points[i].x, points[i].y, points[i].z),
+          new THREE.Vector3(points[i + 1].x, points[i + 1].y, points[i + 1].z),
+          segment.diameter,
+        );
+        if (mesh) meshes.push(mesh);
+      }
+      return meshes;
+    }
+
+    const mesh = this.generateShaftMesh(start, end, segment.diameter);
+    return mesh ? [mesh] : [];
   }
 
   public static generateShaftMesh(start: THREE.Vector3, end: THREE.Vector3, diameter: number): THREE.Mesh | null {

--- a/src/features/export/logic/__tests__/supportExportReconstruction.test.ts
+++ b/src/features/export/logic/__tests__/supportExportReconstruction.test.ts
@@ -4,8 +4,8 @@ import * as THREE from 'three';
 import type { KickstandState } from '@/supports/SupportTypes/Kickstand/types';
 import type { SupportState } from '@/supports/types';
 import { JOINT_DIAMETER_OFFSET_MM } from '@/supports/constants';
-import { SupportGeometryGenerator } from './SupportGeometryGenerator';
-import { buildScopedSupportExportDocument, buildScopedSupportGeometryGroup } from './supportExportReconstruction';
+import { SupportGeometryGenerator } from '../SupportGeometryGenerator';
+import { buildScopedSupportExportDocument, buildScopedSupportGeometryGroup } from '../supportExportReconstruction';
 
 function makeSupportState(): SupportState {
   return {
@@ -341,6 +341,46 @@ test('scoped twig export contains disk tip geometry for the requested model', ()
 
   // One shaft cylinder + two disk-tip cylinders (disk A and disk B).
   assert.ok(diskShaftCylinders >= 3, `expected >= 3 cylinders (shaft + 2 disk tips), got ${diskShaftCylinders}`);
+test('curved (bezier) segments export as piecewise cylinders that follow the curve', () => {
+  const chordEnd = { x: 0, y: 0, z: 10 };
+  const group = SupportGeometryGenerator.generateSupportGroup({
+    id: 'curved-support',
+    startPos: { x: 0, y: 0, z: 0 },
+    segments: [{
+      id: 'curved-seg',
+      diameter: 1,
+      type: 'bezier',
+      controlPoint1: { x: 6, y: 0, z: 3 },
+      controlPoint2: { x: 6, y: 0, z: 7 },
+      startTangent: { x: 0, y: 0, z: 1 },
+      endTangent: { x: 0, y: 0, z: 1 },
+      tension: 0.5,
+      bias: 0.5,
+      resolution: 12,
+      topJoint: { id: 'curved-top-joint', pos: chordEnd, diameter: 1.2 },
+    }],
+  });
+
+  const cylinders: THREE.Mesh[] = [];
+  group.traverse((node) => {
+    if ((node as THREE.Mesh).geometry?.type === 'CylinderGeometry') {
+      cylinders.push(node as THREE.Mesh);
+    }
+  });
+
+  // A straight chord would be a single cylinder; the curve must tessellate.
+  assert.equal(cylinders.length, 12);
+
+  // The control points bow the curve toward +X (peak ~4.5mm off the chord at
+  // t=0.5). If the curve were exported as its chord, every piece midpoint
+  // would sit on the x=0 axis.
+  const maxMidpointX = Math.max(...cylinders.map((mesh) => mesh.position.x));
+  assert.ok(maxMidpointX > 2, `expected curved pieces off the chord axis, got max x ${maxMidpointX}`);
+
+  // Piecewise pieces must chain into a connected polyline from start to end.
+  const firstPiece = cylinders[0];
+  const lastPiece = cylinders[cylinders.length - 1];
+  assert.ok(firstPiece.position.z < lastPiece.position.z);
 });
 
 test('kickstand export does not add a host-knot sphere affordance', () => {

--- a/src/features/export/logic/__tests__/supportExportReconstruction.test.ts
+++ b/src/features/export/logic/__tests__/supportExportReconstruction.test.ts
@@ -341,6 +341,8 @@ test('scoped twig export contains disk tip geometry for the requested model', ()
 
   // One shaft cylinder + two disk-tip cylinders (disk A and disk B).
   assert.ok(diskShaftCylinders >= 3, `expected >= 3 cylinders (shaft + 2 disk tips), got ${diskShaftCylinders}`);
+});
+
 test('curved (bezier) segments export as piecewise cylinders that follow the curve', () => {
   const chordEnd = { x: 0, y: 0, z: 10 };
   const group = SupportGeometryGenerator.generateSupportGroup({

--- a/src/features/export/logic/supportExportReconstruction.ts
+++ b/src/features/export/logic/supportExportReconstruction.ts
@@ -223,31 +223,14 @@ function appendStraightOrBezierShafts(
   start: Vec3,
   end: Vec3,
 ) {
-  if (segment.type === 'bezier') {
-    const points = bezierToLineSegments(
-      start,
-      segment.controlPoint1,
-      segment.controlPoint2,
-      end,
-      segment.resolution,
-    );
-    for (let i = 0; i < points.length - 1; i += 1) {
-      const shaft = SupportGeometryGenerator.generateShaftMesh(
-        new THREE.Vector3(points[i].x, points[i].y, points[i].z),
-        new THREE.Vector3(points[i + 1].x, points[i + 1].y, points[i + 1].z),
-        segment.diameter,
-      );
-      if (shaft) group.add(shaft);
-    }
-    return;
-  }
-
-  const shaft = SupportGeometryGenerator.generateShaftMesh(
+  const meshes = SupportGeometryGenerator.generateSegmentShaftMeshes(
+    segment,
     new THREE.Vector3(start.x, start.y, start.z),
     new THREE.Vector3(end.x, end.y, end.z),
-    segment.diameter,
   );
-  if (shaft) group.add(shaft);
+  for (const mesh of meshes) {
+    group.add(mesh);
+  }
 }
 
 function buildAnchorGroup(anchor: Anchor, modelId: string | null | undefined): THREE.Group {

--- a/src/supports/Curves/batchedBezierShaft.ts
+++ b/src/supports/Curves/batchedBezierShaft.ts
@@ -1,0 +1,56 @@
+import type { BezierSegment, Vec3 } from '../types';
+import type { InstancedShaft } from '../SupportPrimitives/Shaft/InstancedShaftGroup';
+
+type Vec3Like = { x: number; y: number; z: number };
+
+const toPlainVec3 = (v: Vec3Like): Vec3 => ({ x: v.x, y: v.y, z: v.z });
+
+/**
+ * Represent a bezier segment as a single curved batched-shaft entry.
+ * InstancedShaftGroup renders curved entries as smooth merged tubes (visual
+ * parity with the detailed BezierRenderer); straight entries stay instanced
+ * cylinders.
+ */
+export function bezierSegmentToBatchedShaft(
+    segment: BezierSegment,
+    startPos: Vec3Like,
+    endPos: Vec3Like,
+    supportId: string,
+    modelId?: string,
+): InstancedShaft {
+    return {
+        id: segment.id,
+        start: toPlainVec3(startPos),
+        end: toPlainVec3(endPos),
+        diameter: segment.diameter,
+        supportId,
+        modelId,
+        controlPoint1: toPlainVec3(segment.controlPoint1),
+        controlPoint2: toPlainVec3(segment.controlPoint2),
+        resolution: segment.resolution,
+    };
+}
+
+export function braceBezierToBatchedShaft(
+    segmentId: string,
+    startPos: Vec3Like,
+    endPos: Vec3Like,
+    controlPoint1: Vec3Like,
+    controlPoint2: Vec3Like,
+    diameter: number,
+    resolution: number | undefined,
+    supportId: string,
+    modelId?: string,
+): InstancedShaft {
+    return {
+        id: segmentId,
+        start: toPlainVec3(startPos),
+        end: toPlainVec3(endPos),
+        diameter,
+        supportId,
+        modelId,
+        controlPoint1: toPlainVec3(controlPoint1),
+        controlPoint2: toPlainVec3(controlPoint2),
+        resolution,
+    };
+}

--- a/src/supports/Curves/batchedBezierTubeGeometry.ts
+++ b/src/supports/Curves/batchedBezierTubeGeometry.ts
@@ -1,0 +1,141 @@
+import * as THREE from 'three';
+import { calculateAdaptiveBezierResolution } from './BezierUtils';
+import type { InstancedShaft } from '../SupportPrimitives/Shaft/InstancedShaftGroup';
+
+export interface BatchedBezierTubes {
+    geometry: THREE.BufferGeometry;
+    /**
+     * Cumulative triangle-end offsets aligned with the input curve list:
+     * curve i owns triangles [i === 0 ? 0 : ends[i-1], ends[i]).
+     */
+    triangleRangeEnds: number[];
+}
+
+export function isCurvedBatchedShaft(shaft: InstancedShaft): boolean {
+    return shaft.controlPoint1 != null && shaft.controlPoint2 != null;
+}
+
+/** Map a raycast faceIndex back to the owning curve's index; -1 if out of range. */
+export function resolveCurvedShaftIndexForFace(triangleRangeEnds: number[], faceIndex: number): number {
+    let lo = 0;
+    let hi = triangleRangeEnds.length - 1;
+    if (hi < 0 || faceIndex < 0 || faceIndex >= triangleRangeEnds[hi]) return -1;
+    while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (triangleRangeEnds[mid] > faceIndex) {
+            hi = mid;
+        } else {
+            lo = mid + 1;
+        }
+    }
+    return lo;
+}
+
+/**
+ * Merge curved batched shafts into one smooth tube geometry (one draw call per
+ * batch group). Each curve is swept with the same resolution rules as the
+ * detailed BezierRenderer and closed with flat end caps so the proxy-layer
+ * scene graph stays serializable as a closed mesh by the STL/3MF export path.
+ */
+export function buildBatchedBezierTubes(
+    curvedShafts: InstancedShaft[],
+    radialSegments: number,
+): BatchedBezierTubes | null {
+    if (curvedShafts.length === 0) return null;
+
+    const positions: number[] = [];
+    const normals: number[] = [];
+    const indices: number[] = [];
+    const triangleRangeEnds: number[] = [];
+
+    const addCap = (ringStartVertex: number, center: THREE.Vector3, outward: THREE.Vector3) => {
+        const capBase = positions.length / 3;
+        positions.push(center.x, center.y, center.z);
+        normals.push(outward.x, outward.y, outward.z);
+
+        // Duplicate the rim ring with the cap normal (skip the tube's seam
+        // duplicate at j === radialSegments) so the cap edge shades crisply.
+        for (let j = 0; j < radialSegments; j += 1) {
+            const src = (ringStartVertex + j) * 3;
+            positions.push(positions[src], positions[src + 1], positions[src + 2]);
+            normals.push(outward.x, outward.y, outward.z);
+        }
+
+        // Orient the fan so its winding faces `outward` regardless of the
+        // direction TubeGeometry wound the ring.
+        const a = new THREE.Vector3(
+            positions[(capBase + 1) * 3] - center.x,
+            positions[(capBase + 1) * 3 + 1] - center.y,
+            positions[(capBase + 1) * 3 + 2] - center.z,
+        );
+        const b = new THREE.Vector3(
+            positions[(capBase + 2) * 3] - center.x,
+            positions[(capBase + 2) * 3 + 1] - center.y,
+            positions[(capBase + 2) * 3 + 2] - center.z,
+        );
+        const flip = new THREE.Vector3().crossVectors(a, b).dot(outward) < 0;
+
+        for (let j = 0; j < radialSegments; j += 1) {
+            const r0 = capBase + 1 + j;
+            const r1 = capBase + 1 + ((j + 1) % radialSegments);
+            if (flip) {
+                indices.push(capBase, r1, r0);
+            } else {
+                indices.push(capBase, r0, r1);
+            }
+        }
+    };
+
+    for (const shaft of curvedShafts) {
+        const curve = new THREE.CubicBezierCurve3(
+            new THREE.Vector3(shaft.start.x, shaft.start.y, shaft.start.z),
+            new THREE.Vector3(shaft.controlPoint1!.x, shaft.controlPoint1!.y, shaft.controlPoint1!.z),
+            new THREE.Vector3(shaft.controlPoint2!.x, shaft.controlPoint2!.y, shaft.controlPoint2!.z),
+            new THREE.Vector3(shaft.end.x, shaft.end.y, shaft.end.z),
+        );
+        const tubularSegments = Math.max(2, Math.floor(
+            shaft.resolution
+            ?? calculateAdaptiveBezierResolution(shaft.start, shaft.controlPoint1!, shaft.controlPoint2!, shaft.end),
+        ));
+        const radius = Math.max(0.0005, shaft.diameter / 2);
+
+        const tube = new THREE.TubeGeometry(curve, tubularSegments, radius, radialSegments, false);
+        const vertexBase = positions.length / 3;
+        const pos = tube.getAttribute('position') as THREE.BufferAttribute;
+        const nor = tube.getAttribute('normal') as THREE.BufferAttribute;
+        for (let i = 0; i < pos.count; i += 1) {
+            positions.push(pos.getX(i), pos.getY(i), pos.getZ(i));
+            normals.push(nor.getX(i), nor.getY(i), nor.getZ(i));
+        }
+        const idx = tube.getIndex()!;
+        for (let i = 0; i < idx.count; i += 1) {
+            indices.push(vertexBase + idx.getX(i));
+        }
+        tube.dispose();
+
+        const startOutward = curve.getTangent(0).normalize().negate();
+        const endOutward = curve.getTangent(1).normalize();
+        const fallback = new THREE.Vector3()
+            .subVectors(curve.v3, curve.v0)
+            .normalize();
+        if (!Number.isFinite(startOutward.x + startOutward.y + startOutward.z) || startOutward.lengthSq() < 0.5) {
+            startOutward.copy(fallback).negate();
+        }
+        if (!Number.isFinite(endOutward.x + endOutward.y + endOutward.z) || endOutward.lengthSq() < 0.5) {
+            endOutward.copy(fallback);
+        }
+        addCap(vertexBase, curve.getPoint(0), startOutward);
+        addCap(vertexBase + tubularSegments * (radialSegments + 1), curve.getPoint(1), endOutward);
+
+        triangleRangeEnds.push(indices.length / 3);
+    }
+
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    geometry.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
+    geometry.setIndex(indices);
+    geometry.computeBoundingBox();
+    geometry.computeBoundingSphere();
+
+    return { geometry, triangleRangeEnds };
+}

--- a/src/supports/Renderers/BezierRenderer.tsx
+++ b/src/supports/Renderers/BezierRenderer.tsx
@@ -4,9 +4,23 @@ import * as THREE from 'three';
 import { Vec3 } from '../types';
 import { toVector3 } from '../Curves/BezierUtils';
 import { useBracePlacementState } from '../SupportTypes/Brace/bracePlacementState';
+import { useKickstandPlacementState } from '../SupportTypes/Kickstand/kickstandPlacementState';
+import { useLeafPlacementState } from '../SupportTypes/Leaf/leafPlacementState';
+import { curveInteractionStore } from '../Curves/curveInteractionState';
 import { emitImmediateModelHover, getFrontBlockingModelId } from '../interaction/pointerOcclusion';
 
 const NOOP_RAYCAST: THREE.Object3D['raycast'] = () => {};
+
+// A live bezier handle drag moves the curve under the cursor; placement tools must
+// not treat it as a hover/snap anchor until the drag (and its post-drag guard
+// window) is over.
+function isBezierHandleDragLive(): boolean {
+    if (curveInteractionStore.getSnapshot().isDraggingHandle) return true;
+    if (typeof window === 'undefined') return false;
+    const w = window as unknown as { __bezierGizmoDragging?: boolean; __bezierGizmoGuardUntil?: number };
+    if (w.__bezierGizmoDragging) return true;
+    return typeof w.__bezierGizmoGuardUntil === 'number' && Date.now() < w.__bezierGizmoGuardUntil;
+}
 
 interface BezierRendererProps {
     id: string;
@@ -78,7 +92,16 @@ export function BezierRenderer({
     const visualEndRadius = endRadius * selectedVisualScale;
     const pickRadius = Math.max(Math.max(visualStartRadius, visualEndRadius) * PICK_RADIUS_MULTIPLIER, MIN_PICK_RADIUS_MM);
     const { altActive: braceAltActive } = useBracePlacementState();
-    const enableSegmentInteraction = !!isInteractable && (isParentSelected || (!suppressPlacementInteraction && braceAltActive)) === true;
+    const { hotkeyActive: kickstandHotkeyActive } = useKickstandPlacementState();
+    const { hotkeyActive: leafHotkeyActive, stage: leafStage, sproutParentingLockHeld } = useLeafPlacementState();
+    const leafPlacementActive = leafHotkeyActive || leafStage === 'awaitingBase' || leafStage === 'awaitingSproutTip' || sproutParentingLockHeld;
+    // Placement modes suppress general support interaction (isInteractable goes
+    // false), so placement must override BOTH clauses — mirrors the ShaftRenderer
+    // gate so curved and straight segments accept placement hover/clicks identically.
+    // Branch placement shares the Alt hotkey action with brace placement, so
+    // braceAltActive also covers branch/twig/stick placement.
+    const placementInteractionActive = !suppressPlacementInteraction && (braceAltActive || kickstandHotkeyActive || leafPlacementActive);
+    const enableSegmentInteraction = !!((isParentSelected || placementInteractionActive) && (isInteractable || placementInteractionActive));
     const [frontBlockingModelId, setFrontBlockingModelId] = useState<string | null>(null);
     const [pointerHoverActive, setPointerHoverActive] = useState(false);
     const pickRef = useRef<THREE.Mesh>(null);
@@ -222,6 +245,7 @@ export function BezierRenderer({
 
     const handlePointerMove = (e: any) => {
         if (!enableSegmentInteraction) return;
+        if (isBezierHandleDragLive()) return;
 
         const topIntersectionObject = Array.isArray(e?.intersections)
             ? ((e.intersections[0] as { object?: THREE.Object3D | null } | undefined)?.object ?? null)

--- a/src/supports/SupportPrimitives/Shaft/InstancedShaftGroup.tsx
+++ b/src/supports/SupportPrimitives/Shaft/InstancedShaftGroup.tsx
@@ -196,6 +196,15 @@ export function InstancedShaftGroup({
         onShaftClick(shaft, event);
     };
 
+
+    const handleCurvedPointerDown = (event: ThreeEvent<PointerEvent>) => {
+        if (!onShaftPointerDown) return;
+        event.stopPropagation();
+        const shaft = resolveCurvedShaft(event);
+        if (!shaft) return;
+        onShaftPointerDown(shaft, event);
+    };
+
     const handleCurvedPointerMove = (event: ThreeEvent<PointerEvent>) => {
         if (!onShaftPointerMove) return;
         event.stopPropagation();
@@ -215,6 +224,7 @@ export function InstancedShaftGroup({
                     frustumCulled={false}
                     renderOrder={100000}
                     onClick={onShaftClick ? handleClick : undefined}
+                    onPointerDown={onShaftPointerDown ? handlePointerDown : undefined}
                     onPointerMove={onShaftPointerMove ? handlePointerMove : undefined}
                     onPointerOut={onShaftPointerOut ? handlePointerOut : undefined}
                 >
@@ -249,6 +259,7 @@ export function InstancedShaftGroup({
                     frustumCulled={false}
                     renderOrder={100000}
                     onClick={onShaftClick ? handleCurvedClick : undefined}
+                    onPointerDown={onShaftPointerDown ? handleCurvedPointerDown : undefined}
                     onPointerMove={onShaftPointerMove ? handleCurvedPointerMove : undefined}
                     onPointerOut={onShaftPointerOut ? handlePointerOut : undefined}
                 >

--- a/src/supports/SupportPrimitives/Shaft/InstancedShaftGroup.tsx
+++ b/src/supports/SupportPrimitives/Shaft/InstancedShaftGroup.tsx
@@ -1,7 +1,12 @@
-import React, { useLayoutEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import type { ThreeEvent } from '@react-three/fiber';
 import type { Vec3 } from '../../types';
+import {
+    buildBatchedBezierTubes,
+    isCurvedBatchedShaft,
+    resolveCurvedShaftIndexForFace,
+} from '../../Curves/batchedBezierTubeGeometry';
 
 export interface InstancedShaft {
     id: string;
@@ -10,6 +15,14 @@ export interface InstancedShaft {
     diameter: number;
     supportId?: string;
     modelId?: string;
+    /**
+     * Present on curved (bezier) segments. Curved entries render as a smooth
+     * merged tube (visual parity with the detailed BezierRenderer) instead of
+     * a straight instanced cylinder; straight entries leave these unset.
+     */
+    controlPoint1?: Vec3;
+    controlPoint2?: Vec3;
+    resolution?: number;
 }
 
 interface InstancedShaftGroupProps {
@@ -29,6 +42,7 @@ interface InstancedShaftGroupProps {
 }
 
 const UP = new THREE.Vector3(0, 1, 0);
+const NOOP_RAYCAST: THREE.Object3D['raycast'] = () => {};
 
 export function InstancedShaftGroup({
     shafts,
@@ -49,15 +63,40 @@ export function InstancedShaftGroup({
     const overlayMeshRef = useRef<THREE.InstancedMesh>(null);
     const lastHoveredShaftRef = useRef<InstancedShaft | null>(null);
 
-    const validShafts = useMemo(() => {
-        return shafts.filter((shaft) => {
+    const { straightShafts, curvedShafts } = useMemo(() => {
+        const straight: InstancedShaft[] = [];
+        const curved: InstancedShaft[] = [];
+        for (const shaft of shafts) {
+            if (isCurvedBatchedShaft(shaft)) {
+                // Degenerate only when the whole control net collapses to a point.
+                const points = [shaft.controlPoint1!, shaft.controlPoint2!, shaft.end];
+                const collapsed = points.every((p) => {
+                    const dx = p.x - shaft.start.x;
+                    const dy = p.y - shaft.start.y;
+                    const dz = p.z - shaft.start.z;
+                    return dx * dx + dy * dy + dz * dz < 1e-6;
+                });
+                if (!collapsed) curved.push(shaft);
+                continue;
+            }
             const dx = shaft.end.x - shaft.start.x;
             const dy = shaft.end.y - shaft.start.y;
             const dz = shaft.end.z - shaft.start.z;
-            const lengthSq = dx * dx + dy * dy + dz * dz;
-            return lengthSq >= 1e-6;
-        });
+            if (dx * dx + dy * dy + dz * dz >= 1e-6) straight.push(shaft);
+        }
+        return { straightShafts: straight, curvedShafts: curved };
     }, [shafts]);
+
+    const curvedTubes = useMemo(
+        () => buildBatchedBezierTubes(curvedShafts, radialSegments),
+        [curvedShafts, radialSegments],
+    );
+
+    useEffect(() => {
+        return () => {
+            curvedTubes?.geometry.dispose();
+        };
+    }, [curvedTubes]);
 
     const hasOverlay = !!outOfBoundsMaterial;
 
@@ -72,8 +111,8 @@ export function InstancedShaftGroup({
         const direction = new THREE.Vector3();
         const midpoint = new THREE.Vector3();
 
-        for (let i = 0; i < validShafts.length; i += 1) {
-            const shaft = validShafts[i];
+        for (let i = 0; i < straightShafts.length; i += 1) {
+            const shaft = straightShafts[i];
 
             start.set(shaft.start.x, shaft.start.y, shaft.start.z);
             end.set(shaft.end.x, shaft.end.y, shaft.end.z);
@@ -93,22 +132,22 @@ export function InstancedShaftGroup({
             if (overlayMesh) overlayMesh.setMatrixAt(i, tempObject.matrix);
         }
 
-        mesh.count = validShafts.length;
+        mesh.count = straightShafts.length;
         mesh.instanceMatrix.needsUpdate = true;
         if (overlayMesh) {
-            overlayMesh.count = validShafts.length;
+            overlayMesh.count = straightShafts.length;
             overlayMesh.instanceMatrix.needsUpdate = true;
         }
-    }, [validShafts, hasOverlay]);
+    }, [straightShafts, hasOverlay]);
 
-    if (validShafts.length === 0) return null;
+    if (straightShafts.length === 0 && !curvedTubes) return null;
 
     const handleClick = (event: ThreeEvent<MouseEvent>) => {
         if (!onShaftClick) return;
         event.stopPropagation();
         const instanceId = event.instanceId;
         if (instanceId == null) return;
-        const shaft = validShafts[instanceId];
+        const shaft = straightShafts[instanceId];
         if (!shaft) return;
         onShaftClick(shaft, event);
     };
@@ -118,7 +157,7 @@ export function InstancedShaftGroup({
         event.stopPropagation();
         const instanceId = event.instanceId;
         if (instanceId == null) return;
-        const shaft = validShafts[instanceId];
+        const shaft = straightShafts[instanceId];
         if (!shaft) return;
         onShaftPointerDown(shaft, event);
     };
@@ -128,7 +167,7 @@ export function InstancedShaftGroup({
         event.stopPropagation();
         const instanceId = event.instanceId;
         if (instanceId == null) return;
-        const shaft = validShafts[instanceId];
+        const shaft = straightShafts[instanceId];
         if (!shaft) return;
         lastHoveredShaftRef.current = shaft;
         onShaftPointerMove(shaft, event);
@@ -141,40 +180,97 @@ export function InstancedShaftGroup({
         lastHoveredShaftRef.current = null;
     };
 
+    const resolveCurvedShaft = (event: { faceIndex?: number | null }): InstancedShaft | null => {
+        if (!curvedTubes) return null;
+        const faceIndex = event.faceIndex;
+        if (faceIndex == null) return null;
+        const index = resolveCurvedShaftIndexForFace(curvedTubes.triangleRangeEnds, faceIndex);
+        return index >= 0 ? curvedShafts[index] ?? null : null;
+    };
+
+    const handleCurvedClick = (event: ThreeEvent<MouseEvent>) => {
+        if (!onShaftClick) return;
+        event.stopPropagation();
+        const shaft = resolveCurvedShaft(event);
+        if (!shaft) return;
+        onShaftClick(shaft, event);
+    };
+
+    const handleCurvedPointerMove = (event: ThreeEvent<PointerEvent>) => {
+        if (!onShaftPointerMove) return;
+        event.stopPropagation();
+        const shaft = resolveCurvedShaft(event);
+        if (!shaft) return;
+        lastHoveredShaftRef.current = shaft;
+        onShaftPointerMove(shaft, event);
+    };
+
     return (
         <>
-            <instancedMesh
-                ref={meshRef}
-                args={[undefined, undefined, validShafts.length]}
-                frustumCulled={false}
-                renderOrder={100000}
-                onClick={onShaftClick ? handleClick : undefined}
-                onPointerDown={onShaftPointerDown ? handlePointerDown : undefined}
-                onPointerMove={onShaftPointerMove ? handlePointerMove : undefined}
-                onPointerOut={onShaftPointerOut ? handlePointerOut : undefined}
-            >
-                <cylinderGeometry args={[0.5, 0.5, 1, radialSegments, 1, false]} />
-                <meshStandardMaterial
-                    color={color}
-                    emissive={emissive}
-                    emissiveIntensity={emissiveIntensity}
-                    transparent={transparent}
-                    opacity={opacity}
-                    depthWrite={!transparent}
-                    clippingPlanes={clippingPlanes ?? undefined}
-                />
-            </instancedMesh>
-            {outOfBoundsMaterial && (
+            {straightShafts.length > 0 && (
                 <instancedMesh
-                    ref={overlayMeshRef}
-                    args={[undefined, undefined, validShafts.length]}
+                    key={`straight:${straightShafts.length}`}
+                    ref={meshRef}
+                    args={[undefined, undefined, straightShafts.length]}
                     frustumCulled={false}
-                    raycast={() => null}
+                    renderOrder={100000}
+                    onClick={onShaftClick ? handleClick : undefined}
+                    onPointerMove={onShaftPointerMove ? handlePointerMove : undefined}
+                    onPointerOut={onShaftPointerOut ? handlePointerOut : undefined}
+                >
+                    <cylinderGeometry args={[0.5, 0.5, 1, radialSegments, 1, false]} />
+                    <meshStandardMaterial
+                        color={color}
+                        emissive={emissive}
+                        emissiveIntensity={emissiveIntensity}
+                        transparent={transparent}
+                        opacity={opacity}
+                        depthWrite={!transparent}
+                        clippingPlanes={clippingPlanes ?? undefined}
+                    />
+                </instancedMesh>
+            )}
+            {straightShafts.length > 0 && outOfBoundsMaterial && (
+                <instancedMesh
+                    key={`straight-overlay:${straightShafts.length}`}
+                    ref={overlayMeshRef}
+                    args={[undefined, undefined, straightShafts.length]}
+                    frustumCulled={false}
+                    raycast={NOOP_RAYCAST}
                     renderOrder={100000}
                     material={outOfBoundsMaterial}
                 >
                     <cylinderGeometry args={[0.5, 0.5, 1, radialSegments, 1, false]} />
                 </instancedMesh>
+            )}
+            {curvedTubes && (
+                <mesh
+                    geometry={curvedTubes.geometry}
+                    frustumCulled={false}
+                    renderOrder={100000}
+                    onClick={onShaftClick ? handleCurvedClick : undefined}
+                    onPointerMove={onShaftPointerMove ? handleCurvedPointerMove : undefined}
+                    onPointerOut={onShaftPointerOut ? handlePointerOut : undefined}
+                >
+                    <meshStandardMaterial
+                        color={color}
+                        emissive={emissive}
+                        emissiveIntensity={emissiveIntensity}
+                        transparent={transparent}
+                        opacity={opacity}
+                        depthWrite={!transparent}
+                        clippingPlanes={clippingPlanes ?? undefined}
+                    />
+                </mesh>
+            )}
+            {curvedTubes && outOfBoundsMaterial && (
+                <mesh
+                    geometry={curvedTubes.geometry}
+                    frustumCulled={false}
+                    raycast={NOOP_RAYCAST}
+                    renderOrder={100000}
+                    material={outOfBoundsMaterial}
+                />
             )}
         </>
     );

--- a/src/supports/SupportProxyMeshLayer.tsx
+++ b/src/supports/SupportProxyMeshLayer.tsx
@@ -14,37 +14,9 @@ import { InstancedContactConeGroup, type InstancedContactCone } from './SupportP
 import { getFinalSocketPosition } from './SupportPrimitives/ContactCone/contactConeUtils';
 import { calculateDiskThickness } from './SupportPrimitives/ContactDisk/contactDiskUtils';
 import { emitSupportModelPointerHover } from './interaction/clickHandlers';
-import type { ContactDisk, Vec3 } from './types';
+import { bezierSegmentToBatchedShaft, braceBezierToBatchedShaft } from './Curves/batchedBezierShaft';
+import type { ContactDisk, Segment, Vec3 } from './types';
 import { MARQUEE_CANDIDATE_TINT_FACTOR } from '@/utils/marqueeCandidateTint';
-
-// Tapered straight shaft type (kept for data flow, no longer creates per-item meshes -
-// all proxy shafts go through InstancedShaftGroup now).
-interface ProxyTaperedShaft {
-    id: string;
-    supportId?: string;
-    modelId?: string;
-    start: Vec3;
-    end: Vec3;
-    diameterStart: number;
-    diameterEnd: number;
-}
-
-// Unused in the simplified proxy — bezier curves become straight instanced
-// shafts with averaged diameter. The full SupportRenderer shows real curves.
-interface ProxyBezierShaft {
-    id: string;
-    supportId?: string;
-    modelId?: string;
-    start: Vec3;
-    end: Vec3;
-    control1: Vec3;
-    control2: Vec3;
-    resolution: number;
-    diameterStart: number;
-    diameterEnd: number;
-}
-
-function isBezierSegment(_seg: Vec3 & { type?: string }): boolean { return false; }
 
 interface SupportProxyMeshLayerProps {
   mode?: 'prepare' | 'analysis' | 'support' | 'export' | 'printing';
@@ -570,6 +542,26 @@ export function SupportProxyMeshLayer({
       registerSegmentMeta(shaft.id, shaft.modelId, shaft.supportId);
     };
 
+    // Curved segments become curved batched-shaft entries; InstancedShaftGroup
+    // renders them as smooth capped tubes (same approach as the support-mode
+    // scene batch). This keeps curves visible in proxy views AND in mesh
+    // export: the unscoped STL/3MF path serializes this layer's live scene
+    // graph in prepare/export modes.
+    const pushSegmentShafts = (segment: Segment, start: Vec3, end: Vec3, supportId: string, modelId?: string) => {
+      if (segment.type === 'bezier') {
+        pushShaft(bezierSegmentToBatchedShaft(segment, start, end, supportId, modelId));
+        return;
+      }
+      pushShaft({
+        id: segment.id,
+        supportId,
+        modelId,
+        start,
+        end,
+        diameter: segment.diameter,
+      });
+    };
+
     const pushRoot = (root: InstancedRoot) => {
       const effectiveDiskHeight = Math.max(0.001, root.effectiveDiskHeight);
       const verticalOffset = 0;
@@ -649,14 +641,7 @@ export function SupportProxyMeshLayer({
         const end = segment.topJoint?.pos
           ?? (trunk.contactCone ? getFinalSocketPosition(trunk.contactCone) : { x: currentStart.x, y: currentStart.y, z: currentStart.z + 5 });
 
-        pushShaft({
-          id: segment.id,
-          supportId: trunk.id,
-          modelId: trunk.modelId,
-          start: currentStart,
-          end,
-          diameter: segment.diameter,
-        });
+        pushSegmentShafts(segment, currentStart, end, trunk.id, trunk.modelId);
 
         if (includeDetailedPrimitives && segment.topJoint) {
           pushJoint({
@@ -701,14 +686,7 @@ export function SupportProxyMeshLayer({
         const end = segment.topJoint?.pos
           ?? (branch.contactCone ? getFinalSocketPosition(branch.contactCone) : { x: currentStart.x, y: currentStart.y, z: currentStart.z + 5 });
 
-        pushShaft({
-          id: segment.id,
-          supportId: branch.id,
-          modelId: branch.modelId,
-          start: currentStart,
-          end,
-          diameter: segment.diameter,
-        });
+        pushSegmentShafts(segment, currentStart, end, branch.id, branch.modelId);
 
         if (includeDetailedPrimitives && segment.topJoint) {
           pushJoint({
@@ -843,14 +821,7 @@ export function SupportProxyMeshLayer({
         const start = segment.bottomJoint?.pos ?? getDiskTipCenter(twig.contactDiskA);
         const end = segment.topJoint?.pos ?? getDiskTipCenter(twig.contactDiskB);
 
-        pushShaft({
-          id: segment.id,
-          supportId: twig.id,
-          modelId: twig.modelId,
-          start,
-          end,
-          diameter: segment.diameter,
-        });
+        pushSegmentShafts(segment, start, end, twig.id, twig.modelId);
 
         if (includeDetailedPrimitives && segment.topJoint) {
           pushJoint({
@@ -893,14 +864,7 @@ export function SupportProxyMeshLayer({
         const start = segment.bottomJoint?.pos ?? getFinalSocketPosition(stick.contactConeA);
         const end = segment.topJoint?.pos ?? getFinalSocketPosition(stick.contactConeB);
 
-        pushShaft({
-          id: segment.id,
-          supportId: stick.id,
-          modelId: stick.modelId,
-          start,
-          end,
-          diameter: segment.diameter,
-        });
+        pushSegmentShafts(segment, start, end, stick.id, stick.modelId);
 
         if (includeDetailedPrimitives && segment.topJoint) {
           pushJoint({
@@ -941,14 +905,29 @@ export function SupportProxyMeshLayer({
         ),
       );
 
-      pushShaft({
-        id: `braceSegment:${brace.id}`,
-        supportId: brace.id,
-        modelId: brace.modelId,
-        start: startKnot.pos,
-        end: endKnot.pos,
-        diameter: (startHostDiameter + endHostDiameter) * 0.5,
-      });
+      const braceDiameter = (startHostDiameter + endHostDiameter) * 0.5;
+      if (brace.curve?.type === 'bezier') {
+        pushShaft(braceBezierToBatchedShaft(
+          `braceSegment:${brace.id}`,
+          startKnot.pos,
+          endKnot.pos,
+          brace.curve.controlPoint1,
+          brace.curve.controlPoint2,
+          braceDiameter,
+          brace.curve.resolution,
+          brace.id,
+          brace.modelId,
+        ));
+      } else {
+        pushShaft({
+          id: `braceSegment:${brace.id}`,
+          supportId: brace.id,
+          modelId: brace.modelId,
+          start: startKnot.pos,
+          end: endKnot.pos,
+          diameter: braceDiameter,
+        });
+      }
     }
 
     // Knots that the scene renders always (leaf base knots and branch parent
@@ -1016,14 +995,7 @@ export function SupportProxyMeshLayer({
         }
 
         const end = segment.topJoint?.pos ?? hostKnot.pos;
-        pushShaft({
-          id: segment.id,
-          supportId: kickstand.id,
-          modelId: kickstand.modelId,
-          start: currentStart,
-          end,
-          diameter: segment.diameter,
-        });
+        pushSegmentShafts(segment, currentStart, end, kickstand.id, kickstand.modelId);
 
         if (includeDetailedPrimitives && segment.topJoint) {
           pushJoint({

--- a/src/supports/SupportProxyMeshLayer.tsx
+++ b/src/supports/SupportProxyMeshLayer.tsx
@@ -1273,11 +1273,14 @@ export function SupportProxyMeshLayer({
         target.shafts.push(shaft);
         return;
       }
-      target.shafts.push({
+      const pushed: InstancedShaft = {
         ...shaft,
         start: { x: shaft.start.x, y: shaft.start.y, z: shaft.start.z + zOffset },
         end: { x: shaft.end.x, y: shaft.end.y, z: shaft.end.z + zOffset },
-      });
+      };
+      if (shaft.controlPoint1) pushed.controlPoint1 = { x: shaft.controlPoint1.x, y: shaft.controlPoint1.y, z: shaft.controlPoint1.z + zOffset };
+      if (shaft.controlPoint2) pushed.controlPoint2 = { x: shaft.controlPoint2.x, y: shaft.controlPoint2.y, z: shaft.controlPoint2.z + zOffset };
+      target.shafts.push(pushed);
     };
 
     const appendRoot = (target: FlatProxyGeometry, root: InstancedRoot, zOffset: number) => {

--- a/src/supports/SupportRenderer.tsx
+++ b/src/supports/SupportRenderer.tsx
@@ -31,7 +31,7 @@ import { KnotGizmo } from './SupportPrimitives/Knot/KnotGizmo';
 import { BezierGizmoManager } from './Curves/BezierGizmo/BezierGizmoManager';
 import { ContactDisk, SupportMode, BezierSegment, type Brace, type Knot, type Leaf, type Twig, type SupportOrigin } from './types';
 import { resolveTwigDiameterAtSegmentT } from './SupportTypes/Twig/twigTaper';
-import { bezierToLineSegments, calculateAdaptiveBezierResolution } from './Curves/BezierUtils';
+import { bezierSegmentToBatchedShaft, braceBezierToBatchedShaft } from './Curves/batchedBezierShaft';
 import type { SupportData } from './rendering';
 import type { BracePreviewData } from './SupportTypes/Brace/bracePlacementState';
 import { useJointCreationState } from './SupportPrimitives/Joint/jointCreationState';
@@ -136,125 +136,6 @@ type InteriorContactPoint = {
     placementSurface?: PlacementSurface;
 };
 type InteriorContactFilter = (contact: InteriorContactPoint | null | undefined, modelId?: string) => boolean;
-
-function applyBatchedBezierSeamOverlap(
-    points: Array<{ x: number; y: number; z: number }>,
-    index: number,
-    diameter: number,
-) {
-    const start = points[index];
-    const end = points[index + 1];
-    const dx = end.x - start.x;
-    const dy = end.y - start.y;
-    const dz = end.z - start.z;
-    const length = Math.sqrt((dx * dx) + (dy * dy) + (dz * dz));
-
-    if (length < 1e-6) {
-        return { start, end };
-    }
-
-    const invLen = 1 / length;
-    const ux = dx * invLen;
-    const uy = dy * invLen;
-    const uz = dz * invLen;
-
-    const baseOverlap = Math.max(0.015, Math.min(0.45, diameter * 0.22));
-    const overlap = Math.min(baseOverlap, Math.max(0, length * 0.45));
-    const isFirst = index === 0;
-    const isLast = index === points.length - 2;
-    const startShift = isFirst ? 0 : overlap;
-    const endShift = isLast ? 0 : overlap;
-
-    return {
-        start: {
-            x: start.x - (ux * startShift),
-            y: start.y - (uy * startShift),
-            z: start.z - (uz * startShift),
-        },
-        end: {
-            x: end.x + (ux * endShift),
-            y: end.y + (uy * endShift),
-            z: end.z + (uz * endShift),
-        },
-    };
-}
-
-/** Tessellate a bezier segment into multiple straight InstancedShaft entries for batched rendering. */
-function tesselllateBezierToShafts(
-    segment: BezierSegment,
-    startPos: { x: number; y: number; z: number },
-    endPos: { x: number; y: number; z: number },
-    supportId: string,
-    modelId?: string,
-): InstancedShaft[] {
-    const BATCHED_BEZIER_MIN_RESOLUTION = 4;
-    const BATCHED_BEZIER_MAX_RESOLUTION = 24;
-    const adaptiveResolution = calculateAdaptiveBezierResolution(
-        startPos,
-        segment.controlPoint1,
-        segment.controlPoint2,
-        endPos,
-        {
-            minResolution: BATCHED_BEZIER_MIN_RESOLUTION,
-            maxResolution: BATCHED_BEZIER_MAX_RESOLUTION,
-            targetChordLengthMm: 2.5,
-            curvatureWeight: 2.0,
-        },
-    );
-    const res = Math.max(2, segment.resolution ?? adaptiveResolution);
-    const points = bezierToLineSegments(startPos, segment.controlPoint1, segment.controlPoint2, endPos, res);
-    const shafts: InstancedShaft[] = [];
-    for (let i = 0; i < points.length - 1; i++) {
-        const overlapped = applyBatchedBezierSeamOverlap(points, i, segment.diameter);
-        shafts.push({
-            id: segment.id,
-            start: overlapped.start,
-            end: overlapped.end,
-            diameter: segment.diameter,
-            supportId,
-            modelId,
-        });
-    }
-    return shafts;
-}
-
-function tessellateBraceBezierToShafts(
-    segmentId: string,
-    startPos: { x: number; y: number; z: number },
-    endPos: { x: number; y: number; z: number },
-    controlPoint1: { x: number; y: number; z: number },
-    controlPoint2: { x: number; y: number; z: number },
-    diameter: number,
-    supportId: string,
-    modelId?: string,
-): InstancedShaft[] {
-    const adaptiveResolution = calculateAdaptiveBezierResolution(
-        startPos,
-        controlPoint1,
-        controlPoint2,
-        endPos,
-        {
-            minResolution: 4,
-            maxResolution: 24,
-            targetChordLengthMm: 2.5,
-            curvatureWeight: 2.0,
-        },
-    );
-    const points = bezierToLineSegments(startPos, controlPoint1, controlPoint2, endPos, adaptiveResolution);
-    const shafts: InstancedShaft[] = [];
-    for (let i = 0; i < points.length - 1; i++) {
-        const overlapped = applyBatchedBezierSeamOverlap(points, i, diameter);
-        shafts.push({
-            id: segmentId,
-            start: overlapped.start,
-            end: overlapped.end,
-            diameter,
-            supportId,
-            modelId,
-        });
-    }
-    return shafts;
-}
 
 function recomputeLeafPreviewContactCone(
     leaf: Leaf,
@@ -621,7 +502,7 @@ function buildSupportPlacementPreviewBatch(
 
         if (segment.type === 'bezier') {
             shafts.push(
-                ...tesselllateBezierToShafts(
+                bezierSegmentToBatchedShaft(
                     segment as BezierSegment,
                     { x: currentStart.x, y: currentStart.y, z: currentStart.z },
                     { x: endPoint.x, y: endPoint.y, z: endPoint.z },
@@ -1767,6 +1648,19 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
         };
     }, [resolveModelDropOffsetZ]);
 
+    // Curved batched shafts carry bezier control points; the drop offset must
+    // move them together with the endpoints or the curve deforms.
+    const applyDropToInstancedShaft = React.useCallback((shaft: InstancedShaft): InstancedShaft => {
+        const dropped: InstancedShaft = {
+            ...shaft,
+            start: applyDropToVec3Like(shaft.start, shaft.modelId),
+            end: applyDropToVec3Like(shaft.end, shaft.modelId),
+        };
+        if (shaft.controlPoint1) dropped.controlPoint1 = applyDropToVec3Like(shaft.controlPoint1, shaft.modelId);
+        if (shaft.controlPoint2) dropped.controlPoint2 = applyDropToVec3Like(shaft.controlPoint2, shaft.modelId);
+        return dropped;
+    }, [applyDropToVec3Like]);
+
     const trunkIdByRootIdForSelection = useMemo(() => {
         const map = new Map<string, string>();
         for (const trunk of trunkList) {
@@ -2366,7 +2260,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 }
 
                 if (segment.type === 'bezier') {
-                    shafts.push(...tesselllateBezierToShafts(segment, currentStart, endPoint, trunk.id, trunk.modelId));
+                    shafts.push(bezierSegmentToBatchedShaft(segment, currentStart, endPoint, trunk.id, trunk.modelId));
                     currentStart = endPoint;
                     continue;
                 }
@@ -2418,7 +2312,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 }
 
                 if (segment.type === 'bezier') {
-                    shafts.push(...tesselllateBezierToShafts(segment, currentStart, endPoint, branch.id, branch.modelId));
+                    shafts.push(bezierSegmentToBatchedShaft(segment, currentStart, endPoint, branch.id, branch.modelId));
                     currentStart = endPoint;
                     continue;
                 }
@@ -2487,16 +2381,17 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             const diameter = (startHostDiameter + endHostDiameter) * 0.5;
             const segmentId = `braceSegment:${brace.id}`;
             const shafts = brace.curve?.type === 'bezier'
-                ? tessellateBraceBezierToShafts(
+                ? [braceBezierToBatchedShaft(
                     segmentId,
                     startKnot.pos,
                     endKnot.pos,
                     brace.curve.controlPoint1,
                     brace.curve.controlPoint2,
                     diameter,
+                    brace.curve.resolution,
                     brace.id,
                     brace.modelId,
-                )
+                )]
                 : [{
                     id: segmentId,
                     start: startKnot.pos,
@@ -2567,7 +2462,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 }
 
                 if (segment.type === 'bezier') {
-                    shafts.push(...tesselllateBezierToShafts(segment, startPoint, endPoint, twig.id, twig.modelId));
+                    shafts.push(bezierSegmentToBatchedShaft(segment, startPoint, endPoint, twig.id, twig.modelId));
                 } else if (isUniformDiameter) {
                     shafts.push({
                         id: segment.id,
@@ -2616,7 +2511,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                     })();
 
                 if (segment.type === 'bezier') {
-                    shafts.push(...tesselllateBezierToShafts(segment, startPoint, endPoint, stick.id, stick.modelId));
+                    shafts.push(bezierSegmentToBatchedShaft(segment, startPoint, endPoint, stick.id, stick.modelId));
                 } else {
                     shafts.push({
                         id: segment.id,
@@ -2678,7 +2573,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 }
 
                 if (segment.type === 'bezier') {
-                    shafts.push(...tesselllateBezierToShafts(segment, currentStart, endPoint, kickstand.id, kickstand.modelId));
+                    shafts.push(bezierSegmentToBatchedShaft(segment, currentStart, endPoint, kickstand.id, kickstand.modelId));
                 } else if (isUniformDiameter) {
                     shafts.push({
                         id: segment.id,
@@ -3225,16 +3120,12 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             const modelKey = shaftSet.modelId ?? '__unassigned__';
             const groupKey = `${modelKey}:${color}`;
             const existing = grouped.get(groupKey) ?? { modelId: shaftSet.modelId, color, shafts: [] };
-            existing.shafts.push(...shaftSet.shafts.map((shaft) => ({
-                ...shaft,
-                start: applyDropToVec3Like(shaft.start, shaft.modelId),
-                end: applyDropToVec3Like(shaft.end, shaft.modelId),
-            })));
+            existing.shafts.push(...shaftSet.shafts.map(applyDropToInstancedShaft));
             if (existing.shafts.length > 0) grouped.set(groupKey, existing);
         }
 
         return Array.from(grouped.values());
-    }, [renderTwigList, twigShaftsBySupport, selectedTwigIds, isModelVisible, applyDropToVec3Like, enableTwigSceneBatching, resolveSceneSupportColor]);
+    }, [renderTwigList, twigShaftsBySupport, selectedTwigIds, isModelVisible, applyDropToInstancedShaft, enableTwigSceneBatching, resolveSceneSupportColor]);
 
     const sceneBatchedStickShaftGroups = useMemo(() => {
         const grouped = new Map<string, { modelId?: string; color: string; shafts: InstancedShaft[] }>();
@@ -3249,16 +3140,12 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             const modelKey = shaftSet.modelId ?? '__unassigned__';
             const groupKey = `${modelKey}:${color}`;
             const existing = grouped.get(groupKey) ?? { modelId: shaftSet.modelId, color, shafts: [] };
-            existing.shafts.push(...shaftSet.shafts.map((shaft) => ({
-                ...shaft,
-                start: applyDropToVec3Like(shaft.start, shaft.modelId),
-                end: applyDropToVec3Like(shaft.end, shaft.modelId),
-            })));
+            existing.shafts.push(...shaftSet.shafts.map(applyDropToInstancedShaft));
             if (existing.shafts.length > 0) grouped.set(groupKey, existing);
         }
 
         return Array.from(grouped.values());
-    }, [renderStickList, stickShaftsBySupport, selectedStickIds, isModelVisible, applyDropToVec3Like, resolveSceneSupportColor]);
+    }, [renderStickList, stickShaftsBySupport, selectedStickIds, isModelVisible, applyDropToInstancedShaft, resolveSceneSupportColor]);
 
     const sceneBatchedKickstandShaftGroups = useMemo(() => {
         const grouped = new Map<string, { modelId?: string; color: string; shafts: InstancedShaft[] }>();
@@ -3273,16 +3160,12 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             const modelKey = shaftSet.modelId ?? '__unassigned__';
             const groupKey = `${modelKey}:${color}`;
             const existing = grouped.get(groupKey) ?? { modelId: shaftSet.modelId, color, shafts: [] };
-            existing.shafts.push(...shaftSet.shafts.map((shaft) => ({
-                ...shaft,
-                start: applyDropToVec3Like(shaft.start, shaft.modelId),
-                end: applyDropToVec3Like(shaft.end, shaft.modelId),
-            })));
+            existing.shafts.push(...shaftSet.shafts.map(applyDropToInstancedShaft));
             if (existing.shafts.length > 0) grouped.set(groupKey, existing);
         }
 
         return Array.from(grouped.values());
-    }, [renderKickstandList, kickstandShaftsBySupport, selectedKickstandIds, isModelVisible, applyDropToVec3Like, resolveSceneSupportColor]);
+    }, [renderKickstandList, kickstandShaftsBySupport, selectedKickstandIds, isModelVisible, applyDropToInstancedShaft, resolveSceneSupportColor]);
 
     const sceneBatchedBraceShaftGroups = useMemo(() => {
         const grouped = new Map<string, { modelId?: string; color: string; shafts: InstancedShaft[] }>();
@@ -3308,26 +3191,18 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
 
             const existing = grouped.get(groupKey);
             if (existing) {
-                existing.shafts.push(...shaftSet.shafts.map((shaft) => ({
-                    ...shaft,
-                    start: applyDropToVec3Like(shaft.start, shaft.modelId),
-                    end: applyDropToVec3Like(shaft.end, shaft.modelId),
-                })));
+                existing.shafts.push(...shaftSet.shafts.map(applyDropToInstancedShaft));
             } else {
                 grouped.set(groupKey, {
                     modelId: shaftSet.modelId,
                     color,
-                    shafts: shaftSet.shafts.map((shaft) => ({
-                        ...shaft,
-                        start: applyDropToVec3Like(shaft.start, shaft.modelId),
-                        end: applyDropToVec3Like(shaft.end, shaft.modelId),
-                    })),
+                    shafts: shaftSet.shafts.map(applyDropToInstancedShaft),
                 });
             }
         }
 
         return Array.from(grouped.values());
-    }, [renderBraceList, braceShaftsBySupport, selectedBraceIds, ghostedBraceIdSet, isModelVisible, applyDropToVec3Like, settings.autoBracing.debugSectionColorsEnabled, dimNonSelected, resolveSceneSupportColor]);
+    }, [renderBraceList, braceShaftsBySupport, selectedBraceIds, ghostedBraceIdSet, isModelVisible, applyDropToInstancedShaft, settings.autoBracing.debugSectionColorsEnabled, dimNonSelected, resolveSceneSupportColor]);
 
     const sceneBatchedTrunkShaftGroups = useMemo(() => {
         const grouped = new Map<string, { modelId?: string; color: string; shafts: InstancedShaft[] }>();
@@ -3343,17 +3218,13 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             const modelKey = shaftSet.modelId ?? '__unassigned__';
             const groupKey = `${modelKey}:${color}`;
             const existing = grouped.get(groupKey) ?? { modelId: shaftSet.modelId, color, shafts: [] };
-            existing.shafts.push(...shaftSet.shafts.map((shaft) => ({
-                ...shaft,
-                start: applyDropToVec3Like(shaft.start, shaft.modelId),
-                end: applyDropToVec3Like(shaft.end, shaft.modelId),
-            })));
+            existing.shafts.push(...shaftSet.shafts.map(applyDropToInstancedShaft));
 
             if (existing.shafts.length > 0) grouped.set(groupKey, existing);
         }
 
         return Array.from(grouped.values());
-    }, [renderTrunkList, trunkShaftsBySupport, selectedTrunkIds, isModelVisible, applyDropToVec3Like, resolveSceneSupportColor]);
+    }, [renderTrunkList, trunkShaftsBySupport, selectedTrunkIds, isModelVisible, applyDropToInstancedShaft, resolveSceneSupportColor]);
 
     const sceneBatchedBranchShaftGroups = useMemo(() => {
         const grouped = new Map<string, { modelId?: string; color: string; shafts: InstancedShaft[] }>();
@@ -3369,11 +3240,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
             const modelKey = shaftSet.modelId ?? '__unassigned__';
             const groupKey = `${modelKey}:${color}`;
             const existing = grouped.get(groupKey) ?? { modelId: shaftSet.modelId, color, shafts: [] };
-            existing.shafts.push(...shaftSet.shafts.map((shaft) => ({
-                ...shaft,
-                start: applyDropToVec3Like(shaft.start, shaft.modelId),
-                end: applyDropToVec3Like(shaft.end, shaft.modelId),
-            })));
+            existing.shafts.push(...shaftSet.shafts.map(applyDropToInstancedShaft));
 
             if (existing.shafts.length > 0) {
                 grouped.set(groupKey, existing);
@@ -3381,7 +3248,7 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
         }
 
         return Array.from(grouped.values());
-    }, [renderBranchList, branchShaftsBySupport, selectedBranchIds, isModelVisible, applyDropToVec3Like, resolveSceneSupportColor]);
+    }, [renderBranchList, branchShaftsBySupport, selectedBranchIds, isModelVisible, applyDropToInstancedShaft, resolveSceneSupportColor]);
 
     const sceneBatchedTrunkRootGroups = useMemo(() => {
         if (hidePlateContactPrimitivesEffective) return [] as Array<{ modelId: string | null; color: string; roots: InstancedRoot[] }>;
@@ -3685,12 +3552,10 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
         if (!hoveredSupportShaftSet) return [] as InstancedShaft[];
 
         return hoveredSupportShaftSet.shafts.map((shaft) => ({
-            ...shaft,
-            start: applyDropToVec3Like(shaft.start, shaft.modelId),
-            end: applyDropToVec3Like(shaft.end, shaft.modelId),
+            ...applyDropToInstancedShaft(shaft),
             diameter: shaft.diameter * 1.02,
         }));
-    }, [hoveredSupportShaftSet, applyDropToVec3Like]);
+    }, [hoveredSupportShaftSet, applyDropToInstancedShaft]);
 
     const hoveredSupportConeSet = useMemo(() => {
         if (!isInteractable) return null;
@@ -3865,14 +3730,12 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
                 ?? null;
             if (!shaftSet) continue;
             overlays.push(...shaftSet.shafts.map((shaft) => ({
-                ...shaft,
-                start: applyDropToVec3Like(shaft.start, shaft.modelId),
-                end: applyDropToVec3Like(shaft.end, shaft.modelId),
+                ...applyDropToInstancedShaft(shaft),
                 diameter: shaft.diameter * 1.02,
             })));
         }
         return overlays;
-    }, [additionalMarqueeHoveredSupportIds, trunkShaftsBySupport, branchShaftsBySupport, braceShaftsBySupport, twigShaftsBySupport, stickShaftsBySupport, kickstandShaftsBySupport, applyDropToVec3Like]);
+    }, [additionalMarqueeHoveredSupportIds, trunkShaftsBySupport, branchShaftsBySupport, braceShaftsBySupport, twigShaftsBySupport, stickShaftsBySupport, kickstandShaftsBySupport, applyDropToInstancedShaft]);
 
     const marqueeHoveredOverlayCones = useMemo(() => {
         if (additionalMarqueeHoveredSupportIds.length === 0) return [] as InstancedContactCone[];

--- a/src/supports/__tests__/batchedBezierTubeGeometry.test.ts
+++ b/src/supports/__tests__/batchedBezierTubeGeometry.test.ts
@@ -1,0 +1,146 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import * as THREE from 'three';
+import {
+    buildBatchedBezierTubes,
+    isCurvedBatchedShaft,
+    resolveCurvedShaftIndexForFace,
+} from '../Curves/batchedBezierTubeGeometry';
+import type { InstancedShaft } from '../SupportPrimitives/Shaft/InstancedShaftGroup';
+
+const RADIAL_SEGMENTS = 10;
+
+function makeCurvedShaft(overrides: Partial<InstancedShaft> = {}): InstancedShaft {
+    return {
+        id: 'seg-1',
+        start: { x: 0, y: 0, z: 0 },
+        controlPoint1: { x: 0, y: 0, z: 5 },
+        controlPoint2: { x: 6, y: 0, z: 10 },
+        end: { x: 6, y: 0, z: 15 },
+        diameter: 2,
+        resolution: 16,
+        supportId: 'trunk-1',
+        ...overrides,
+    };
+}
+
+function triangleCount(geometry: THREE.BufferGeometry): number {
+    return geometry.getIndex()!.count / 3;
+}
+
+/**
+ * A closed (watertight) triangle surface has every positional edge shared by
+ * an even number of triangles, with matched opposing windings. Cap rims are
+ * duplicated vertices, so compare positions (quantized), not vertex indices.
+ */
+function assertClosedSurface(geometry: THREE.BufferGeometry) {
+    const pos = geometry.getAttribute('position') as THREE.BufferAttribute;
+    const idx = geometry.getIndex()!;
+    const keyOf = (v: number) => [
+        Math.round(pos.getX(v) * 1e4),
+        Math.round(pos.getY(v) * 1e4),
+        Math.round(pos.getZ(v) * 1e4),
+    ].join(',');
+
+    // Track directed edges: a closed, consistently wound surface has every
+    // directed edge cancelled by its reverse.
+    const directed = new Map<string, number>();
+    for (let t = 0; t < idx.count; t += 3) {
+        const verts = [idx.getX(t), idx.getX(t + 1), idx.getX(t + 2)].map(keyOf);
+        for (let e = 0; e < 3; e += 1) {
+            const a = verts[e];
+            const b = verts[(e + 1) % 3];
+            if (a === b) continue; // degenerate cap-center sliver, ignore
+            const forward = `${a}|${b}`;
+            const reverse = `${b}|${a}`;
+            if ((directed.get(reverse) ?? 0) > 0) {
+                directed.set(reverse, directed.get(reverse)! - 1);
+            } else {
+                directed.set(forward, (directed.get(forward) ?? 0) + 1);
+            }
+        }
+    }
+    const unmatched = Array.from(directed.values()).filter((count) => count !== 0);
+    assert.strictEqual(unmatched.length, 0, `surface has ${unmatched.length} unmatched directed edges (open or inconsistently wound)`);
+}
+
+describe('isCurvedBatchedShaft', () => {
+    it('detects curved entries by control-point presence', () => {
+        assert.strictEqual(isCurvedBatchedShaft(makeCurvedShaft()), true);
+        assert.strictEqual(isCurvedBatchedShaft({
+            id: 's',
+            start: { x: 0, y: 0, z: 0 },
+            end: { x: 0, y: 0, z: 1 },
+            diameter: 1,
+        }), false);
+    });
+});
+
+describe('buildBatchedBezierTubes', () => {
+    it('returns null for an empty list', () => {
+        assert.strictEqual(buildBatchedBezierTubes([], RADIAL_SEGMENTS), null);
+    });
+
+    it('builds a closed tube whose surface follows the curve at the segment radius', () => {
+        const shaft = makeCurvedShaft();
+        const result = buildBatchedBezierTubes([shaft], RADIAL_SEGMENTS)!;
+
+        assert.ok(result);
+        assert.strictEqual(result.triangleRangeEnds.length, 1);
+        assert.strictEqual(result.triangleRangeEnds[0], triangleCount(result.geometry));
+        assert.ok(result.geometry.boundingSphere, 'bounding sphere must be precomputed');
+
+        assertClosedSurface(result.geometry);
+
+        // Every side vertex must sit ~radius away from the curve.
+        const curve = new THREE.CubicBezierCurve3(
+            new THREE.Vector3(0, 0, 0),
+            new THREE.Vector3(0, 0, 5),
+            new THREE.Vector3(6, 0, 10),
+            new THREE.Vector3(6, 0, 15),
+        );
+        const samples = curve.getPoints(400);
+        const pos = result.geometry.getAttribute('position') as THREE.BufferAttribute;
+        const sideVertexCount = (16 + 1) * (RADIAL_SEGMENTS + 1);
+        const v = new THREE.Vector3();
+        for (let i = 0; i < sideVertexCount; i += 1) {
+            v.fromBufferAttribute(pos, i);
+            let minDist = Infinity;
+            for (const s of samples) minDist = Math.min(minDist, v.distanceTo(s));
+            assert.ok(Math.abs(minDist - 1) < 0.05, `side vertex ${i} is ${minDist} from curve, expected ~1`);
+        }
+    });
+
+    it('maps face indices back to the owning curve across multiple merged tubes', () => {
+        const a = makeCurvedShaft({ id: 'seg-a' });
+        const b = makeCurvedShaft({
+            id: 'seg-b',
+            start: { x: 20, y: 0, z: 0 },
+            controlPoint1: { x: 20, y: 5, z: 4 },
+            controlPoint2: { x: 24, y: 5, z: 8 },
+            end: { x: 24, y: 0, z: 12 },
+            resolution: 8,
+        });
+        const result = buildBatchedBezierTubes([a, b], RADIAL_SEGMENTS)!;
+
+        assert.strictEqual(result.triangleRangeEnds.length, 2);
+        const [endA, endB] = result.triangleRangeEnds;
+        assert.strictEqual(endB, triangleCount(result.geometry));
+
+        assert.strictEqual(resolveCurvedShaftIndexForFace(result.triangleRangeEnds, 0), 0);
+        assert.strictEqual(resolveCurvedShaftIndexForFace(result.triangleRangeEnds, endA - 1), 0);
+        assert.strictEqual(resolveCurvedShaftIndexForFace(result.triangleRangeEnds, endA), 1);
+        assert.strictEqual(resolveCurvedShaftIndexForFace(result.triangleRangeEnds, endB - 1), 1);
+        assert.strictEqual(resolveCurvedShaftIndexForFace(result.triangleRangeEnds, endB), -1);
+        assert.strictEqual(resolveCurvedShaftIndexForFace(result.triangleRangeEnds, -1), -1);
+        assert.strictEqual(resolveCurvedShaftIndexForFace([], 0), -1);
+    });
+
+    it('falls back to adaptive resolution when a curve does not specify one', () => {
+        const shaft = makeCurvedShaft({ resolution: undefined });
+        const result = buildBatchedBezierTubes([shaft], RADIAL_SEGMENTS)!;
+        assert.ok(result);
+        assert.ok(triangleCount(result.geometry) > 0);
+        assertClosedSurface(result.geometry);
+    });
+});


### PR DESCRIPTION
Fixes #203. This branch collects the bezier segment fixes: the attachment bug from the issue, plus the curve rendering and export problems found while validating it.

## 1. Branches would not attach to a curved segment while it was selected (#203)

During placement, branch anchoring finds curves through the `shaft-hover` fast path. For a selected support the only curve emitter is the detailed `BezierRenderer`, whose interaction gate hard-required `isInteractable`. Every active placement mode disables selection and hover, which drives `isInteractable` false exactly when placement needs the emitter. `ShaftRenderer` already lets active placement override that flag, which is why straight segments always worked.

Fix: give `BezierRenderer` the same gate semantics as `ShaftRenderer` (including the kickstand and leaf placement signals), and ignore segment pointer-move while a bezier handle drag is live so placement can't snap to a curve mid-edit.

Validated in-app: both gray branches in the screenshot below were placed directly on the selected (magenta) curve.

![Branches attached to a selected curved segment](https://raw.githubusercontent.com/Open-Resin-Alliance/DragonFruit/53bea39c501b79482a15b62d48200984ac1c6e21/docs/assets/issue-203-branch-attach-curved-segment.png)

## 2. Deselected curved segments rendered as chunky cylinder stacks

Since the Rendering Engine V2 batching refactor (#92), deselected supports render through a scene batch that approximated each bezier as straight instanced cylinders stretched to overlap at the seams; the interpenetrating cap rims read as shingle-like creases next to the smooth `TubeGeometry` shown while selected.

Fix: a bezier now enters the batch as a single entry carrying its control points, and `InstancedShaftGroup` renders all curved entries of a group as one merged, end-capped `TubeGeometry` mesh (same resolution rules as the detailed renderer, one draw call per group). Straight shafts stay instanced. Hover and click on the tube resolve back to the owning segment, so the batched `shaft-hover` anchoring from fix 1 keeps working, with hit points now on the true curve. End caps keep the proxy layer's scene graph watertight for the unscoped STL/3MF serialization, and the model drop offset now moves control points together with endpoints. Validated in-app: deselected curves render as smooth continuous tubes.

## 3. Exports flattened curved segments into a straight cylinder

`SupportGeometryGenerator` emitted a single straight cylinder for bezier segments. It now reconstructs them as piecewise cylinders along the curve (matching the raster slicing path), and `supportExportReconstruction` reuses that instead of duplicating the tessellation inline. The reconstruction test moves under `__tests__/` so the npm test glob actually runs it, with new bezier coverage.

## Checks

`npx tsc --noEmit` clean, no new eslint findings, 136 supports tests plus 6 export reconstruction tests pass, and 5 new unit tests cover the merged tube geometry (face-range event mapping, watertightness and winding, adaptive resolution fallback).