### PR TITLE
Handle missing Apple secrets on fork PRs, correct workflow name

### DIFF
--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -1,4 +1,4 @@
-name: PR macOS Build Check
+name: PR macOS build check
 
 on:
   pull_request:

--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -39,7 +39,13 @@ jobs:
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      - name: Check for Apple signing secret
+        id: apple_cert
+        shell: bash
+        run: echo "available=${{ secrets.APPLE_CERTIFICATE != '' }}" >> "$GITHUB_OUTPUT"
+
       - name: Install Apple Certificate
+        if: steps.apple_cert.outputs.available == 'true'
         uses: apple-actions/import-codesign-certs@v7
         with:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}


### PR DESCRIPTION
GitHub never passes repo secrets to pull_request-triggered runs when
the PR head is an external fork, so run that step only if secrets exist.

Also fix workflow name so the follow-up trigger can work.