### PR TITLE
fix: proper release with MSI/NSIS bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
             df_build_triple: universal-apple-darwin
           - platform: windows-latest
             build_kind: tauri
-            args: --target x86_64-pc-windows-msvc --bundles nsis
+            args: --target x86_64-pc-windows-msvc --bundles nsis,msi
             artifact_name: dragonfruit-windows-x64
           - platform: ubuntu-22.04
             build_kind: flatpak


### PR DESCRIPTION
Apparently it's a known bug in Tauri to avoid building the MSI in some cases, so force building both NSIS and MSI explicitly.