### PR TITLE
ci(release): setup and document dev releases and issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,3 +409,120 @@ jobs:
           files: |
             release-assets/**/*
             ${{ needs.detect-version-bump.outputs.publish_updater_json == 'true' && needs.detect-version-bump.outputs.updater_json || '' }}
+
+  label-dev-fixes:
+    name: Label issues fixed in dev
+    needs:
+      - detect-version-bump
+      - publish-release
+    # A final (no -suffix) version on dev is the "train" passing a station:
+    # every issue closed by a commit since the last final dev release gets
+    # labeled instead of closed, since dev isn't the default branch and
+    # GitHub only auto-closes issues for commits that land on that one.
+    if: |
+      needs.detect-version-bump.outputs.should_release == 'true' &&
+      github.ref_name == 'dev' &&
+      needs.detect-version-bump.outputs.has_prerelease_suffix == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Find previous dev release tag
+        id: prev_tag
+        run: |
+          current_tag="${{ needs.detect-version-bump.outputs.tag_name }}"
+          prev_tag="$(git tag --list 'v*' --merged HEAD | grep -v "^${current_tag}\$" | sort -V | tail -n1)"
+          echo "prev_tag=${prev_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Label issues closed since previous dev release
+        uses: actions/github-script@v9
+        env:
+          PREV_TAG: ${{ steps.prev_tag.outputs.prev_tag }}
+          LABEL_NAME: "fixed in dev"
+          VERSION: ${{ needs.detect-version-bump.outputs.version }}
+          TAG_NAME: ${{ needs.detect-version-bump.outputs.tag_name }}
+        with:
+          script: |
+            const { execSync } = require('child_process');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const label = process.env.LABEL_NAME;
+            const version = process.env.VERSION;
+            const tag = process.env.TAG_NAME;
+            const range = process.env.PREV_TAG ? `${process.env.PREV_TAG}..HEAD` : 'HEAD';
+
+            const releaseUrl = `https://github.com/${owner}/${repo}/releases/tag/${tag}`;
+            // dev only ships odd MINORs (see docs/dev/releases.md); the next
+            // stable is the following even MINOR, .0 patch — a naming guess,
+            // not a promise, since the actual promotion date isn't known yet.
+            const [major, minor] = version.split('.').map(Number);
+            const nextStable = `${major}.${minor + 1}.0`;
+            const commentBody = [
+              `A fix for this issue has been included in development version \`v${version}\`, ` +
+                `available for download here: ${releaseUrl} — this is a \`dev\`-line build, offered without any guarantees.`,
+              '',
+              `It should ship as part of a stable release (tentatively \`v${nextStable}\`, naming not final) ` +
+                'within the next few days to weeks, depending on the release cadence.',
+            ].join('\n');
+
+            const log = execSync(`git log ${range} --pretty=format:%B%x00`, { maxBuffer: 1024 * 1024 * 32 }).toString();
+
+            // Same closing-keyword grammar GitHub uses: a keyword followed by
+            // one or more #NNN references (comma/"and"-separated).
+            const closingRe = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b((?:\s*,?\s*(?:and\s+)?#\d+)+)/gi;
+            const issueRe = /#(\d+)/g;
+
+            const issueNumbers = new Set();
+            let match;
+            while ((match = closingRe.exec(log)) !== null) {
+              let issueMatch;
+              while ((issueMatch = issueRe.exec(match[1])) !== null) {
+                issueNumbers.add(Number(issueMatch[1]));
+              }
+            }
+
+            if (issueNumbers.size === 0) {
+              core.info('No closing references found in this range; nothing to label.');
+              return;
+            }
+
+            core.info(`Found closing references to: ${[...issueNumbers].join(', ')}`);
+
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: label });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              core.info(`Label "${label}" does not exist yet; creating it.`);
+              await github.rest.issues.createLabel({ owner, repo, name: label, color: '5319e7' });
+            }
+
+            for (const issueNumber of issueNumbers) {
+              let issue;
+              try {
+                issue = await github.rest.issues.get({ owner, repo, issue_number: issueNumber });
+              } catch (error) {
+                core.warning(`#${issueNumber}: could not fetch (${error.message}); skipping.`);
+                continue;
+              }
+
+              if (issue.data.pull_request) {
+                core.info(`#${issueNumber} is a pull request, not an issue; skipping.`);
+                continue;
+              }
+
+              if (issue.data.labels.some((l) => (typeof l === 'string' ? l : l.name) === label)) {
+                core.info(`#${issueNumber}: already labeled "${label}"; skipping (no duplicate comment).`);
+                continue;
+              }
+
+              await github.rest.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: [label] });
+              await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body: commentBody });
+              core.info(`#${issueNumber}: labeled "${label}" and commented.`);
+            }

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -156,6 +156,37 @@ but worth knowing. Folding the bump into the first real feature commit of the
 new cycle avoids the empty release, at the cost of a less clean "here's where
 0.3.x began" marker in history.
 
+## Issue tracking across the "train" (`label-dev-fixes` in `release.yml`)
+
+GitHub only auto-closes an issue for a commit's closing keyword (`Closes #X`,
+`Fixes #X`, `Resolves #X`, ...) when that commit lands on the repo's
+**default branch**. `dev` isn't the default branch (`main` is), so those
+commits would otherwise never mark anything as done — the issue would sit
+open even after the fix has shipped in a dev build.
+
+To compensate, every time a **final** version (no `-rc`/`-beta`/etc. suffix)
+is pushed on `dev`, the `label-dev-fixes` job in `release.yml`:
+
+1. Finds the previous `v*` tag reachable in `dev`'s history (i.e. the last
+   dev release, of any kind).
+2. Scans every commit message in that range for GitHub's closing-keyword
+   grammar (`close(s/d)`, `fix(es/ed)`, `resolve(s/d)` followed by one or
+   more `#NNN`, comma/`and`-separated).
+3. Applies the `fixed in dev` label to each referenced issue — it does
+   **not** close it, since the fix hasn't reached the stable line yet — and
+   posts a comment pointing at the dev build (with the usual "no guarantees"
+   caveat) and naming the tentative next stable version (current dev MINOR
+   + 1, patch `.0`; a guess, not a promise, since promotion timing isn't
+   fixed). If the issue is already labeled, the job skips it — no repeat
+   comments across multiple final dev releases.
+
+This mirrors the Mozilla-style "train" model: an issue accumulates the
+`fixed in dev` label as soon as its fix rides a dev release, and stays open
+(for tracking "is this in `main` yet") until whoever promotes `dev` → `main`
+closes it as part of that release, or closes it by hand. RC builds on `dev`
+or `main` don't trigger this job — only a final version bump does, so labels
+land once per train stop rather than once per commit.
+
 ## Branch preview builds (`build-nightly.yml`)
 
 We are dropping the `nightly` codeword in favor of `preview` or


### PR DESCRIPTION
Add logic (and documentation) to tag issues with fixes in a dev release with "fixed in dev" and append a small text describing what happened and where to get the fix if interested.