### PR TITLE
feat: Add wide arching CSG check

### DIFF
--- a/rust/dragonfruit-mesh-repair/src/repair.rs
+++ b/rust/dragonfruit-mesh-repair/src/repair.rs
@@ -735,9 +735,97 @@ pub fn repair(mut mesh: IndexedMesh, options: &RepairOptions) -> RepairOutcome {
 
     report.fully_repaired = residuals.is_empty();
     report.residual_issues = residuals;
+
+    // Final validity gate: feed the model section (everything before the
+    // support split, or the whole mesh when there is no split) through the
+    // manifold_csg backend and inspect its status — the same check hollowing
+    // and hole-punching rely on. Any non-manifold status (not just a
+    // non-closed mesh) flags the model, and the frontend renders it red instead
+    // of the usual model color.
+    #[cfg(feature = "manifold")]
+    record_model_manifold_status(&mesh, &mut report);
+
     report.total_ms = t_start.elapsed().as_secs_f64() * 1000.0;
 
     RepairOutcome { mesh, report }
+}
+
+/// Extract the model section — the first `model_tri_count` triangles, or every
+/// triangle when there is no split — into a standalone [`IndexedMesh`] with
+/// compacted (zero-based) vertex indices so it can be fed to `manifold_csg`.
+#[cfg(feature = "manifold")]
+fn extract_model_section_submesh(mesh: &IndexedMesh, model_tri_count: Option<usize>) -> IndexedMesh {
+    let tri_end = model_tri_count
+        .map(|n| n.min(mesh.triangles.len()))
+        .unwrap_or(mesh.triangles.len());
+
+    let mut vert_map: AHashMap<u32, u32> = AHashMap::new();
+    let mut new_verts: Vec<Vec3> = Vec::new();
+    let new_tris: Vec<[u32; 3]> = mesh.triangles[..tri_end]
+        .iter()
+        .map(|tri| {
+            tri.map(|gi| {
+                let next = new_verts.len() as u32;
+                *vert_map.entry(gi).or_insert_with(|| {
+                    new_verts.push(mesh.positions[gi as usize]);
+                    next
+                })
+            })
+        })
+        .collect();
+
+    IndexedMesh {
+        positions: new_verts,
+        triangles: new_tris,
+    }
+}
+
+/// Runs the model section through the manifold_csg backend and returns its
+/// status. `manifold_csg::Manifold::from_mesh_f32` rejects *any* mesh the CSG
+/// backend flags — not only open/non-closed geometry but also `NotManifold`,
+/// `NonFiniteVertex`, `VertexOutOfBounds`, etc. — returning
+/// `Err(CsgError::ManifoldStatus(..))`, which is exactly the gate the hollowing
+/// and hole-punching paths rely on. `Ok(())` means a valid, non-empty manifold;
+/// `Err(reason)` carries the specific CSG status string.
+#[cfg(feature = "manifold")]
+fn model_section_manifold_status(
+    mesh: &IndexedMesh,
+    model_tri_count: Option<usize>,
+) -> Result<(), String> {
+    use manifold_csg::Manifold;
+
+    let model = extract_model_section_submesh(mesh, model_tri_count);
+    if model.triangles.is_empty() || model.positions.is_empty() {
+        return Err("empty model section".into());
+    }
+
+    let positions: Vec<f32> = model.positions.iter().flat_map(|v| [v.x, v.y, v.z]).collect();
+    let indices: Vec<u32> = model.triangles.iter().flat_map(|t| *t).collect();
+
+    // Any non-`NoError` CSG status surfaces here as `Err` and is treated as a
+    // failed manifold check, regardless of which non-manifold condition it is.
+    let model = Manifold::from_mesh_f32(&positions, 3, &indices).map_err(|e| e.to_string())?;
+    if model.is_empty() || model.num_tri() == 0 {
+        return Err("manifold became empty".into());
+    }
+    Ok(())
+}
+
+/// Records the model section's manifold status onto `report`
+/// (`model_is_manifold` + `model_manifold_status`). Shared by the full repair
+/// routine and the lightweight classify pass.
+#[cfg(feature = "manifold")]
+fn record_model_manifold_status(mesh: &IndexedMesh, report: &mut MeshHealthReport) {
+    match model_section_manifold_status(mesh, report.model_triangle_count) {
+        Ok(()) => {
+            report.model_is_manifold = Some(true);
+            report.model_manifold_status = None;
+        }
+        Err(reason) => {
+            report.model_is_manifold = Some(false);
+            report.model_manifold_status = Some(reason);
+        }
+    }
 }
 
 /// Lightweight model/support section classification pass.
