### PR TITLE
fix: restore twig disk tips in STL/3MF export

### DIFF
--- a/src/features/export/logic/SupportGeometryGenerator.ts
+++ b/src/features/export/logic/SupportGeometryGenerator.ts
@@ -286,7 +286,12 @@ export class SupportGeometryGenerator {
     const pos = coneData.pos;
     const surfaceNormal = coneData.surfaceNormal || coneData.normal; // Fallback to cone normal
     const coneAxis = coneData.normal;
-    const contactDiameterMm = profile.contactDiameterMm;
+    // Twig disks carry contactDiameterMm on the disk object; cone profiles
+    // (SupportTipProfile) carry it inside the profile. Prefer the object-level
+    // value so twig disks — whose ContactDiskProfile has no contactDiameterMm —
+    // don't build a NaN-radius cylinder/sphere that silently drops the tip from
+    // the STL export.
+    const contactDiameterMm = coneData.contactDiameterMm ?? profile.contactDiameterMm;
     const overrideThickness = coneData.diskLengthOverride;
     
     // Calculate geometry based on angle between Surface Normal and Cone Axis

--- a/src/features/export/logic/supportExportReconstruction.test.ts
+++ b/src/features/export/logic/supportExportReconstruction.test.ts
@@ -79,7 +79,36 @@ function makeSupportState(): SupportState {
         },
       },
     },
