### PR TITLE
fix: ignore SpaceMouse input when the app window isn't focused

### DIFF
--- a/src/components/scene/camera/SpaceMouseController.tsx
+++ b/src/components/scene/camera/SpaceMouseController.tsx
@@ -303,6 +303,28 @@ export function SpaceMouseController({
       return;
     }
 
+    // Ignore SpaceMouse input unless our window is the active/focused window.
+    // The Gamepad API keeps reporting axis values for background windows on
+    // Windows, macOS, and Linux, which would otherwise let the SpaceMouse drive
+    // the camera while another app is in front. document.hasFocus() (unlike
+    // document.hidden / visibilitychange) is false whenever the window is not
+    // active, even while it remains visible.
+    if (typeof document !== 'undefined' && typeof document.hasFocus === 'function' && !document.hasFocus()) {
+      if (isNavigatingRef.current) {
+        isNavigatingRef.current = false;
+        onNavigationActiveChange?.(false);
+      }
+      if (weDisabledOrbitRef.current) {
+        const handoffTarget = getHandoffTarget();
+        controls.target.copy(handoffTarget);
+        controls.enabled = true;
+        controls.update();
+        weDisabledOrbitRef.current = false;
+        pendingHorizonResetRef.current = true;
+      }
+      return;
+    }
+
     // Capture once per frame — shared by detection loop and active-pad selection.
     const allCandidates = getCandidateGamepads();
 


### PR DESCRIPTION
## Problem

A SpaceMouse moved the camera even when DragonFruit was not the active
window, on Windows, macOS, and Linux.

The camera is driven by `SpaceMouseController`'s `useFrame` loop, which
polls `navigator.getGamepads()` and applies movement every frame. The
Gamepad API continues to report axis values for background windows on all
three platforms, so nudging the SpaceMouse while another app was in front
still panned/orbited the scene underneath.

## Fix

Add a `document.hasFocus()` guard at the top of the active portion of the
frame loop, before any gamepad polling. When the window isn't the active
window, the loop:

- clears navigation state (`onNavigationActiveChange(false)`), and
- hands control back to OrbitControls (re-enabling it, restoring the
  handoff target, and flagging a horizon reset) — mirroring the existing
  no-device / idle handback paths, so pivot state is preserved and
  navigation resumes cleanly when focus returns.

### Why `hasFocus()` and not `visibilitychange`

The codebase already uses `visibilitychange` / `document.hidden` for
pointer and orbit teardown, but those only fire when the window is
minimized or its tab is backgrounded. They stay "visible" when the window
is simply behind another app, which is exactly the reported case.
`document.hasFocus()` returns `false` whenever the window is not active,
even while it remains on screen.

## Testing

- With another app focused, moving the SpaceMouse no longer moves the
  camera.
- Refocusing the app restores normal SpaceMouse navigation from the same
  pivot.
- Regular mouse OrbitControls continue to work after focus is regained
  (control is handed back, not left disabled).
- Tested on Windows. MacOS and Linux validation would be helpful.

Fixes #260.