### PR TITLE
ci(release): support odd/even release scheme, add release doc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,9 @@ jobs:
       release_name: ${{ steps.version.outputs.release_name }}
       release_body: ${{ steps.version.outputs.release_body }}
       is_prerelease: ${{ steps.version.outputs.is_prerelease }}
+      has_prerelease_suffix: ${{ steps.version.outputs.has_prerelease_suffix }}
       updater_json: ${{ steps.version.outputs.updater_json }}
+      publish_updater_json: ${{ steps.version.outputs.publish_updater_json }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -44,28 +46,66 @@ jobs:
         shell: bash
         run: |
           current_version="$(node -p "require('./package.json').version")"
+          branch="${{ github.ref_name }}"
+          tag_name="v${current_version}"
 
-          if [[ "${{ github.ref_name }}" == "dev" ]]; then
-            tag_prefix="dev_"
-            is_prerelease="true"
-            updater_json="latest-dev.json"
+          # A version carries a prerelease identifier (-rc.1, -beta, ...) when
+          # it has a hyphen, per SemVer grammar (MAJOR.MINOR.PATCH-prerelease).
+          if [[ "${current_version}" == *-* ]]; then
+            has_prerelease_suffix="true"
           else
-            tag_prefix="v"
-            is_prerelease="false"
-            updater_json="latest.json"
+            has_prerelease_suffix="false"
           fi
 
+          # GitHub's prerelease flag means "not the stable/production channel",
+          # not "not yet finished". Only a final (no prerelease id) version on
+          # main is the stable channel — every dev-branch build (final or
+          # RC/beta of the dev line) and every RC/beta on main is a
+          # GitHub prerelease.
+          if [[ "$branch" == "main" && "$has_prerelease_suffix" == "false" ]]; then
+            is_prerelease="false"
+          else
+            is_prerelease="true"
+          fi
+
+          # Updater feed selection: dev only updates the dev feed on final releases
+          # (but it's very unlikely that we ever make those). main only updates the
+          # stable feed for a final release — an RC on main is downloadable for
+          # testing but never wired to the auto-updater, so stable users can't land on it.
+          if [[ "$branch" == "dev" && "$has_prerelease_suffix" == "false" ]]; then
+            updater_json="latest-dev.json"
+            publish_updater_json="true"
+          elif [[ "$branch" == "main" && "$has_prerelease_suffix" == "false" ]]; then
+            updater_json="latest.json"
+            publish_updater_json="true"
+          else
+            updater_json=""
+            publish_updater_json="false"
+          fi
+
+          if [[ "$branch" == "main" ]]; then
+            if [[ "$has_prerelease_suffix" == "true" ]]; then
+              release_label="Release candidate ${tag_name}"
+            else
+              release_label="DragonFruit ${tag_name}"
+            fi
+          else
+            release_label="Dev build ${tag_name}"
+          fi
+
+          echo "has_prerelease_suffix=${has_prerelease_suffix}" >> "$GITHUB_OUTPUT"
           echo "is_prerelease=${is_prerelease}" >> "$GITHUB_OUTPUT"
           echo "updater_json=${updater_json}" >> "$GITHUB_OUTPUT"
+          echo "publish_updater_json=${publish_updater_json}" >> "$GITHUB_OUTPUT"
 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "should_release=true" >> "$GITHUB_OUTPUT"
-            echo "version=$current_version" >> "$GITHUB_OUTPUT"
-            echo "tag_name=${tag_prefix}${current_version}" >> "$GITHUB_OUTPUT"
-            echo "release_name=Pre-Release ${tag_prefix}${current_version}" >> "$GITHUB_OUTPUT"
+            echo "version=${current_version}" >> "$GITHUB_OUTPUT"
+            echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+            echo "release_name=${release_label}" >> "$GITHUB_OUTPUT"
             {
               echo "release_body<<EOF"
-              echo "Manually triggered release for version ${current_version} from the ${{ github.ref_name }} branch."
+              echo "Manually triggered release for version ${current_version} from the ${branch} branch."
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
             exit 0
@@ -77,18 +117,18 @@ jobs:
             previous_version=""
           fi
 
-          if [[ -n "$previous_version" && "$previous_version" == "$current_version" ]]; then
+          if [[ -n "$previous_version" && "$previous_version" == "${current_version}" ]]; then
             echo "should_release=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "should_release=true" >> "$GITHUB_OUTPUT"
-          echo "version=$current_version" >> "$GITHUB_OUTPUT"
-          echo "tag_name=${tag_prefix}${current_version}" >> "$GITHUB_OUTPUT"
-          echo "release_name=Pre-Release ${tag_prefix}${current_version}" >> "$GITHUB_OUTPUT"
+          echo "version=${current_version}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+          echo "release_name=${release_label}" >> "$GITHUB_OUTPUT"
           {
             echo "release_body<<EOF"
-            echo "Automated release for version ${current_version} from the ${{ github.ref_name }} branch."
+            echo "Automated release for version ${current_version} from the ${branch} branch."
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -258,6 +298,7 @@ jobs:
           path: release-assets
 
       - name: Generate updater JSON
+        if: needs.detect-version-bump.outputs.publish_updater_json == 'true'
         uses: actions/github-script@v9
         env:
           VERSION: ${{ needs.detect-version-bump.outputs.version }}
@@ -322,9 +363,9 @@ jobs:
               await github.rest.git.createRef({ owner, repo, ref, sha: context.sha });
             }
 
-      - name: Resolve release notes from matching dev prerelease
+      - name: Resolve release notes from matching prerelease
         id: release_notes
-        if: needs.detect-version-bump.outputs.is_prerelease == 'false'
+        if: needs.detect-version-bump.outputs.has_prerelease_suffix == 'false'
         uses: actions/github-script@v9
         env:
           VERSION: ${{ needs.detect-version-bump.outputs.version }}
@@ -334,23 +375,24 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const version = process.env.VERSION;
-            const devTag = `dev_${version}`;
+            // Same X.Y.Z, any prerelease identifier: v0.2.0-rc.1, v0.2.0-rc.2, v0.2.0-beta...
+            const prefix = `v${version}-`;
             let body = process.env.FALLBACK_BODY || "";
 
             try {
-              const { data } = await github.rest.repos.getReleaseByTag({ owner, repo, tag: devTag });
-              if (data?.body?.trim()) {
-                body = data.body;
-                core.info(`Using hand-written notes from prerelease ${devTag}`);
+              const releases = await github.paginate(github.rest.repos.listReleases, { owner, repo, per_page: 100 });
+              const candidates = releases
+                .filter((r) => r.tag_name.startsWith(prefix) && r.body?.trim())
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+              if (candidates.length > 0) {
+                body = candidates[0].body;
+                core.info(`Using hand-written notes from prerelease ${candidates[0].tag_name}`);
               } else {
-                core.warning(`Prerelease ${devTag} has no body; using fallback notes.`);
+                core.warning(`No prerelease found matching ${prefix}*; using fallback notes.`);
               }
             } catch (error) {
-              if (error.status === 404) {
-                core.warning(`Prerelease ${devTag} not found; using fallback notes.`);
-              } else {
-                core.warning(`Failed fetching ${devTag}: ${error.message}; using fallback notes.`);
-              }
+              core.warning(`Failed listing releases: ${error.message}; using fallback notes.`);
             }
 
             core.setOutput("body", body);
@@ -366,4 +408,4 @@ jobs:
           target_commitish: ${{ github.sha }}
           files: |
             release-assets/**/*
-            ${{ needs.detect-version-bump.outputs.updater_json }}
+            ${{ needs.detect-version-bump.outputs.publish_updater_json == 'true' && needs.detect-version-bump.outputs.updater_json || '' }}

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -15,6 +15,7 @@ This section documents DragonFruit internals for contributors and maintainers.
 - Plugin framework contracts (simple vs complex)
 - Complex plugin contribution workflow
 - RTSP relay reclaim API behavior
+- Release process: branching, versioning, and channels
 
 ## Source-of-truth intent
 

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -1,0 +1,188 @@
+# Release process
+
+How DragonFruit versions, branches, and ships builds. This is the
+source-of-truth for anyone cutting a release or touching
+[`.github/workflows/release.yml`](https://github.com/Open-Resin-Alliance/DragonFruit/blob/main/.github/workflows/release.yml)
+or [`src-tauri/src/updater_channel.rs`](https://github.com/Open-Resin-Alliance/DragonFruit/blob/main/src-tauri/src/updater_channel.rs).
+
+## The model
+
+We will be using semantic versioning, i.e. vMAJOR.MINOR.PATCH-prerelease.
+
+Two branches, two channels, classic odd/even MINOR convention:
+
+- **`dev`** — the development line. **Odd MINOR** (`0.1.x`, `0.3.x`, `0.5.x`, ...).
+  Features land here continuously. Every version bump on `dev` is a real,
+  shippable devel release — there's no RC ceremony for it. Bump the version,
+  push, done.
+- **`main`** — the stable line. **Even MINOR** (`0.2.x`, `0.4.x`, ...). Only
+  reachable by promoting a `dev` commit when the odd line is feature-complete.
+  Once on `main`, only bugfixes land — no new features.
+
+There is currently no dedicated `release-X.Y` maintenance branch: `main`
+*is* the stable maintenance branch. We will revisit this only if DragonFruit
+ever needs to support two stable lines concurrently; until then, a separate
+branch per stable release would be pure ceremony.
+
+## Versioning: real SemVer, prerelease identifiers included
+
+The channel is **not** a tag prefix anymore. It's encoded directly in the
+version string, following [SemVer 2.0](https://semver.org)'s
+`MAJOR.MINOR.PATCH-prerelease` grammar — because `tauri-plugin-updater`
+parses the updater feed's `version` field as a real `semver::Version` and
+compares it with plain `>`, which already implements full SemVer precedence
+(including "a prerelease has lower precedence than the same version without
+one"). Nothing needs to be taught to compare `1.3.0-rc.1 < 1.3.0` — the
+`semver` crate already does that. What has to be correct is what you put in
+the version field.
+
+Set the version in **`package.json`, `src-tauri/tauri.conf.json`, and
+`src-tauri/Cargo.toml`** together — all three must agree, since Tauri reads
+its own version from the bundle config and that's what ends up baked into the
+running binary as `current_version`.
+
+Rules:
+
+- Use dot-separated numeric identifiers for RC/beta counters:
+  `-rc.1`, `-rc.2`, `-rc.10`, not `-rc1`/`-rc2`/`-rc10`. SemVer compares
+  numeric fields numerically, but only if they're their own dot-separated
+  field — `"rc1"` is a single alphanumeric identifier and sorts as a string
+  (`rc1 < rc10 < rc2`), which silently breaks ordering once you pass RC 9.
+- `alpha < beta < rc` is not something SemVer understands semantically — it's
+  ASCII lexical order on whatever word you chose. It works here because
+  English happens to alphabetize that way. Don't rename these words casually.
+
+## What "prerelease" means on GitHub
+
+GitHub's `prerelease` flag has exactly one practical effect: a non-prerelease,
+non-draft release is eligible to be the repo's "Latest release" (and what
+`GET /releases/latest` returns). It has no concept of channels. So the flag
+is assigned by **"is this the stable/production channel"**, not by "is this a
+finished version number".  The release number is stored in one JSON per channel
+in the GitHub pages for the project, under the URLs
+https://open-resin-alliance.github.io/DragonFruit/latest{,-dev}.json, and these
+will be the rules that the release workflows are following:
+
+| Version example | Branch | `is_prerelease` | Updater feed |
+|---|---|---|---|
+| `0.1.10` | `dev` | `true` | `latest-dev.json` |
+| `0.1.11-rc.1` | `dev` | `true` | *none* |
+| `0.2.0-rc.1` | `main` | `true` | *none* — downloadable, not auto-installed |
+| `0.2.0-rc.2` | `main` | `true` | *none* |
+| `0.2.0` | `main` | `false` | `latest.json` |
+| `0.2.1` | `main` | `false` | `latest.json` |
+| `0.3.0` | `dev` | `true` | `latest-dev.json` |
+
+A dev-line build is *never* eligible to be "Latest release" and never touches
+the stable updater feed, no matter how "final" its own version number is.
+Only a final (no prerelease identifier) version pushed on `main` is stable.
+
+An RC on `main` still builds and publishes installers — testers can grab it
+from the Releases page — it's just never wired into `latest.json`, so nobody
+on the stable auto-update channel can land on it by accident.
+
+This logic lives entirely in the `detect-version-bump` job of `release.yml`;
+nothing else needs to change if you're just cutting releases.
+
+## Tags
+
+Always `v{version}` — `v0.1.10`, `v0.2.0-rc.1`, `v0.2.0`. No more `dev_`
+prefix; the branch/channel is already implied by the version's MINOR parity
+and prerelease identifier, so the tag doesn't need to encode it separately.
+
+## How to cut a release
+
+### Regular dev release
+
+```
+# on dev, version already odd (e.g. currently 0.1.9)
+bump package.json / tauri.conf.json / Cargo.toml → 0.1.10
+git commit -m "chore: release 0.1.10"
+git push origin dev
+```
+
+That's it — `release.yml` tags `v0.1.10`, builds, publishes a GitHub
+prerelease, and points `latest-dev.json` at it. Repeat for `0.1.11`,
+`0.1.12`, etc. No RC step required for dev releases.
+
+### Promoting dev → main (odd → even transition)
+
+This is the one point where a branch cut is doing real work — `dev` needs to
+keep absorbing new (0.3.x) work the moment this happens, while `main`
+stabilizes what's already there.
+
+```
+git checkout main
+git merge --ff-only v0.1.11        # or whatever the last dev tag was
+# bump version → 0.2.0-rc.1
+git commit -m "chore: release 0.2.0-rc.1"
+git push origin main
+```
+
+Fix anything that comes up with normal commits on `main` (cherry-picked from
+`dev` or written directly against `main` — either is fine at this scale).
+When ready to cut another candidate, bump to `0.2.0-rc.2` and push again.
+When satisfied:
+
+```
+# bump version → 0.2.0 (drop the -rc suffix)
+git commit -m "chore: release 0.2.0"
+git push origin main
+```
+
+`release.yml` will look for a prior GitHub release tagged `v0.2.0-rc.*` and
+carry its notes forward automatically if you don't override `release_body`.
+
+### Stable patch release
+
+Same as above, entirely on `main`: bump to `0.2.1`, commit, push. No branch
+needed — `main` already is the maintenance line for the current stable
+series.
+
+### Reopening dev for the next cycle
+
+There is nothing to do here until you're actually ready to ship the first
+release of the new odd line. `dev`'s version field can sit at whatever it was
+before the promotion (e.g. still reading `0.1.11`) indefinitely — nothing in
+the pipeline reacts to anything except a version bump being pushed. The
+"0.3.x" line has no existence anywhere in the repo — no tag, no branch, no
+marker — until the commit that bumps the version to `0.3.0` (or whatever the
+first real 0.3.x version is). That commit is both the only record of the
+reopening and the release trigger itself.
+
+If you bump the version as its own empty commit right after the promotion,
+that alone will cut a `0.3.0` devel release with no new content — harmless,
+but worth knowing. Folding the bump into the first real feature commit of the
+new cycle avoids the empty release, at the cost of a less clean "here's where
+0.3.x began" marker in history.
+
+## Branch preview builds (`build-nightly.yml`)
+
+We are dropping the `nightly` codeword in favor of `preview` or
+`branch-preview`, as the former has a very specific meaning in software.
+
+Until we drop the term, the reality is this: Separate from all of the above:
+`build-nightly.yml` builds an arbitrary branch on demand (`workflow_dispatch`
+or a `/nightly` PR comment) and publishes a rolling `nightly_{branch}`
+prerelease so a reviewer can download and try an exact commit. It is **not**
+a scheduled build of `dev`, doesn't participate in the versioning/channel
+model above, and isn't wired to the auto-updater at all. The name is
+inherited from an older convention and is somewhat misleading given it isn't
+on any schedule — treat it as a branch/PR preview mechanism, not a "nightly
+channel."
+
+## Updater implementation notes
+
+- `src-tauri/tauri.conf.json`'s `plugins.updater.endpoints` points at the
+  stable feed by default; `src-tauri/src/updater_channel.rs` overrides the
+  endpoint at runtime based on the user's saved channel preference
+  (`STABLE_ENDPOINT` / `DEV_ENDPOINT`), independent of the static config.
+- The plugin's default version comparator is a plain `release.version >
+  current_version` using `semver::Version::Ord` — no custom comparator is
+  registered. This means there's no downgrade support: a user who updates to
+  a higher-MINOR prerelease and then switches their channel preference back
+  to stable will not be offered the (numerically lower) stable version until
+  stable catches back up. This is expected given the current setup, not a
+  bug — if channel-switch-triggered downgrades are ever wanted, that
+  requires registering a custom `version_comparator` in
+  `updater_channel.rs`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,4 +91,5 @@ nav:
       - VOXL Format Spec: dev/voxl-format-spec.md
       - LYS Mesh Extraction Spec: dev/lys-mesh-extraction-spec.md
       - RTSP Relay: dev/rtsp-relay.md
+      - Release Process: dev/releases.md
       - Contributing: dev/contributing.md


### PR DESCRIPTION
These are the necessary changes to support the new odd/even
version scheme, including semantic versioning, and drop the
previous dev_/v system.  From now on, only final dev versions
will update `latest-dev.json`, and only final stable (i.e. in main)
versions will update `latest.json`.

Release-notes carryover now looks for any matching v{version}-rc.*
prerelease instead of assuming dev and main always share one version.

Included a document with the entire procedure.