### PR TITLE
fix: open Settings with Cmd+, on macOS

### DIFF
--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -22,6 +22,7 @@ import {
   dispatchProfileSettingsModalOpenChange,
   type ProfileSettingsTab,
 } from '@/components/settings/profileModalEvents';
+import { OPEN_SETTINGS_MODAL_EVENT } from '@/components/settings/settingsModalEvents';
 import { OPEN_SETTINGS_ABOUT_EVENT } from '@/features/updater/updateNotificationEvents';
 import {
   getActivePrinterProfile,
@@ -487,6 +488,20 @@ export function TopBar({
     window.addEventListener(OPEN_PROFILE_SETTINGS_MODAL_EVENT, handleOpenProfileModal as EventListener);
     return () => {
       window.removeEventListener(OPEN_PROFILE_SETTINGS_MODAL_EVENT, handleOpenProfileModal as EventListener);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleOpenSettings = () => {
+      setSettingsInitialTab('general');
+      setIsSettingsOpen(true);
+    };
+
+    window.addEventListener(OPEN_SETTINGS_MODAL_EVENT, handleOpenSettings);
+    return () => {
+      window.removeEventListener(OPEN_SETTINGS_MODAL_EVENT, handleOpenSettings);
     };
   }, []);
 

--- a/src/components/settings/settingsModalEvents.ts
+++ b/src/components/settings/settingsModalEvents.ts
@@ -1,0 +1,6 @@
+export const OPEN_SETTINGS_MODAL_EVENT = 'dragonfruit:open-settings-modal';
+
+export function openSettingsModal(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(OPEN_SETTINGS_MODAL_EVENT));
+}

--- a/src/hotkeys/HotkeyRegistryManager.tsx
+++ b/src/hotkeys/HotkeyRegistryManager.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { getPrimaryModifierKey, hotkeyStore, isActionActiveSync } from './hotkeyStore';
 import { useHotkeyConfig } from './HotkeyContext';
+import { openSettingsModal } from '@/components/settings/settingsModalEvents';
 
 // Monkey-patch EventTarget.prototype.addEventListener to block/warn keydown/keyup listeners from forbidden paths
 let selfChunkName = '';
@@ -123,10 +124,21 @@ function isCanvasElement(element: EventTarget | null): boolean {
 
 export function setupHotkeyListeners() {
     const handleKeyDown = (e: KeyboardEvent) => {
+        const key = e.key.toLowerCase();
+        const isMacSettingsShortcut = e.metaKey
+            && !e.ctrlKey
+            && !e.shiftKey
+            && !e.altKey
+            && key === ',';
+        if (isMacSettingsShortcut) {
+            e.preventDefault();
+            openSettingsModal();
+            return;
+        }
+
         if (isTextInput(e.target)) return;
 
         const isPrimaryModifier = getPrimaryModifierKey() === 'meta' ? e.metaKey : e.ctrlKey;
-        const key = e.key.toLowerCase();
         
         // Prevent browser default behaviors
         if (

--- a/src/hotkeys/__tests__/hotkeyStore.test.ts
+++ b/src/hotkeys/__tests__/hotkeyStore.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { hotkeyStore, isKeyPressedSync, isActionActiveSync } from '../hotkeyStore';
 import { setupHotkeyListeners } from '../HotkeyRegistryManager';
+import { OPEN_SETTINGS_MODAL_EVENT } from '@/components/settings/settingsModalEvents';
 
 // Mock global window and HTMLElement if running in Node.js without DOM
 const listeners = new Map<string, Set<Function>>();
@@ -128,6 +129,44 @@ test('Hotkey Registry: clears all active keys on window blur', () => {
     assert.equal(isKeyPressedSync('w'), false, 'Keys should be cleared on blur');
     assert.equal(isKeyPressedSync('Shift'), false, 'Keys should be cleared on blur');
 
+    cleanup();
+});
+
+test('Hotkey Registry: Cmd+, opens settings and suppresses the native shortcut', () => {
+    hotkeyStore.getState().clearKeys();
+    const cleanup = setupHotkeyListeners();
+    const divTarget = new HTMLElement();
+    let openSettingsEvents = 0;
+    const handleOpenSettings = () => { openSettingsEvents += 1; };
+    window.addEventListener(OPEN_SETTINGS_MODAL_EVENT, handleOpenSettings);
+
+    const cmdCommaEvent = {
+        key: ',',
+        target: divTarget,
+        metaKey: true,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        preventDefaultCalled: false,
+        preventDefault() { this.preventDefaultCalled = true; },
+    };
+    dispatchWindowEvent('keydown', cmdCommaEvent);
+
+    assert.equal(openSettingsEvents, 1, 'Cmd+, should request the Settings modal');
+    assert.equal(cmdCommaEvent.preventDefaultCalled, true, 'Cmd+, should suppress the native shortcut');
+
+    const ctrlCommaEvent = {
+        ...cmdCommaEvent,
+        metaKey: false,
+        ctrlKey: true,
+        preventDefaultCalled: false,
+    };
+    dispatchWindowEvent('keydown', ctrlCommaEvent);
+
+    assert.equal(openSettingsEvents, 1, 'Ctrl+, should not trigger the macOS Settings shortcut');
+    assert.equal(ctrlCommaEvent.preventDefaultCalled, false);
+
+    window.removeEventListener(OPEN_SETTINGS_MODAL_EVENT, handleOpenSettings);
     cleanup();
 });
 
@@ -297,5 +336,3 @@ test('macOS uses Command, not Control, for primary-modifier shortcuts', () => {
         }
     }
 });
-
-


### PR DESCRIPTION
## Summary

Adds the standard macOS Cmd+, shortcut for opening Settings. The shortcut works even when a text field is focused and does not change Ctrl+, behavior.

---

## What changed

### Hotkey handling

- Routes the exact Meta+, combination through the centralized hotkey registry.
- Prevents the native default before opening the general Settings tab.
- Uses the existing application event pattern to keep modal state in TopBar.
- Preserves the platform-aware primary-modifier handling from dev for all existing shortcuts.

### Regression coverage

- Verifies that Cmd+, requests Settings and prevents the default action.
- Verifies that Ctrl+, does not trigger the macOS shortcut.

---

## Validation notes

- Focused Cmd+, regression passes.
- TypeScript check passes.
- Production Next.js build passes.
- The complete hotkey test file has three existing failures on macOS because older tests still assert Control-based shortcuts after #417 changed the primary modifier to Command. The new regression passes and the same failures are present on untouched dev.
- Repo-wide ESLint currently reports existing baseline violations. No new violation originates from this change.

Closes #292