### PR TITLE
fix(supports): keep branches/leaves anchored when inserting a joint, and let knots cross joints

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -319,14 +319,31 @@ import {
   getSavedUvToolsSettings,
   resolveUvToolsExecutablePath,
 } from '@/components/settings/uvToolsPreferences';
-import { subscribe as subscribeSupportState, getSnapshot as getSupportSnapshot, toggleSegmentCurve, transformSupportsForModel, updateTrunk, updateBranch, updateTwig, updateStick } from '@/supports/state';
+import { subscribe as subscribeSupportState, getSnapshot as getSupportSnapshot, toggleSegmentCurve, transformSupportsForModel, updateTrunk, updateBranch, updateTwig, updateStick, updateKnot } from '@/supports/state';
 import {
   getKickstandSnapshot,
   subscribeToKickstandStore,
 } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 import { bracePlacementStore } from '@/supports/SupportTypes/Brace/bracePlacementState';
 import { splitShaft, splitBranchShaft, splitTwigShaft, splitStickShaft } from '@/supports/SupportPrimitives/Joint/jointUtils';
+import type { KnotSplitRemap } from '@/supports/SupportPrimitives/Knot/knotUtils';
 import { captureSupportEditSnapshot, pushSupportEditHistory } from '@/supports/history/supportEditHistory';
+
+/**
+ * Apply knot re-anchor patches from a segment split BEFORE the host update runs,
+ * so attached branches/leaves keep their world position when a joint is inserted
+ * (issue #204). Mirror of the helper in useJointCreation for the context-menu
+ * "Add joint" path.
+ */
+function applyJointSplitKnotRemaps(remaps: KnotSplitRemap[]) {
+    if (remaps.length === 0) return;
+    const knots = getSupportSnapshot().knots;
+    for (const remap of remaps) {
+        const knot = knots[remap.knotId];
+        if (!knot) continue;
+        updateKnot({ ...knot, parentShaftId: remap.parentShaftId, t: remap.t });
+    }
+}
 import { getRaftSettings, subscribeToRaftStore } from '@/supports/Rafts/Crenelated/RaftState';
 import { computeFootprint } from '@/supports/Rafts/Crenelated/geometry/computeFootprint';
 import { computeRaftOuterBoundary } from '@/supports/Rafts/Crenelated/geometry/computeRaftOuterBoundary';
@@ -5900,7 +5917,8 @@ export default function Home() {
               const projected = segment.type === 'bezier'
                 ? projectBezierSplitPoint(start, segment.controlPoint1, segment.controlPoint2, end, splitTargetPoint)
                 : projectSplitPoint(start, end, splitTargetPoint);
-              const updated = splitShaft(trunk, segmentId, projected.point, projected.t, root);
+              const { trunk: updated, knotRemaps } = splitShaft(trunk, segmentId, projected.point, projected.t, root, state.knots);
+              applyJointSplitKnotRemaps(knotRemaps);
               updateTrunk(updated);
               pushSupportEditHistory('Create trunk joint', beforeSnapshot, captureSupportEditSnapshot());
             }
@@ -5925,7 +5943,8 @@ export default function Home() {
               const projected = segment.type === 'bezier'
                 ? projectBezierSplitPoint(start, segment.controlPoint1, segment.controlPoint2, end, splitTargetPoint)
                 : projectSplitPoint(start, end, splitTargetPoint);
-              const updated = splitBranchShaft(branch, segmentId, projected.point, projected.t, parentKnot);
+              const { branch: updated, knotRemaps } = splitBranchShaft(branch, segmentId, projected.point, projected.t, parentKnot, state.knots);
+              applyJointSplitKnotRemaps(knotRemaps);
               updateBranch(updated);
               pushSupportEditHistory('Create branch joint', beforeSnapshot, captureSupportEditSnapshot());
             }
@@ -5947,7 +5966,8 @@ export default function Home() {
               const projected = segment.type === 'bezier'
                 ? projectBezierSplitPoint(start, segment.controlPoint1, segment.controlPoint2, end, splitTargetPoint)
                 : projectSplitPoint(start, end, splitTargetPoint);
-              const updated = splitTwigShaft(twig, segmentId, projected.point, projected.t);
+              const { twig: updated, knotRemaps } = splitTwigShaft(twig, segmentId, projected.point, projected.t, state.knots);
+              applyJointSplitKnotRemaps(knotRemaps);
               updateTwig(updated);
               pushSupportEditHistory('Create twig joint', beforeSnapshot, captureSupportEditSnapshot());
             }
@@ -5969,7 +5989,8 @@ export default function Home() {
               const projected = segment.type === 'bezier'
                 ? projectBezierSplitPoint(start, segment.controlPoint1, segment.controlPoint2, end, splitTargetPoint)
                 : projectSplitPoint(start, end, splitTargetPoint);
-              const updated = splitStickShaft(stick, segmentId, projected.point, projected.t);
+              const { stick: updated, knotRemaps } = splitStickShaft(stick, segmentId, projected.point, projected.t, state.knots);
+              applyJointSplitKnotRemaps(knotRemaps);
               updateStick(updated);
               pushSupportEditHistory('Create stick joint', beforeSnapshot, captureSupportEditSnapshot());
             }

--- a/src/supports/SupportPrimitives/Joint/jointUtils.ts
+++ b/src/supports/SupportPrimitives/Joint/jointUtils.ts
@@ -7,143 +7,144 @@ import { getJointDiameter } from '../../constants';
 import { getBezierPointAtT, toVector3, subdivideCubicBezier, toVec3 } from '../../Curves/BezierUtils';
 import { getKnotById } from '../../state';
 import { solveJointConstraint } from '../../PlacementLogic/JointConstraintSolver';
