### PR TITLE
feat(profiles): add printer format version choices

### DIFF
--- a/src/components/settings/ProfileSettingsModal.tsx
+++ b/src/components/settings/ProfileSettingsModal.tsx
@@ -56,6 +56,10 @@ import {
   resolveOutputSettingsMode,
 } from '@/features/slicing/formats/registry';
 import {
+  resolveFormatVersionFromOptions,
+  resolvePrinterFormatVersionOptions,
+} from '@/features/profiles/printerFormatVersionOptions';
+import {
   getPrinterReachabilityServerSnapshot,
   getPrinterReachabilitySnapshot,
   subscribeToPrinterReachability,
@@ -543,16 +547,26 @@ export function ProfileSettingsModal({
 
   const selectedFormatVersionOptions = React.useMemo(() => {
     if (!selectedPrinter) return [] as Array<{ value: string; label: string; isDefault?: boolean }>;
-    return getAvailableFormatVersionOptions(selectedPrinter.display.outputFormat);
-  }, [selectedPrinter]);
+    const availableOptions = getAvailableFormatVersionOptions(selectedPrinter.display.outputFormat);
+    const presetId = selectedPrinter.officialPresetId?.trim();
+    const preset = presetId
+      ? availablePrinterPresets.find((candidate) => candidate.presetId === presetId)
+      : undefined;
+    return resolvePrinterFormatVersionOptions(availableOptions, preset?.display.formatVersionOptions);
+  }, [availablePrinterPresets, selectedPrinter]);
 
   const selectedResolvedFormatVersion = React.useMemo(() => {
     if (!selectedPrinter) return undefined;
-    return resolveOutputFormatVersion(
-      selectedPrinter.display.outputFormat,
+    const presetId = selectedPrinter.officialPresetId?.trim();
+    const preset = presetId
+      ? availablePrinterPresets.find((candidate) => candidate.presetId === presetId)
+      : undefined;
+    return resolveFormatVersionFromOptions(
       selectedPrinter.display.formatVersion,
+      preset?.display.formatVersion,
+      selectedFormatVersionOptions,
     );
-  }, [selectedPrinter]);
+  }, [availablePrinterPresets, selectedFormatVersionOptions, selectedPrinter]);
 
   const selectedSettingsModeOptions = React.useMemo(() => {
     if (!selectedPrinter) return [] as Array<{ value: string; label: string; isDefault?: boolean }>;

--- a/src/features/plugins/pluginRegistry.ts
+++ b/src/features/plugins/pluginRegistry.ts
@@ -13,6 +13,7 @@ import type {
 import { getBuiltinComplexPluginDefinitions } from '@/features/plugins/builtinComplexPlugins';
 import { BUILTIN_SIMPLE_PLUGIN_MANIFESTS } from '@/features/plugins/builtinSimplePlugins';
 import { normalizeOutputFormat, normalizeFormatVersion, normalizeSettingsMode, normalizeWebcamRotationDeg, DEFAULT_WEBCAM_ROTATION_DEG } from '@/features/profiles/outputFormatUtils';
+import { sanitizePrinterFormatVersionOptions } from '@/features/profiles/printerFormatVersionOptions';
 
 export type PluginSource = 'builtin' | 'github';
 export type PluginInstallTrust = 'allowlisted' | 'unverified-user-approved';
@@ -402,6 +403,7 @@ function sanitizePrinterPreset(input: unknown): PrinterPreset | null {
       resolutionY,
       outputFormat: sanitizeOutputFormat((value as any).display?.outputFormat),
       formatVersion: normalizeFormatVersion((value as any).display?.formatVersion),
+      formatVersionOptions: sanitizePrinterFormatVersionOptions((value as any).display?.formatVersionOptions),
       settingsMode: normalizeSettingsMode((value as any).display?.settingsMode),
       webcamRotationDeg: normalizeWebcamRotationDeg(
         (value as any).display?.webcamRotationDeg ?? (value as any).display?.webcamOrientation,

--- a/src/features/profiles/__tests__/printerFormatVersionOptions.test.ts
+++ b/src/features/profiles/__tests__/printerFormatVersionOptions.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  resolveFormatVersionFromOptions,
+  resolvePrinterFormatVersionOptions,
+  sanitizePrinterFormatVersionOptions,
+} from '../printerFormatVersionOptions';
+
+const registeredOptions = [
+  { value: 'v3', label: 'CTB V3' },
+  { value: 'v4', label: 'CTB V4' },
+  { value: 'v5enc', label: 'CTB V5 encrypted', isDefault: true },
+];
+
+test('curated options retain labels and registered values', () => {
+  const options = resolvePrinterFormatVersionOptions(registeredOptions, [
+    { value: 'V4', label: 'V4 (Firmware 4.4+)', isDefault: true },
+    { value: 'v3', label: 'V3 (Firmware 4.3.x)' },
+  ]);
+
+  assert.deepEqual(options, [
+    { value: 'v4', label: 'V4 (Firmware 4.4+)', isDefault: true },
+    { value: 'v3', label: 'V3 (Firmware 4.3.x)' },
+  ]);
+});
+
+test('invalid curated options fall back to registered options', () => {
+  const options = resolvePrinterFormatVersionOptions(registeredOptions, [
+    { value: 'v99', label: 'Unsupported' },
+  ]);
+
+  assert.equal(options, registeredOptions);
+});
+
+test('official profile updates preserve an allowed selected version', () => {
+  const version = resolveFormatVersionFromOptions('v3', 'v4', [
+    { value: 'v4', label: 'V4 (Firmware 4.4+)', isDefault: true },
+    { value: 'v3', label: 'V3 (Firmware 4.3.x)' },
+  ]);
+
+  assert.equal(version, 'v3');
+});
+
+test('official profile updates use the preset default when selection is no longer allowed', () => {
+  const version = resolveFormatVersionFromOptions('v2', 'v4', [
+    { value: 'v4', label: 'V4 (Firmware 4.4+)', isDefault: true },
+    { value: 'v3', label: 'V3 (Firmware 4.3.x)' },
+  ]);
+
+  assert.equal(version, 'v4');
+});
+
+test('sanitization removes malformed and duplicate options', () => {
+  const options = sanitizePrinterFormatVersionOptions([
+    { value: 'v4', label: ' V4 ' },
+    { value: 'V4', label: 'Duplicate' },
+    { value: 'bad value', label: 'Invalid' },
+  ]);
+
+  assert.deepEqual(options, [{ value: 'v4', label: 'V4' }]);
+});

--- a/src/features/profiles/printerFormatVersionOptions.ts
+++ b/src/features/profiles/printerFormatVersionOptions.ts
@@ -1,0 +1,76 @@
+import { normalizeFormatVersion } from './outputFormatUtils';
+
+export type PrinterFormatVersionOption = {
+  value: string;
+  label: string;
+  isDefault?: boolean;
+};
+
+export function sanitizePrinterFormatVersionOptions(value: unknown): PrinterFormatVersionOption[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+
+  const seen = new Set<string>();
+  const options = value.slice(0, 16).flatMap((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return [];
+
+    const option = entry as Record<string, unknown>;
+    const normalizedValue = normalizeFormatVersion(option.value);
+    const label = typeof option.label === 'string' ? option.label.trim().slice(0, 120) : '';
+    if (!normalizedValue || !label) return [];
+
+    const key = normalizedValue.toLowerCase();
+    if (seen.has(key)) return [];
+    seen.add(key);
+
+    return [{
+      value: normalizedValue,
+      label,
+      ...(option.isDefault === true ? { isDefault: true } : {}),
+    }];
+  });
+
+  return options.length > 0 ? options : undefined;
+}
+
+export function resolvePrinterFormatVersionOptions(
+  availableOptions: PrinterFormatVersionOption[],
+  curatedOptions: PrinterFormatVersionOption[] | undefined,
+): PrinterFormatVersionOption[] {
+  if (!curatedOptions?.length) return availableOptions;
+
+  const availableByValue = new Map(
+    availableOptions.map((option) => [option.value.toLowerCase(), option] as const),
+  );
+  const resolved = curatedOptions.flatMap((option) => {
+    const available = availableByValue.get(option.value.toLowerCase());
+    if (!available) return [];
+    return [{
+      value: available.value,
+      label: option.label,
+      ...(option.isDefault === true ? { isDefault: true } : {}),
+    }];
+  });
+
+  return resolved.length > 0 ? resolved : availableOptions;
+}
+
+export function resolveFormatVersionFromOptions(
+  requestedVersion: unknown,
+  fallbackVersion: unknown,
+  options: PrinterFormatVersionOption[] | undefined,
+): string | undefined {
+  const normalizedRequested = normalizeFormatVersion(requestedVersion);
+  const normalizedFallback = normalizeFormatVersion(fallbackVersion);
+  if (!options?.length) return normalizedRequested ?? normalizedFallback;
+
+  const match = (value: string | undefined) => (
+    value ? options.find((option) => option.value.toLowerCase() === value.toLowerCase()) : undefined
+  );
+
+  return (
+    match(normalizedRequested)
+    ?? match(normalizedFallback)
+    ?? options.find((option) => option.isDefault)
+    ?? options[0]
+  )?.value;
+}

--- a/src/features/profiles/profileStore.ts
+++ b/src/features/profiles/profileStore.ts
@@ -19,6 +19,11 @@ import {
     DEFAULT_OUTPUT_FORMAT,
     DEFAULT_WEBCAM_ROTATION_DEG,
 } from '@/features/profiles/outputFormatUtils';
+import {
+    resolveFormatVersionFromOptions,
+    sanitizePrinterFormatVersionOptions,
+    type PrinterFormatVersionOption,
+} from '@/features/profiles/printerFormatVersionOptions';
 
 export type PrinterOutputFormat = string;
 export type PrinterNetworkSupport = string;
@@ -99,6 +104,7 @@ export type PrinterPreset = {
         resolutionY: number;
         outputFormat: PrinterOutputFormat;
         formatVersion?: string;
+        formatVersionOptions?: PrinterFormatVersionOption[];
         settingsMode?: string;
         webcamRotationDeg?: PrinterWebcamRotationDeg;
         mirrorX?: boolean;
@@ -837,6 +843,9 @@ const BUILTIN_PRINTER_PRESETS: PrinterPreset[] = (printerPresetsData as PrinterP
         ...preset.display,
         outputFormat: normalizeOutputFormat(preset.display?.outputFormat),
         formatVersion: normalizeFormatVersion((preset.display as { formatVersion?: unknown } | undefined)?.formatVersion),
+        formatVersionOptions: sanitizePrinterFormatVersionOptions(
+            (preset.display as { formatVersionOptions?: unknown } | undefined)?.formatVersionOptions,
+        ),
         settingsMode: normalizeSettingsMode((preset.display as { settingsMode?: unknown } | undefined)?.settingsMode),
         webcamRotationDeg: normalizeWebcamRotationDeg(
             (preset.display as { webcamRotationDeg?: unknown; webcamOrientation?: unknown } | undefined)?.webcamRotationDeg
@@ -2668,7 +2677,11 @@ export function applyOfficialPrinterProfileUpdate(printerProfileId: string): App
                         resolutionX: preset.display.resolutionX,
                         resolutionY: preset.display.resolutionY,
                         outputFormat: normalizeOutputFormat(preset.display.outputFormat),
-                        formatVersion: normalizeFormatVersion((preset.display as { formatVersion?: unknown }).formatVersion),
+                        formatVersion: resolveFormatVersionFromOptions(
+                            item.display.formatVersion,
+                            preset.display.formatVersion,
+                            preset.display.formatVersionOptions,
+                        ),
                         settingsMode: normalizeSettingsMode((preset.display as { settingsMode?: unknown }).settingsMode),
                         mirrorX: normalizeMirrorFlag((preset.display as { mirrorX?: unknown }).mirrorX, false),
                         mirrorY: normalizeMirrorFlag((preset.display as { mirrorY?: unknown }).mirrorY, false),


### PR DESCRIPTION
## Problem

Some printers support only a subset of their container format versions, usually based on firmware. The global list exposes incompatible choices, and official profile updates can replace a compatible user selection.

## Changes

I added preset-level format choices with printer-specific labels. Invalid metadata falls back to the registered format list, and official updates preserve the selected version while it remains allowed. Open-Resin-Alliance/df-plugin-elegoo#9 uses this for Mars 2.

## How did you test this code?

I ran the focused Node tests, `npx tsc --noEmit`, and `npm run build`. I also verified the rendered Mars 2 menu shows only the V4 and V3 firmware choices and accepts V3. The full suite reached 126/128, with two failures in unrelated support-routing tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*