-    twigs: {},
+    twigs: {
+      'twig-a': {
+        id: 'twig-a',
+        modelId: 'model-a',
+        segments: [{
+          id: 'twig-a-seg',
+          diameter: 0.5,
+          bottomJoint: { id: 'twig-a-joint-a', pos: { x: 2, y: 0, z: 10 }, diameter: 0.6 },
+          topJoint: { id: 'twig-a-joint-b', pos: { x: 4, y: 0, z: 10 }, diameter: 0.6 },
+        }],
+        contactDiskA: {
+          id: 'twig-a-disk-a',
+          pos: { x: 1.7, y: 0, z: 10 },
+          surfaceNormal: { x: 1, y: 0, z: 0 },
+          coneAxis: { x: 1, y: 0, z: 0 },
+          diskLengthOverride: 0.3,
+          contactDiameterMm: 0.6,
+          profile: { type: 'disk', diskThicknessMm: 0.1, maxStandoffMm: 1.5, standoffAngleThreshold: Math.PI / 4 },
+        },
+        contactDiskB: {
+          id: 'twig-a-disk-b',
+          pos: { x: 4.3, y: 0, z: 10 },
+          surfaceNormal: { x: -1, y: 0, z: 0 },
+          coneAxis: { x: -1, y: 0, z: 0 },
+          diskLengthOverride: 0.3,
+          contactDiameterMm: 0.6,
+          profile: { type: 'disk', diskThicknessMm: 0.1, maxStandoffMm: 1.5, standoffAngleThreshold: Math.PI / 4 },
+        },
+      },
+    },
     sticks: {},
     braces: {
       'brace-a': {
@@ -248,6 +277,70 @@ test('export cone mesh uses the visible contact-side sphere instead of a socket 
   const sphereMeshes = coneGroup.children.filter((child) => (child as THREE.Mesh).geometry?.type === 'SphereGeometry');
   assert.equal(sphereMeshes.length, 1);
   assert.equal(sphereMeshes[0]?.position.z, 9.5);
+});
+
+test('twig disk tips export with finite geometry (no NaN radius)', () => {
+  // Regression: a twig's ContactDiskProfile has no contactDiameterMm (it lives
+  // on the disk object), so reading the diameter from the profile produced a
+  // NaN radius and the disk tip silently vanished from the STL export.
+  const disk = {
+    pos: { x: 0, y: 0, z: 10 },
+    normal: { x: 0, y: 0, z: -1 },
+    surfaceNormal: { x: 0, y: 0, z: -1 },
+    diskLengthOverride: 0.3,
+    contactDiameterMm: 0.6,
+    profile: { type: 'disk', diskThicknessMm: 0.1, maxStandoffMm: 1.5, standoffAngleThreshold: Math.PI / 4 },
+  };
+
+  const group = SupportGeometryGenerator.generateContactDiskMesh(disk);
+  assert.ok(group.children.length > 0);
+
+  group.traverse((node) => {
+    const geo = (node as THREE.Mesh).geometry;
+    if (!geo) return;
+    const position = geo.getAttribute('position');
+    if (!position) return;
+    for (let i = 0; i < position.count; i += 1) {
+      assert.ok(
+        Number.isFinite(position.getX(i))
+        && Number.isFinite(position.getY(i))
+        && Number.isFinite(position.getZ(i)),
+        'twig disk geometry must not contain NaN vertices',
+      );
+    }
+  });
+});
+
+test('scoped twig export contains disk tip geometry for the requested model', () => {
+  const supportState = makeSupportState();
+  const kickstandState = makeKickstandState();
+  const group = buildScopedSupportGeometryGroup(supportState, kickstandState, ['model-a']);
+
+  const twigGroup = group.children.find((child) => child.name === 'Twig_twig-a');
+  assert.ok(twigGroup, 'expected a Twig_ group in the scoped export');
+
+  // The disk tips are the two CylinderGeometry meshes (shaft) that must survive
+  // to the STL. Before the fix their radius was NaN, so assert both the tip
+  // cylinders exist and that no vertex anywhere in the twig is NaN.
+  let diskShaftCylinders = 0;
+  twigGroup!.traverse((node) => {
+    const geo = (node as THREE.Mesh).geometry;
+    if (!geo) return;
+    if (geo.type === 'CylinderGeometry') diskShaftCylinders += 1;
+    const position = geo.getAttribute('position');
+    if (!position) return;
+    for (let i = 0; i < position.count; i += 1) {
+      assert.ok(
+        Number.isFinite(position.getX(i))
+        && Number.isFinite(position.getY(i))
+        && Number.isFinite(position.getZ(i)),
+        'twig export geometry must not contain NaN vertices',
+      );
+    }
+  });
+
+  // One shaft cylinder + two disk-tip cylinders (disk A and disk B).
+  assert.ok(diskShaftCylinders >= 3, `expected >= 3 cylinders (shaft + 2 disk tips), got ${diskShaftCylinders}`);
 });
 
 test('kickstand export does not add a host-knot sphere affordance', () => {

--- a/src/features/export/logic/supportExportReconstruction.ts
+++ b/src/features/export/logic/supportExportReconstruction.ts
@@ -299,6 +299,7 @@ function buildTwigGroup(twig: Twig, modelId: string | null | undefined): THREE.G
     surfaceNormal: twig.contactDiskA.surfaceNormal,
     diskLengthOverride: twig.contactDiskA.diskLengthOverride,
     profile: twig.contactDiskA.profile,
+    contactDiameterMm: twig.contactDiskA.contactDiameterMm,
   });
   const diskB = SupportGeometryGenerator.generateContactDiskMesh({
     pos: twig.contactDiskB.pos,
@@ -306,6 +307,7 @@ function buildTwigGroup(twig: Twig, modelId: string | null | undefined): THREE.G
     surfaceNormal: twig.contactDiskB.surfaceNormal,
     diskLengthOverride: twig.contactDiskB.diskLengthOverride,
     profile: twig.contactDiskB.profile,
+    contactDiameterMm: twig.contactDiskB.contactDiameterMm,
   });
   if (diskA.children.length > 0) group.add(diskA);
   if (diskB.children.length > 0) group.add(diskB);


### PR DESCRIPTION
### Summary
Twig ("minisup") contact-disk tips were silently dropped from exported meshes — visible on screen, gone in the exported file. This restores them and adds regression coverage.

### Root cause
STL/3MF export always runs through the headless *scoped reconstruction* path (`buildScopedSupportGeometryGroup`), not the live R3F scene — so what you see is not what gets serialized. That path rebuilds twig disk tips via `SupportGeometryGenerator.generateContactDiskMesh`, which read the contact size from `profile.contactDiameterMm`.

The catch: a twig's `ContactDiskProfile` has **no** `contactDiameterMm` — that value lives on the `ContactDisk` object itself. So the lookup returned `undefined`, giving `radius = undefined / 2 = NaN`. The disk's cylinder + tip sphere were built entirely from NaN vertices and dropped during serialization.

Cones (stick / leaf / anchor) use `SupportTipProfile`, which embeds `contactDiameterMm`, so **only twigs** were affected — and **only in export**, since the live `ContactDiskRenderer` receives the diameter as a separate prop.

### Changes
- **`SupportGeometryGenerator.ts`** — `generateContactDiskMesh` now reads `coneData.contactDiameterMm ?? profile.contactDiameterMm`, so object-level diameters win and cone callers keep their existing profile-based behavior.
- **`supportExportReconstruction.ts`** — `buildTwigGroup` passes each twig disk's `contactDiameterMm` through.
- **`supportExportReconstruction.test.ts`** — added a twig fixture (previously `twigs: {}`, i.e. zero coverage) plus two regression tests.

### Testing
- Reproduced the NaN geometry directly: a twig disk profile yields 34/34 NaN vertices; a stick cone yields 0.
- New tests **fail without the fix, pass with it**.
- Full suite: **150/150 passing**; `tsc --noEmit` clean on the changed files.

<img width="413" height="332" alt="image" src="https://github.com/user-attachments/assets/a14ebed0-697c-443e-9780-d8c54a717a9c" />


Closes #416.