@@ -793,6 +881,13 @@ pub fn classify_support_split(mut mesh: IndexedMesh) -> RepairOutcome {
     report.post = minimal_analysis(&mesh, component_count);
     report.fully_repaired = true;
     report.residual_issues = Vec::new();
+
+    // Same final manifold-status gate as the full repair routine: feed the
+    // model section through manifold_csg and flag any non-manifold status so
+    // the frontend can render a non-manifold model red.
+    #[cfg(feature = "manifold")]
+    record_model_manifold_status(&mesh, &mut report);
+
     report.total_ms = t_start.elapsed().as_secs_f64() * 1000.0;
 
     RepairOutcome { mesh, report }

--- a/rust/dragonfruit-mesh-repair/src/repair.rs
+++ b/rust/dragonfruit-mesh-repair/src/repair.rs
@@ -741,9 +741,22 @@ pub fn repair(mut mesh: IndexedMesh, options: &RepairOptions) -> RepairOutcome {
     // manifold_csg backend and inspect its status — the same check hollowing
     // and hole-punching rely on. Any non-manifold status (not just a
     // non-closed mesh) flags the model, and the frontend renders it red instead
-    // of the usual model color.
+    // of the usual model color. If the model is still not a valid manifold after
+    // repair, the repair is reported as unsuccessful in the summary.
     #[cfg(feature = "manifold")]
-    record_model_manifold_status(&mesh, &mut report);
+    {
+        record_model_manifold_status(&mesh, &mut report);
+        if report.model_is_manifold == Some(false) {
+            let detail = report
+                .model_manifold_status
+                .clone()
+                .unwrap_or_else(|| "non-manifold model".into());
+            report
+                .residual_issues
+                .push(format!("model is still not a valid manifold after repair ({detail})"));
+            report.fully_repaired = false;
+        }
+    }
 
     report.total_ms = t_start.elapsed().as_secs_f64() * 1000.0;
 

--- a/rust/dragonfruit-mesh-repair/src/report.rs
+++ b/rust/dragonfruit-mesh-repair/src/report.rs
@@ -22,6 +22,21 @@ pub struct MeshHealthReport {
     /// geometry has no spatial split (all one group, or repair did not run).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_triangle_count: Option<usize>,
+    /// Result of feeding the model section (the first `model_triangle_count`
+    /// triangles, or the whole mesh when there is no split) through the
+    /// `manifold_csg` backend and checking its status. `Some(true)` = a valid
+    /// manifold (`NoError`), `Some(false)` = the CSG backend reported *any*
+    /// non-manifold status — not just an open/non-closed mesh but also
+    /// non-finite vertices, out-of-bounds indices, etc. (the UI renders such a
+    /// model red), `None` = the check did not run (manifold backend disabled or
+    /// no geometry).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_is_manifold: Option<bool>,
+    /// The specific `manifold_csg` status string when `model_is_manifold` is
+    /// `Some(false)` (e.g. `manifold3d status: NotManifold`), for diagnostics.
+    /// `None` when the model is a valid manifold or the check did not run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_manifold_status: Option<String>,
     /// If any defect classes remain after repair, they are listed here as
     /// human-readable strings so the UI can surface them.
     pub residual_issues: Vec<String>,
@@ -49,6 +64,8 @@ impl MeshHealthReport {
             steps: Vec::new(),
             likely_support_geometry: false,
             model_triangle_count: None,
+            model_is_manifold: None,
+            model_manifold_status: None,
             residual_issues: Vec::new(),
             fully_repaired: false,
             total_ms: 0.0,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -492,22 +492,22 @@ export default function Home() {
   // 1. Scene & Geometry (Multi-Model)
   const scene = useSceneCollectionManager();
 
-  // Warn once (per model) when an imported mesh fails the manifold_csg validity
-  // check — the same models shown with the red striped overlay in the viewport.
+  // Warn when an imported mesh fails the manifold_csg validity check — the same
+  // models shown with the red striped overlay in the viewport. Only a single
+  // warning is shown per import job: as soon as any newly-imported model is
+  // flagged, every currently-flagged model is marked as warned so the rest of
+  // the batch does not pop additional modals.
   const warnedManifoldModelIdsRef = React.useRef<Set<string>>(new Set());
-  const [manifoldWarningModelName, setManifoldWarningModelName] = React.useState<string | null>(null);
+  const [showManifoldWarning, setShowManifoldWarning] = React.useState(false);
   React.useEffect(() => {
-    if (manifoldWarningModelName) return; // one warning shown at a time
-    const next = scene.models.find(
-      (model) =>
-        model.geometry?.meshDefects?.nativeRepairReport?.model_is_manifold === false &&
-        !warnedManifoldModelIdsRef.current.has(model.id),
+    const flagged = scene.models.filter(
+      (model) => model.geometry?.meshDefects?.nativeRepairReport?.model_is_manifold === false,
     );
-    if (next) {
-      warnedManifoldModelIdsRef.current.add(next.id);
-      setManifoldWarningModelName(next.name || 'This model');
-    }
-  }, [scene.models, manifoldWarningModelName]);
+    const hasUnwarned = flagged.some((model) => !warnedManifoldModelIdsRef.current.has(model.id));
+    if (!hasUnwarned) return;
+    for (const model of flagged) warnedManifoldModelIdsRef.current.add(model.id);
+    setShowManifoldWarning(true);
+  }, [scene.models]);
   const importSceneFile = scene.importSceneFile;
   const importSceneFiles = scene.importSceneFiles;
   const recentOpenedFiles = scene.recentOpenedFiles;
@@ -9866,9 +9866,8 @@ export default function Home() {
       />
 
       <ManifoldWarningModal
-        isOpen={manifoldWarningModelName != null}
-        modelName={manifoldWarningModelName ?? ''}
-        onAcknowledge={() => setManifoldWarningModelName(null)}
+        isOpen={showManifoldWarning}
+        onAcknowledge={() => setShowManifoldWarning(false)}
       />
 
       <MeshRepairModals

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -320,6 +320,7 @@ import { useSceneAutosave, suppressSceneAutosave } from '@/hooks/useSceneAutosav
 import { SceneAutosaveRecoveryModal } from '@/components/scene/SceneAutosaveRecoveryModal';
 import { MeshRepairReportModal } from '@/components/scene/MeshRepairReportModal';
 import { MeshRepairConfirmModal } from '@/components/scene/MeshRepairConfirmModal';
+import { ManifoldWarningModal } from '@/components/modals/ManifoldWarningModal';
 
 import { IslandScanWorkflowCard } from '@/volumeAnalysis/IslandScan/workflow/IslandScanWorkflowCard';
 import { IslandVolumesHierarchyCard } from '@/volumeAnalysis/IslandVolumes/components/IslandVolumesHierarchyCard';
@@ -490,6 +491,23 @@ export default function Home() {
   const { stage, sproutParentingLockHeld } = useLeafPlacementState();
   // 1. Scene & Geometry (Multi-Model)
   const scene = useSceneCollectionManager();
+
+  // Warn once (per model) when an imported mesh fails the manifold_csg validity
+  // check — the same models shown with the red striped overlay in the viewport.
+  const warnedManifoldModelIdsRef = React.useRef<Set<string>>(new Set());
+  const [manifoldWarningModelName, setManifoldWarningModelName] = React.useState<string | null>(null);
+  React.useEffect(() => {
+    if (manifoldWarningModelName) return; // one warning shown at a time
+    const next = scene.models.find(
+      (model) =>
+        model.geometry?.meshDefects?.nativeRepairReport?.model_is_manifold === false &&
+        !warnedManifoldModelIdsRef.current.has(model.id),
+    );
+    if (next) {
+      warnedManifoldModelIdsRef.current.add(next.id);
+      setManifoldWarningModelName(next.name || 'This model');
+    }
+  }, [scene.models, manifoldWarningModelName]);
   const importSceneFile = scene.importSceneFile;
   const importSceneFiles = scene.importSceneFiles;
   const recentOpenedFiles = scene.recentOpenedFiles;
@@ -9845,6 +9863,12 @@ export default function Home() {
         showModifierApplyBlockingOverlay={showModifierApplyBlockingOverlay}
         showUnappliedHolePunchModal={showUnappliedHolePunchModal}
         unappliedHolePunchResolveRef={unappliedHolePunchResolveRef}
+      />
+
+      <ManifoldWarningModal
+        isOpen={manifoldWarningModelName != null}
+        modelName={manifoldWarningModelName ?? ''}
+        onAcknowledge={() => setManifoldWarningModelName(null)}
       />
 
       <MeshRepairModals

--- a/src/components/modals/ManifoldWarningModal.tsx
+++ b/src/components/modals/ManifoldWarningModal.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
+
+type ManifoldWarningModalProps = {
+  isOpen: boolean;
+  modelName: string;
+  onAcknowledge: () => void;
+};
+
+export function ManifoldWarningModal({
+  isOpen,
+  modelName,
+  onAcknowledge,
+}: ManifoldWarningModalProps) {
+  return (
+    <StructuredDialogModal
+      open={isOpen}
+      ariaLabel="Possible mesh manifold issues"
+      title="Mesh Manifold Warning"
+      subtitle="This mesh may not be a valid solid"
+      icon={<AlertTriangle className="h-4 w-4" />}
+      iconTone="warning"
+      zIndexClassName="z-[130]"
+      // No close-X and backdrop clicks are ignored: the user must press OK to
+      // acknowledge the manifold warning.
+      onBackdropClick={() => {}}
+      actions={(
+        <button
+          type="button"
+          className="ui-button ui-button-accent !h-9 w-full px-3 text-xs"
+          onClick={onAcknowledge}
+        >
+          OK
+        </button>
+      )}
+    >
+      <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+        <strong className="text-sm font-medium" style={{ color: 'var(--text-strong)' }}>{modelName}</strong>{' '}
+        may have manifold issues &mdash; it did not pass our closed-solid validity check. Meshes that
+        are not watertight, valid solids can lead to problems further in the workflow, such as during
+        support generation, slicing, or export.
+      </p>
+      <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+        This is why the mesh is shown with a red striped overlay in the viewport. You can continue
+        working with it, but results may be unreliable until the mesh is repaired.
+      </p>
+    </StructuredDialogModal>
+  );
+}

--- a/src/components/modals/ManifoldWarningModal.tsx
+++ b/src/components/modals/ManifoldWarningModal.tsx
@@ -19,7 +19,7 @@ export function ManifoldWarningModal({
     <StructuredDialogModal
       open={isOpen}
       ariaLabel="Possible mesh manifold issues"
-      title="Mesh Manifold Warning"
+      title="Warning: Non-manifold mesh"
       subtitle="This mesh may not be a valid solid"
       icon={<AlertTriangle className="h-4 w-4" />}
       iconTone="warning"

--- a/src/components/modals/ManifoldWarningModal.tsx
+++ b/src/components/modals/ManifoldWarningModal.tsx
@@ -36,14 +36,14 @@ export function ManifoldWarningModal({
       )}
     >
       <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
-        Failed manifold validation. It is recommended this mesh be repaired before continuing.
+        Failed manifold validation. Recommend mesh repair before continuing.
       </p>
       <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
-        This may cause issues with supports and printability, including issues with support placement
-        and slicing. Some issues may not be immediately visible (e.g. slicing defects).
+        This may cause issues with printability including support placement and slicing. Some may not
+        be immediately visible (e.g. slicing defects, etc.).
       </p>
       <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
-        The red overlay indicates components for multi-component imports which failed validation.
+        Red overlay indicates individual components failing validation.
       </p>
     </StructuredDialogModal>
   );

--- a/src/components/modals/ManifoldWarningModal.tsx
+++ b/src/components/modals/ManifoldWarningModal.tsx
@@ -39,13 +39,14 @@ export function ManifoldWarningModal({
     >
       <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
         <strong className="text-sm font-medium" style={{ color: 'var(--text-strong)' }}>{modelName}</strong>{' '}
-        may have manifold issues &mdash; it did not pass our closed-solid validity check. Meshes that
-        are not watertight, valid solids can lead to problems further in the workflow, such as during
-        support generation, slicing, or export.
+        failed manifold validation. It is recommended this mesh be repaired before continuing.
       </p>
       <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
-        This is why the mesh is shown with a red striped overlay in the viewport. You can continue
-        working with it, but results may be unreliable until the mesh is repaired.
+        This may cause issues with supports and printability, including issues with support placement
+        and slicing. Some issues may not be immediately visible (e.g. slicing defects).
+      </p>
+      <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+        The red overlay indicates components for multi-component imports which failed validation.
       </p>
     </StructuredDialogModal>
   );

--- a/src/components/modals/ManifoldWarningModal.tsx
+++ b/src/components/modals/ManifoldWarningModal.tsx
@@ -6,13 +6,11 @@ import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
 
 type ManifoldWarningModalProps = {
   isOpen: boolean;
-  modelName: string;
   onAcknowledge: () => void;
 };
 
 export function ManifoldWarningModal({
   isOpen,
-  modelName,
   onAcknowledge,
 }: ManifoldWarningModalProps) {
   return (
@@ -38,8 +36,7 @@ export function ManifoldWarningModal({
       )}
     >
       <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
-        <strong className="text-sm font-medium" style={{ color: 'var(--text-strong)' }}>{modelName}</strong>{' '}
-        failed manifold validation. It is recommended this mesh be repaired before continuing.
+        Failed manifold validation. It is recommended this mesh be repaired before continuing.
       </p>
       <p className="text-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
         This may cause issues with supports and printability, including issues with support placement

--- a/src/components/scene/MeshRepairReportModal.tsx
+++ b/src/components/scene/MeshRepairReportModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { CheckCircle2, AlertTriangle, X, Wrench, ClipboardCopy, ChevronDown, ChevronRight } from 'lucide-react';
+import { CheckCircle2, AlertTriangle, XCircle, X, Wrench, ClipboardCopy, ChevronDown, ChevronRight } from 'lucide-react';
 import type { MeshRepairReportEntry } from '@/features/scene/useSceneCollectionManager';
 import type { MeshAnalysisJson } from '@/utils/meshRepair';
 
@@ -94,9 +94,17 @@ export function MeshRepairReportModal({ reports, presentation = 'default', onDis
       ? reports[0].modelName
       : `${reports.length} meshes · ${formatMs(totals.totalMs)} · ${totals.repaired} clean · ${totals.residual} with issues`;
 
-  const headerTitle = effectivePresentation === 'optimistic' ? 'Repair Complete' : 'Mesh Repair Report';
-  const headerToneColor = effectivePresentation === 'optimistic' ? '#22c55e' : toneColor;
+  // On the optimistic "Repair Complete" page, an unsuccessful repair (mesh still
+  // not valid) is flagged with a red cross instead of the green check.
+  const optimisticFailed = effectivePresentation === 'optimistic' && hasResidual;
+  const headerTitle = effectivePresentation === 'optimistic'
+    ? (optimisticFailed ? 'Repair Incomplete' : 'Repair Complete')
+    : 'Mesh Repair Report';
+  const headerToneColor = optimisticFailed
+    ? '#ef4444'
+    : effectivePresentation === 'optimistic' ? '#22c55e' : toneColor;
   const headerHasWarningTone = effectivePresentation !== 'optimistic' && hasResidual;
+  const headerAccentColor = optimisticFailed ? '#ef4444' : headerHasWarningTone ? '#d97706' : '#22c55e';
   const panelMaxWidthClassName = effectivePresentation === 'optimistic' ? 'max-w-2xl' : 'max-w-3xl';
   const headerClassName = effectivePresentation === 'optimistic'
     ? 'flex items-center justify-between gap-4 border-b px-4 py-3'
@@ -126,16 +134,16 @@ export function MeshRepairReportModal({ reports, presentation = 'default', onDis
             <span
               className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border"
               style={{
-                borderColor: headerHasWarningTone
-                  ? 'color-mix(in srgb, #d97706, var(--border-subtle) 50%)'
-                  : 'color-mix(in srgb, #22c55e, var(--border-subtle) 50%)',
-                background: headerHasWarningTone
-                  ? 'color-mix(in srgb, #d97706, var(--surface-1) 85%)'
-                  : 'color-mix(in srgb, #22c55e, var(--surface-1) 85%)',
+                borderColor: `color-mix(in srgb, ${headerAccentColor}, var(--border-subtle) 50%)`,
+                background: `color-mix(in srgb, ${headerAccentColor}, var(--surface-1) 85%)`,
                 color: headerToneColor,
               }}
             >
-              {headerHasWarningTone ? <AlertTriangle className="h-4 w-4" /> : <CheckCircle2 className="h-4 w-4" />}
+              {optimisticFailed
+                ? <XCircle className="h-4 w-4" />
+                : headerHasWarningTone
+                  ? <AlertTriangle className="h-4 w-4" />
+                  : <CheckCircle2 className="h-4 w-4" />}
             </span>
             <div className="min-w-0 pr-2">
               <h2 className="text-base font-semibold leading-tight" style={{ color: 'var(--text-strong)' }}>
@@ -215,30 +223,34 @@ function OptimisticReportBody({ entry }: { entry: MeshRepairReportEntry }) {
 
   const summaryText = report.fully_repaired
     ? 'DragonFruit repaired this mesh and replaced the model in your current scene.'
-    : 'DragonFruit repaired this mesh and improved the main issues it found.';
+    : 'DragonFruit could not fully repair this mesh — it is still not a valid manifold and may cause problems later in your workflow.';
+
+  const summaryAccent = report.fully_repaired ? '#22c55e' : '#ef4444';
 
   return (
     <div className="space-y-2.5">
       <div
         className="rounded-lg border px-3 py-2.5"
         style={{
-          borderColor: 'color-mix(in srgb, #22c55e, var(--border-subtle) 50%)',
-          background: 'color-mix(in srgb, #22c55e, var(--surface-1) 90%)',
+          borderColor: `color-mix(in srgb, ${summaryAccent}, var(--border-subtle) 50%)`,
+          background: `color-mix(in srgb, ${summaryAccent}, var(--surface-1) 90%)`,
         }}
       >
         <div className="flex items-start gap-2.5">
-          <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" style={{ color: '#22c55e' }} />
+          {report.fully_repaired
+            ? <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" style={{ color: summaryAccent }} />
+            : <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" style={{ color: summaryAccent }} />}
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
               <div className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
-                Repair finished
+                {report.fully_repaired ? 'Repair finished' : 'Repair incomplete'}
               </div>
               <span
                 className="inline-flex rounded-full border px-2 py-0.5 text-[10px] font-semibold tabular-nums"
                 style={{
                   color: 'var(--text-strong)',
-                  borderColor: 'color-mix(in srgb, #22c55e, var(--border-subtle) 45%)',
-                  background: 'color-mix(in srgb, #22c55e, transparent 86%)',
+                  borderColor: `color-mix(in srgb, ${summaryAccent}, var(--border-subtle) 45%)`,
+                  background: `color-mix(in srgb, ${summaryAccent}, transparent 86%)`,
                 }}
               >
                 {formatMs(report.total_ms)}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -5454,6 +5454,13 @@ export function SceneCanvas({
                 if (shouldHideDuplicateSourceModel) return null;
                 if (arrangeArraySourceModelIdSet.has(model.id)) return null;
 
+                // The native repair/classify routines end with a manifold_csg
+                // status check on the model section. When the CSG backend reports
+                // any non-manifold status, render the model red instead of its
+                // usual color.
+                const modelClosedCheckFailed =
+                  model.geometry.meshDefects?.nativeRepairReport?.model_is_manifold === false;
+
                 return (
                   <React.Fragment key={model.id}>
                     <StlMesh
@@ -5461,7 +5468,7 @@ export function SceneCanvas({
                       geometry={model.geometry.geometry}
                       clipLower={clipLower}
                       clipUpper={clipUpper}
-                      meshColor={model.color || meshColor} // Use model color
+                      meshColor={modelClosedCheckFailed ? '#ff0000' : (model.color || meshColor)} // Red when the mesh fails the manifold closed check; otherwise model color
                       meshRef={meshGroupRefCallback}
                       actualMeshRef={actualMeshRefCallback}
                       materialRoughness={materialRoughness}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -5534,6 +5534,7 @@ export function SceneCanvas({
                         && (isGizmoDragging || isPostGizmoInteractionGuardActive)
                       }
                       supportSectionGeometry={model.geometry.meshDefects?.supportSectionGeometry ?? null}
+                      modelSectionGeometry={model.geometry.meshDefects?.modelSectionGeometry ?? null}
                       onHolePunchClick={onHolePunchClick}
                       onHolePunchHover={onHolePunchHover}
                     >

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -5456,7 +5456,7 @@ export function SceneCanvas({
 
                 // The native repair/classify routines end with a manifold_csg
                 // status check on the model section. When the CSG backend reports
-                // any non-manifold status, overlay a red checkerboard pattern on
+                // any non-manifold status, overlay a red stripe pattern on
                 // the model to flag it.
                 const modelIsNonManifold =
                   model.geometry.meshDefects?.nativeRepairReport?.model_is_manifold === false;

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -5456,9 +5456,9 @@ export function SceneCanvas({
 
                 // The native repair/classify routines end with a manifold_csg
                 // status check on the model section. When the CSG backend reports
-                // any non-manifold status, render the model red instead of its
-                // usual color.
-                const modelClosedCheckFailed =
+                // any non-manifold status, overlay a red checkerboard pattern on
+                // the model to flag it.
+                const modelIsNonManifold =
                   model.geometry.meshDefects?.nativeRepairReport?.model_is_manifold === false;
 
                 return (
@@ -5468,7 +5468,8 @@ export function SceneCanvas({
                       geometry={model.geometry.geometry}
                       clipLower={clipLower}
                       clipUpper={clipUpper}
-                      meshColor={modelClosedCheckFailed ? '#ff0000' : (model.color || meshColor)} // Red when the mesh fails the manifold closed check; otherwise model color
+                      meshColor={model.color || meshColor} // Use model color
+                      nonManifold={modelIsNonManifold} // Red checkerboard overlay when the model fails the manifold status check
                       meshRef={meshGroupRefCallback}
                       actualMeshRef={actualMeshRefCallback}
                       materialRoughness={materialRoughness}

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -830,8 +830,10 @@ if (uDitherAmount > 0.0) {
   ]);
 
   // Red/clear striped overlay flagging a non-manifold model (failed the
-  // manifold_csg status check). World-space stripes along X so the pattern stays
-  // fixed on the surface; clear stripes discard so the underlying model shows through.
+  // manifold_csg status check). Uses the SAME world-space stripe seed and
+  // frequency as the out-of-bounds overlay (see outOfBoundsMaterial above) so
+  // the red stripes land directly on the green out-of-bounds stripes and, being
+  // translucent, blend with them where the two overlap.
   const nonManifoldCheckerMaterial = React.useMemo(() => {
     if (!nonManifold) return null;
 
@@ -845,7 +847,8 @@ if (uDitherAmount > 0.0) {
       polygonOffsetFactor: -1,
       polygonOffsetUnits: -1,
       uniforms: {
-        uStripeWidthMm: { value: 1.6 },
+        // Match the out-of-bounds overlay's stripe frequency so the patterns coincide.
+        uStripeFreq: { value: 0.22 },
         uColor: { value: new THREE.Color('#ff0000') },
         uOpacity: { value: 0.72 },
       },
@@ -859,13 +862,16 @@ if (uDitherAmount > 0.0) {
       `,
       fragmentShader: `
         varying vec3 vWorldPos;
-        uniform float uStripeWidthMm;
+        uniform float uStripeFreq;
         uniform vec3 uColor;
         uniform float uOpacity;
 
         void main() {
-          float stripe = mod(floor(vWorldPos.x / uStripeWidthMm), 2.0);
-          if (stripe < 0.5) discard; // clear stripes
+          // Identical seed to the out-of-bounds shader; its green (colorA) band
+          // is where step(0.5, fract(seed)) == 0, so draw red there to overlap it.
+          float stripeSeed = (vWorldPos.x + vWorldPos.y + vWorldPos.z) * uStripeFreq;
+          float band = step(0.5, fract(stripeSeed));
+          if (band > 0.5) discard; // clear on the non-green bands
           gl_FragColor = vec4(uColor, uOpacity);
         }
       `,

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -829,9 +829,9 @@ if (uDitherAmount > 0.0) {
     supportPlacementGuidePlaneZ,
   ]);
 
-  // Red/clear checkerboard overlay flagging a non-manifold model (failed the
-  // manifold_csg status check). World-space checker so the pattern stays fixed
-  // on the surface; clear cells discard so the underlying model shows through.
+  // Red/clear striped overlay flagging a non-manifold model (failed the
+  // manifold_csg status check). World-space stripes along X so the pattern stays
+  // fixed on the surface; clear stripes discard so the underlying model shows through.
   const nonManifoldCheckerMaterial = React.useMemo(() => {
     if (!nonManifold) return null;
 
@@ -845,7 +845,7 @@ if (uDitherAmount > 0.0) {
       polygonOffsetFactor: -1,
       polygonOffsetUnits: -1,
       uniforms: {
-        uCellSizeMm: { value: 1.6 },
+        uStripeWidthMm: { value: 1.6 },
         uColor: { value: new THREE.Color('#ff0000') },
         uOpacity: { value: 0.72 },
       },
@@ -859,14 +859,13 @@ if (uDitherAmount > 0.0) {
       `,
       fragmentShader: `
         varying vec3 vWorldPos;
-        uniform float uCellSizeMm;
+        uniform float uStripeWidthMm;
         uniform vec3 uColor;
         uniform float uOpacity;
 
         void main() {
-          vec3 cell = floor(vWorldPos / uCellSizeMm);
-          float checker = mod(cell.x + cell.y + cell.z, 2.0);
-          if (checker < 0.5) discard; // clear squares
+          float stripe = mod(floor(vWorldPos.x / uStripeWidthMm), 2.0);
+          if (stripe < 0.5) discard; // clear stripes
           gl_FragColor = vec4(uColor, uOpacity);
         }
       `,

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -215,6 +215,7 @@ function StlMeshComponent({
   isExternallyHovered,
   deferExternalTransformUpdates,
   supportSectionGeometry,
+  nonManifold = false,
   higherContrastModelEdges = false,
   edgeGeometry,
   blockerEditMode = false,
@@ -296,6 +297,9 @@ function StlMeshComponent({
   /** When present (model+support mixed import), this geometry contains only the support-section
    *  triangles and is rendered as an orange overlay on top of the main mesh. */
   supportSectionGeometry?: THREE.BufferGeometry | null;
+  /** When true, the model failed the manifold_csg status check (any non-manifold
+   *  status). A red/clear checkerboard pattern is overlaid on the mesh to flag it. */
+  nonManifold?: boolean;
   children?: React.ReactNode;
 }) {
   // Access GPU picking state to detect gizmo hover
@@ -825,6 +829,56 @@ if (uDitherAmount > 0.0) {
     supportPlacementGuidePlaneZ,
   ]);
 
+  // Red/clear checkerboard overlay flagging a non-manifold model (failed the
+  // manifold_csg status check). World-space checker so the pattern stays fixed
+  // on the surface; clear cells discard so the underlying model shows through.
+  const nonManifoldCheckerMaterial = React.useMemo(() => {
+    if (!nonManifold) return null;
+
+    return new THREE.ShaderMaterial({
+      transparent: true,
+      depthWrite: false,
+      clippingPlanes: planes,
+      side: THREE.DoubleSide,
+      toneMapped: false,
+      polygonOffset: true,
+      polygonOffsetFactor: -1,
+      polygonOffsetUnits: -1,
+      uniforms: {
+        uCellSizeMm: { value: 1.6 },
+        uColor: { value: new THREE.Color('#ff0000') },
+        uOpacity: { value: 0.72 },
+      },
+      vertexShader: `
+        varying vec3 vWorldPos;
+        void main() {
+          vec4 worldPos = modelMatrix * vec4(position, 1.0);
+          vWorldPos = worldPos.xyz;
+          gl_Position = projectionMatrix * viewMatrix * worldPos;
+        }
+      `,
+      fragmentShader: `
+        varying vec3 vWorldPos;
+        uniform float uCellSizeMm;
+        uniform vec3 uColor;
+        uniform float uOpacity;
+
+        void main() {
+          vec3 cell = floor(vWorldPos / uCellSizeMm);
+          float checker = mod(cell.x + cell.y + cell.z, 2.0);
+          if (checker < 0.5) discard; // clear squares
+          gl_FragColor = vec4(uColor, uOpacity);
+        }
+      `,
+    });
+  }, [nonManifold, planes]);
+
+  React.useEffect(() => {
+    return () => {
+      nonManifoldCheckerMaterial?.dispose();
+    };
+  }, [nonManifoldCheckerMaterial]);
+
   React.useEffect(() => {
     return () => {
       outOfBoundsMaterial?.dispose();
@@ -1340,6 +1394,12 @@ if (uDitherAmount > 0.0) {
       {supportPlacementGuideEnabled && supportPlacementGuideMaterial && (
         <mesh geometry={geometry} position={meshLocalOffset} renderOrder={4} raycast={() => null}>
           <primitive object={supportPlacementGuideMaterial} attach="material" />
+        </mesh>
+      )}
+
+      {nonManifoldCheckerMaterial && (
+        <mesh geometry={geometry} position={meshLocalOffset} renderOrder={5} raycast={() => null}>
+          <primitive object={nonManifoldCheckerMaterial} attach="material" />
         </mesh>
       )}
 

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -215,6 +215,7 @@ function StlMeshComponent({
   isExternallyHovered,
   deferExternalTransformUpdates,
   supportSectionGeometry,
+  modelSectionGeometry,
   nonManifold = false,
   higherContrastModelEdges = false,
   edgeGeometry,
@@ -297,8 +298,12 @@ function StlMeshComponent({
   /** When present (model+support mixed import), this geometry contains only the support-section
    *  triangles and is rendered as an orange overlay on top of the main mesh. */
   supportSectionGeometry?: THREE.BufferGeometry | null;
+  /** When present (model+support mixed import), this geometry contains only the model-section
+   *  (part) triangles. The non-manifold red overlay is scoped to this so it never stripes the
+   *  supports. Falls back to the full geometry when there is no split (whole mesh is the part). */
+  modelSectionGeometry?: THREE.BufferGeometry | null;
   /** When true, the model failed the manifold_csg status check (any non-manifold
-   *  status). A red/clear checkerboard pattern is overlaid on the mesh to flag it. */
+   *  status). A red/clear checkerboard pattern is overlaid on the part to flag it. */
   nonManifold?: boolean;
   children?: React.ReactNode;
 }) {
@@ -1403,7 +1408,15 @@ if (uDitherAmount > 0.0) {
       )}
 
       {nonManifoldCheckerMaterial && (
-        <mesh geometry={geometry} position={meshLocalOffset} renderOrder={5} raycast={() => null}>
+        // Scope the red flag to the model section (the part) so supports are never
+        // striped. Falls back to the full geometry when there is no model/support
+        // split, in which case the whole mesh is the part.
+        <mesh
+          geometry={modelSectionGeometry ?? geometry}
+          position={meshLocalOffset}
+          renderOrder={5}
+          raycast={() => null}
+        >
           <primitive object={nonManifoldCheckerMaterial} attach="material" />
         </mesh>
       )}

--- a/src/features/mesh-modifiers/prepareModelGeometry.ts
+++ b/src/features/mesh-modifiers/prepareModelGeometry.ts
@@ -161,10 +161,12 @@ function splitClassifiedModelForOutput(model: LoadedModel): {
     ...sourceDefects,
     nativeRepairReport: undefined,
     supportSectionGeometry: undefined,
+    modelSectionGeometry: undefined,
   } : undefined;
   const supportDefects = sourceDefects ? {
     ...sourceDefects,
     supportSectionGeometry: undefined,
+    modelSectionGeometry: undefined,
     nativeRepairReport: report ? {
       ...report,
       model_triangle_count: null,

--- a/src/hooks/useStlGeometry.ts
+++ b/src/hooks/useStlGeometry.ts
@@ -35,6 +35,10 @@ export type MeshDefects = {
   /** When the repaired mesh has a model/support split (model_triangle_count in the report),
    *  this geometry holds only the support-section triangles for separate orange rendering. */
   supportSectionGeometry?: THREE.BufferGeometry;
+  /** When the repaired mesh has a model/support split, this geometry holds only the
+   *  model-section (part) triangles, so overlays such as the non-manifold red flag can
+   *  be scoped to the part alone and never stripe the supports. */
+  modelSectionGeometry?: THREE.BufferGeometry;
 };
 
 export type GeometryWithBounds = {
@@ -405,7 +409,20 @@ export async function processGeometry(bufferGeometry: THREE.BufferGeometry, opti
             const supportGeo = new THREE.BufferGeometry();
             supportGeo.setAttribute('position', new THREE.BufferAttribute(supportPositions, 3));
             supportGeo.computeVertexNormals();
-            meshDefects = { ...meshDefects, supportSectionGeometry: supportGeo };
+
+            // Model-section (part) geometry: the first model_triangle_count triangles.
+            // Used to scope the non-manifold red overlay to the part alone so it never
+            // stripes the supports. Normals are unnecessary — the overlay shader only
+            // reads world-space position.
+            const modelPositions = allPos.slice(0, modelFloatEnd);
+            const modelGeo = new THREE.BufferGeometry();
+            modelGeo.setAttribute('position', new THREE.BufferAttribute(modelPositions, 3));
+
+            meshDefects = {
+              ...meshDefects,
+              supportSectionGeometry: supportGeo,
+              modelSectionGeometry: modelGeo,
+            };
           }
         }
       }

--- a/src/utils/meshRepair.ts
+++ b/src/utils/meshRepair.ts
@@ -57,6 +57,14 @@ export interface MeshHealthReport {
   /** When present, the first N triangles in the repaired mesh are model body;
    *  the remainder are support geometry. Used to bake per-triangle vertex colors. */
   model_triangle_count?: number | null;
+  /** Result of the final manifold_csg status check on the model section, run at
+   *  the end of the native repair and classify routines. `false` means the CSG
+   *  backend reported some non-manifold status (open mesh, non-finite vertices,
+   *  out-of-bounds indices, etc.) and the model should render red;
+   *  `null`/undefined means the check did not run (manifold backend disabled). */
+  model_is_manifold?: boolean | null;
+  /** Specific manifold_csg status string when `model_is_manifold` is false. */
+  model_manifold_status?: string | null;
   residual_issues: string[];
   fully_repaired: boolean;
   total_ms: number;
@@ -120,6 +128,8 @@ interface RawMeshHealthReport extends UnknownRecord {
   likely_support_geometry?: unknown;
   likelySupportGeometry?: unknown;
   model_triangle_count?: unknown;
+  model_is_manifold?: unknown;
+  model_manifold_status?: unknown;
   residual_issues?: unknown;
   fully_repaired?: unknown;
   total_ms?: unknown;
@@ -207,6 +217,8 @@ function normalizeMeshHealthReport(input: unknown): MeshHealthReport {
     model_triangle_count: typeof raw.model_triangle_count === 'number' && raw.model_triangle_count > 0
       ? raw.model_triangle_count
       : null,
+    model_is_manifold: typeof raw.model_is_manifold === 'boolean' ? raw.model_is_manifold : null,
+    model_manifold_status: typeof raw.model_manifold_status === 'string' ? raw.model_manifold_status : null,
     residual_issues: asStringArray(raw.residual_issues),
     fully_repaired: asBoolean(raw.fully_repaired),
     total_ms: asNumber(raw.total_ms),


### PR DESCRIPTION
Mark meshes as "non-manifold" if Manifold_CSG replies with any non-manifold code to indicate to the user if a mesh *may* be non-manifold.

This check is purely visual and is overzealous to any failure of the mesh.
Runs at the end of a repair and at the end of classification.