+import { remapKnotAcrossSplit, type KnotSplitRemap } from '../Knot/knotUtils';
+
+function remapKnotsForSplit(
+    knots: Record<string, Knot> | undefined,
+    originalSegmentId: string,
+    topSegmentId: string,
+    splitT: number | undefined
+): KnotSplitRemap[] {
+    if (!knots || splitT === undefined) return [];
+    const remaps: KnotSplitRemap[] = [];
+    for (const knot of Object.values(knots)) {
+        const remap = remapKnotAcrossSplit(knot, originalSegmentId, originalSegmentId, topSegmentId, splitT);
+        if (remap) remaps.push(remap);
+    }
+    return remaps;
+}
+
+/**
+ * Generic segment splitter that preserves bezier geometry via De Casteljau
+ * subdivision and falls back to a linear split. Host-specific start/end
+ * resolution is supplied by the light wrappers below so the core logic lives
+ * in one place (Jo review: single place to change split geometry).
+ */
+function splitSegmentArray(
+    segments: Segment[],
+    segmentId: string,
+    splitPoint: Vec3,
+    splitT: number | undefined,
+    resolveStart: (segIndex: number, seg: Segment) => Vec3 | null,
+    resolveEnd: (startPos: Vec3, seg: Segment) => Vec3 | null,
+): { newSegments: Segment[]; topSegmentId: string; joint: Joint } | null {
+    const segIndex = segments.findIndex((s) => s.id === segmentId);
+    if (segIndex === -1) return null;
+    const originalSegment = segments[segIndex];
+    const joint: Joint = {
+        id: uuidv4(),
+        pos: splitPoint,
+        diameter: getJointDiameter(originalSegment.diameter),
+    };
+
+    let bottomSegment: Segment;
+    let topSegment: Segment;
+
+    const isBezierSplit = originalSegment.type === 'bezier' && splitT !== undefined;
+    if (isBezierSplit) {
+        const startPos = resolveStart(segIndex, originalSegment);
+        const endPos = startPos ? resolveEnd(startPos, originalSegment) : null;
+        if (startPos && endPos) {
+            const [leftCurve, rightCurve] = subdivideCubicBezier(
+                startPos,
+                (originalSegment as BezierSegment).controlPoint1,
+                (originalSegment as BezierSegment).controlPoint2,
+                endPos,
+                splitT!,
+            );
+            bottomSegment = {
+                ...originalSegment,
+                id: originalSegment.id,
+                topJoint: joint,
+                controlPoint1: leftCurve[1],
+                controlPoint2: leftCurve[2],
+            } as BezierSegment;
+            topSegment = {
+                ...originalSegment,
+                id: uuidv4(),
+                bottomJoint: joint,
+                topJoint: originalSegment.topJoint,
+                controlPoint1: rightCurve[1],
+                controlPoint2: rightCurve[2],
+            } as BezierSegment;
+            const newSegments = [
+                ...segments.slice(0, segIndex),
+                bottomSegment,
+                topSegment,
+                ...segments.slice(segIndex + 1),
+            ];
+            return { newSegments, topSegmentId: topSegment.id, joint };
+        }
+    }
+
+    bottomSegment = {
+        ...originalSegment,
+        id: originalSegment.id,
+        topJoint: joint,
+    };
+    topSegment = {
+        ...originalSegment,
+        id: uuidv4(),
+        bottomJoint: joint,
+        topJoint: originalSegment.topJoint,
+    };
+    return {
+        newSegments: [...segments.slice(0, segIndex), bottomSegment, topSegment, ...segments.slice(segIndex + 1)],
+        topSegmentId: topSegment.id,
+        joint,
+    };
+}
+
 
 /**
  * Splits a trunk shaft segment by inserting a new joint.
- * 
- * @param trunk The trunk to modify
- * @param segmentId The ID of the segment to split
- * @param splitPoint The 3D position where the joint should be created
- * @param splitT The parameter t along the curve where the split occurs (required for Bezier preservation)
- * @param root The root of the trunk (required to determine start position)
- * @returns A new Trunk object with the split segment
  */
 export function splitShaft(
     trunk: Trunk,
     segmentId: string,
     splitPoint: Vec3,
     splitT?: number,
-    root?: Roots
-): Trunk {
-    // 1. Find segment index
-    const segIndex = trunk.segments.findIndex(s => s.id === segmentId);
-    if (segIndex === -1) {
+    root?: Roots,
+    knots?: Record<string, Knot>
+): { trunk: Trunk; knotRemaps: KnotSplitRemap[] } {
+    const res = splitSegmentArray(
+        trunk.segments,
+        segmentId,
+        splitPoint,
+        splitT,
+        (segIndex, seg) => {
+            if (seg.bottomJoint) return seg.bottomJoint.pos;
+            if (segIndex === 0 && root) {
+                const rPos = root.transform.pos;
+                const startZ = rPos.z + root.diskHeight + root.coneHeight;
+                return { x: rPos.x, y: rPos.y, z: startZ };
+            }
+            if (segIndex > 0) return trunk.segments[segIndex - 1].topJoint?.pos ?? null;
+            return null;
+        },
+        (startPos, seg) => {
+            if (seg.topJoint) return seg.topJoint.pos;
+            if (trunk.contactCone) return getFinalSocketPosition(trunk.contactCone);
+            return { x: startPos.x, y: startPos.y, z: startPos.z + 10 };
+        }
+    );
+    if (!res) {
         console.warn('[JointUtils] Segment not found:', segmentId);
-        return trunk;
+        return { trunk, knotRemaps: [] };
     }
-
-    const originalSegment = trunk.segments[segIndex];
-
-    // 2. Create new Joint
-    const joint: Joint = {
-        id: uuidv4(),
-        pos: splitPoint,
-        diameter: getJointDiameter(originalSegment.diameter)
-    };
-
-    let bottomSegment: Segment;
-    let topSegment: Segment;
-
-    if (originalSegment.type === 'bezier' && splitT !== undefined && root) {
-        // Bezier Subdivision (Exact Geometry Preservation)
-
-        // Find Start Point
-        let startPos: Vec3;
-        if (originalSegment.bottomJoint) {
-            startPos = originalSegment.bottomJoint.pos;
-        } else if (segIndex === 0) {
-            const rPos = root.transform.pos;
-            const startZ = rPos.z + root.diskHeight + root.coneHeight;
-            startPos = { x: rPos.x, y: rPos.y, z: startZ };
-        } else {
-            const prev = trunk.segments[segIndex - 1];
-            startPos = prev.topJoint!.pos;
-        }
-
-        // Find End Point
-        let endPos: Vec3;
-        if (originalSegment.topJoint) {
-            endPos = originalSegment.topJoint.pos;
-        } else if (trunk.contactCone) {
-            endPos = getFinalSocketPosition(trunk.contactCone);
-        } else {
-            endPos = { x: startPos.x, y: startPos.y, z: startPos.z + 10 }; // Fallback
-        }
-
-        const [leftCurve, rightCurve] = subdivideCubicBezier(
-            startPos,
-            originalSegment.controlPoint1,
-            originalSegment.controlPoint2,
-            endPos,
-            splitT
-        );
-
-        // leftCurve = [p0, p1, p2, p3] (p0=start, p3=split)
-        // rightCurve = [p0, p1, p2, p3] (p0=split, p3=end)
-
-        // Bottom (Left)
-        bottomSegment = {
-            ...originalSegment,
-            id: originalSegment.id,
-            topJoint: joint,
-            // bottomJoint preserved
-            controlPoint1: leftCurve[1],
-            controlPoint2: leftCurve[2],
-            // startTangent is v1-v0? No, we store tangents as vectors.
-            // We should update tangents? Or do renderers use CP directly?
-            // The type defines CP1, CP2. Tangents are usually derived or auxiliary.
-            // Let's ensure we don't break tangent continuity logic later.
-            // Tangent at split point = derivative.
-            // Left End Tangent = (p3 - p2) normalized
-            // Right Start Tangent = (p1 - p0) normalized (of right curve)
-            // They should be opposite?
-            // Wait, renderer uses CP. curveUtils uses Tangents to *derive* CP.
-            // If we set CP directly, curveUtils might overwrite them if we call `updateCurves` later.
-            // But we are preserving geometry here.
-            // Let's just set CPs.
-        } as BezierSegment;
-
-        // Top (Right)
-        topSegment = {
-            ...originalSegment,
-            id: uuidv4(),
-            bottomJoint: joint,
-            topJoint: originalSegment.topJoint,
-            controlPoint1: rightCurve[1],
-            controlPoint2: rightCurve[2]
-        } as BezierSegment;
-
-    } else {
-        // Linear Split (Original Logic)
-        bottomSegment = {
-            ...originalSegment,
-            id: originalSegment.id, // Keep original ID for the bottom part usually
-            topJoint: joint
-            // bottomJoint: originalSegment.bottomJoint (preserved)
-        };
-
-        topSegment = {
-            ...originalSegment,
-            id: uuidv4(),
-            bottomJoint: joint,
-            topJoint: originalSegment.topJoint
-        };
-    }
-
-    // 4. Construct new segments array
-    const newSegments = [
-        ...trunk.segments.slice(0, segIndex),
-        bottomSegment,
-        topSegment,
-        ...trunk.segments.slice(segIndex + 1)
-    ];
-
-    return {
-        ...trunk,
-        segments: newSegments
-    };
+    const knotRemaps = remapKnotsForSplit(knots, segmentId, res.topSegmentId, splitT);
+    return { trunk: { ...trunk, segments: res.newSegments }, knotRemaps };
 }
-
 
 /**
  * Splits a branch shaft segment by inserting a new joint.
@@ -154,275 +155,84 @@ export function splitBranchShaft(
     segmentId: string,
     splitPoint: Vec3,
     splitT?: number,
-    parentKnot?: Knot
-): Branch {
-    // 1. Find segment index
-    const segIndex = branch.segments.findIndex(s => s.id === segmentId);
-    if (segIndex === -1) {
+    parentKnot?: Knot,
+    knots?: Record<string, Knot>
+): { branch: Branch; knotRemaps: KnotSplitRemap[] } {
+    const res = splitSegmentArray(
+        branch.segments,
+        segmentId,
+        splitPoint,
+        splitT,
+        (segIndex) => {
+            if (segIndex === 0) return parentKnot?.pos ?? null;
+            return branch.segments[segIndex - 1].topJoint?.pos ?? null;
+        },
+        (startPos, seg) => {
+            if (seg.topJoint) return seg.topJoint.pos;
+            if (branch.contactCone) return getFinalSocketPosition(branch.contactCone);
+            return { x: startPos.x, y: startPos.y, z: startPos.z + 5 };
+        }
+    );
+    if (!res) {
         console.warn('[JointUtils] Segment not found in branch:', segmentId);
-        return branch;
+        return { branch, knotRemaps: [] };
     }
-
-    const originalSegment = branch.segments[segIndex];
-
-    // 2. Create new Joint
-    const joint: Joint = {
-        id: uuidv4(),
-        pos: splitPoint,
-        diameter: getJointDiameter(originalSegment.diameter)
-    };
-
-    let bottomSegment: Segment;
-    let topSegment: Segment;
-
-    if (originalSegment.type === 'bezier' && splitT !== undefined && parentKnot) {
-        // Bezier Subdivision (Exact Geometry Preservation)
-
-        // Find Start Point
-        let startPos: Vec3;
-        if (segIndex === 0) {
-            startPos = parentKnot.pos;
-        } else {
-            const prev = branch.segments[segIndex - 1];
-            startPos = prev.topJoint!.pos;
-        }
-
-        // Find End Point
-        let endPos: Vec3;
-        if (originalSegment.topJoint) {
-            endPos = originalSegment.topJoint.pos;
-        } else if (branch.contactCone) {
-            endPos = getFinalSocketPosition(branch.contactCone);
-        } else {
-            endPos = { x: startPos.x, y: startPos.y, z: startPos.z + 5 };
-        }
-
-        const [leftCurve, rightCurve] = subdivideCubicBezier(
-            startPos,
-            originalSegment.controlPoint1,
-            originalSegment.controlPoint2,
-            endPos,
-            splitT
-        );
-
-        bottomSegment = {
-            ...originalSegment,
-            id: originalSegment.id,
-            topJoint: joint,
-            controlPoint1: leftCurve[1],
-            controlPoint2: leftCurve[2],
-        } as BezierSegment;
-
-        topSegment = {
-            ...originalSegment,
-            id: uuidv4(),
-            bottomJoint: joint,
-            topJoint: originalSegment.topJoint,
-            controlPoint1: rightCurve[1],
-            controlPoint2: rightCurve[2]
-        } as BezierSegment;
-
-    } else {
-        // Linear Split
-        bottomSegment = {
-            ...originalSegment,
-            id: originalSegment.id,
-            topJoint: joint
-        };
-
-        topSegment = {
-            ...originalSegment,
-            id: uuidv4(),
-            bottomJoint: joint,
-            topJoint: originalSegment.topJoint
-        };
-    }
-
-    // 4. Construct new segments array
-    const newSegments = [
-        ...branch.segments.slice(0, segIndex),
-        bottomSegment,
-        topSegment,
-        ...branch.segments.slice(segIndex + 1)
-    ];
-
-    return {
-        ...branch,
-        segments: newSegments
-    };
+    const knotRemaps = remapKnotsForSplit(knots, segmentId, res.topSegmentId, splitT);
+    return { branch: { ...branch, segments: res.newSegments }, knotRemaps };
 }
 
- export function splitTwigShaft(
-     twig: Twig,
-     segmentId: string,
-     splitPoint: Vec3,
-     splitT?: number,
- ): Twig {
-     const segIndex = twig.segments.findIndex((s: Segment) => s.id === segmentId);
-     if (segIndex === -1) {
-         console.warn('[JointUtils] Segment not found in twig:', segmentId);
-         return twig;
-     }
+export function splitTwigShaft(
+    twig: Twig,
+    segmentId: string,
+    splitPoint: Vec3,
+    splitT?: number,
+    knots?: Record<string, Knot>
+): { twig: Twig; knotRemaps: KnotSplitRemap[] } {
+    const res = splitSegmentArray(
+        twig.segments,
+        segmentId,
+        splitPoint,
+        splitT,
+        (segIndex, seg) => {
+            if (segIndex === 0) return seg.bottomJoint?.pos ?? splitPoint;
+            return twig.segments[segIndex - 1].topJoint?.pos ?? splitPoint;
+        },
+        (startPos, seg) => seg.topJoint?.pos ?? { x: startPos.x, y: startPos.y, z: startPos.z + 5 }
+    );
+    if (!res) {
+        console.warn('[JointUtils] Segment not found in twig:', segmentId);
+        return { twig, knotRemaps: [] };
+    }
+    const knotRemaps = remapKnotsForSplit(knots, segmentId, res.topSegmentId, splitT);
+    return { twig: { ...twig, segments: res.newSegments }, knotRemaps };
+}
 
-     const originalSegment = twig.segments[segIndex];
+export function splitStickShaft(
+    stick: Stick,
+    segmentId: string,
+    splitPoint: Vec3,
+    splitT?: number,
+    knots?: Record<string, Knot>
+): { stick: Stick; knotRemaps: KnotSplitRemap[] } {
+    const res = splitSegmentArray(
+        stick.segments,
+        segmentId,
+        splitPoint,
+        splitT,
+        (segIndex, seg) => {
+            if (segIndex === 0) return seg.bottomJoint?.pos ?? splitPoint;
+            return stick.segments[segIndex - 1].topJoint?.pos ?? splitPoint;
+        },
+        (startPos, seg) => seg.topJoint?.pos ?? { x: startPos.x, y: startPos.y, z: startPos.z + 5 }
+    );
+    if (!res) {
+        console.warn('[JointUtils] Segment not found in stick:', segmentId);
+        return { stick, knotRemaps: [] };
+    }
+    const knotRemaps = remapKnotsForSplit(knots, segmentId, res.topSegmentId, splitT);
+    return { stick: { ...stick, segments: res.newSegments }, knotRemaps };
+}
 
-     const joint: Joint = {
-         id: uuidv4(),
-         pos: splitPoint,
-         diameter: getJointDiameter(originalSegment.diameter)
-     };
-
-     let bottomSegment: Segment;
-     let topSegment: Segment;
-
-     if (originalSegment.type === 'bezier' && splitT !== undefined) {
-         let startPos: Vec3;
-         if (segIndex === 0) {
-             startPos = originalSegment.bottomJoint?.pos ?? splitPoint;
-         } else {
-             const prev = twig.segments[segIndex - 1];
-             startPos = prev.topJoint?.pos ?? splitPoint;
-         }
-
-         const endPos: Vec3 = originalSegment.topJoint?.pos ?? { x: startPos.x, y: startPos.y, z: startPos.z + 5 };
-
-         const [leftCurve, rightCurve] = subdivideCubicBezier(
-             startPos,
-             originalSegment.controlPoint1,
-             originalSegment.controlPoint2,
-             endPos,
-             splitT
-         );
-
-         bottomSegment = {
-             ...originalSegment,
-             id: originalSegment.id,
-             topJoint: joint,
-             controlPoint1: leftCurve[1],
-             controlPoint2: leftCurve[2],
-         } as BezierSegment;
-
-         topSegment = {
-             ...originalSegment,
-             id: uuidv4(),
-             bottomJoint: joint,
-             topJoint: originalSegment.topJoint,
-             controlPoint1: rightCurve[1],
-             controlPoint2: rightCurve[2]
-         } as BezierSegment;
-     } else {
-         bottomSegment = {
-             ...originalSegment,
-             id: originalSegment.id,
-             topJoint: joint
-         };
-
-         topSegment = {
-             ...originalSegment,
-             id: uuidv4(),
-             bottomJoint: joint,
-             topJoint: originalSegment.topJoint
-         };
-     }
-
-     const newSegments = [
-         ...twig.segments.slice(0, segIndex),
-         bottomSegment,
-         topSegment,
-         ...twig.segments.slice(segIndex + 1)
-     ];
-
-     return {
-         ...twig,
-         segments: newSegments
-     };
- }
-
- export function splitStickShaft(
-     stick: Stick,
-     segmentId: string,
-     splitPoint: Vec3,
-     splitT?: number,
- ): Stick {
-     const segIndex = stick.segments.findIndex((s: Segment) => s.id === segmentId);
-     if (segIndex === -1) {
-         console.warn('[JointUtils] Segment not found in stick:', segmentId);
-         return stick;
-     }
-
-     const originalSegment = stick.segments[segIndex];
-
-     const joint: Joint = {
-         id: uuidv4(),
-         pos: splitPoint,
-         diameter: getJointDiameter(originalSegment.diameter)
-     };
-
-     let bottomSegment: Segment;
-     let topSegment: Segment;
-
-     if (originalSegment.type === 'bezier' && splitT !== undefined) {
-         let startPos: Vec3;
-         if (segIndex === 0) {
-             startPos = originalSegment.bottomJoint?.pos ?? splitPoint;
-         } else {
-             const prev = stick.segments[segIndex - 1];
-             startPos = prev.topJoint?.pos ?? splitPoint;
-         }
-
-         const endPos: Vec3 = originalSegment.topJoint?.pos ?? { x: startPos.x, y: startPos.y, z: startPos.z + 5 };
-
-         const [leftCurve, rightCurve] = subdivideCubicBezier(
-             startPos,
-             originalSegment.controlPoint1,
-             originalSegment.controlPoint2,
-             endPos,
-             splitT
-         );
-
-         bottomSegment = {
-             ...originalSegment,
-             id: originalSegment.id,
-             topJoint: joint,
-             controlPoint1: leftCurve[1],
-             controlPoint2: leftCurve[2],
-         } as BezierSegment;
-
-         topSegment = {
-             ...originalSegment,
-             id: uuidv4(),
-             bottomJoint: joint,
-             topJoint: originalSegment.topJoint,
-             controlPoint1: rightCurve[1],
-             controlPoint2: rightCurve[2]
-         } as BezierSegment;
-     } else {
-         bottomSegment = {
-             ...originalSegment,
-             id: originalSegment.id,
-             topJoint: joint
-         };
-
-         topSegment = {
-             ...originalSegment,
-             id: uuidv4(),
-             bottomJoint: joint,
-             topJoint: originalSegment.topJoint
-         };
-     }
-
-     const newSegments = [
-         ...stick.segments.slice(0, segIndex),
-         bottomSegment,
-         topSegment,
-         ...stick.segments.slice(segIndex + 1)
-     ];
-
-     return {
-         ...stick,
-         segments: newSegments
-     };
- }
 
 export function findClosestSegment(trunk: Trunk, root: Roots, point: Vec3): { segment: Segment, t: number, pointOnLine: Vec3 } | null {
     // Reconstruct skeleton start

--- a/src/supports/SupportPrimitives/Joint/useJointCreation.ts
+++ b/src/supports/SupportPrimitives/Joint/useJointCreation.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback, useMemo, useSyncExternalStore } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
-import { subscribe, getSnapshot, updateTrunk, updateBranch, updateTwig, updateStick } from '../../state';
+import { subscribe, getSnapshot, updateTrunk, updateBranch, updateTwig, updateStick, updateKnot } from '../../state';
 import { splitShaft, splitBranchShaft, splitTwigShaft, splitStickShaft } from './jointUtils';
+import type { KnotSplitRemap } from '../Knot/knotUtils';
 import { SnapTarget } from '../../interaction/SnappingManager';
 import { Vec3 } from '../../types';
 import { useJointCreationState } from './jointCreationState';
@@ -10,6 +11,23 @@ import { getJointDiameter } from '../../constants';
 import { usePlacementSnappingSession } from '../../interaction/shared/placement/snapping/usePlacementSnappingSession';
 import { buildPrimarySnapTargetIndex, buildSupportPathSnapTargets } from '../../interaction/shared/placement/snapping/supportPathTargets';
 import { captureSupportEditSnapshot, pushSupportEditHistory } from '../../history/supportEditHistory';
+
+/**
+ * Apply knot re-anchor patches from a segment split BEFORE the host update runs.
+ * The host update re-derives every attached knot's world position from its `t`
+ * against the new, shorter segment span, so the corrected `t` /
+ * `parentShaftId` must already be in the store when it runs. Otherwise
+ * attached branches/leaves slide down below the inserted joint (#204).
+ */
+function applyKnotSplitRemaps(remaps: KnotSplitRemap[]) {
+    if (remaps.length === 0) return;
+    const knots = getSnapshot().knots;
+    for (const remap of remaps) {
+        const knot = knots[remap.knotId];
+        if (!knot) continue;
+        updateKnot({ ...knot, parentShaftId: remap.parentShaftId, t: remap.t });
+    }
+}
 
 export function useJointCreation() {
     const { gl } = useThree();
@@ -124,7 +142,8 @@ export function useJointCreation() {
                 const trunk = trunks.find(t => t.id === target.trunkId);
                 if (trunk) {
                     const root = state.roots[trunk.rootId];
-                    const newTrunk = splitShaft(trunk, target.segmentId, preview.pos, target.t, root);
+                    const { trunk: newTrunk, knotRemaps } = splitShaft(trunk, target.segmentId, preview.pos, target.t, root, state.knots);
+                    applyKnotSplitRemaps(knotRemaps);
                     updateTrunk(newTrunk);
                     pushSupportEditHistory('Create trunk joint', beforeSnapshot, captureSupportEditSnapshot());
                     console.log('[V2] Joint created on trunk:', trunk.id);
@@ -140,7 +159,8 @@ export function useJointCreation() {
                 if (branch) {
                     const knots = Object.values(state.knots);
                     const parentKnot = knots.find(k => k.id === branch.parentKnotId);
-                    const newBranch = splitBranchShaft(branch, target.segmentId, preview.pos, target.t, parentKnot);
+                    const { branch: newBranch, knotRemaps } = splitBranchShaft(branch, target.segmentId, preview.pos, target.t, parentKnot, state.knots);
+                    applyKnotSplitRemaps(knotRemaps);
                     updateBranch(newBranch);
                     pushSupportEditHistory('Create branch joint', beforeSnapshot, captureSupportEditSnapshot());
                     console.log('[V2] Joint created on branch:', branch.id);
@@ -154,7 +174,8 @@ export function useJointCreation() {
                 const twigs = Object.values(state.twigs);
                 const twig = twigs.find(tg => tg.id === target.trunkId);
                 if (twig) {
-                    const newTwig = splitTwigShaft(twig, target.segmentId, preview.pos, target.t);
+                    const { twig: newTwig, knotRemaps } = splitTwigShaft(twig, target.segmentId, preview.pos, target.t, state.knots);
+                    applyKnotSplitRemaps(knotRemaps);
                     updateTwig(newTwig);
                     pushSupportEditHistory('Create twig joint', beforeSnapshot, captureSupportEditSnapshot());
                     console.log('[V2] Joint created on twig:', twig.id);
@@ -168,7 +189,8 @@ export function useJointCreation() {
                 const sticks = Object.values(state.sticks);
                 const stick = sticks.find(st => st.id === target.trunkId);
                 if (stick) {
-                    const newStick = splitStickShaft(stick, target.segmentId, preview.pos, target.t);
+                    const { stick: newStick, knotRemaps } = splitStickShaft(stick, target.segmentId, preview.pos, target.t, state.knots);
+                    applyKnotSplitRemaps(knotRemaps);
                     updateStick(newStick);
                     pushSupportEditHistory('Create stick joint', beforeSnapshot, captureSupportEditSnapshot());
                     console.log('[V2] Joint created on stick:', stick.id);

--- a/src/supports/SupportPrimitives/Knot/knotUtils.ts
+++ b/src/supports/SupportPrimitives/Knot/knotUtils.ts
@@ -111,6 +111,83 @@ export function getBranchSegmentEndpoints(
 }
 
 /**
+ * Decide whether a dragged knot should stay on its current segment or hand off
+ * to the closest neighbouring segment.
+ *
+ * While dragging a knot along a multi-segment shaft, each frame picks the
+ * segment whose curve is closest to the pointer ray. A small stickiness bias
+ * keeps the knot on its current segment when distances are near-equal, which
+ * stops flicker mid-segment. That bias must NOT apply when the current
+ * segment's closest point has saturated at one of its endpoints (i.e. right at
+ * a joint): there the neighbour's closest point also starts at the same joint,
+ * so a blanket bias would pin the knot to the joint and refuse to cross until
+ * the neighbour won by more than the bias margin. That is the "knot hangs on
+ * the joint" bug (only intermittent because whether the neighbour ever wins by
+ * the margin depends on the camera angle).
+ */
+export function shouldStayOnCurrentSegment(
+    currentT: number,
+    currentDistSq: number,
+    bestDistSq: number,
+    stickiness: number,
+    interiorEps: number
+): boolean {
+    const interior = currentT > interiorEps && currentT < 1 - interiorEps;
+    if (!interior) return false;
+    return currentDistSq <= bestDistSq * stickiness;
+}
+
+/**
+ * A minimal patch describing how a knot re-anchors when its host segment is
+ * split in two by an inserted joint. `parentShaftId` moves to the top segment
+ * only when the knot sat above the split; `t` is always rescaled onto whichever
+ * half the knot now lives on so its absolute world position is preserved.
+ */
+export interface KnotSplitRemap {
+    knotId: string;
+    parentShaftId: string;
+    t: number;
+}
+
+/**
+ * Re-anchor a knot across a segment split so it stays at the same world point.
+ *
+ * When a joint is inserted at parametric position `splitT` on the original
+ * segment, that segment becomes a bottom half (keeps the original id) and a top
+ * half (new id). A knot's stored `t` is expressed against the WHOLE original
+ * segment, so after the split it must be converted to the sub-segment it now
+ * belongs to. De Casteljau subdivision guarantees the original curve at `t`
+ * equals the left sub-curve at `t / splitT` (for t <= splitT) and the right
+ * sub-curve at `(t - splitT) / (1 - splitT)` (for t >= splitT). The same
+ * reparametrization holds for straight segments (the degenerate cubic case), so
+ * one formula covers both.
+ *
+ * Returns null when the knot is not attached to the split segment, has no `t`,
+ * or the split is too degenerate to remap safely (the caller leaves it as-is).
+ */
+export function remapKnotAcrossSplit(
+    knot: Knot,
+    originalSegmentId: string,
+    bottomSegmentId: string,
+    topSegmentId: string,
+    splitT: number
+): KnotSplitRemap | null {
+    if (knot.parentShaftId !== originalSegmentId) return null;
+    if (knot.t === undefined) return null;
+    const EPS = 1e-6;
+    if (!(splitT > EPS) || !(splitT < 1 - EPS)) return null;
+    const t = Math.min(1, Math.max(0, knot.t));
+    if (t <= splitT) {
+        return { knotId: knot.id, parentShaftId: bottomSegmentId, t: t / splitT };
+    }
+    return {
+        knotId: knot.id,
+        parentShaftId: topSegmentId,
+        t: (t - splitT) / (1 - splitT),
+    };
+}
+
+/**
  * Calculate the position of a knot along a segment using its t parameter (0-1).
  * This is used to update knot positions when the parent segment moves.
  */

--- a/src/supports/SupportPrimitives/Knot/useKnotInteraction.ts
+++ b/src/supports/SupportPrimitives/Knot/useKnotInteraction.ts
@@ -1084,7 +1084,7 @@ export function useKnotInteraction(enabled: boolean = true) {
                 // the projection is interior to the current segment. Right at a joint the
                 // current segment's closest point saturates at its shared endpoint, so a
                 // blanket bias there would pin the knot to the joint and refuse to hand
-                // off to the neighbour until it won by >5% — that is the "knot hangs on
+                // off to the neighbour until it won by >5% -- that is the "knot hangs on
                 // the joint" bug. At the ends we drop the bias and let closest-wins move
                 // the knot across the joint as soon as the neighbour is genuinely closer.
                 const CURRENT_SEGMENT_STICKINESS = 1.05;

--- a/src/supports/SupportPrimitives/Knot/useKnotInteraction.ts
+++ b/src/supports/SupportPrimitives/Knot/useKnotInteraction.ts
@@ -6,7 +6,7 @@ import { getBranches, getKnotById, getLeaves, getRootById, getTrunks, getTwigs, 
 import { Branch, Brace, Knot, Roots, Trunk, Twig, Stick, Vec3 } from '../../types';
 import { getKickstandSnapshot } from '../../SupportTypes/Kickstand/kickstandStore';
 import type { Kickstand } from '../../SupportTypes/Kickstand/types';
-import { getBranchSegmentEndpoints, getTrunkSegmentEndpoints, projectOntoSegment } from './knotUtils';
+import { getBranchSegmentEndpoints, getTrunkSegmentEndpoints, projectOntoSegment, shouldStayOnCurrentSegment } from './knotUtils';
 import { getSettings } from '../../Settings';
 import { solveKnotConstraint } from '../../PlacementLogic/JointConstraintSolver';
 import { ElasticChainInitialState, ElasticChainResult, solveElasticChain } from '../../PlacementLogic/ElasticChainSolver';
@@ -1079,12 +1079,21 @@ export function useKnotInteraction(enabled: boolean = true) {
                     }
                 }
 
-                // Prefer staying on the current segment if distances are extremely close (reduce flicker at joints)
+                // Prefer staying on the current segment when distances are extremely
+                // close, to reduce flicker mid-segment. This bias is applied ONLY while
+                // the projection is interior to the current segment. Right at a joint the
+                // current segment's closest point saturates at its shared endpoint, so a
+                // blanket bias there would pin the knot to the joint and refuse to hand
+                // off to the neighbour until it won by >5% — that is the "knot hangs on
+                // the joint" bug. At the ends we drop the bias and let closest-wins move
+                // the knot across the joint as soon as the neighbour is genuinely closer.
+                const CURRENT_SEGMENT_STICKINESS = 1.05;
+                const INTERIOR_EPS = 1e-3;
                 const current = candidates.find(c => c.segmentId === host.segmentId);
                 if (current) {
                     if (current.bezier) {
                         const proj = projectOntoBezierCurve(raycaster.ray, current.start, current.end, current.bezier.control1, current.bezier.control2, BEZIER_PROJECTION_STEPS);
-                        if (proj.distSq <= bestDistSq * 1.05) {
+                        if (shouldStayOnCurrentSegment(proj.t, proj.distSq, bestDistSq, CURRENT_SEGMENT_STICKINESS, INTERIOR_EPS)) {
                             bestSegmentId = current.segmentId;
                             bestDiameter = current.diameter;
                             bestPoint = proj.point;
@@ -1095,7 +1104,7 @@ export function useKnotInteraction(enabled: boolean = true) {
                         const pointOnRay = new THREE.Vector3();
                         const pointOnSeg = new THREE.Vector3();
                         const currentDistSq = raycaster.ray.distanceSqToSegment(current.start, current.end, pointOnRay, pointOnSeg);
-                        if (currentDistSq <= bestDistSq * 1.05) {
+                        if (shouldStayOnCurrentSegment(pr.t, currentDistSq, bestDistSq, CURRENT_SEGMENT_STICKINESS, INTERIOR_EPS)) {
                             bestSegmentId = current.segmentId;
                             bestDiameter = current.diameter;
                             bestPoint = pr.point;

--- a/src/supports/SupportTypes/Trunk/TrunkReplacement/maxConnectedDiameter.ts
+++ b/src/supports/SupportTypes/Trunk/TrunkReplacement/maxConnectedDiameter.ts
@@ -442,7 +442,9 @@ export function computeAndApplyTrunkDiameterProfile(
         const splitPoint = knot.pos;
         const segIdToSplit = seg.id;
 
-        const trunkAfterSplit = splitShaft(nextTrunk, segIdToSplit, splitPoint, splitT, root);
+        // This caller performs its own knot rehosting below, so it does not pass
+        // knots into splitShaft and only consumes the trunk.
+        const { trunk: trunkAfterSplit } = splitShaft(nextTrunk, segIdToSplit, splitPoint, splitT, root);
         const bottomSegIndex = trunkAfterSplit.segments.findIndex((s) => s.id === segIdToSplit);
         if (bottomSegIndex === -1) {
             nextTrunk = trunkAfterSplit;

--- a/src/supports/__tests__/jointInsertionKnotRemap.test.ts
+++ b/src/supports/__tests__/jointInsertionKnotRemap.test.ts
@@ -1,0 +1,175 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { remapKnotAcrossSplit, calculateKnotPositionOnSegmentFromT } from '../SupportPrimitives/Knot/knotUtils';
+import { splitShaft } from '../SupportPrimitives/Joint/jointUtils';
+import { subdivideCubicBezier, getBezierPointAtT } from '../Curves/BezierUtils';
+import type { Knot, Trunk, Roots, Vec3, BezierSegment, StraightSegment } from '../types';
+
+// Issue #204: inserting a joint splits a host segment into a bottom half (keeps the
+// original id) and a top half (new id). Attached knots must be re-anchored so their
+// absolute world position does not change, otherwise branches/leaves slide down.
+
+const dist = (a: Vec3, b: Vec3) =>
+    Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z);
+
+function makeKnot(overrides: Partial<Knot>): Knot {
+    return {
+        id: 'knot-1',
+        parentShaftId: 'seg-orig',
+        t: 0.5,
+        pos: { x: 0, y: 0, z: 0 },
+        ...overrides,
+    };
+}
+
+describe('remapKnotAcrossSplit', () => {
+    it('returns null when the knot is not on the split segment', () => {
+        const knot = makeKnot({ parentShaftId: 'other-seg' });
+        assert.strictEqual(remapKnotAcrossSplit(knot, 'seg-orig', 'seg-orig', 'seg-top', 0.5), null);
+    });
+
+    it('returns null when the knot has no t', () => {
+        const knot = makeKnot({ t: undefined });
+        assert.strictEqual(remapKnotAcrossSplit(knot, 'seg-orig', 'seg-orig', 'seg-top', 0.5), null);
+    });
+
+    it('returns null for a degenerate split at t≈0 or t≈1 (no safe rescale)', () => {
+        const knot = makeKnot({ t: 0.5 });
+        assert.strictEqual(remapKnotAcrossSplit(knot, 'seg-orig', 'seg-orig', 'seg-top', 0), null);
+        assert.strictEqual(remapKnotAcrossSplit(knot, 'seg-orig', 'seg-orig', 'seg-top', 1), null);
+    });
+
+    it('keeps a below-split knot on the bottom segment and rescales t = t/splitT', () => {
+        const knot = makeKnot({ t: 0.2 });
+        const remap = remapKnotAcrossSplit(knot, 'seg-orig', 'seg-orig', 'seg-top', 0.5);
+        assert.ok(remap);
+        assert.strictEqual(remap!.parentShaftId, 'seg-orig');
+        assert.ok(Math.abs(remap!.t - 0.4) < 1e-9); // 0.2 / 0.5
+    });
+
+    it('moves an above-split knot to the top segment and rescales t = (t-splitT)/(1-splitT)', () => {
+        const knot = makeKnot({ t: 0.8 });
+        const remap = remapKnotAcrossSplit(knot, 'seg-orig', 'seg-orig', 'seg-top', 0.5);
+        assert.ok(remap);
+        assert.strictEqual(remap!.parentShaftId, 'seg-top');
+        assert.ok(Math.abs(remap!.t - 0.6) < 1e-9); // (0.8 - 0.5) / 0.5
+    });
+
+    it('keeps a knot exactly at the split on the bottom segment (t = 1)', () => {
+        const knot = makeKnot({ t: 0.5 });
+        const remap = remapKnotAcrossSplit(knot, 'seg-orig', 'seg-orig', 'seg-top', 0.5);
+        assert.ok(remap);
+        assert.strictEqual(remap!.parentShaftId, 'seg-orig');
+        assert.ok(Math.abs(remap!.t - 1) < 1e-9);
+    });
+});
+
+describe('remap preserves world position on a STRAIGHT segment', () => {
+    it('the rescaled t on the correct half maps to the same world point', () => {
+        const start: Vec3 = { x: 0, y: 0, z: 0 };
+        const end: Vec3 = { x: 0, y: 0, z: 10 };
+        const straight: StraightSegment = { id: 'seg-orig', diameter: 1, type: 'straight' };
+
+        const splitT = 0.3;
+        const split: Vec3 = { x: 0, y: 0, z: 3 };
+
+        for (const originalT of [0.1, 0.3, 0.55, 0.9]) {
+            const worldBefore = calculateKnotPositionOnSegmentFromT(start, end, straight, originalT);
+            const knot = makeKnot({ t: originalT });
+            const remap = remapKnotAcrossSplit(knot, 'seg-orig', 'seg-orig', 'seg-top', splitT)!;
+
+            const half = remap.parentShaftId === 'seg-orig'
+                ? { s: start, e: split }
+                : { s: split, e: end };
+            const worldAfter = calculateKnotPositionOnSegmentFromT(half.s, half.e, straight, remap.t);
+
+            assert.ok(dist(worldBefore, worldAfter) < 1e-6, `t=${originalT} drifted ${dist(worldBefore, worldAfter)}`);
+        }
+    });
+});
+
+describe('remap preserves world position on a BEZIER segment', () => {
+    it('rescaled t on the matching sub-curve reproduces the original curve point', () => {
+        const p0: Vec3 = { x: 0, y: 0, z: 0 };
+        const cp1: Vec3 = { x: 4, y: 0, z: 2 };
+        const cp2: Vec3 = { x: 4, y: 0, z: 8 };
+        const p3: Vec3 = { x: 0, y: 0, z: 10 };
+
+        const splitT = 0.4;
+        const [leftCurve, rightCurve] = subdivideCubicBezier(p0, cp1, cp2, p3, splitT);
+
+        // Bottom half keeps original id; top half is the right sub-curve.
+        const bottomSeg: BezierSegment = {
+            id: 'seg-orig', diameter: 1, type: 'bezier',
+            controlPoint1: leftCurve[1], controlPoint2: leftCurve[2],
+            startTangent: { x: 0, y: 0, z: 1 }, endTangent: { x: 0, y: 0, z: 1 },
+            tension: 0.5, bias: 0.5, resolution: 16,
+        };
+        const topSeg: BezierSegment = {
+            id: 'seg-top', diameter: 1, type: 'bezier',
+            controlPoint1: rightCurve[1], controlPoint2: rightCurve[2],
+            startTangent: { x: 0, y: 0, z: 1 }, endTangent: { x: 0, y: 0, z: 1 },
+            tension: 0.5, bias: 0.5, resolution: 16,
+        };
+
+        for (const originalT of [0.1, 0.4, 0.65, 0.95]) {
+            const worldBefore = getBezierPointAtT(p0, cp1, cp2, p3, originalT);
+            const knot = makeKnot({ t: originalT });
+            const remap = remapKnotAcrossSplit(knot, 'seg-orig', 'seg-orig', 'seg-top', splitT)!;
+
+            const worldAfter = remap.parentShaftId === 'seg-orig'
+                ? calculateKnotPositionOnSegmentFromT(leftCurve[0], leftCurve[3], bottomSeg, remap.t)
+                : calculateKnotPositionOnSegmentFromT(rightCurve[0], rightCurve[3], topSeg, remap.t);
+
+            assert.ok(dist(worldBefore, worldAfter) < 1e-6, `bezier t=${originalT} drifted ${dist(worldBefore, worldAfter)}`);
+        }
+    });
+});
+
+describe('splitShaft emits knot remaps for attached knots', () => {
+    const root: Roots = {
+        id: 'root-1',
+        transform: { pos: { x: 0, y: 0, z: 0 }, rot: { x: 0, y: 0, z: 0 }, scale: { x: 1, y: 1, z: 1 } },
+        diskHeight: 0,
+        coneHeight: 0,
+    } as unknown as Roots;
+
+    const trunk: Trunk = {
+        id: 'trunk-1',
+        rootId: 'root-1',
+        modelId: 'model-1',
+        segments: [
+            { id: 'seg-orig', diameter: 1, type: 'straight', topJoint: { id: 'j-top', pos: { x: 0, y: 0, z: 10 }, diameter: 1.5 } } as StraightSegment,
+        ],
+    } as unknown as Trunk;
+
+    it('splits the segment and rehosts an above-split knot onto the new top segment', () => {
+        const knots: Record<string, Knot> = {
+            'k-below': makeKnot({ id: 'k-below', parentShaftId: 'seg-orig', t: 0.2 }),
+            'k-above': makeKnot({ id: 'k-above', parentShaftId: 'seg-orig', t: 0.8 }),
+            'k-other': makeKnot({ id: 'k-other', parentShaftId: 'seg-elsewhere', t: 0.5 }),
+        };
+
+        const { trunk: after, knotRemaps } = splitShaft(trunk, 'seg-orig', { x: 0, y: 0, z: 5 }, 0.5, root, knots);
+
+        // Bottom keeps original id, top is new.
+        assert.strictEqual(after.segments.length, 2);
+        assert.strictEqual(after.segments[0].id, 'seg-orig');
+        const topId = after.segments[1].id;
+        assert.notStrictEqual(topId, 'seg-orig');
+
+        // Only the two knots on seg-orig are remapped.
+        assert.strictEqual(knotRemaps.length, 2);
+        const below = knotRemaps.find((r) => r.knotId === 'k-below')!;
+        const above = knotRemaps.find((r) => r.knotId === 'k-above')!;
+        assert.strictEqual(below.parentShaftId, 'seg-orig');
+        assert.ok(Math.abs(below.t - 0.4) < 1e-9);
+        assert.strictEqual(above.parentShaftId, topId);
+        assert.ok(Math.abs(above.t - 0.6) < 1e-9);
+    });
+
+    it('emits no remaps when no knots are supplied', () => {
+        const { knotRemaps } = splitShaft(trunk, 'seg-orig', { x: 0, y: 0, z: 5 }, 0.5, root);
+        assert.strictEqual(knotRemaps.length, 0);
+    });
+});

--- a/src/supports/__tests__/knotDragJointCrossing.test.ts
+++ b/src/supports/__tests__/knotDragJointCrossing.test.ts
@@ -1,0 +1,51 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { shouldStayOnCurrentSegment } from '../SupportPrimitives/Knot/knotUtils';
+
+// Regression cover for the "knot hangs on a joint" bug. When a knot is dragged
+// along a shaft that has a joint on it, the per-frame segment picker keeps the
+// knot on its current segment when distances are near-equal (anti-flicker). That
+// stickiness must NOT apply once the projection saturates at a segment endpoint
+// (right at the joint), otherwise the knot can never cross to the neighbour until
+// the neighbour beats the current segment by the full stickiness margin — which
+// only happens at some camera angles, hence the intermittent "sometimes it lets
+// me past" behaviour.
+
+const STICKINESS = 1.05;
+const EPS = 1e-3;
+
+describe('shouldStayOnCurrentSegment', () => {
+    it('keeps the knot on the current segment when interior and distances are near-equal', () => {
+        // Mid-segment, current is slightly farther but within the 5% bias → stay (no flicker).
+        assert.strictEqual(shouldStayOnCurrentSegment(0.5, 1.04, 1.0, STICKINESS, EPS), true);
+    });
+
+    it('hands off mid-segment when the neighbour is clearly closer (beyond the bias)', () => {
+        // Interior but current is much farther than 5% → allow the switch.
+        assert.strictEqual(shouldStayOnCurrentSegment(0.5, 1.2, 1.0, STICKINESS, EPS), false);
+    });
+
+    it('hands off at the TOP joint end even when distances are a dead tie (the bug)', () => {
+        // Projection saturated at t≈1 (knot pushed up to the joint), tie distance.
+        // Old code returned true here and pinned the knot; must now return false.
+        assert.strictEqual(shouldStayOnCurrentSegment(1.0, 1.0, 1.0, STICKINESS, EPS), false);
+        assert.strictEqual(shouldStayOnCurrentSegment(0.9995, 1.0, 1.0, STICKINESS, EPS), false);
+    });
+
+    it('hands off at the BOTTOM joint end even on a dead tie', () => {
+        // Projection saturated at t≈0 (knot pushed down to the joint).
+        assert.strictEqual(shouldStayOnCurrentSegment(0.0, 1.0, 1.0, STICKINESS, EPS), false);
+        assert.strictEqual(shouldStayOnCurrentSegment(0.0005, 1.0, 1.0, STICKINESS, EPS), false);
+    });
+
+    it('still lets a genuinely closer current segment win in the interior', () => {
+        // Current is strictly closest → obviously stay.
+        assert.strictEqual(shouldStayOnCurrentSegment(0.5, 0.8, 1.0, STICKINESS, EPS), true);
+    });
+
+    it('treats just-inside-the-epsilon as interior', () => {
+        // Just past the epsilon boundary → interior, bias applies.
+        assert.strictEqual(shouldStayOnCurrentSegment(0.01, 1.04, 1.0, STICKINESS, EPS), true);
+        assert.strictEqual(shouldStayOnCurrentSegment(0.99, 1.04, 1.0, STICKINESS, EPS), true);
+    });
+});


### PR DESCRIPTION
Two related joint fixes on the support shafts.

## 1. Branches and leaves slide down when a joint is added (Fixes #204)

Inserting a joint splits a shaft segment into a bottom half (which keeps the original segment id) and a top half (a new id). Branches and leaves store their attachment as a parametric `t` against the segment, not an absolute height. After the split the store re-derived their position from `t` against the now shorter bottom span, dragging them down, sometimes below the newly inserted joint.

**Fix:** re-anchor every affected knot as part of the split, preserving absolute world position.
- Knot at or below the split stays on the bottom segment, `t` rescaled to `t / splitT`.
- Knot above the split moves to the top segment, `t` rescaled to `(t - splitT) / (1 - splitT)`.

This is the De Casteljau reparametrization, so it is exact for both straight and bezier hosts. Degenerate splits (`t` at 0 or 1) are guarded. The remap runs in both joint-creation paths (the joint tool and the right-click "Add joint" menu) and across all four host types (trunk, branch, twig, stick). `maxConnectedDiameter` keeps its own knot rehosting and only consumes the split geometry.

## 2. Dragging a knot could hang on a joint

Dragging a knot along a shaft could get it stuck on a joint: it slid past sometimes and hung other times. The per-frame segment picker had a blanket "prefer current segment within 5%" anti-flicker rule. Right at a joint the current segment's closest point saturates at its shared endpoint, so that bias built a wall: the knot could not hand off to the neighbour until the neighbour beat the current segment by more than 5%, which only happens at some camera angles, hence the intermittent behaviour.

**Fix:** apply the stickiness bias only while the projection is interior to the current segment. Once it saturates at a segment end (pushing into the joint), pure closest-wins takes over and the knot crosses as soon as the neighbour is genuinely closer. Mid-segment flicker protection is unchanged.

## Tests

- `jointInsertionKnotRemap.test.ts`: reparametrization preserves world position for straight and bezier hosts; below/above/at-split routing; `splitShaft` emits correct remaps.
- `knotDragJointCrossing.test.ts`: interior stickiness kept; dead-tie at a joint end now hands off (the bug); genuine mid-segment ties still stay.

`tsc --noEmit` clean; full supports suite green (147 tests); no new lint findings on any touched file.