### PR TITLE
feat: add auto-bracing shortcut

### DIFF
--- a/src/hotkeys/hotkeyConfig.ts
+++ b/src/hotkeys/hotkeyConfig.ts
@@ -68,8 +68,8 @@ export const DEFAULT_KEYBINDINGS: HotkeyConfig = {
             description: 'Hold to force placing support'
         },
         AUTO_BRACING: {
-            key: 'q',
-            description: 'Run auto bracing while the Bracing settings page is open'
+            key: 'g',
+            description: 'Generate auto bracing while the Bracing settings page is open'
         },
         SPROUTED_PARENTING_LOCK: {
             key: 'w',

--- a/src/hotkeys/hotkeyConfig.ts
+++ b/src/hotkeys/hotkeyConfig.ts
@@ -67,6 +67,10 @@ export const DEFAULT_KEYBINDINGS: HotkeyConfig = {
             key: 'q',
             description: 'Hold to force placing support'
         },
+        AUTO_BRACING: {
+            key: 'q',
+            description: 'Run auto bracing while the Bracing settings page is open'
+        },
         SPROUTED_PARENTING_LOCK: {
             key: 'w',
             description: 'Hold to enter Sprouted Leaf Fanning Mode'

--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -46,6 +46,8 @@ import { SupportAnatomyPreviewSlot } from './AnatomyPreview/SupportAnatomyPrevie
 import { AutoBracingSettingsCard } from '../autoBracing/AutoBracingSettingsCard';
 import { CurveSettingsCard, getCurveSettingsSelection } from '../Curves/CurveSettingsCard';
 import { runAutoBracing } from '../autoBracing/autoBrace';
+import { shouldRunAutoBracingHotkey } from '../autoBracing/autoBracingHotkey';
+import { useActionActive } from '@/hotkeys/hotkeyStore';
 import { setAnatomyPreviewActiveSettingKey, subscribeToAnatomyPreviewState, getAnatomyPreviewState } from './AnatomyPreview/previewState';
 import {
     getSupportKindSnapshot,
@@ -207,6 +209,7 @@ function applySettingsToAllSelectedSupports(settings: SupportSettings): void {
  */
 export function SupportSidebar() {
     usePresetHotkeys();
+    const autoBracingHotkeyActive = useActionActive('SUPPORTS', 'AUTO_BRACING');
     const settings = useSyncExternalStore(subscribeToSettings, getSettings, getSettings);
     const [saveStatus, setSaveStatus] = useState<'idle' | 'saved' | 'error'>('idle');
     const [presetSaveTrigger, setPresetSaveTrigger] = useState(0);
@@ -216,6 +219,7 @@ export function SupportSidebar() {
     const [devToolsOpen, setDevToolsOpen] = useState(false);
     const saveStatusTimeoutRef = React.useRef<number | null>(null);
     const autoBraceStatusTimeoutRef = React.useRef<number | null>(null);
+    const autoBracingHotkeyWasActiveRef = React.useRef(false);
     const isAdaptiveConeAngle = (settings.tip.coneAngleMode ?? 'normal') === 'adaptive';
     const supportKindState = React.useSyncExternalStore(subscribeToSupportKindState, getSupportKindSnapshot, getSupportKindSnapshot);
     const activeKind = supportKindState.kind;
@@ -640,6 +644,24 @@ export function SupportSidebar() {
             autoBraceStatusTimeoutRef.current = null;
         }, 2800);
     }, []);
+
+    useEffect(() => {
+        if (shouldRunAutoBracingHotkey({
+            active: autoBracingHotkeyActive,
+            wasActive: autoBracingHotkeyWasActiveRef.current,
+            sidebarExpanded: expanded,
+            activeSupportKind: activeKind,
+            curvePageVisible: showCurvePage,
+            modalOpen: document.querySelector('[role="dialog"][aria-modal="true"]') !== null,
+        })) {
+            // This effect translates the centralized hotkey's rising edge into
+            // the same UI action as clicking the Auto Brace button.
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            handleAutoBrace();
+        }
+
+        autoBracingHotkeyWasActiveRef.current = autoBracingHotkeyActive;
+    }, [activeKind, autoBracingHotkeyActive, expanded, handleAutoBrace, showCurvePage]);
 
     const getInputProps = React.useCallback((key: string, baseClass: string) => {
         const isActive = activeKey === key;

--- a/src/supports/autoBracing/__tests__/autoBracingHotkey.test.ts
+++ b/src/supports/autoBracing/__tests__/autoBracingHotkey.test.ts
@@ -65,7 +65,7 @@ test('auto bracing ignores presses outside its visible settings context', () => 
     }), false, 'a modal must suppress actions on the obscured Bracing page');
 });
 
-test('the Q shortcut preserves the existing Q bindings', () => {
+test('G activates auto bracing without taking over the existing B or Q bindings', () => {
     const originalState = hotkeyStore.getState();
 
     try {
@@ -73,9 +73,23 @@ test('the Q shortcut preserves the existing Q bindings', () => {
             activeKeys: new Set<string>(),
             config: DEFAULT_KEYBINDINGS,
         });
-        hotkeyStore.getState().pressKey('q');
+        hotkeyStore.getState().pressKey('g');
 
         assert.equal(isActionActiveSync('SUPPORTS', 'AUTO_BRACING'), true);
+        assert.equal(isActionActiveSync('SUPPORTS', 'FORCE_PLACE_SUPPORT'), false);
+        assert.equal(isActionActiveSync('CANVAS', 'TOOL_SELECT'), false);
+
+        hotkeyStore.getState().releaseKey('g');
+        hotkeyStore.getState().pressKey('b');
+
+        assert.equal(isActionActiveSync('SUPPORTS', 'AUTO_BRACING'), false);
+        assert.equal(isActionActiveSync('SUPPORTS', 'FORCE_PLACE_SUPPORT'), false);
+        assert.equal(isActionActiveSync('CANVAS', 'TOOL_SELECT'), false);
+
+        hotkeyStore.getState().releaseKey('b');
+        hotkeyStore.getState().pressKey('q');
+
+        assert.equal(isActionActiveSync('SUPPORTS', 'AUTO_BRACING'), false);
         assert.equal(isActionActiveSync('SUPPORTS', 'FORCE_PLACE_SUPPORT'), true);
         assert.equal(isActionActiveSync('CANVAS', 'TOOL_SELECT'), true);
     } finally {

--- a/src/supports/autoBracing/__tests__/autoBracingHotkey.test.ts
+++ b/src/supports/autoBracing/__tests__/autoBracingHotkey.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { DEFAULT_KEYBINDINGS } from '../../../hotkeys/hotkeyConfig';
+import {
+    hotkeyStore,
+    isActionActiveSync,
+} from '../../../hotkeys/hotkeyStore';
+import { shouldRunAutoBracingHotkey } from '../autoBracingHotkey';
+
+test('auto bracing runs only on the initial press while its expanded page is active', () => {
+    assert.equal(shouldRunAutoBracingHotkey({
+        active: true,
+        wasActive: false,
+        sidebarExpanded: true,
+        activeSupportKind: 'stick',
+        curvePageVisible: false,
+        modalOpen: false,
+    }), true);
+
+    assert.equal(shouldRunAutoBracingHotkey({
+        active: true,
+        wasActive: true,
+        sidebarExpanded: true,
+        activeSupportKind: 'stick',
+        curvePageVisible: false,
+        modalOpen: false,
+    }), false, 'key repeat must not rerun auto bracing');
+});
+
+test('auto bracing ignores presses outside its visible settings context', () => {
+    assert.equal(shouldRunAutoBracingHotkey({
+        active: true,
+        wasActive: false,
+        sidebarExpanded: false,
+        activeSupportKind: 'stick',
+        curvePageVisible: false,
+        modalOpen: false,
+    }), false, 'a collapsed Support Studio must not handle the shortcut');
+
+    assert.equal(shouldRunAutoBracingHotkey({
+        active: true,
+        wasActive: false,
+        sidebarExpanded: true,
+        activeSupportKind: 'trunk',
+        curvePageVisible: false,
+        modalOpen: false,
+    }), false, 'another Support Studio page must not handle the shortcut');
+
+    assert.equal(shouldRunAutoBracingHotkey({
+        active: true,
+        wasActive: false,
+        sidebarExpanded: true,
+        activeSupportKind: 'stick',
+        curvePageVisible: true,
+        modalOpen: false,
+    }), false, 'the curve page must not inherit the Bracing shortcut');
+
+    assert.equal(shouldRunAutoBracingHotkey({
+        active: true,
+        wasActive: false,
+        sidebarExpanded: true,
+        activeSupportKind: 'stick',
+        curvePageVisible: false,
+        modalOpen: true,
+    }), false, 'a modal must suppress actions on the obscured Bracing page');
+});
+
+test('the Q shortcut preserves the existing Q bindings', () => {
+    const originalState = hotkeyStore.getState();
+
+    try {
+        hotkeyStore.setState({
+            activeKeys: new Set<string>(),
+            config: DEFAULT_KEYBINDINGS,
+        });
+        hotkeyStore.getState().pressKey('q');
+
+        assert.equal(isActionActiveSync('SUPPORTS', 'AUTO_BRACING'), true);
+        assert.equal(isActionActiveSync('SUPPORTS', 'FORCE_PLACE_SUPPORT'), true);
+        assert.equal(isActionActiveSync('CANVAS', 'TOOL_SELECT'), true);
+    } finally {
+        hotkeyStore.setState({
+            activeKeys: originalState.activeKeys,
+            config: originalState.config,
+        });
+    }
+});

--- a/src/supports/autoBracing/autoBracingHotkey.ts
+++ b/src/supports/autoBracing/autoBracingHotkey.ts
@@ -1,0 +1,26 @@
+import type { SupportKind } from '../Settings/supportKindState';
+
+type AutoBracingHotkeyContext = {
+    active: boolean;
+    wasActive: boolean;
+    sidebarExpanded: boolean;
+    activeSupportKind: SupportKind;
+    curvePageVisible: boolean;
+    modalOpen: boolean;
+};
+
+export function shouldRunAutoBracingHotkey({
+    active,
+    wasActive,
+    sidebarExpanded,
+    activeSupportKind,
+    curvePageVisible,
+    modalOpen,
+}: AutoBracingHotkeyContext): boolean {
+    return active
+        && !wasActive
+        && sidebarExpanded
+        && activeSupportKind === 'stick'
+        && !curvePageVisible
+        && !modalOpen;
+}


### PR DESCRIPTION
## Summary
- add a configurable `SUPPORTS.AUTO_BRACING` action with the requested default `Q` binding
- trigger the existing Auto Brace action only on the initial key press while the expanded Bracing page is visible
- suppress the shortcut while another Support page, the Curves page, or any modal is in the foreground
- preserve the existing `Q` bindings for force placement and canvas selection

## Verification
- `node --import tsx --test src/supports/autoBracing/__tests__/autoBracingHotkey.test.ts src/supports/__tests__/autoBraceHistoryKickstand.test.ts` (4/4)
- `npx tsc --noEmit`
- scoped ESLint on the new helper/test and hotkey config
- `git diff --check`
- full `npm test`: 148/151 pass; the remaining three are pre-existing macOS primary-modifier expectations unrelated to this change

Closes #445