### PR TITLE
Refactor history management and enhance undo/redo handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,20 @@ Rule (temporary, until Lingui moves to the Babel macro ordered before React Comp
 translations that interpolate values live in **module-scope helper functions** (e.g. the
 duration formatters in `src/app/page.tsx`), which React Compiler leaves untouched. See
 `docs/dev/backlog.md`.
+
+## Undo/redo — history handlers
+
+Register and push through the typed façade (`createTypedHistory<Map>()` per domain), not
+the raw `pushHistory`/`registerHistoryHandler`. The map binds each action type to its
+payload, so a push can't drift from the handler that inverts it. Copy an existing domain
+(`src/supports/history/`, `src/features/mesh-smoothing/history/`) for the shape.
+
+Two invariants that mimicry won't teach — get either wrong and undo breaks **silently**:
+
+- **Register at an app-root / always-mounted lifetime**, never gated on a render component.
+  Handlers gated on a mesh being on screen mean Ctrl+Z stops working depending on the render
+  tree (the bug this seam fixed). Supports register via `useSupportHistoryHandlers()` at the
+  app root; scene/mesh-smoothing register in always-mounted hooks.
+- **Everything pushed to the stack needs a handler** — even a marker with no undo behaviour
+  needs a pass-through (`() => true`), or an unhandled entry strands the stack (see
+  `SCENE_SLICED`). A handler returning `false` means "unrecoverable"; the entry is discarded.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -206,7 +206,7 @@ import {
 } from '@/features/scene/arrange/highPrecisionArrangeWorkerClient';
 
 // Domain Features
-import { useSceneCollectionManager, SCENE_SLICED } from '@/features/scene/useSceneCollectionManager';
+import { useSceneCollectionManager, SCENE_SLICED, pushSceneSlicedMarker } from '@/features/scene/useSceneCollectionManager';
 import { useSupportHistoryHandlers } from '@/supports/history/useSupportHistoryHandlers';
 import { useSlicingManager } from '@/features/slicing/useSlicingManager';
 import { useTransformManager } from '@/features/transform/useTransformManager';
@@ -232,7 +232,6 @@ import {
   getHistoryDebugEvents,
   getRedoCount,
   getUndoCount,
-  pushHistory,
   redo,
   subscribeHistory,
   subscribeHistoryDebug,
@@ -2226,11 +2225,7 @@ export default function Home() {
     setPrintingArtifactIsInvalid(false);
     setShowPrintingResliceModal(false);
     // Push a "Sliced Scene" marker to history so we can detect changes after this point
-    pushHistory({
-      type: SCENE_SLICED,
-      description: 'Scene sliced for printing',
-      payload: {},
-    });
+    pushSceneSlicedMarker();
     setPrintingSendStatusText(null);
     setPrintingSendProgress(0);
     setPrintingSendStageText(null);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -206,7 +206,7 @@ import {
 } from '@/features/scene/arrange/highPrecisionArrangeWorkerClient';
 
 // Domain Features
-import { useSceneCollectionManager } from '@/features/scene/useSceneCollectionManager';
+import { useSceneCollectionManager, SCENE_SLICED } from '@/features/scene/useSceneCollectionManager';
 import { useSupportHistoryHandlers } from '@/supports/history/useSupportHistoryHandlers';
 import { useSlicingManager } from '@/features/slicing/useSlicingManager';
 import { useTransformManager } from '@/features/transform/useTransformManager';
@@ -2227,7 +2227,7 @@ export default function Home() {
     setShowPrintingResliceModal(false);
     // Push a "Sliced Scene" marker to history so we can detect changes after this point
     pushHistory({
-      type: 'SCENE_SLICED',
+      type: SCENE_SLICED,
       description: 'Scene sliced for printing',
       payload: {},
     });
@@ -6474,7 +6474,7 @@ export default function Home() {
     // Find the most recent "SCENE_SLICED" marker
     let sliceMarkerIndex = -1;
     for (let i = historyEvents.length - 1; i >= 0; i--) {
-      if (historyEvents[i].actionType === 'SCENE_SLICED') {
+      if (historyEvents[i].actionType === SCENE_SLICED) {
         sliceMarkerIndex = i;
         break;
       }
@@ -6484,7 +6484,7 @@ export default function Home() {
       // Check if there are any OTHER events (non-undo/redo) after the slice marker
       const eventsAfterSlice = historyEvents.slice(sliceMarkerIndex + 1);
       const hasModifications = eventsAfterSlice.some(
-        (e) => e.kind === 'push' && e.actionType !== 'SCENE_SLICED'
+        (e) => e.kind === 'push' && e.actionType !== SCENE_SLICED
       );
       
       if (hasModifications) {
@@ -6504,7 +6504,7 @@ export default function Home() {
       // Find the most recent "SCENE_SLICED" marker
       let sliceMarkerIndex = -1;
       for (let i = historyEvents.length - 1; i >= 0; i--) {
-        if (historyEvents[i].actionType === 'SCENE_SLICED') {
+        if (historyEvents[i].actionType === SCENE_SLICED) {
           sliceMarkerIndex = i;
           break;
         }
@@ -6514,7 +6514,7 @@ export default function Home() {
         // Check if there are any OTHER events (non-undo/redo) after the slice marker
         const eventsAfterSlice = historyEvents.slice(sliceMarkerIndex + 1);
         const hasModifications = eventsAfterSlice.some(
-          (e) => e.kind === 'push' && e.actionType !== 'SCENE_SLICED'
+          (e) => e.kind === 'push' && e.actionType !== SCENE_SLICED
         );
         
         if (hasModifications) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -207,6 +207,7 @@ import {
 
 // Domain Features
 import { useSceneCollectionManager } from '@/features/scene/useSceneCollectionManager';
+import { useSupportHistoryHandlers } from '@/supports/history/useSupportHistoryHandlers';
 import { useSlicingManager } from '@/features/slicing/useSlicingManager';
 import { useTransformManager } from '@/features/transform/useTransformManager';
 import { useIslandManager } from '@/volumeAnalysis/IslandScan/useIslandManager';
@@ -521,6 +522,10 @@ function createModelTransformKey(modelId: string, transform: ModelTransform): st
 export default function Home() {
   const { _ } = useLingui();
   const { stage, sproutParentingLockHeld } = useLeafPlacementState();
+  // Supports undo/redo handlers register for the lifetime of the app root, not
+  // for the lifetime of a scene renderer. Otherwise Ctrl+Z depends on which
+  // render branch happens to be mounted.
+  useSupportHistoryHandlers();
   // 1. Scene & Geometry (Multi-Model)
   const scene = useSceneCollectionManager();
 

--- a/src/components/modals/HistoryDebugModal.tsx
+++ b/src/components/modals/HistoryDebugModal.tsx
@@ -86,6 +86,8 @@ export function HistoryDebugModal({
         };
       case 'undo-handler-missing':
       case 'redo-handler-missing':
+      case 'undo-declined':
+      case 'redo-declined':
         return {
           dot: '#fb7185',
           badgeBg: 'color-mix(in srgb, #fb7185, var(--surface-0) 90%)',

--- a/src/features/mesh-smoothing/history/actionTypes.ts
+++ b/src/features/mesh-smoothing/history/actionTypes.ts
@@ -6,3 +6,8 @@ export type MeshSmoothingStrokePayload = {
   before: Float32Array;
   after: Float32Array;
 };
+
+/** Action→payload map for the mesh-smoothing history domain. */
+export type MeshSmoothingHistoryPayloadMap = {
+  [MESH_SMOOTHING_STROKE]: MeshSmoothingStrokePayload;
+};

--- a/src/features/mesh-smoothing/history/useMeshSmoothingHistoryHandlers.ts
+++ b/src/features/mesh-smoothing/history/useMeshSmoothingHistoryHandlers.ts
@@ -1,10 +1,9 @@
 import { useEffect } from 'react';
 import * as THREE from 'three';
 
-import { pushHistory, registerHistoryHandler } from '@/history/historyStore';
-import type { HistoryDirection, HistoryAction } from '@/history/types';
+import { createTypedHistory } from '@/history/typedHistory';
 
-import { MESH_SMOOTHING_STROKE, type MeshSmoothingStrokePayload } from './actionTypes';
+import { MESH_SMOOTHING_STROKE, type MeshSmoothingHistoryPayloadMap } from './actionTypes';
 import { getMeshSmoothingGeometryByKey, subscribeToMeshSmoothingStrokeFinalized } from '../meshSmoothingEngine';
 import { getMeshTopology } from '../topologyCache';
 
@@ -92,14 +91,13 @@ function applyUniquePositions(geometry: THREE.BufferGeometry, uniqueIds: Uint32A
   return true;
 }
 
+const meshSmoothingHistory = createTypedHistory<MeshSmoothingHistoryPayloadMap>();
+
 export function useMeshSmoothingHistoryHandlers() {
   useEffect(() => {
-    const unregisterStroke = registerHistoryHandler(
+    const unregisterStroke = meshSmoothingHistory.register(
       MESH_SMOOTHING_STROKE,
-      (action: HistoryAction, direction: HistoryDirection) => {
-        const payload = action.payload as MeshSmoothingStrokePayload | undefined;
-        if (!payload) return false;
-
+      (payload, direction) => {
         const geometry = getMeshSmoothingGeometryByKey(payload.geometryKey);
         if (!geometry) return false;
 
@@ -109,7 +107,7 @@ export function useMeshSmoothingHistoryHandlers() {
     );
 
     const unsubFinalize = subscribeToMeshSmoothingStrokeFinalized((payload) => {
-      pushHistory({ type: MESH_SMOOTHING_STROKE, payload: payload as MeshSmoothingStrokePayload });
+      meshSmoothingHistory.push({ type: MESH_SMOOTHING_STROKE, payload });
     });
 
     return () => {

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -93,6 +93,11 @@ const RECENT_FILES_DB_NAME = 'dragonfruit-recent-files';
 const RECENT_FILES_DB_VERSION = 1;
 const RECENT_FILES_STORE_NAME = 'files';
 const SCENE_MODELS_SNAPSHOT_APPLY = 'scene_models_snapshot_apply';
+// A marker pushed after a slice so change-detection can tell whether the scene
+// was edited since. It carries no undo behaviour, but it still lands on the undo
+// stack, so it must have a (pass-through) handler — otherwise undoing onto it
+// would strand the stack. Exported so the push site keys off the same constant.
+export const SCENE_SLICED = 'SCENE_SLICED';
 const SCENE_HISTORY_MAX_SNAPSHOTS = 200;
 // Belt-and-suspenders alongside the count cap above: a handful of
 // full-resolution geometry swaps (e.g. repeated hollowing on a large model)
@@ -1705,8 +1710,14 @@ export function useSceneCollectionManager() {
       },
     );
 
+    // Pass-through: the slice marker carries no undo behaviour, but registering
+    // it keeps undo/redo moving it between stacks instead of stranding an entry
+    // with no handler.
+    const unregisterSceneSliced = registerHistoryHandler(SCENE_SLICED, () => true);
+
     return () => {
       unregisterSceneModelsHistory();
+      unregisterSceneSliced();
     };
   }, [applySceneSnapshot]);
 

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -113,6 +113,11 @@ type SceneHistoryPayloadMap = {
 };
 const sceneHistory = createTypedHistory<SceneHistoryPayloadMap>();
 
+/** Push the post-slice marker used to detect edits made after a slice. */
+export function pushSceneSlicedMarker(): void {
+  sceneHistory.push({ type: SCENE_SLICED, description: 'Scene sliced for printing', payload: {} });
+}
+
 type SceneSnapshot = {
   models: LoadedModel[];
   activeModelId: string | null;

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -9,8 +9,7 @@ import { clearPaintToBase } from '@/components/analysis/MeshPainter';
 import { getSnapshot, loadFromImportFormat, mergeFromImportFormat, reassignAllSupportModelIds, setSnapshot as setSupportSnapshot, transformAllSupportsForSingleModel, transformSupportsForModel } from '@/supports/state';
 import type { SelectionHighlightMode } from '@/components/selection';
 import { registerDeleteHandler } from '@/features/delete/deleteRegistry';
-import { pushHistory, registerHistoryHandler } from '@/history/historyStore';
-import type { HistoryAction, HistoryDirection } from '@/history/types';
+import { createTypedHistory } from '@/history/typedHistory';
 import type { ModelTransform } from '@/hooks/useModelTransform';
 import type { DragonfruitImportFormat, SupportMode, SupportState } from '@/supports/types';
 import { GENERATED_BUILTIN_COMPLEX_PLUGIN_DEFINITIONS } from '@/features/plugins/generatedBuiltinComplexPlugins';
@@ -92,12 +91,12 @@ const RECENT_OPENED_FILES_LIMIT = 10;
 const RECENT_FILES_DB_NAME = 'dragonfruit-recent-files';
 const RECENT_FILES_DB_VERSION = 1;
 const RECENT_FILES_STORE_NAME = 'files';
-const SCENE_MODELS_SNAPSHOT_APPLY = 'scene_models_snapshot_apply';
+const SCENE_MODELS_SNAPSHOT_APPLY = 'scene_models_snapshot_apply' as const;
 // A marker pushed after a slice so change-detection can tell whether the scene
 // was edited since. It carries no undo behaviour, but it still lands on the undo
 // stack, so it must have a (pass-through) handler — otherwise undoing onto it
 // would strand the stack. Exported so the push site keys off the same constant.
-export const SCENE_SLICED = 'SCENE_SLICED';
+export const SCENE_SLICED = 'SCENE_SLICED' as const;
 const SCENE_HISTORY_MAX_SNAPSHOTS = 200;
 // Belt-and-suspenders alongside the count cap above: a handful of
 // full-resolution geometry swaps (e.g. repeated hollowing on a large model)
@@ -106,6 +105,13 @@ const SCENE_HISTORY_MAX_SNAPSHOTS = 200;
 const SCENE_HISTORY_MAX_ESTIMATED_GEOMETRY_BYTES = 300 * 1024 * 1024;
 
 type SceneSnapshotPayload = { key: string };
+
+/** Action→payload map for the scene history domain. */
+type SceneHistoryPayloadMap = {
+  [SCENE_MODELS_SNAPSHOT_APPLY]: SceneSnapshotPayload;
+  [SCENE_SLICED]: Record<string, never>;
+};
+const sceneHistory = createTypedHistory<SceneHistoryPayloadMap>();
 
 type SceneSnapshot = {
   models: LoadedModel[];
@@ -1696,10 +1702,9 @@ export function useSceneCollectionManager() {
   }, []);
 
   useEffect(() => {
-    const unregisterSceneModelsHistory = registerHistoryHandler(
+    const unregisterSceneModelsHistory = sceneHistory.register(
       SCENE_MODELS_SNAPSHOT_APPLY,
-      (action: HistoryAction, direction: HistoryDirection) => {
-        const payload = action.payload as SceneSnapshotPayload | undefined;
+      (payload, direction) => {
         if (!payload?.key) return false;
 
         const pair = sceneSnapshotRegistry.get(payload.key);
@@ -1713,7 +1718,7 @@ export function useSceneCollectionManager() {
     // Pass-through: the slice marker carries no undo behaviour, but registering
     // it keeps undo/redo moving it between stacks instead of stranding an entry
     // with no handler.
-    const unregisterSceneSliced = registerHistoryHandler(SCENE_SLICED, () => true);
+    const unregisterSceneSliced = sceneHistory.register(SCENE_SLICED, () => true);
 
     return () => {
       unregisterSceneModelsHistory();
@@ -1723,10 +1728,10 @@ export function useSceneCollectionManager() {
 
   const pushSceneSnapshotHistory = useCallback((before: SceneSnapshot, after: SceneSnapshot, description?: string) => {
     const key = storeSceneSnapshotPair({ before, after });
-    pushHistory({
+    sceneHistory.push({
       type: SCENE_MODELS_SNAPSHOT_APPLY,
       description,
-      payload: { key } satisfies SceneSnapshotPayload,
+      payload: { key },
     });
   }, []);
 

--- a/src/features/supports/useSupportInteractionManager.ts
+++ b/src/features/supports/useSupportInteractionManager.ts
@@ -36,8 +36,8 @@ import {
   subscribe,
 } from '@/supports/state';
 import { registerDeleteHandler } from '@/features/delete/deleteRegistry';
-import { pushHistory } from '@/history/historyStore';
-import { SUPPORT_REMOVE_ANCHOR, SUPPORT_REMOVE_BRANCH, SUPPORT_REMOVE_BRACE, SUPPORT_REMOVE_LEAF, SUPPORT_REMOVE_TRUNK, SUPPORT_UPDATE_TRUNK, SUPPORT_UPDATE_BRANCH, SUPPORT_REMOVE_TWIG, SUPPORT_REMOVE_STICK, SUPPORT_AUTO_BRACE_REPLACE, SUPPORT_REMOVE_KICKSTAND } from '@/supports/history/actionTypes';
+import { pushSupportHistory } from '@/supports/history/supportHistory';
+import { SUPPORT_REMOVE_ANCHOR, SUPPORT_REMOVE_BRANCH, SUPPORT_REMOVE_BRACE, SUPPORT_REMOVE_LEAF, SUPPORT_REMOVE_TRUNK, SUPPORT_UPDATE_TRUNK, SUPPORT_UPDATE_BRANCH, SUPPORT_REMOVE_TWIG, SUPPORT_REMOVE_STICK, SUPPORT_AUTO_BRACE_REPLACE, SUPPORT_REMOVE_KICKSTAND, type SupportBranchRemovePayload } from '@/supports/history/actionTypes';
 import { clearSupportSelection, getResolvedPrimarySelection, selectSupportIds } from '@/supports/interaction/shared/selection/selectionController';
 import { getKickstandSnapshot } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
@@ -372,7 +372,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
         }
         if (result.kind === 'trunk') {
           if (recordHistory) {
-            pushHistory({
+            pushSupportHistory({
               type: SUPPORT_UPDATE_TRUNK,
               description: 'Delete trunk joint',
               payload: { before: result.before, after: result.after },
@@ -381,7 +381,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
           setSelectedId(result.trunkId);
         } else {
           if (recordHistory) {
-            pushHistory({
+            pushSupportHistory({
               type: SUPPORT_UPDATE_BRANCH,
               payload: { before: result.before, after: result.after },
             });
@@ -401,7 +401,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
         const snapshots = removeTrunk(id);
         if (!snapshots) return false;
         if (recordHistory) {
-          pushHistory({
+          pushSupportHistory({
             type: SUPPORT_REMOVE_TRUNK,
             payload: {
               trunk: snapshots.trunk,
@@ -422,7 +422,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
         const snapshots = removeLeaf(id);
         if (!snapshots) return false;
         if (recordHistory) {
-          pushHistory({
+          pushSupportHistory({
             type: SUPPORT_REMOVE_LEAF,
             payload: { leaf: snapshots.leaf, knot: snapshots.knot ?? undefined },
           });
@@ -438,7 +438,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
           const snapshots = removeLeaf(leaf.id);
           if (!snapshots) return false;
           if (recordHistory) {
-            pushHistory({
+            pushSupportHistory({
               type: SUPPORT_REMOVE_LEAF,
               payload: { leaf: snapshots.leaf, knot: snapshots.knot ?? undefined },
             });
@@ -455,8 +455,8 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
           if (!snapshots) return false;
           const afterSnapshot = getSnapshot();
 
-          let trunkUpdate: { before: unknown; after: unknown } | undefined;
-          let knotUpdates: unknown[] | undefined;
+          let trunkUpdate: SupportBranchRemovePayload['trunkUpdate'];
+          let knotUpdates: SupportBranchRemovePayload['knotUpdates'];
           const parentKnot = branch.parentKnotId ? beforeSnapshot.knots[branch.parentKnotId] : undefined;
           const parentSegId = parentKnot?.parentShaftId;
           const trunkId = parentSegId
@@ -477,7 +477,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
           }
 
           if (recordHistory) {
-            pushHistory({
+            pushSupportHistory({
               type: SUPPORT_REMOVE_BRANCH,
               payload: {
                 ...snapshots,
@@ -496,7 +496,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
           const snapshots = removeBrace(brace.id);
           if (!snapshots) return false;
           if (recordHistory) {
-            pushHistory({
+            pushSupportHistory({
               type: SUPPORT_REMOVE_BRACE,
               payload: { brace: snapshots.brace, startKnot: snapshots.startKnot ?? undefined, endKnot: snapshots.endKnot ?? undefined },
             });
@@ -511,7 +511,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
           const kickstandSnapshots = removeKickstandCascade(kickstand.id);
           if (!kickstandSnapshots) return false;
           if (recordHistory) {
-            pushHistory({
+            pushSupportHistory({
               type: SUPPORT_REMOVE_KICKSTAND,
               payload: kickstandSnapshots,
             });
@@ -529,8 +529,8 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
         if (!snapshots) return false;
         const afterSnapshot = getSnapshot();
 
-        let trunkUpdate: { before: unknown; after: unknown } | undefined;
-        let knotUpdates: unknown[] | undefined;
+        let trunkUpdate: SupportBranchRemovePayload['trunkUpdate'];
+        let knotUpdates: SupportBranchRemovePayload['knotUpdates'];
         const removedRootBranch = snapshots.branches.find(b => b.id === id) ?? snapshots.branches[0];
         const parentKnot = removedRootBranch?.parentKnotId ? beforeSnapshot.knots[removedRootBranch.parentKnotId] : undefined;
         const parentSegId = parentKnot?.parentShaftId;
@@ -552,7 +552,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
         }
 
         if (recordHistory) {
-          pushHistory({
+          pushSupportHistory({
             type: SUPPORT_REMOVE_BRANCH,
             payload: {
               ...snapshots,
@@ -569,7 +569,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
         const snapshots = removeTwig(id);
         if (!snapshots) return false;
         if (recordHistory) {
-          pushHistory({
+          pushSupportHistory({
             type: SUPPORT_REMOVE_TWIG,
             payload: snapshots,
           });
@@ -582,7 +582,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
         const snapshots = removeStick(id);
         if (!snapshots) return false;
         if (recordHistory) {
-          pushHistory({
+          pushSupportHistory({
             type: SUPPORT_REMOVE_STICK,
             payload: snapshots,
           });
@@ -595,7 +595,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
         const snapshots = removeAnchor(id);
         if (!snapshots) return false;
         if (recordHistory) {
-          pushHistory({
+          pushSupportHistory({
             type: SUPPORT_REMOVE_ANCHOR,
             payload: { anchor: snapshots.anchor },
           });
@@ -608,7 +608,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
         const kickstandSnapshots = removeKickstandCascade(id);
         if (kickstandSnapshots) {
           if (recordHistory) {
-            pushHistory({
+            pushSupportHistory({
               type: SUPPORT_REMOVE_KICKSTAND,
               payload: kickstandSnapshots,
             });
@@ -620,7 +620,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
         const snapshots = removeBrace(id);
         if (!snapshots) return false;
         if (recordHistory) {
-          pushHistory({
+          pushSupportHistory({
             type: SUPPORT_REMOVE_BRACE,
             payload: { brace: snapshots.brace, startKnot: snapshots.startKnot ?? undefined, endKnot: snapshots.endKnot ?? undefined },
           });
@@ -683,7 +683,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
           const afterSupportSnapshot = structuredClone(getSnapshot());
           const afterKickstandSnapshot = structuredClone(getKickstandSnapshot());
 
-          pushHistory({
+          pushSupportHistory({
             type: SUPPORT_AUTO_BRACE_REPLACE,
             description: `Delete ${multiSelectedIds.length} supports`,
             payload: {

--- a/src/history/__tests__/historyStore.test.ts
+++ b/src/history/__tests__/historyStore.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  pushHistory,
+  undo,
+  redo,
+  clearHistory,
+  registerHistoryHandler,
+  getUndoCount,
+  getRedoCount,
+} from '../historyStore';
+
+const ACTION = { type: 'test:action', payload: { value: 1 } } as const;
+
+describe('historyStore', () => {
+  const cleanups: Array<() => void> = [];
+  const originalWarn = console.warn;
+
+  beforeEach(() => {
+    clearHistory();
+    console.warn = () => {};
+  });
+
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()!();
+    console.warn = originalWarn;
+  });
+
+  function register(type: string, handler: Parameters<typeof registerHistoryHandler>[1]) {
+    cleanups.push(registerHistoryHandler(type, handler));
+  }
+
+  it('moves an entry from undo to redo when a handler applies it', () => {
+    register(ACTION.type, () => true);
+    pushHistory(ACTION);
+
+    undo();
+
+    assert.equal(getUndoCount(), 0);
+    assert.equal(getRedoCount(), 1);
+  });
+
+  it('does not treat a void-returning handler as a decline', () => {
+    register(ACTION.type, () => {});
+    pushHistory(ACTION);
+
+    undo();
+
+    assert.equal(getUndoCount(), 0);
+    assert.equal(getRedoCount(), 1);
+  });
+
+  // no-handler: transient (registration can lag the push) — keep the entry.
+  it('keeps the entry when no handler is registered', () => {
+    pushHistory(ACTION);
+
+    undo();
+
+    assert.equal(getUndoCount(), 1, 'entry must not be discarded');
+    assert.equal(getRedoCount(), 0, 'unapplied entry must not become redoable');
+  });
+
+  it('replays an entry once its handler registers late', () => {
+    pushHistory(ACTION);
+    undo();
+    assert.equal(getUndoCount(), 1, 'still pending while unhandled');
+
+    register(ACTION.type, () => true);
+    undo();
+
+    assert.equal(getUndoCount(), 0);
+    assert.equal(getRedoCount(), 1);
+  });
+
+  it('keeps the entry when redo finds no handler', () => {
+    const unregister = registerHistoryHandler(ACTION.type, () => true);
+    pushHistory(ACTION);
+    undo();
+    assert.equal(getRedoCount(), 1);
+
+    unregister();
+    redo();
+
+    assert.equal(getRedoCount(), 1, 'entry must not be discarded');
+    assert.equal(getUndoCount(), 0);
+  });
+
+  // declined: a handler ran but refused — unrecoverable, so discard it.
+  it('discards the entry when a handler declines it', () => {
+    register(ACTION.type, () => false);
+    pushHistory(ACTION);
+
+    undo();
+
+    assert.equal(getUndoCount(), 0, 'unrecoverable entry must not be retained');
+    assert.equal(getRedoCount(), 0, 'declined entry must not become redoable');
+  });
+
+  it('does not let a declined entry block undo of entries beneath it', () => {
+    register('good', () => true);
+    register('bad', () => false);
+    pushHistory({ type: 'good', payload: {} });
+    pushHistory({ type: 'bad', payload: {} }); // now on top
+
+    undo(); // pops 'bad' → declined → discarded, not pushed back
+    assert.equal(getUndoCount(), 1, 'the good entry is still reachable');
+
+    undo(); // pops 'good' → applied
+    assert.equal(getUndoCount(), 0);
+    assert.equal(getRedoCount(), 1);
+  });
+
+  it('discards a redo entry when its handler declines', () => {
+    let accepts = true;
+    register(ACTION.type, () => accepts);
+    pushHistory(ACTION);
+    undo(); // applied → sits on redo stack
+    assert.equal(getRedoCount(), 1);
+
+    accepts = false;
+    redo(); // declined → discarded
+
+    assert.equal(getRedoCount(), 0);
+    assert.equal(getUndoCount(), 0);
+  });
+});

--- a/src/history/historyStore.ts
+++ b/src/history/historyStore.ts
@@ -71,16 +71,28 @@ export function undo() {
     appendHistoryDebugEvent('undo-empty');
     return;
   }
-  const handled = dispatch(action, 'undo');
-  if (handled) {
+  const outcome = dispatch(action, 'undo');
+  if (outcome === 'applied') {
     redoStack.push(structuredClone(action));
     notifyHistoryOperation('undo', action);
     appendHistoryDebugEvent('undo', action);
     notifySubscribers();
-  } else {
+    return;
+  }
+  if (outcome === 'no-handler') {
+    // Registration can lag the push, so keep the entry — it replays once a
+    // handler appears. Dropping it would be silent, unrecoverable loss.
+    undoStack.push(action);
     appendHistoryDebugEvent('undo-handler-missing', action);
     console.warn('[HistoryStore] undo handler missing for action', action.type);
+    return;
   }
+  // declined: a handler ran but refused (e.g. the state it needed is gone).
+  // Stable across retries, so discard it rather than let it pin the top of the
+  // stack and block undo of every entry beneath it.
+  appendHistoryDebugEvent('undo-declined', action);
+  console.warn('[HistoryStore] undo handler declined; discarding action', action.type);
+  notifySubscribers();
 }
 
 export function redo() {
@@ -89,16 +101,25 @@ export function redo() {
     appendHistoryDebugEvent('redo-empty');
     return;
   }
-  const handled = dispatch(action, 'redo');
-  if (handled) {
+  const outcome = dispatch(action, 'redo');
+  if (outcome === 'applied') {
     undoStack.push(structuredClone(action));
     notifyHistoryOperation('redo', action);
     appendHistoryDebugEvent('redo', action);
     notifySubscribers();
-  } else {
+    return;
+  }
+  if (outcome === 'no-handler') {
+    // See undo(): keep unhandled entries for a late-registering handler.
+    redoStack.push(action);
     appendHistoryDebugEvent('redo-handler-missing', action);
     console.warn('[HistoryStore] redo handler missing for action', action.type);
+    return;
   }
+  // declined: unrecoverable, so discard rather than pin the redo stack.
+  appendHistoryDebugEvent('redo-declined', action);
+  console.warn('[HistoryStore] redo handler declined; discarding action', action.type);
+  notifySubscribers();
 }
 
 export function clearHistory() {
@@ -154,14 +175,28 @@ export function getRedoCount() {
   return redoStack.length;
 }
 
-function dispatch(action: HistoryAction, direction: HistoryDirection) {
+/**
+ * Result of routing an action to its registered handlers.
+ *
+ * - `applied` — a handler ran and reported success.
+ * - `no-handler` — no handler is registered for this type. Usually transient:
+ *   registration can lag the first push, so callers keep the entry to replay.
+ * - `declined` — a handler ran but refused (e.g. the state it needed is gone).
+ *   Stable across retries, so callers discard the entry rather than let it pin
+ *   the stack.
+ *
+ * The two failure cases were a single `false` before; conflating them made an
+ * unrecoverable entry masquerade as a retryable one and jam the stack.
+ */
+type DispatchOutcome = 'applied' | 'no-handler' | 'declined';
+
+function dispatch(action: HistoryAction, direction: HistoryDirection): DispatchOutcome {
   const handlers = handlerMap.get(action.type);
-  if (!handlers || handlers.size === 0) return false;
+  if (!handlers || handlers.size === 0) return 'no-handler';
   for (const handler of handlers) {
-    const result = handler(action, direction);
-    if (result === false) {
-      return false;
+    if (handler(action, direction) === false) {
+      return 'declined';
     }
   }
-  return true;
+  return 'applied';
 }

--- a/src/history/typedHistory.ts
+++ b/src/history/typedHistory.ts
@@ -1,0 +1,31 @@
+import { pushHistory, registerHistoryHandler } from './historyStore';
+import type { HistoryDirection } from './types';
+
+export interface TypedHistory<M> {
+  /** Push an entry whose payload must match its action type. */
+  push<K extends keyof M & string>(action: { type: K; payload: M[K]; description?: string }): void;
+  /** Register a handler that receives its action's payload already narrowed. */
+  register<K extends keyof M & string>(
+    type: K,
+    handler: (payload: M[K], direction: HistoryDirection) => boolean | void,
+  ): () => void;
+}
+
+/**
+ * A typed façade over the untyped history store for one domain's action→payload
+ * map `M`. It binds each action type to its payload — so a push can't drift from
+ * the handler that inverts it — and confines the store-boundary cast the untyped
+ * store forces to this one place, instead of once per handler.
+ */
+export function createTypedHistory<M>(): TypedHistory<M> {
+  return {
+    push(action) {
+      pushHistory(action);
+    },
+    register(type, handler) {
+      return registerHistoryHandler(type, (action, direction) =>
+        handler(action.payload as M[typeof type], direction),
+      );
+    },
+  };
+}

--- a/src/history/types.ts
+++ b/src/history/types.ts
@@ -22,7 +22,9 @@ export type HistoryDebugEventKind =
   | 'undo-empty'
   | 'redo-empty'
   | 'undo-handler-missing'
-  | 'redo-handler-missing';
+  | 'redo-handler-missing'
+  | 'undo-declined'
+  | 'redo-declined';
 
 export interface HistoryDebugEvent {
   id: number;

--- a/src/supports/Curves/BezierGizmo/BezierGizmoManager.tsx
+++ b/src/supports/Curves/BezierGizmo/BezierGizmoManager.tsx
@@ -7,7 +7,7 @@ import type { Kickstand as KickstandEntity } from '../../SupportTypes/Kickstand/
 import { BezierHandle } from './BezierHandle';
 import { calculateControlPoint } from './utils';
 import { useCurveInteractionState, curveInteractionStore } from '../../Curves/curveInteractionState';
-import { pushHistory } from '@/history/historyStore';
+import { pushSupportHistory } from '@/supports/history/supportHistory';
 import { SUPPORT_UPDATE_TRUNK } from '../../history/actionTypes';
 import { captureSupportEditSnapshot, pushSupportEditHistory } from '../../history/supportEditHistory';
 import { getFinalSocketPosition } from '../../SupportPrimitives/ContactCone';
@@ -682,7 +682,7 @@ export function BezierGizmoManager() {
             if (latestTrunk) {
                 // Final exact reconciliation after drag-time fast-path updates.
                 updateTrunk(latestTrunk);
-                pushHistory({
+                pushSupportHistory({
                     type: SUPPORT_UPDATE_TRUNK,
                     description: 'Edit trunk curve',
                     payload: {

--- a/src/supports/SupportPrimitives/Joint/JointGizmo.tsx
+++ b/src/supports/SupportPrimitives/Joint/JointGizmo.tsx
@@ -2,7 +2,7 @@ import React, { useSyncExternalStore, useCallback, useRef, useEffect, useLayoutE
 import { ScreenSpaceGizmo } from '@/components/gizmo/ScreenSpaceGizmo';
 import { subscribe, getSnapshot, updateTrunk, updateBranch, updateTwig, updateStick, getTrunkById, getBranchById, getTwigById, getStickById } from '../../state';
 import * as THREE from 'three';
-import { pushHistory } from '@/history/historyStore';
+import { pushSupportHistory } from '@/supports/history/supportHistory';
 import { SUPPORT_UPDATE_TRUNK } from '../../history/actionTypes';
 import { captureSupportEditSnapshot, pushSupportEditHistory } from '../../history/supportEditHistory';
 import { useCurveInteractionState } from '../../Curves/curveInteractionState';
@@ -580,14 +580,17 @@ export function JointGizmo() {
             const committedTrunk = liveTrunkPreviewRef.current ?? getTrunkById(trunk.id);
             if (committedTrunk) {
                 const appliedTrunk = commitJointDragSupport('trunk', committedTrunk);
-                pushHistory({
-                    type: SUPPORT_UPDATE_TRUNK,
-                    description: 'Move trunk joint',
-                    payload: {
-                        before: initialTrunkRef.current,
-                        after: cloneObj(appliedTrunk),
-                    },
-                });
+                const appliedTrunkSnapshot = cloneObj(appliedTrunk);
+                if (appliedTrunkSnapshot) {
+                    pushSupportHistory({
+                        type: SUPPORT_UPDATE_TRUNK,
+                        description: 'Move trunk joint',
+                        payload: {
+                            before: initialTrunkRef.current,
+                            after: appliedTrunkSnapshot,
+                        },
+                    });
+                }
             }
             initialTrunkRef.current = null;
         }

--- a/src/supports/SupportPrimitives/Joint/useJointInteraction.ts
+++ b/src/supports/SupportPrimitives/Joint/useJointInteraction.ts
@@ -22,7 +22,7 @@ import { getTrunkSegmentEndpoints } from '../Knot/knotUtils';
 import { Vec3, Trunk, Branch, Roots, Twig, Stick, ContactDisk } from '../../types';
 import { getKickstandSnapshot } from '../../SupportTypes/Kickstand/kickstandStore';
 import type { Kickstand } from '../../SupportTypes/Kickstand/types';
-import { pushHistory } from '@/history/historyStore';
+import { pushSupportHistory } from '@/supports/history/supportHistory';
 import { SUPPORT_UPDATE_TRUNK } from '../../history/actionTypes';
 import { captureSupportEditSnapshot, pushSupportEditHistory } from '../../history/supportEditHistory';
 import { calculateDiskThickness } from '../ContactDisk/contactDiskUtils';
@@ -900,7 +900,7 @@ export function useJointInteraction(enabled: boolean = true) {
             if (initialTrunkSnapshot.current && activeTrunkId.current) {
                 const currentTrunk = getTrunkById(activeTrunkId.current);
                 if (currentTrunk) {
-                    pushHistory({
+                    pushSupportHistory({
                         type: SUPPORT_UPDATE_TRUNK,
                         description: 'Move trunk joint',
                         payload: {

--- a/src/supports/SupportRenderer.tsx
+++ b/src/supports/SupportRenderer.tsx
@@ -35,7 +35,6 @@ import { bezierToLineSegments, calculateAdaptiveBezierResolution } from './Curve
 import type { SupportData } from './rendering';
 import type { BracePreviewData } from './SupportTypes/Brace/bracePlacementState';
 import { useJointCreationState } from './SupportPrimitives/Joint/jointCreationState';
-import { useSupportHistoryHandlers } from './history/useSupportHistoryHandlers';
 import { subscribeToSettings, getSettingsSnapshot } from './Settings/state';
 import { emitSupportModelPointerHover, emitSupportModelPointerSelect, handleSupportClick } from './interaction/clickHandlers';
 import { useResolvedSelectionState } from './interaction/shared/selection/resolvedSelectionStore';
@@ -1662,8 +1661,6 @@ export const SupportRenderer = forwardRef<THREE.Group, SupportRendererProps>(({ 
         hoveredCategoryForVisual,
         hoveredIdForVisual,
     ]);
-
-    useSupportHistoryHandlers(interactionHooksEnabled);
 
     // Backfill Kickstand root/knot into global support state so raft + knot tools include them.
     useEffect(() => {

--- a/src/supports/SupportTypes/Brace/BracePlacementController.tsx
+++ b/src/supports/SupportTypes/Brace/BracePlacementController.tsx
@@ -4,7 +4,7 @@ import { useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
 import { subscribe, getSnapshot, addKnot, addBrace } from '../../state';
-import { pushHistory } from '@/history/historyStore';
+import { pushSupportHistory } from '@/supports/history/supportHistory';
 import type { SnapTarget } from '../../interaction/SnappingManager';
 import type { Brace, Knot, Vec3 } from '../../types';
 import { SUPPORT_ADD_BRACE } from '../../history/actionTypes';
@@ -930,7 +930,7 @@ export function BracePlacementController() {
                 addKnot(endKnot);
                 addBrace(brace);
 
-                pushHistory({
+                pushSupportHistory({
                     type: SUPPORT_ADD_BRACE,
                     payload: {
                         brace,
@@ -1004,7 +1004,7 @@ export function BracePlacementController() {
             addKnot(endKnot);
             addBrace(brace);
 
-            pushHistory({
+            pushSupportHistory({
                 type: SUPPORT_ADD_BRACE,
                 payload: {
                     brace,
@@ -1112,7 +1112,7 @@ export function BracePlacementController() {
                 addKnot(endKnot);
                 addBrace(brace);
 
-                pushHistory({
+                pushSupportHistory({
                     type: SUPPORT_ADD_BRACE,
                     payload: {
                         brace,
@@ -1180,7 +1180,7 @@ export function BracePlacementController() {
             addKnot(endKnot);
             addBrace(brace);
 
-            pushHistory({
+            pushSupportHistory({
                 type: SUPPORT_ADD_BRACE,
                 payload: {
                     brace,

--- a/src/supports/SupportTypes/Branch/BranchPlacementController.tsx
+++ b/src/supports/SupportTypes/Branch/BranchPlacementController.tsx
@@ -19,7 +19,7 @@ import * as THREE from 'three';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
 import { matchesConfiguredHotkeyUp } from '@/hotkeys/hotkeyConfig';
 import { subscribe, getSnapshot, addBranch, addKnot, addTwig, addStick } from '../../state';
-import { pushHistory } from '@/history/historyStore';
+import { pushSupportHistory } from '@/supports/history/supportHistory';
 import { getClipBounds } from '@/components/scene/SceneCanvas/clipBoundsStore';
 import { SUPPORT_ADD_BRANCH, SUPPORT_ADD_TWIG, SUPPORT_ADD_STICK } from '../../history/actionTypes';
 import { SnapTarget } from '../../interaction/SnappingManager';
@@ -744,7 +744,7 @@ export function BranchPlacementController() {
                         }
                         : twig;
                     addTwig(markedTwig);
-                    pushHistory({
+                    pushSupportHistory({
                         type: SUPPORT_ADD_TWIG,
                         payload: { twig: markedTwig },
                     });
@@ -766,7 +766,7 @@ export function BranchPlacementController() {
                         }
                         : stick;
                     addStick(markedStick);
-                    pushHistory({
+                    pushSupportHistory({
                         type: SUPPORT_ADD_STICK,
                         payload: { stick: markedStick },
                     });
@@ -815,7 +815,7 @@ export function BranchPlacementController() {
             addKnot(parentKnot);
             addBranch(markedBranch);
 
-            pushHistory({
+            pushSupportHistory({
                 type: SUPPORT_ADD_BRANCH,
                 payload: {
                     branch: markedBranch,

--- a/src/supports/SupportTypes/Kickstand/KickstandPlacementController.tsx
+++ b/src/supports/SupportTypes/Kickstand/KickstandPlacementController.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'r
 import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
-import { pushHistory } from '@/history/historyStore';
+import { pushSupportHistory } from '@/supports/history/supportHistory';
 import { SUPPORT_ADD_KICKSTAND } from '@/supports/history/actionTypes';
 import { addKnot, addRoot, subscribe, getSnapshot } from '../../state';
 import type { SnapTarget } from '../../interaction/SnappingManager';
@@ -659,7 +659,7 @@ export function KickstandPlacementController() {
             addRoot(finalBuild.root);
             addKnot(finalBuild.hostKnot);
 
-            pushHistory({
+            pushSupportHistory({
                 type: SUPPORT_ADD_KICKSTAND,
                 payload: { build: finalBuild },
             });

--- a/src/supports/SupportTypes/Leaf/LeafPlacementController.tsx
+++ b/src/supports/SupportTypes/Leaf/LeafPlacementController.tsx
@@ -3,7 +3,7 @@ import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
 import { subscribe, getSnapshot, addKnot, addLeaf } from '../../state';
-import { pushHistory } from '@/history/historyStore';
+import { pushSupportHistory } from '@/supports/history/supportHistory';
 import type { SnapTarget } from '../../interaction/SnappingManager';
 import type { Vec3, Knot, Joint, Segment } from '../../types';
 import { leafPlacementStore, useLeafPlacementState } from './leafPlacementState';
@@ -697,7 +697,7 @@ export function LeafPlacementController({ activeModelId }: LeafPlacementControll
                 addKnot(newParentKnot);
                 leafPlacementStore.setJunctionHub(newParentKnotId, true);
 
-                pushHistory({
+                pushSupportHistory({
                     type: SUPPORT_ADD_LEAF,
                     payload: {
                         leaf: markedLeaf,
@@ -765,7 +765,7 @@ export function LeafPlacementController({ activeModelId }: LeafPlacementControll
                 addKnot(parentKnot);
                 addLeaf(markedLeaf);
 
-                pushHistory({
+                pushSupportHistory({
                     type: SUPPORT_ADD_LEAF,
                     payload: {
                         leaf: markedLeaf,

--- a/src/supports/SupportTypes/Trunk/TrunkReplacement/applyTrunkReplacement.ts
+++ b/src/supports/SupportTypes/Trunk/TrunkReplacement/applyTrunkReplacement.ts
@@ -1,6 +1,6 @@
 import type { Branch, Joint, Knot, Roots, SupportState, Trunk, Vec3 } from '../../../types';
 import { addBranch, addKnot, addLeaf, addRoot, addTrunk, getSnapshot, removeBranch, removeLeaf, removeTrunk, updateBranch, updateKnot, updateTrunk } from '../../../state';
-import { pushHistory } from '@/history/historyStore';
+import { pushSupportHistory } from '@/supports/history/supportHistory';
 import { SUPPORT_REPLACE_TRUNK } from '../../../history/actionTypes';
 import type { SupportReplaceTrunkPayload } from '../../../history/actionTypes';
 import { buildTrunkData } from '../trunkBuilder';
@@ -556,7 +556,7 @@ export function applyTrunkReplacement(plan: TrunkReplacementPlan, historyBefore?
         after,
     };
 
-    pushHistory({ type: SUPPORT_REPLACE_TRUNK, payload });
+    pushSupportHistory({ type: SUPPORT_REPLACE_TRUNK, payload });
 
     return true;
 }

--- a/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
+++ b/src/supports/SupportTypes/Trunk/useTrunkPlacement.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState, useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import { addAnchor, addBranch, addKnot, addLeaf, addRoot, addStick, addTrunk, addTwig, getSnapshot, setSnapshot, updateKnot, updateTrunk } from '../../state';
-import { pushHistory } from '@/history/historyStore';
+import { pushSupportHistory } from '@/supports/history/supportHistory';
 import { SUPPORT_ADD_ANCHOR, SUPPORT_ADD_BRANCH, SUPPORT_ADD_LEAF, SUPPORT_ADD_STICK, SUPPORT_ADD_TRUNK, SUPPORT_ADD_TWIG } from '../../history/actionTypes';
 import { useInteractionStatus } from '../../interaction/useInteractionStatus';
 import { buildTrunkData } from './trunkBuilder';
@@ -257,7 +257,7 @@ export function useTrunkPlacementV2() {
         const markedBuild = markTrunkBuildPlacementSurface(trunkBuild, placementSurface);
         addRoot(markedBuild.root);
         addTrunk(markedBuild.trunk);
-        pushHistory({
+        pushSupportHistory({
             type: SUPPORT_ADD_TRUNK,
             payload: {
                 trunk: markedBuild.trunk,
@@ -602,14 +602,14 @@ export function useTrunkPlacementV2() {
                     if (cavityStick.kind === 'twig') {
                         const twig = markTwigPlacementSurface(cavityStick.twig, placementSurface);
                         addTwig(twig);
-                        pushHistory({
+                        pushSupportHistory({
                             type: SUPPORT_ADD_TWIG,
                             payload: { twig },
                         });
                     } else {
                         const stick = markStickPlacementSurface(cavityStick.stick, placementSurface);
                         addStick(stick);
-                        pushHistory({
+                        pushSupportHistory({
                             type: SUPPORT_ADD_STICK,
                             payload: { stick },
                         });
@@ -661,7 +661,7 @@ export function useTrunkPlacementV2() {
         if (decision.kind === 'place_anchor') {
             const anchor = markAnchorPlacementSurface(decision.anchor, placementSurface);
             addAnchor(anchor);
-            pushHistory({
+            pushSupportHistory({
                 type: SUPPORT_ADD_ANCHOR,
                 payload: { anchor },
             });
@@ -690,7 +690,7 @@ export function useTrunkPlacementV2() {
                 })()
                 : null;
 
-            pushHistory({
+            pushSupportHistory({
                 type: SUPPORT_ADD_BRANCH,
                 payload: {
                     branch,
@@ -708,7 +708,7 @@ export function useTrunkPlacementV2() {
             addKnot(decision.knot);
             addLeaf(leaf);
 
-            pushHistory({
+            pushSupportHistory({
                 type: SUPPORT_ADD_LEAF,
                 payload: {
                     leaf,
@@ -765,14 +765,14 @@ export function useTrunkPlacementV2() {
                     if (cavityStick.kind === 'twig') {
                         const twig = markTwigPlacementSurface(cavityStick.twig, placementSurface);
                         addTwig(twig);
-                        pushHistory({
+                        pushSupportHistory({
                             type: SUPPORT_ADD_TWIG,
                             payload: { twig },
                         });
                     } else {
                         const stick = markStickPlacementSurface(cavityStick.stick, placementSurface);
                         addStick(stick);
-                        pushHistory({
+                        pushSupportHistory({
                             type: SUPPORT_ADD_STICK,
                             payload: { stick },
                         });

--- a/src/supports/autoBracing/autoBrace.ts
+++ b/src/supports/autoBracing/autoBrace.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { pushHistory } from '@/history/historyStore';
+import { pushSupportHistory } from '@/supports/history/supportHistory';
 import { getSettings } from '../Settings/state';
 import {
     SUPPORT_AUTO_BRACE_REPLACE,
@@ -949,7 +949,7 @@ export function runAutoBracing(): AutoBraceResult {
     if (!built.changed) return built;
 
     setSnapshot(built.snapshot);
-    pushHistory({
+    pushSupportHistory({
         type: SUPPORT_AUTO_BRACE_REPLACE,
         payload: {
             before,

--- a/src/supports/history/actionTypes.ts
+++ b/src/supports/history/actionTypes.ts
@@ -31,28 +31,8 @@ export const SUPPORT_REPLACE_TRUNK = 'support:replace-trunk' as const;
 export const SUPPORT_AUTO_BRACE_REPLACE = 'support:auto-brace-replace' as const;
 export const SUPPORT_EDIT_REPLACE = 'support:edit-replace' as const;
 
-export type SupportHistoryActionType =
-  | typeof SUPPORT_ADD_TRUNK
-  | typeof SUPPORT_REMOVE_TRUNK
-  | typeof SUPPORT_UPDATE_TRUNK
-  | typeof SUPPORT_ADD_LEAF
-  | typeof SUPPORT_REMOVE_LEAF
-  | typeof SUPPORT_ADD_BRANCH
-  | typeof SUPPORT_REMOVE_BRANCH
-  | typeof SUPPORT_UPDATE_BRANCH
-  | typeof SUPPORT_ADD_TWIG
-  | typeof SUPPORT_REMOVE_TWIG
-  | typeof SUPPORT_ADD_STICK
-  | typeof SUPPORT_REMOVE_STICK
-  | typeof SUPPORT_ADD_BRACE
-  | typeof SUPPORT_REMOVE_BRACE
-  | typeof SUPPORT_ADD_ANCHOR
-  | typeof SUPPORT_REMOVE_ANCHOR
-  | typeof SUPPORT_ADD_KICKSTAND
-  | typeof SUPPORT_REMOVE_KICKSTAND
-  | typeof SUPPORT_REPLACE_TRUNK
-  | typeof SUPPORT_EDIT_REPLACE
-  | typeof SUPPORT_AUTO_BRACE_REPLACE;
+/** Every support history action type, derived from the payload map below. */
+export type SupportHistoryActionType = keyof SupportHistoryPayloadMap;
 
 export interface SupportTrunkPayload {
   trunk: Trunk;
@@ -149,3 +129,32 @@ export interface SupportReplaceStatePayload {
   kickstandBefore?: KickstandState;
   kickstandAfter?: KickstandState;
 }
+
+/**
+ * The payload each support history action carries. One source of truth: push
+ * sites and handlers both key off this map, so a type can't be pushed with a
+ * payload its handler won't understand.
+ */
+export type SupportHistoryPayloadMap = {
+  [SUPPORT_ADD_TRUNK]: SupportTrunkPayload;
+  [SUPPORT_REMOVE_TRUNK]: SupportTrunkPayload;
+  [SUPPORT_UPDATE_TRUNK]: SupportTrunkUpdatePayload;
+  [SUPPORT_ADD_LEAF]: SupportLeafPayload;
+  [SUPPORT_REMOVE_LEAF]: SupportLeafPayload;
+  [SUPPORT_ADD_BRANCH]: SupportBranchPayload;
+  [SUPPORT_REMOVE_BRANCH]: SupportBranchRemovePayload;
+  [SUPPORT_UPDATE_BRANCH]: SupportBranchUpdatePayload;
+  [SUPPORT_ADD_TWIG]: SupportTwigPayload;
+  [SUPPORT_REMOVE_TWIG]: SupportTwigRemovePayload;
+  [SUPPORT_ADD_STICK]: SupportStickPayload;
+  [SUPPORT_REMOVE_STICK]: SupportStickPayload;
+  [SUPPORT_ADD_BRACE]: BraceLinkPayload;
+  [SUPPORT_REMOVE_BRACE]: BraceLinkPayload;
+  [SUPPORT_ADD_ANCHOR]: SupportAnchorPayload;
+  [SUPPORT_REMOVE_ANCHOR]: SupportAnchorPayload;
+  [SUPPORT_ADD_KICKSTAND]: SupportKickstandPayload;
+  [SUPPORT_REMOVE_KICKSTAND]: SupportKickstandRemovePayload;
+  [SUPPORT_REPLACE_TRUNK]: SupportReplaceTrunkPayload;
+  [SUPPORT_EDIT_REPLACE]: SupportReplaceStatePayload;
+  [SUPPORT_AUTO_BRACE_REPLACE]: SupportReplaceStatePayload;
+};

--- a/src/supports/history/supportEditHistory.ts
+++ b/src/supports/history/supportEditHistory.ts
@@ -1,4 +1,4 @@
-import { pushHistory } from '@/history/historyStore';
+import { pushSupportHistory } from '@/supports/history/supportHistory';
 import { SUPPORT_EDIT_REPLACE } from './actionTypes';
 import { getSnapshot, type SupportState } from '../state';
 import { getKickstandSnapshot, type KickstandState } from '../SupportTypes/Kickstand/kickstandStore';
@@ -44,7 +44,7 @@ function flushPendingJobs() {
 
   const jobs = pendingJobs.splice(0, pendingJobs.length);
   for (const job of jobs) {
-    pushHistory({
+    pushSupportHistory({
       type: SUPPORT_EDIT_REPLACE,
       description: job.description,
       payload: {

--- a/src/supports/history/supportHistory.ts
+++ b/src/supports/history/supportHistory.ts
@@ -1,35 +1,17 @@
-import { pushHistory, registerHistoryHandler } from '@/history/historyStore';
-import type { HistoryDirection } from '@/history/types';
-import type { SupportHistoryActionType, SupportHistoryPayloadMap } from './actionTypes';
+import { createTypedHistory } from '@/history/typedHistory';
+import type { SupportHistoryPayloadMap } from './actionTypes';
+
+const supportHistory = createTypedHistory<SupportHistoryPayloadMap>();
 
 /**
  * Push a support history entry with the payload its type requires. The compiler
  * rejects a payload that doesn't match the action type, so a push site can't
  * drift from the handler that inverts it.
  */
-export function pushSupportHistory<K extends SupportHistoryActionType>(action: {
-  type: K;
-  payload: SupportHistoryPayloadMap[K];
-  description?: string;
-}): void {
-  pushHistory(action);
-}
-
-export type SupportHistoryHandler<K extends SupportHistoryActionType> = (
-  payload: SupportHistoryPayloadMap[K],
-  direction: HistoryDirection,
-) => boolean | void;
+export const pushSupportHistory = supportHistory.push;
 
 /**
- * Register a handler that receives its action's payload already narrowed. The
- * single `as` cast the untyped store forces lives here, once, instead of at the
- * top of every handler body.
+ * Register a handler that receives its action's payload already narrowed, so no
+ * handler body has to cast `action.payload`.
  */
-export function registerSupportHistoryHandler<K extends SupportHistoryActionType>(
-  type: K,
-  handler: SupportHistoryHandler<K>,
-): () => void {
-  return registerHistoryHandler(type, (action, direction) =>
-    handler(action.payload as SupportHistoryPayloadMap[K], direction),
-  );
-}
+export const registerSupportHistoryHandler = supportHistory.register;

--- a/src/supports/history/supportHistory.ts
+++ b/src/supports/history/supportHistory.ts
@@ -1,0 +1,35 @@
+import { pushHistory, registerHistoryHandler } from '@/history/historyStore';
+import type { HistoryDirection } from '@/history/types';
+import type { SupportHistoryActionType, SupportHistoryPayloadMap } from './actionTypes';
+
+/**
+ * Push a support history entry with the payload its type requires. The compiler
+ * rejects a payload that doesn't match the action type, so a push site can't
+ * drift from the handler that inverts it.
+ */
+export function pushSupportHistory<K extends SupportHistoryActionType>(action: {
+  type: K;
+  payload: SupportHistoryPayloadMap[K];
+  description?: string;
+}): void {
+  pushHistory(action);
+}
+
+export type SupportHistoryHandler<K extends SupportHistoryActionType> = (
+  payload: SupportHistoryPayloadMap[K],
+  direction: HistoryDirection,
+) => boolean | void;
+
+/**
+ * Register a handler that receives its action's payload already narrowed. The
+ * single `as` cast the untyped store forces lives here, once, instead of at the
+ * top of every handler body.
+ */
+export function registerSupportHistoryHandler<K extends SupportHistoryActionType>(
+  type: K,
+  handler: SupportHistoryHandler<K>,
+): () => void {
+  return registerHistoryHandler(type, (action, direction) =>
+    handler(action.payload as SupportHistoryPayloadMap[K], direction),
+  );
+}

--- a/src/supports/history/useSupportHistoryHandlers.ts
+++ b/src/supports/history/useSupportHistoryHandlers.ts
@@ -57,290 +57,298 @@ function applySnapshotHistory(payload: SupportReplaceStatePayload, direction: 'u
   }
 }
 
-export function useSupportHistoryHandlers(enabled = true) {
-  useEffect(() => {
-    if (!enabled) return;
+/**
+ * Register every supports undo/redo handler and return a disposer.
+ *
+ * Plain module function on purpose: the handlers close over the support
+ * stores, not over React state, so registration must not depend on whether
+ * any particular renderer happens to be mounted.
+ */
+export function registerSupportHistoryHandlers(): () => void {
+  const unregisters = [
+    registerHistoryHandler(SUPPORT_ADD_TRUNK, (action, direction) => {
+      const payload = action.payload as SupportTrunkPayload | undefined;
+      if (!payload?.trunk) return false;
+      if (direction === 'undo') {
+        removeTrunk(payload.trunk.id);
+      } else {
+        if (payload.root) addRoot(payload.root);
+        addTrunk(payload.trunk);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_ADD_LEAF, (action, direction) => {
+      const payload = action.payload as SupportLeafPayload | undefined;
+      if (!payload?.leaf) return false;
+      if (direction === 'undo') {
+        removeLeaf(payload.leaf.id);
+      } else {
+        if (payload.knot) addKnot(payload.knot);
+        addLeaf(payload.leaf);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_ADD_BRANCH, (action, direction) => {
+      const payload = action.payload as SupportBranchPayload | undefined;
+      if (!payload?.branch) return false;
+      if (direction === 'undo') {
+        removeBranch(payload.branch.id);
+        for (const u of payload.knotUpdates ?? []) {
+          updateKnot(u.before);
+        }
+        if (payload.trunkUpdate?.before) {
+          updateTrunk(payload.trunkUpdate.before);
+        }
+      } else {
+        if (payload.knot) addKnot(payload.knot);
+        addBranch(payload.branch);
+        for (const u of payload.knotUpdates ?? []) {
+          updateKnot(u.after);
+        }
+        if (payload.trunkUpdate?.after) {
+          updateTrunk(payload.trunkUpdate.after);
+        }
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_ADD_TWIG, (action, direction) => {
+      const payload = action.payload as SupportTwigPayload | undefined;
+      if (!payload?.twig) return false;
+      if (direction === 'undo') {
+        removeTwig(payload.twig.id);
+      } else {
+        addTwig(payload.twig);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_ADD_STICK, (action, direction) => {
+      const payload = action.payload as SupportStickPayload | undefined;
+      if (!payload?.stick) return false;
+      if (direction === 'undo') {
+        removeStick(payload.stick.id);
+      } else {
+        addStick(payload.stick);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_ADD_BRACE, (action, direction) => {
+      const payload = action.payload as BraceLinkPayload | undefined;
+      if (!payload?.brace) return false;
+      if (direction === 'undo') {
+        removeBrace(payload.brace.id);
+      } else {
+        if (payload.startKnot) addKnot(payload.startKnot);
+        if (payload.endKnot) addKnot(payload.endKnot);
+        addBrace(payload.brace);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_ADD_ANCHOR, (action, direction) => {
+      const payload = action.payload as SupportAnchorPayload | undefined;
+      if (!payload?.anchor) return false;
+      if (direction === 'undo') {
+        removeAnchor(payload.anchor.id);
+      } else {
+        addAnchor(payload.anchor);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_REMOVE_ANCHOR, (action, direction) => {
+      const payload = action.payload as SupportAnchorPayload | undefined;
+      if (!payload?.anchor) return false;
+      if (direction === 'undo') {
+        addAnchor(payload.anchor);
+      } else {
+        removeAnchor(payload.anchor.id);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_REMOVE_TRUNK, (action, direction) => {
+      const payload = action.payload as SupportTrunkPayload | undefined;
+      if (!payload?.trunk) return false;
+      if (direction === 'undo') {
+        if (payload.root) addRoot(payload.root);
+        addTrunk(payload.trunk);
+        for (const knot of payload.knots ?? []) addKnot(knot);
+        for (const leaf of payload.leaves ?? []) addLeaf(leaf);
+        for (const brace of payload.braces ?? []) addBrace(brace);
+        for (const kickstand of payload.kickstands ?? []) {
+          addKickstand(kickstand);
+          addRoot(kickstand.root);
+          addKnot(kickstand.hostKnot);
+        }
+        for (const branch of payload.branches ?? []) addBranch(branch);
+      } else {
+        removeTrunk(payload.trunk.id);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_REMOVE_LEAF, (action, direction) => {
+      const payload = action.payload as SupportLeafPayload | undefined;
+      if (!payload?.leaf) return false;
+      if (direction === 'undo') {
+        if (payload.knot) addKnot(payload.knot);
+        addLeaf(payload.leaf);
+      } else {
+        removeLeaf(payload.leaf.id);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_REMOVE_BRANCH, (action, direction) => {
+      const payload = action.payload as SupportBranchRemovePayload | undefined;
+      if (!payload?.branches || payload.branches.length === 0) return false;
+      if (direction === 'undo') {
+        for (const knot of payload.knots ?? []) addKnot(knot);
+        for (const leaf of payload.leaves ?? []) addLeaf(leaf);
+        for (const brace of payload.braces ?? []) addBrace(brace);
+        for (const kickstand of payload.kickstands ?? []) {
+          addKickstand(kickstand);
+          addRoot(kickstand.root);
+          addKnot(kickstand.hostKnot);
+        }
+        for (const branch of payload.branches ?? []) addBranch(branch);
+        for (const u of payload.knotUpdates ?? []) {
+          updateKnot(u.before);
+        }
+        if (payload.trunkUpdate?.before) {
+          updateTrunk(payload.trunkUpdate.before);
+        }
+      } else {
+        // Use the first removed branch as the entrypoint; the store handles cascade.
+        removeBranch(payload.branches[0].id);
+        for (const u of payload.knotUpdates ?? []) {
+          updateKnot(u.after);
+        }
+        if (payload.trunkUpdate?.after) {
+          updateTrunk(payload.trunkUpdate.after);
+        }
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_REMOVE_TWIG, (action, direction) => {
+      const payload = action.payload as SupportTwigRemovePayload | undefined;
+      if (!payload?.twig) return false;
+      if (direction === 'undo') {
+        addTwig(payload.twig);
+        for (const knot of payload.knots ?? []) {
+          addKnot(knot);
+        }
+        for (const leaf of payload.leaves ?? []) {
+          addLeaf(leaf);
+        }
+      } else {
+        removeTwig(payload.twig.id);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_REMOVE_STICK, (action, direction) => {
+      const payload = action.payload as SupportStickPayload | undefined;
+      if (!payload?.stick) return false;
+      if (direction === 'undo') {
+        addStick(payload.stick);
+      } else {
+        removeStick(payload.stick.id);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_REMOVE_BRACE, (action, direction) => {
+      const payload = action.payload as BraceLinkPayload | undefined;
+      if (!payload?.brace) return false;
+      if (direction === 'undo') {
+        if (payload.startKnot) addKnot(payload.startKnot);
+        if (payload.endKnot) addKnot(payload.endKnot);
+        addBrace(payload.brace);
+      } else {
+        removeBrace(payload.brace.id);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_ADD_KICKSTAND, (action, direction) => {
+      const payload = action.payload as SupportKickstandPayload | undefined;
+      if (!payload?.build) return false;
+      if (direction === 'undo') {
+        removeKickstandCascade(payload.build.kickstand.id);
+      } else {
+        addKickstand(payload.build);
+        addRoot(payload.build.root);
+        addKnot(payload.build.hostKnot);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_REMOVE_KICKSTAND, (action, direction) => {
+      const payload = action.payload as SupportKickstandRemovePayload | undefined;
+      if (!payload?.build) return false;
+      if (direction === 'undo') {
+        addRoot(payload.build.root);
+        addKickstand(payload.build);
+        addKnot(payload.build.hostKnot);
+        for (const knot of payload.knots ?? []) addKnot(knot);
+        for (const leaf of payload.leaves ?? []) addLeaf(leaf);
+        for (const brace of payload.braces ?? []) addBrace(brace);
+        for (const kickstand of payload.kickstands ?? []) {
+          addKickstand(kickstand);
+          addRoot(kickstand.root);
+          addKnot(kickstand.hostKnot);
+        }
+        for (const branch of payload.branches ?? []) addBranch(branch);
+      } else {
+        removeKickstandCascade(payload.build.kickstand.id);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_UPDATE_TRUNK, (action, direction) => {
+      const payload = action.payload as SupportTrunkUpdatePayload | undefined;
+      if (!payload?.before || !payload?.after) return false;
+      clearSupportSelection();
+      if (direction === 'undo') {
+        updateTrunk(payload.before);
+      } else {
+        updateTrunk(payload.after);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_UPDATE_BRANCH, (action, direction) => {
+      const payload = action.payload as SupportBranchUpdatePayload | undefined;
+      if (!payload?.before || !payload?.after) return false;
+      clearSupportSelection();
+      if (direction === 'undo') {
+        updateBranch(payload.before);
+      } else {
+        updateBranch(payload.after);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_REPLACE_TRUNK, (action, direction) => {
+      const payload = action.payload as SupportReplaceTrunkPayload | undefined;
+      if (!payload?.before || !payload?.after) return false;
+      clearSupportSelection();
+      if (direction === 'undo') {
+        setSnapshot(payload.before);
+      } else {
+        setSnapshot(payload.after);
+      }
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_EDIT_REPLACE, (action, direction) => {
+      const payload = action.payload as SupportReplaceStatePayload | undefined;
+      if (!payload?.before || !payload?.after) return false;
+      applySnapshotHistory(payload, direction);
+      return true;
+    }),
+    registerHistoryHandler(SUPPORT_AUTO_BRACE_REPLACE, (action, direction) => {
+      const payload = action.payload as SupportReplaceStatePayload | undefined;
+      if (!payload?.before || !payload?.after) return false;
+      applySnapshotHistory(payload, direction);
+      return true;
+    }),
+  ];
 
-    const unregisters = [
-      registerHistoryHandler(SUPPORT_ADD_TRUNK, (action, direction) => {
-        const payload = action.payload as SupportTrunkPayload | undefined;
-        if (!payload?.trunk) return false;
-        if (direction === 'undo') {
-          removeTrunk(payload.trunk.id);
-        } else {
-          if (payload.root) addRoot(payload.root);
-          addTrunk(payload.trunk);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_ADD_LEAF, (action, direction) => {
-        const payload = action.payload as SupportLeafPayload | undefined;
-        if (!payload?.leaf) return false;
-        if (direction === 'undo') {
-          removeLeaf(payload.leaf.id);
-        } else {
-          if (payload.knot) addKnot(payload.knot);
-          addLeaf(payload.leaf);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_ADD_BRANCH, (action, direction) => {
-        const payload = action.payload as SupportBranchPayload | undefined;
-        if (!payload?.branch) return false;
-        if (direction === 'undo') {
-          removeBranch(payload.branch.id);
-          for (const u of payload.knotUpdates ?? []) {
-            updateKnot(u.before);
-          }
-          if (payload.trunkUpdate?.before) {
-            updateTrunk(payload.trunkUpdate.before);
-          }
-        } else {
-          if (payload.knot) addKnot(payload.knot);
-          addBranch(payload.branch);
-          for (const u of payload.knotUpdates ?? []) {
-            updateKnot(u.after);
-          }
-          if (payload.trunkUpdate?.after) {
-            updateTrunk(payload.trunkUpdate.after);
-          }
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_ADD_TWIG, (action, direction) => {
-        const payload = action.payload as SupportTwigPayload | undefined;
-        if (!payload?.twig) return false;
-        if (direction === 'undo') {
-          removeTwig(payload.twig.id);
-        } else {
-          addTwig(payload.twig);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_ADD_STICK, (action, direction) => {
-        const payload = action.payload as SupportStickPayload | undefined;
-        if (!payload?.stick) return false;
-        if (direction === 'undo') {
-          removeStick(payload.stick.id);
-        } else {
-          addStick(payload.stick);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_ADD_BRACE, (action, direction) => {
-        const payload = action.payload as BraceLinkPayload | undefined;
-        if (!payload?.brace) return false;
-        if (direction === 'undo') {
-          removeBrace(payload.brace.id);
-        } else {
-          if (payload.startKnot) addKnot(payload.startKnot);
-          if (payload.endKnot) addKnot(payload.endKnot);
-          addBrace(payload.brace);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_ADD_ANCHOR, (action, direction) => {
-        const payload = action.payload as SupportAnchorPayload | undefined;
-        if (!payload?.anchor) return false;
-        if (direction === 'undo') {
-          removeAnchor(payload.anchor.id);
-        } else {
-          addAnchor(payload.anchor);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_REMOVE_ANCHOR, (action, direction) => {
-        const payload = action.payload as SupportAnchorPayload | undefined;
-        if (!payload?.anchor) return false;
-        if (direction === 'undo') {
-          addAnchor(payload.anchor);
-        } else {
-          removeAnchor(payload.anchor.id);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_REMOVE_TRUNK, (action, direction) => {
-        const payload = action.payload as SupportTrunkPayload | undefined;
-        if (!payload?.trunk) return false;
-        if (direction === 'undo') {
-          if (payload.root) addRoot(payload.root);
-          addTrunk(payload.trunk);
-          for (const knot of payload.knots ?? []) addKnot(knot);
-          for (const leaf of payload.leaves ?? []) addLeaf(leaf);
-          for (const brace of payload.braces ?? []) addBrace(brace);
-          for (const kickstand of payload.kickstands ?? []) {
-            addKickstand(kickstand);
-            addRoot(kickstand.root);
-            addKnot(kickstand.hostKnot);
-          }
-          for (const branch of payload.branches ?? []) addBranch(branch);
-        } else {
-          removeTrunk(payload.trunk.id);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_REMOVE_LEAF, (action, direction) => {
-        const payload = action.payload as SupportLeafPayload | undefined;
-        if (!payload?.leaf) return false;
-        if (direction === 'undo') {
-          if (payload.knot) addKnot(payload.knot);
-          addLeaf(payload.leaf);
-        } else {
-          removeLeaf(payload.leaf.id);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_REMOVE_BRANCH, (action, direction) => {
-        const payload = action.payload as SupportBranchRemovePayload | undefined;
-        if (!payload?.branches || payload.branches.length === 0) return false;
-        if (direction === 'undo') {
-          for (const knot of payload.knots ?? []) addKnot(knot);
-          for (const leaf of payload.leaves ?? []) addLeaf(leaf);
-          for (const brace of payload.braces ?? []) addBrace(brace);
-          for (const kickstand of payload.kickstands ?? []) {
-            addKickstand(kickstand);
-            addRoot(kickstand.root);
-            addKnot(kickstand.hostKnot);
-          }
-          for (const branch of payload.branches ?? []) addBranch(branch);
-          for (const u of payload.knotUpdates ?? []) {
-            updateKnot(u.before);
-          }
-          if (payload.trunkUpdate?.before) {
-            updateTrunk(payload.trunkUpdate.before);
-          }
-        } else {
-          // Use the first removed branch as the entrypoint; the store handles cascade.
-          removeBranch(payload.branches[0].id);
-          for (const u of payload.knotUpdates ?? []) {
-            updateKnot(u.after);
-          }
-          if (payload.trunkUpdate?.after) {
-            updateTrunk(payload.trunkUpdate.after);
-          }
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_REMOVE_TWIG, (action, direction) => {
-        const payload = action.payload as SupportTwigRemovePayload | undefined;
-        if (!payload?.twig) return false;
-        if (direction === 'undo') {
-          addTwig(payload.twig);
-          for (const knot of payload.knots ?? []) {
-            addKnot(knot);
-          }
-          for (const leaf of payload.leaves ?? []) {
-            addLeaf(leaf);
-          }
-        } else {
-          removeTwig(payload.twig.id);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_REMOVE_STICK, (action, direction) => {
-        const payload = action.payload as SupportStickPayload | undefined;
-        if (!payload?.stick) return false;
-        if (direction === 'undo') {
-          addStick(payload.stick);
-        } else {
-          removeStick(payload.stick.id);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_REMOVE_BRACE, (action, direction) => {
-        const payload = action.payload as BraceLinkPayload | undefined;
-        if (!payload?.brace) return false;
-        if (direction === 'undo') {
-          if (payload.startKnot) addKnot(payload.startKnot);
-          if (payload.endKnot) addKnot(payload.endKnot);
-          addBrace(payload.brace);
-        } else {
-          removeBrace(payload.brace.id);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_ADD_KICKSTAND, (action, direction) => {
-        const payload = action.payload as SupportKickstandPayload | undefined;
-        if (!payload?.build) return false;
-        if (direction === 'undo') {
-          removeKickstandCascade(payload.build.kickstand.id);
-        } else {
-          addKickstand(payload.build);
-          addRoot(payload.build.root);
-          addKnot(payload.build.hostKnot);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_REMOVE_KICKSTAND, (action, direction) => {
-        const payload = action.payload as SupportKickstandRemovePayload | undefined;
-        if (!payload?.build) return false;
-        if (direction === 'undo') {
-          addRoot(payload.build.root);
-          addKickstand(payload.build);
-          addKnot(payload.build.hostKnot);
-          for (const knot of payload.knots ?? []) addKnot(knot);
-          for (const leaf of payload.leaves ?? []) addLeaf(leaf);
-          for (const brace of payload.braces ?? []) addBrace(brace);
-          for (const kickstand of payload.kickstands ?? []) {
-            addKickstand(kickstand);
-            addRoot(kickstand.root);
-            addKnot(kickstand.hostKnot);
-          }
-          for (const branch of payload.branches ?? []) addBranch(branch);
-        } else {
-          removeKickstandCascade(payload.build.kickstand.id);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_UPDATE_TRUNK, (action, direction) => {
-        const payload = action.payload as SupportTrunkUpdatePayload | undefined;
-        if (!payload?.before || !payload?.after) return false;
-        clearSupportSelection();
-        if (direction === 'undo') {
-          updateTrunk(payload.before);
-        } else {
-          updateTrunk(payload.after);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_UPDATE_BRANCH, (action, direction) => {
-        const payload = action.payload as SupportBranchUpdatePayload | undefined;
-        if (!payload?.before || !payload?.after) return false;
-        clearSupportSelection();
-        if (direction === 'undo') {
-          updateBranch(payload.before);
-        } else {
-          updateBranch(payload.after);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_REPLACE_TRUNK, (action, direction) => {
-        const payload = action.payload as SupportReplaceTrunkPayload | undefined;
-        if (!payload?.before || !payload?.after) return false;
-        clearSupportSelection();
-        if (direction === 'undo') {
-          setSnapshot(payload.before);
-        } else {
-          setSnapshot(payload.after);
-        }
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_EDIT_REPLACE, (action, direction) => {
-        const payload = action.payload as SupportReplaceStatePayload | undefined;
-        if (!payload?.before || !payload?.after) return false;
-        applySnapshotHistory(payload, direction);
-        return true;
-      }),
-      registerHistoryHandler(SUPPORT_AUTO_BRACE_REPLACE, (action, direction) => {
-        const payload = action.payload as SupportReplaceStatePayload | undefined;
-        if (!payload?.before || !payload?.after) return false;
-        applySnapshotHistory(payload, direction);
-        return true;
-      }),
-    ];
+  return () => {
+    unregisters.forEach((fn) => fn());
+  };
+}
 
-    return () => {
-      unregisters.forEach((fn) => fn());
-    };
-  }, [enabled]);
+/** Binds {@link registerSupportHistoryHandlers} to the lifetime of the app. */
+export function useSupportHistoryHandlers() {
+  useEffect(() => registerSupportHistoryHandlers(), []);
 }

--- a/src/supports/history/useSupportHistoryHandlers.ts
+++ b/src/supports/history/useSupportHistoryHandlers.ts
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-import { registerHistoryHandler } from '@/history/historyStore';
 import {
   SUPPORT_ADD_TRUNK,
   SUPPORT_ADD_LEAF,
@@ -22,22 +21,9 @@ import {
   SUPPORT_REPLACE_TRUNK,
   SUPPORT_EDIT_REPLACE,
   SUPPORT_AUTO_BRACE_REPLACE,
-  SupportLeafPayload,
-  SupportBranchPayload,
-  SupportTwigPayload,
-  SupportTwigRemovePayload,
-  SupportStickPayload,
-  SupportBranchRemovePayload,
-  BraceLinkPayload,
-  SupportTrunkPayload,
-  SupportTrunkUpdatePayload,
-  SupportBranchUpdatePayload,
-  SupportReplaceTrunkPayload,
   SupportReplaceStatePayload,
-  SupportAnchorPayload,
-  SupportKickstandPayload,
-  SupportKickstandRemovePayload,
 } from './actionTypes';
+import { registerSupportHistoryHandler } from './supportHistory';
 import { addAnchor, addKnot, addLeaf, addRoot, addTrunk, addBranch, addTwig, addStick, addBrace, removeAnchor, removeLeaf, removeTrunk, removeBranch, removeTwig, removeStick, removeBrace, removeKickstandCascade, updateTrunk, updateBranch, updateKnot, setSnapshot } from '../state';
 import { addKickstand, setKickstandSnapshot } from '../SupportTypes/Kickstand/kickstandStore';
 import { clearSupportSelection } from '../interaction/shared/selection/selectionController';
@@ -66,8 +52,7 @@ function applySnapshotHistory(payload: SupportReplaceStatePayload, direction: 'u
  */
 export function registerSupportHistoryHandlers(): () => void {
   const unregisters = [
-    registerHistoryHandler(SUPPORT_ADD_TRUNK, (action, direction) => {
-      const payload = action.payload as SupportTrunkPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_ADD_TRUNK, (payload, direction) => {
       if (!payload?.trunk) return false;
       if (direction === 'undo') {
         removeTrunk(payload.trunk.id);
@@ -77,8 +62,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_ADD_LEAF, (action, direction) => {
-      const payload = action.payload as SupportLeafPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_ADD_LEAF, (payload, direction) => {
       if (!payload?.leaf) return false;
       if (direction === 'undo') {
         removeLeaf(payload.leaf.id);
@@ -88,8 +72,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_ADD_BRANCH, (action, direction) => {
-      const payload = action.payload as SupportBranchPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_ADD_BRANCH, (payload, direction) => {
       if (!payload?.branch) return false;
       if (direction === 'undo') {
         removeBranch(payload.branch.id);
@@ -111,8 +94,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_ADD_TWIG, (action, direction) => {
-      const payload = action.payload as SupportTwigPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_ADD_TWIG, (payload, direction) => {
       if (!payload?.twig) return false;
       if (direction === 'undo') {
         removeTwig(payload.twig.id);
@@ -121,8 +103,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_ADD_STICK, (action, direction) => {
-      const payload = action.payload as SupportStickPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_ADD_STICK, (payload, direction) => {
       if (!payload?.stick) return false;
       if (direction === 'undo') {
         removeStick(payload.stick.id);
@@ -131,8 +112,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_ADD_BRACE, (action, direction) => {
-      const payload = action.payload as BraceLinkPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_ADD_BRACE, (payload, direction) => {
       if (!payload?.brace) return false;
       if (direction === 'undo') {
         removeBrace(payload.brace.id);
@@ -143,8 +123,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_ADD_ANCHOR, (action, direction) => {
-      const payload = action.payload as SupportAnchorPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_ADD_ANCHOR, (payload, direction) => {
       if (!payload?.anchor) return false;
       if (direction === 'undo') {
         removeAnchor(payload.anchor.id);
@@ -153,8 +132,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_REMOVE_ANCHOR, (action, direction) => {
-      const payload = action.payload as SupportAnchorPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_REMOVE_ANCHOR, (payload, direction) => {
       if (!payload?.anchor) return false;
       if (direction === 'undo') {
         addAnchor(payload.anchor);
@@ -163,8 +141,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_REMOVE_TRUNK, (action, direction) => {
-      const payload = action.payload as SupportTrunkPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_REMOVE_TRUNK, (payload, direction) => {
       if (!payload?.trunk) return false;
       if (direction === 'undo') {
         if (payload.root) addRoot(payload.root);
@@ -183,8 +160,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_REMOVE_LEAF, (action, direction) => {
-      const payload = action.payload as SupportLeafPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_REMOVE_LEAF, (payload, direction) => {
       if (!payload?.leaf) return false;
       if (direction === 'undo') {
         if (payload.knot) addKnot(payload.knot);
@@ -194,8 +170,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_REMOVE_BRANCH, (action, direction) => {
-      const payload = action.payload as SupportBranchRemovePayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_REMOVE_BRANCH, (payload, direction) => {
       if (!payload?.branches || payload.branches.length === 0) return false;
       if (direction === 'undo') {
         for (const knot of payload.knots ?? []) addKnot(knot);
@@ -225,8 +200,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_REMOVE_TWIG, (action, direction) => {
-      const payload = action.payload as SupportTwigRemovePayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_REMOVE_TWIG, (payload, direction) => {
       if (!payload?.twig) return false;
       if (direction === 'undo') {
         addTwig(payload.twig);
@@ -241,8 +215,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_REMOVE_STICK, (action, direction) => {
-      const payload = action.payload as SupportStickPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_REMOVE_STICK, (payload, direction) => {
       if (!payload?.stick) return false;
       if (direction === 'undo') {
         addStick(payload.stick);
@@ -251,8 +224,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_REMOVE_BRACE, (action, direction) => {
-      const payload = action.payload as BraceLinkPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_REMOVE_BRACE, (payload, direction) => {
       if (!payload?.brace) return false;
       if (direction === 'undo') {
         if (payload.startKnot) addKnot(payload.startKnot);
@@ -263,8 +235,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_ADD_KICKSTAND, (action, direction) => {
-      const payload = action.payload as SupportKickstandPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_ADD_KICKSTAND, (payload, direction) => {
       if (!payload?.build) return false;
       if (direction === 'undo') {
         removeKickstandCascade(payload.build.kickstand.id);
@@ -275,8 +246,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_REMOVE_KICKSTAND, (action, direction) => {
-      const payload = action.payload as SupportKickstandRemovePayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_REMOVE_KICKSTAND, (payload, direction) => {
       if (!payload?.build) return false;
       if (direction === 'undo') {
         addRoot(payload.build.root);
@@ -296,8 +266,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_UPDATE_TRUNK, (action, direction) => {
-      const payload = action.payload as SupportTrunkUpdatePayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_UPDATE_TRUNK, (payload, direction) => {
       if (!payload?.before || !payload?.after) return false;
       clearSupportSelection();
       if (direction === 'undo') {
@@ -307,8 +276,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_UPDATE_BRANCH, (action, direction) => {
-      const payload = action.payload as SupportBranchUpdatePayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_UPDATE_BRANCH, (payload, direction) => {
       if (!payload?.before || !payload?.after) return false;
       clearSupportSelection();
       if (direction === 'undo') {
@@ -318,8 +286,7 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_REPLACE_TRUNK, (action, direction) => {
-      const payload = action.payload as SupportReplaceTrunkPayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_REPLACE_TRUNK, (payload, direction) => {
       if (!payload?.before || !payload?.after) return false;
       clearSupportSelection();
       if (direction === 'undo') {
@@ -329,14 +296,12 @@ export function registerSupportHistoryHandlers(): () => void {
       }
       return true;
     }),
-    registerHistoryHandler(SUPPORT_EDIT_REPLACE, (action, direction) => {
-      const payload = action.payload as SupportReplaceStatePayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_EDIT_REPLACE, (payload, direction) => {
       if (!payload?.before || !payload?.after) return false;
       applySnapshotHistory(payload, direction);
       return true;
     }),
-    registerHistoryHandler(SUPPORT_AUTO_BRACE_REPLACE, (action, direction) => {
-      const payload = action.payload as SupportReplaceStatePayload | undefined;
+    registerSupportHistoryHandler(SUPPORT_AUTO_BRACE_REPLACE, (payload, direction) => {
       if (!payload?.before || !payload?.after) return false;
       applySnapshotHistory(payload, direction);
       return true;


### PR DESCRIPTION
The history seam (where a `push` meets its undo/redo handler) collapsed two very different failures into one `false`:

- **No handler yet** (transient): handler registration runs in a `useEffect` that can land *after* the first push. The old code silently and permanently dropped the entry on undo.
- **Handler declined** (stable): it ran but refused (the state it needed is gone); retrying won't help.

`dispatch()` now returns `'applied' | 'no-handler' | 'declined'`: applied moves the entry across stacks, **no-handler keeps** it (replays once the handler registers), **declined discards** it so it can't pin the top of the stack and block undo of everything beneath. Concrete case fixed: the `SCENE_SLICED` marker had no handler, so undoing onto it stranded the stack.

New `createTypedHistory<M>()` façade to bind each action type to its payload and confine the store-boundary cast to one place. Supports get a single-source-of-truth `SupportHistoryPayloadMap`; all push sites route through `pushSupportHistory` and handlers receive the payload already narrowed (casts gone). Scene and mesh-smoothing migrated to the same façade; support handlers now register at app root. `AGENTS.md` records the invariant: anything that lands on the stack needs a registered handler, pass-through if nothing else.

New `historyStore.test.ts` covering the distinction — keeps unhandled entries, replays them on late registration, discards declined ones, and verifies a declined entry doesn't block undo beneath it.