### PR TITLE
Reset settings scroll on tab changes

### DIFF
--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -62,6 +62,7 @@ import {
 } from '../Rafts/Crenelated/RaftState';
 import { DEFAULT_RAFT_SETTINGS } from '../Rafts/Crenelated/RaftDefaults';
 import type { SupportKind } from './supportKindState';
+import { resetSupportSettingsScrollForTabChange } from './supportSidebarScroll';
 
 const INPUT_CLASS = 'ui-input h-8 w-full px-2.5 text-xs sm:text-sm text-center no-spinners';
 const SECTION_CARD_STYLE: React.CSSProperties = {
@@ -1213,6 +1214,11 @@ export function SupportSidebar() {
                                     <SupportKindTabs
                                         value={tabKind}
                                         onChange={(kind) => {
+                                            resetSupportSettingsScrollForTabChange(
+                                                scrollViewportRef.current,
+                                                tabKind,
+                                                kind,
+                                            );
                                             setAnatomyPreviewActiveSettingKey(null);
                                             setActiveSupportKind(kind);
                                         }}

--- a/src/supports/Settings/__tests__/supportSidebarScroll.test.ts
+++ b/src/supports/Settings/__tests__/supportSidebarScroll.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resetSupportSettingsScrollForTabChange } from '../supportSidebarScroll';
+
+test('resets settings scroll when the user selects a different support tab', () => {
+    const calls: ScrollToOptions[] = [];
+    const viewport = {
+        scrollTo(options?: ScrollToOptions) {
+            calls.push(options ?? {});
+        },
+    };
+
+    assert.equal(resetSupportSettingsScrollForTabChange(viewport, 'trunk', 'raft'), true);
+    assert.deepEqual(calls, [{ top: 0 }]);
+});
+
+test('preserves settings scroll when the user selects the already-active tab', () => {
+    let callCount = 0;
+    const viewport = {
+        scrollTo() {
+            callCount += 1;
+        },
+    };
+
+    assert.equal(resetSupportSettingsScrollForTabChange(viewport, 'grid', 'grid'), false);
+    assert.equal(callCount, 0);
+});
+
+test('safely ignores a tab change before the settings viewport is mounted', () => {
+    assert.equal(resetSupportSettingsScrollForTabChange(null, 'stick', 'trunk'), false);
+});

--- a/src/supports/Settings/supportSidebarScroll.ts
+++ b/src/supports/Settings/supportSidebarScroll.ts
@@ -1,0 +1,16 @@
+import type { SupportKind } from './supportKindState';
+
+type ScrollViewport = {
+    scrollTo(options?: ScrollToOptions): void;
+};
+
+export function resetSupportSettingsScrollForTabChange(
+    viewport: ScrollViewport | null,
+    currentTab: SupportKind,
+    nextTab: SupportKind,
+): boolean {
+    if (!viewport || currentTab === nextTab) return false;
+
+    viewport.scrollTo({ top: 0 });
+    return true;
+}


### PR DESCRIPTION
## Summary
- reset the Support Studio settings viewport when the user switches to a different support tab
- preserve scroll position when the active tab is clicked again
- keep programmatic support-kind changes independent from the user-triggered scroll reset
- cover the scroll side effect, same-tab behavior, and an unmounted viewport with focused tests

## Verification
- focused scroll tests: 3/3 passed
- `npx tsc --noEmit`
- targeted ESLint on the new helper and tests
- full test suite: 148/151 passed; the three failures are the existing macOS primary-modifier expectations in `hotkeyStore.test.ts`
- `git diff --check`

Closes #294