### PR TITLE
Use Command-only application shortcuts on macOS

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -217,7 +217,7 @@ import { IslandsPanel } from '@/components/controls/IslandsPanel';
 import { IslandOverlay } from '@/components/scene/IslandOverlay';
 import { useSupportInteractionManager } from '@/features/supports/useSupportInteractionManager';
 import { useUndoRedoHotkeys } from '@/hotkeys/useUndoRedoHotkeys';
-import { hotkeyStore, useActionActive, isActionActiveSync } from '@/hotkeys/hotkeyStore';
+import { hotkeyStore, useActionActive, isActionActiveSync, isPrimaryModifierPressed } from '@/hotkeys/hotkeyStore';
 import { useDeleteHotkey } from '@/features/delete/useDeleteHotkey';
 import { registerDeleteHandler } from '@/features/delete/deleteRegistry';
 import { useCameraProjectionHotkey } from '@/hotkeys/useCameraProjectionHotkey';
@@ -8551,11 +8551,11 @@ export default function Home() {
 
     const unsubscribe = hotkeyStore.subscribe((state) => {
       const active = state.activeKeys;
-      const isCtrlOrMeta = active.has('ctrl') || active.has('meta') || active.has('control');
-      const isAPressed = active.has('a') && isCtrlOrMeta;
-      const isCPressed = active.has('c') && isCtrlOrMeta;
-      const isVPressed = active.has('v') && isCtrlOrMeta;
-      const isSPressed = active.has('s') && isCtrlOrMeta;
+      const hasPrimaryModifier = isPrimaryModifierPressed(active);
+      const isAPressed = active.has('a') && hasPrimaryModifier;
+      const isCPressed = active.has('c') && hasPrimaryModifier;
+      const isVPressed = active.has('v') && hasPrimaryModifier;
+      const isSPressed = active.has('s') && hasPrimaryModifier;
 
       const isAJustPressed = isAPressed && !wasAPressed;
       const isCJustPressed = isCPressed && !wasCPressed;

--- a/src/hotkeys/HotkeyRegistryManager.tsx
+++ b/src/hotkeys/HotkeyRegistryManager.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { hotkeyStore, isActionActiveSync } from './hotkeyStore';
+import { getPrimaryModifierKey, hotkeyStore, isActionActiveSync } from './hotkeyStore';
 import { useHotkeyConfig } from './HotkeyContext';
 
 // Monkey-patch EventTarget.prototype.addEventListener to block/warn keydown/keyup listeners from forbidden paths
@@ -125,14 +125,14 @@ export function setupHotkeyListeners() {
     const handleKeyDown = (e: KeyboardEvent) => {
         if (isTextInput(e.target)) return;
 
-        const isCtrlOrMeta = e.ctrlKey || e.metaKey;
+        const isPrimaryModifier = getPrimaryModifierKey() === 'meta' ? e.metaKey : e.ctrlKey;
         const key = e.key.toLowerCase();
         
         // Prevent browser default behaviors
         if (
-            (isCtrlOrMeta && ['s', 'a', 'c', 'v', 'z', 'y'].includes(key)) ||
+            (isPrimaryModifier && ['s', 'a', 'c', 'v', 'z', 'y'].includes(key)) ||
             ['delete', 'backspace', 'arrowup', 'arrowdown'].includes(key) ||
-            (e.shiftKey && isCtrlOrMeta && ['d', 'c', 'x', 'a', 'n', 'm', 'k'].includes(key))
+            (e.shiftKey && isPrimaryModifier && ['d', 'c', 'x', 'a', 'n', 'm', 'k'].includes(key))
         ) {
             e.preventDefault();
         }

--- a/src/hotkeys/__tests__/hotkeyStore.test.ts
+++ b/src/hotkeys/__tests__/hotkeyStore.test.ts
@@ -263,5 +263,39 @@ test('Newly migrated configurations: GLOBAL, DEBUG, MESH, NAVIGATION, PRESETS, H
     hotkeyStore.getState().clearKeys();
 });
 
+test('macOS uses Command, not Control, for primary-modifier shortcuts', () => {
+    const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+    Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        value: { platform: 'MacIntel' },
+    });
+
+    try {
+        hotkeyStore.getState().clearKeys();
+        hotkeyStore.getState().pressKey('Control');
+        hotkeyStore.getState().pressKey('v');
+        assert.equal(
+            isActionActiveSync('CANVAS', 'PASTE'),
+            false,
+            'macOS Ctrl+V must not activate paste',
+        );
+
+        hotkeyStore.getState().clearKeys();
+        hotkeyStore.getState().pressKey('Meta');
+        hotkeyStore.getState().pressKey('v');
+        assert.equal(
+            isActionActiveSync('CANVAS', 'PASTE'),
+            true,
+            'macOS Cmd+V must activate paste',
+        );
+    } finally {
+        hotkeyStore.getState().clearKeys();
+        if (navigatorDescriptor) {
+            Object.defineProperty(globalThis, 'navigator', navigatorDescriptor);
+        } else {
+            delete (globalThis as { navigator?: unknown }).navigator;
+        }
+    }
+});
 
 

--- a/src/hotkeys/hotkeyStore.ts
+++ b/src/hotkeys/hotkeyStore.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from 'react';
 import { createStore } from 'zustand';
+import { detectPlatform } from '../hooks/usePlatform';
 import { HotkeyConfig, DEFAULT_KEYBINDINGS } from './hotkeyConfig';
 
 export interface HotkeyState {
@@ -55,6 +56,20 @@ function normalizeKey(key: string): string {
     return normalized;
 }
 
+export function getPrimaryModifierKey(): 'ctrl' | 'meta' {
+    return detectPlatform() === 'mac' ? 'meta' : 'ctrl';
+}
+
+export function isPrimaryModifierPressed(activeKeys: ReadonlySet<string>): boolean {
+    const primaryModifier = getPrimaryModifierKey();
+    for (const key of activeKeys) {
+        if (normalizeKey(key) === primaryModifier) {
+            return true;
+        }
+    }
+    return false;
+}
+
 function getRequiredKeys(binding: { key: string; modifier?: string }): Set<string> {
     const keys = new Set<string>();
     const baseKey = normalizeKey(binding.key);
@@ -63,7 +78,10 @@ function getRequiredKeys(binding: { key: string; modifier?: string }): Set<strin
     }
     if (binding.modifier) {
         binding.modifier.split('+').forEach(m => {
-            const normalizedM = normalizeKey(m);
+            const configuredModifier = normalizeKey(m);
+            const normalizedM = configuredModifier === 'ctrl'
+                ? getPrimaryModifierKey()
+                : configuredModifier;
             if (normalizedM) {
                 keys.add(normalizedM);
             }
@@ -144,5 +162,4 @@ export function useKeyPressed(key: string): boolean {
         () => false
     );
 }
-
 

--- a/src/hotkeys/useUndoRedoHotkeys.ts
+++ b/src/hotkeys/useUndoRedoHotkeys.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { redo, undo } from '@/history/historyStore';
-import { hotkeyStore } from './hotkeyStore';
+import { hotkeyStore, isPrimaryModifierPressed } from './hotkeyStore';
 
 export function useUndoRedoHotkeys({ disabled = false }: { disabled?: boolean } = {}) {
   useEffect(() => {
@@ -11,7 +11,7 @@ export function useUndoRedoHotkeys({ disabled = false }: { disabled?: boolean } 
 
     const unsubscribe = hotkeyStore.subscribe((state) => {
       const active = state.activeKeys;
-      const hasCtrl = active.has('ctrl') || active.has('meta') || active.has('control');
+      const hasPrimaryModifier = isPrimaryModifierPressed(active);
       const hasShift = active.has('shift');
       const hasZ = active.has('z');
       const hasY = active.has('y');
@@ -19,7 +19,7 @@ export function useUndoRedoHotkeys({ disabled = false }: { disabled?: boolean } 
       const isZJustPressed = hasZ && !wasZPressed;
       const isYJustPressed = hasY && !wasYPressed;
 
-      if (hasCtrl) {
+      if (hasPrimaryModifier) {
         if (isYJustPressed) {
           redo();
         } else if (isZJustPressed) {


### PR DESCRIPTION
## Summary
- map primary shortcut modifiers to Command on macOS and Control on other platforms
- use the platform-aware modifier for browser-default suppression, editing shortcuts, and undo/redo
- add a regression test proving macOS Ctrl+V is rejected while Cmd+V is accepted

## Checks
- `node --import tsx --test src/hotkeys/__tests__/hotkeyStore.test.ts` (current `dev` base failed and the corrected head passed in the clean network-off verifier)
- `npm test` (150 tests passed in a network-off disposable writable workspace)
- targeted ESLint reports the same pre-existing 36 errors and 439 warnings on the base and corrected head; this patch adds no lint finding

## Limitations
- No manual macOS UI verification was performed.

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

Closes #381.

<!-- northset-receipt:M-1011:start -->
### Verification

[Northset proof-of-pass receipt M-1011](https://northset-oss.github.io/verification-pilot/receipts/M-1011/)  
This record covers Northset’s own contribution; it is not maintainer verification.
Maintainers can request a separate, private run for a PR already in their queue at oss@northset.ai.
For repositories already onboarded with Northset, adding `northset-verify` to a PR requests a run on that PR.
<!-- northset-receipt:M-1011:end -->
