### PR TITLE
Make remaining hardcoded hotkeys editable

### DIFF
--- a/src/components/settings/HotkeysSettingsTab.tsx
+++ b/src/components/settings/HotkeysSettingsTab.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { Keyboard, RotateCcw } from 'lucide-react';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
 import { HotkeyBinding } from '@/hotkeys/hotkeyConfig';
+import { resumeHotkeyDispatch, suspendHotkeyDispatch } from '@/hotkeys/HotkeyRegistryManager';
 import { SECONDARY_DELETE_KEY } from '@/features/delete/useDeleteHotkey';
 
 const PINNED_SLOT_LABELS: Record<string, string> = {
@@ -91,6 +92,10 @@ export function HotkeysSettingsTab() {
   useEffect(() => {
     if (!recordingKey) return;
 
+    // Silence the app while recording: otherwise the key being captured also reaches
+    // its normal handlers — Escape would close Settings instead of cancelling here.
+    suspendHotkeyDispatch();
+
     let pressedNonModifier = false;
 
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -168,6 +173,7 @@ export function HotkeysSettingsTab() {
     return () => {
       window.removeEventListener('keydown', handleKeyDown, true);
       window.removeEventListener('keyup', handleKeyUp, true);
+      resumeHotkeyDispatch();
     };
   }, [recordingKey, config, updateHotkey]);
 

--- a/src/components/settings/HotkeysSettingsTab.tsx
+++ b/src/components/settings/HotkeysSettingsTab.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { Keyboard, RotateCcw } from 'lucide-react';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
 import { HotkeyBinding } from '@/hotkeys/hotkeyConfig';
+import { SECONDARY_DELETE_KEY } from '@/features/delete/useDeleteHotkey';
 
 const PINNED_SLOT_LABELS: Record<string, string> = {
   SLOT_1: 'Slot 1',
@@ -83,7 +84,7 @@ function getBindingTokens(binding: HotkeyBinding): string[] {
 }
 
 export function HotkeysSettingsTab() {
-  const { config, updateHotkey, resetToDefaults } = useHotkeyConfig();
+  const { config, updateHotkey, resetCategories } = useHotkeyConfig();
   const [recordingKey, setRecordingKey] = useState<{ category: string, action: string } | null>(null);
 
   // Effect to handle key recording
@@ -256,6 +257,21 @@ export function HotkeysSettingsTab() {
             {section.description}
           </p>
         </div>
+
+        <button
+          type="button"
+          onClick={() => resetCategories(section.categories.map((category) => category.category))}
+          title="Reset section to default shortcuts"
+          aria-label={`Reset ${section.title} section to default shortcuts`}
+          className="inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md border transition-colors hover:brightness-125"
+          style={{
+            borderColor: 'color-mix(in srgb, var(--success), transparent 55%)',
+            background: 'color-mix(in srgb, var(--success), transparent 88%)',
+            color: 'var(--success)',
+          }}
+        >
+          <RotateCcw className="h-3.5 w-3.5" />
+        </button>
       </div>
 
       <div className="mt-2 space-y-2">
@@ -267,16 +283,20 @@ export function HotkeysSettingsTab() {
               </div>
             )}
 
-            {category.entries.map((entry) => (
-              <HotkeyRow
-                key={`${category.category}-${entry.action}`}
-                label={entry.label}
-                binding={entry.binding}
-                isRecording={recordingKey?.category === category.category && recordingKey?.action === entry.action}
-                onRecord={() => setRecordingKey({ category: category.category, action: entry.action })}
-                onCancel={() => setRecordingKey(null)}
-              />
-            ))}
+            {category.entries.map((entry) => {
+              const isDeleteAction = category.category === 'GLOBAL' && entry.action === 'DELETE';
+              return (
+                <HotkeyRow
+                  key={`${category.category}-${entry.action}`}
+                  label={entry.label}
+                  binding={entry.binding}
+                  isRecording={recordingKey?.category === category.category && recordingKey?.action === entry.action}
+                  onRecord={() => setRecordingKey({ category: category.category, action: entry.action })}
+                  onCancel={() => setRecordingKey(null)}
+                  secondaryToken={isDeleteAction ? toKeyLabel(SECONDARY_DELETE_KEY) : undefined}
+                />
+              );
+            })}
           </div>
         ))}
       </div>
@@ -295,25 +315,6 @@ export function HotkeysSettingsTab() {
             </div>
           ))}
         </div>
-      </div>
-
-      <div
-        className="mt-auto flex items-center justify-end border-t pt-2"
-        style={{ borderColor: 'var(--border-subtle)' }}
-      >
-        <button
-          type="button"
-          onClick={resetToDefaults}
-          className="ui-button ui-button-secondary !h-8 !px-3 !py-0 text-xs inline-flex items-center gap-1 rounded-md"
-          style={{
-            color: 'var(--accent-secondary-action-color)',
-            borderColor: 'var(--accent-secondary-action-border)',
-            background: 'var(--accent-secondary-action-bg-92)',
-          }}
-        >
-          <RotateCcw className="w-3.5 h-3.5" />
-          Reset to Defaults
-        </button>
       </div>
 
       {/* Recording Overlay/Hint */}
@@ -360,26 +361,18 @@ export function HotkeysSettingsTab() {
   );
 }
 
-function HotkeyRow({ label, binding, isRecording, onRecord, onCancel }: {
+function HotkeyRow({ label, binding, isRecording, onRecord, onCancel, secondaryToken }: {
   label: string,
   binding: HotkeyBinding,
   isRecording: boolean,
   onRecord: () => void,
-  onCancel: () => void
+  onCancel: () => void,
+  secondaryToken?: string,
 }) {
   const tokens = getBindingTokens(binding);
 
   return (
-    <button
-      type="button"
-      onClick={(event) => {
-        event.stopPropagation();
-        if (isRecording) {
-          onCancel();
-        } else {
-          onRecord();
-        }
-      }}
+    <div
       className="flex w-full items-center justify-between gap-2 rounded-md border px-2 py-1.5 transition-colors"
       style={isRecording
         ? {
@@ -397,26 +390,53 @@ function HotkeyRow({ label, binding, isRecording, onRecord, onCancel }: {
         {label}
       </span>
 
-      <span className="inline-flex min-w-[108px] items-center justify-center gap-1">
-        {isRecording ? (
-          <span className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Press keys…</span>
-        ) : (
-          tokens.map((token) => <KbdToken key={`${binding.description}-${token}`}>{token}</KbdToken>)
+      <span className="inline-flex items-center justify-end gap-1">
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            if (isRecording) {
+              onCancel();
+            } else {
+              onRecord();
+            }
+          }}
+          title={isRecording ? 'Cancel' : 'Click to change'}
+          className="inline-flex min-w-[92px] items-center justify-center gap-1 rounded-md px-1 py-0.5 transition-colors hover:brightness-110"
+        >
+          {isRecording ? (
+            <span className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Press keys…</span>
+          ) : (
+            tokens.map((token) => <KbdToken key={`${binding.description}-${token}`}>{token}</KbdToken>)
+          )}
+        </button>
+
+        {!isRecording && secondaryToken && (
+          <span className="inline-flex items-center gap-1" title="Always available">
+            <span className="text-[10px]" style={{ color: 'var(--text-muted)' }} aria-hidden>/</span>
+            <KbdToken muted>{secondaryToken}</KbdToken>
+          </span>
         )}
       </span>
-    </button>
+    </div>
   );
 }
 
-function KbdToken({ children }: { children: React.ReactNode }) {
+function KbdToken({ children, muted = false }: { children: React.ReactNode, muted?: boolean }) {
   return (
     <kbd
       className="inline-flex min-w-[20px] items-center justify-center rounded border px-1 py-1 font-mono text-[10px]"
-      style={{
-        borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 50%)',
-        background: 'color-mix(in srgb, var(--surface-2), transparent 4%)',
-        color: 'var(--text-strong)',
-      }}
+      style={muted
+        ? {
+          borderColor: 'var(--border-subtle)',
+          background: 'color-mix(in srgb, var(--surface-2), transparent 40%)',
+          color: 'var(--text-muted)',
+        }
+        : {
+          borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 50%)',
+          background: 'color-mix(in srgb, var(--surface-2), transparent 4%)',
+          color: 'var(--text-strong)',
+        }}
     >
       {children}
     </kbd>

--- a/src/components/settings/HotkeysSettingsTab.tsx
+++ b/src/components/settings/HotkeysSettingsTab.tsx
@@ -4,7 +4,9 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { Keyboard, RotateCcw } from 'lucide-react';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
 import { HotkeyBinding } from '@/hotkeys/hotkeyConfig';
+import { getBindingTokens, toKeyLabel } from '@/hotkeys/hotkeyLabels';
 import { resumeHotkeyDispatch, suspendHotkeyDispatch } from '@/hotkeys/HotkeyRegistryManager';
+import { usePlatformModifier } from '@/hooks/usePlatformModifier';
 import { SECONDARY_DELETE_KEY } from '@/features/delete/useDeleteHotkey';
 
 const PINNED_SLOT_LABELS: Record<string, string> = {
@@ -57,32 +59,11 @@ const SECTION_GROUPS: Array<{
   },
 ];
 
-function toModifierLabel(modifier: string): string {
-  const normalized = modifier.trim().toLowerCase();
-  if (normalized === 'ctrl') return 'Ctrl';
-  if (normalized === 'shift') return 'Shift';
-  if (normalized === 'alt') return 'Alt';
-  if (normalized === 'meta') return 'Meta';
-  return modifier;
-}
-
-function toKeyLabel(key: string): string {
-  if (key.length === 1) return key.toUpperCase();
-  if (key.toLowerCase() === ' ') return 'Space';
-  return key;
-}
-
 function normalizeRecordedKey(rawKey: string): string {
   if (rawKey === ' ') return 'Space';
   return rawKey.length === 1 ? rawKey.toLowerCase() : rawKey;
 }
 
-function getBindingTokens(binding: HotkeyBinding): string[] {
-  const modifierTokens = binding.modifier
-    ? binding.modifier.split('+').map(toModifierLabel)
-    : [];
-  return [...modifierTokens, toKeyLabel(binding.key)];
-}
 
 export function HotkeysSettingsTab() {
   const { config, updateHotkey, resetCategories } = useHotkeyConfig();
@@ -375,7 +356,8 @@ function HotkeyRow({ label, binding, isRecording, onRecord, onCancel, secondaryT
   onCancel: () => void,
   secondaryToken?: string,
 }) {
-  const tokens = getBindingTokens(binding);
+  const primaryModifierLabel = usePlatformModifier();
+  const tokens = getBindingTokens(binding, primaryModifierLabel);
 
   return (
     <div

--- a/src/features/delete/useDeleteHotkey.ts
+++ b/src/features/delete/useDeleteHotkey.ts
@@ -1,17 +1,32 @@
 import { useEffect } from 'react';
 import { triggerDelete } from './deleteRegistry';
-import { UNIVERSAL_HOTKEYS } from '@/hotkeys/hotkeyConfig';
+import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
+import { matchesConfiguredHotkeyDown } from '@/hotkeys/hotkeyConfig';
+
+// `Delete` is always available as a fixed, non-configurable secondary delete key.
+// The primary delete key is user-configurable via GLOBAL.DELETE (defaults to Backspace).
+const SECONDARY_DELETE_KEY = 'Delete';
 
 export function useDeleteHotkey() {
+  const { getHotkey } = useHotkeyConfig();
+
   useEffect(() => {
     const handleKeyDown = (event: CustomEvent) => {
-      const { key, ctrlKey, metaKey, repeat } = event.detail;
-      if (repeat || ctrlKey || metaKey) return;
-      if (!(UNIVERSAL_HOTKEYS.DELETE.keys as readonly string[]).includes(key)) return;
+      const detail = event.detail;
+      if (detail.repeat) return;
+
+      const isSecondaryDelete =
+        detail.key === SECONDARY_DELETE_KEY &&
+        !detail.ctrlKey && !detail.metaKey && !detail.altKey && !detail.shiftKey;
+
+      if (!isSecondaryDelete && !matchesConfiguredHotkeyDown(detail, getHotkey('GLOBAL', 'DELETE'))) {
+        return;
+      }
+
       triggerDelete();
     };
 
     window.addEventListener('app-hotkey-keydown', handleKeyDown as EventListener);
     return () => window.removeEventListener('app-hotkey-keydown', handleKeyDown as EventListener);
-  }, []);
+  }, [getHotkey]);
 }

--- a/src/features/delete/useDeleteHotkey.ts
+++ b/src/features/delete/useDeleteHotkey.ts
@@ -5,7 +5,7 @@ import { matchesConfiguredHotkeyDown } from '@/hotkeys/hotkeyConfig';
 
 // `Delete` is always available as a fixed, non-configurable secondary delete key.
 // The primary delete key is user-configurable via GLOBAL.DELETE (defaults to Backspace).
-const SECONDARY_DELETE_KEY = 'Delete';
+export const SECONDARY_DELETE_KEY = 'Delete';
 
 export function useDeleteHotkey() {
   const { getHotkey } = useHotkeyConfig();

--- a/src/features/supports/useSupportInteractionManager.ts
+++ b/src/features/supports/useSupportInteractionManager.ts
@@ -140,11 +140,6 @@ function resolveSupportOwnerFromJointId(jointId: string): { category: 'brace'; i
   return null;
 }
 
-function getNativeEventSource(source: unknown): unknown {
-  if (!source || typeof source !== 'object') return null;
-  return (source as { nativeEvent?: unknown }).nativeEvent ?? null;
-}
-
 export function useSupportInteractionManager({ mode }: SupportInteractionOptions) {
   // V2 Trunk Placement
   const trunkPlacementV2 = useTrunkPlacementV2();
@@ -170,7 +165,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
 
   const selectedJointId = globalSelectedCategory === 'joint' ? globalSelectedId : null;
 
-  const resolvePlacementRouting = useCallback((source: unknown) => {
+  const resolvePlacementRouting = useCallback(() => {
     const bindings = resolveSupportPlacementHotkeyBindings(getHotkey);
     return resolveSupportPlacementRouting({
       bindings,
@@ -194,8 +189,6 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
 
   // Handler for MODEL hover (used for trunk placement preview, or branch tip preview)
   const onModelHover = useCallback((hit: THREE.Intersection | null) => {
-    const nativeEvent = getNativeEventSource(hit);
-
     if (isSupportEditInteractionActive()) {
       trunkPlacementV2.onSupportHover(null);
       branchPlacement.onModelHover(null);
@@ -232,7 +225,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
       return;
     }
 
-    const routing = resolvePlacementRouting(nativeEvent ?? hit);
+    const routing = resolvePlacementRouting();
 
     if (routing.modelHoverOwner === 'leaf') {
       trunkPlacementV2.onSupportHover(null);
@@ -260,8 +253,6 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
 
   // Handler for MODEL click (trunk placement, or branch tip placement)
   const onModelClick = useCallback((hit: THREE.Intersection) => {
-    const nativeEvent = getNativeEventSource(hit);
-
     if (isSupportEditInteractionActive()) {
       return;
     }
@@ -276,7 +267,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
       return;
     }
 
-    const routing = resolvePlacementRouting(nativeEvent ?? hit);
+    const routing = resolvePlacementRouting();
 
     if (routing.modelClickOwner === 'leaf') {
       leafPlacement.onModelClick(hit);
@@ -315,8 +306,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
       return;
     }
 
-    const nativeEvent = getNativeEventSource(hit);
-    const routing = resolvePlacementRouting(nativeEvent ?? hit);
+    const routing = resolvePlacementRouting();
 
     if (routing.supportHoverOwner === 'leaf') {
       leafPlacement.onSupportHover(hit);
@@ -344,8 +334,7 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
       return;
     }
 
-    const nativeEvent = getNativeEventSource(hit);
-    const routing = resolvePlacementRouting(nativeEvent ?? hit);
+    const routing = resolvePlacementRouting();
 
     if (routing.blocksDefaultSupportPlacement) {
       return;
@@ -741,11 +730,9 @@ export function useSupportInteractionManager({ mode }: SupportInteractionOptions
         return;
       }
 
-      if (!metaKey && !ctrlKey && (key === 'Delete' || key === 'Backspace')) {
-        if (!canDeleteSelection()) return;
-        performDeleteSelection();
-        return;
-      }
+      // Deletion is handled centrally through the delete registry (registered
+      // below with priority 100), which honors the configurable GLOBAL.DELETE
+      // binding plus the fixed `Delete` secondary key. No inline delete here.
 
       if (key === 'Escape') {
         if (getSelectedId() || getResolvedPrimarySelection().selectedIds.length > 0) {

--- a/src/hotkeys/HotkeyContext.tsx
+++ b/src/hotkeys/HotkeyContext.tsx
@@ -8,7 +8,7 @@ const HOTKEY_STORAGE_KEY = 'app-hotkeys-config';
 interface HotkeyContextType {
     config: HotkeyConfig;
     updateHotkey: (category: string, action: string, newBinding: HotkeyBinding) => void;
-    resetToDefaults: () => void;
+    resetCategories: (categories: string[]) => void;
     getHotkey: (category: string, action: string) => HotkeyBinding;
 }
 
@@ -55,8 +55,20 @@ export function HotkeyProvider({ children }: { children: React.ReactNode }) {
         }));
     }, []);
 
-    const resetToDefaults = useCallback(() => {
-        setConfig(DEFAULT_KEYBINDINGS);
+    // Restores every action of the given categories — a Settings card resets all the
+    // categories it displays (e.g. the "Global" card covers GLOBAL, CAMERA, ROTATION).
+    const resetCategories = useCallback((categories: string[]) => {
+        setConfig(prev => {
+            const next = { ...prev };
+            for (const category of categories) {
+                const categoryDefaults = DEFAULT_KEYBINDINGS[category];
+                if (!categoryDefaults) continue;
+                next[category] = Object.fromEntries(
+                    Object.entries(categoryDefaults).map(([action, binding]) => [action, { ...binding }])
+                );
+            }
+            return next;
+        });
     }, []);
 
     const getHotkey = useCallback((category: string, action: string): HotkeyBinding => {
@@ -64,7 +76,7 @@ export function HotkeyProvider({ children }: { children: React.ReactNode }) {
     }, [config]);
 
     return (
-        <HotkeyContext.Provider value={{ config, updateHotkey, resetToDefaults, getHotkey }}>
+        <HotkeyContext.Provider value={{ config, updateHotkey, resetCategories, getHotkey }}>
             {children}
         </HotkeyContext.Provider>
     );

--- a/src/hotkeys/HotkeyRegistryManager.tsx
+++ b/src/hotkeys/HotkeyRegistryManager.tsx
@@ -122,8 +122,29 @@ function isCanvasElement(element: EventTarget | null): boolean {
     return tag === 'canvas';
 }
 
+// While Settings is recording a new binding, the app must stay deaf: this manager
+// registers its capture listener before the recorder's, so by the time the recorder
+// calls stopPropagation the `app-hotkey-*` events have already been dispatched and
+// acted upon (Escape closing the Settings modal, Delete deleting the selection,
+// Cmd+, reopening Settings…). Suspending dispatch at the source is what stops that.
+let dispatchSuspended = false;
+
+export function suspendHotkeyDispatch() {
+    dispatchSuspended = true;
+    hotkeyStore.getState().clearKeys();
+}
+
+export function resumeHotkeyDispatch() {
+    dispatchSuspended = false;
+    // Keys pressed while suspended never reached the store; clear so a modifier held
+    // during recording isn't left latched.
+    hotkeyStore.getState().clearKeys();
+}
+
 export function setupHotkeyListeners() {
     const handleKeyDown = (e: KeyboardEvent) => {
+        if (dispatchSuspended) return;
+
         const key = e.key.toLowerCase();
         const isMacSettingsShortcut = e.metaKey
             && !e.ctrlKey
@@ -167,6 +188,8 @@ export function setupHotkeyListeners() {
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
+        if (dispatchSuspended) return;
+
         hotkeyStore.getState().releaseKey(e.key);
 
         if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {

--- a/src/hotkeys/__tests__/hotkeyLabels.test.ts
+++ b/src/hotkeys/__tests__/hotkeyLabels.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getBindingTokens, toKeyLabel, toModifierLabel } from '../hotkeyLabels';
+
+// Regression: the Settings tab labelled a `ctrl` binding "Ctrl" on every platform,
+// while hotkeyStore resolves that same binding to Cmd on macOS — so the UI showed
+// Ctrl+Z for a shortcut that only fired on Cmd+Z.
+test('Modifier labels follow the platform primary modifier', () => {
+    assert.equal(toModifierLabel('ctrl', 'Cmd'), 'Cmd', 'macOS resolves ctrl bindings to Cmd');
+    assert.equal(toModifierLabel('ctrl', 'Ctrl'), 'Ctrl');
+
+    // `meta` is Cmd on macOS and the Windows/Super key elsewhere.
+    assert.equal(toModifierLabel('meta', 'Cmd'), 'Cmd');
+    assert.equal(toModifierLabel('meta', 'Ctrl'), 'Meta');
+
+    // Platform-independent modifiers are untouched, casing and padding normalised.
+    assert.equal(toModifierLabel('shift', 'Cmd'), 'Shift');
+    assert.equal(toModifierLabel(' ALT ', 'Cmd'), 'Alt');
+});
+
+test('Key labels stay readable', () => {
+    assert.equal(toKeyLabel('z'), 'Z', 'single characters are upper-cased');
+    assert.equal(toKeyLabel(' '), 'Space');
+    assert.equal(toKeyLabel('Backspace'), 'Backspace', 'named keys are left alone');
+});
+
+test('Binding tokens list modifiers before the key', () => {
+    assert.deepEqual(
+        getBindingTokens({ key: 'z', modifier: 'ctrl+shift', description: 'Redo' }, 'Cmd'),
+        ['Cmd', 'Shift', 'Z'],
+        'macOS renders Ctrl+Shift+Z as Cmd Shift Z',
+    );
+    assert.deepEqual(
+        getBindingTokens({ key: 'z', modifier: 'ctrl+shift', description: 'Redo' }, 'Ctrl'),
+        ['Ctrl', 'Shift', 'Z'],
+    );
+    assert.deepEqual(
+        getBindingTokens({ key: 'Backspace', description: 'Delete selected item' }, 'Cmd'),
+        ['Backspace'],
+        'a binding with no modifier is a single keycap',
+    );
+});

--- a/src/hotkeys/__tests__/hotkeyStore.test.ts
+++ b/src/hotkeys/__tests__/hotkeyStore.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { hotkeyStore, isKeyPressedSync, isActionActiveSync } from '../hotkeyStore';
-import { setupHotkeyListeners } from '../HotkeyRegistryManager';
+import { resumeHotkeyDispatch, setupHotkeyListeners, suspendHotkeyDispatch } from '../HotkeyRegistryManager';
 import { OPEN_SETTINGS_MODAL_EVENT } from '@/components/settings/settingsModalEvents';
 
 // Mock global window and HTMLElement if running in Node.js without DOM
@@ -138,6 +138,59 @@ test('Hotkey Registry: clears all active keys on window blur', () => {
     // Expect store to be cleared
     assert.equal(isKeyPressedSync('w'), false, 'Keys should be cleared on blur');
     assert.equal(isKeyPressedSync('Shift'), false, 'Keys should be cleared on blur');
+
+    cleanup();
+});
+
+// Regression: recording a shortcut in Settings used to leak the captured key into
+// the app, because this manager's capture listener runs before the recorder's and
+// had already dispatched `app-hotkey-keydown` by the time the recorder called
+// stopPropagation — so Escape closed the whole Settings modal instead of just
+// cancelling the recording.
+test('Hotkey Registry: suspended dispatch swallows keys entirely', () => {
+    hotkeyStore.getState().clearKeys();
+    const cleanup = setupHotkeyListeners();
+
+    const divTarget = new (global as any).HTMLElement('DIV');
+    let appHotkeyEvents = 0;
+    const countAppHotkey = () => { appHotkeyEvents += 1; };
+    window.addEventListener('app-hotkey-keydown', countAppHotkey);
+
+    suspendHotkeyDispatch();
+
+    dispatchWindowEvent('keydown', { key: 'Escape', target: divTarget });
+    assert.equal(appHotkeyEvents, 0, 'Escape must not reach app-hotkey listeners while recording');
+    assert.equal(isKeyPressedSync('Escape'), false, 'Suspended keys must not enter the store');
+
+    dispatchWindowEvent('keydown', { key: 'w', target: divTarget });
+    assert.equal(isKeyPressedSync('w'), false, 'No key may enter the store while suspended');
+    assert.equal(appHotkeyEvents, 0);
+
+    resumeHotkeyDispatch();
+
+    dispatchWindowEvent('keydown', { key: 'w', target: divTarget });
+    assert.equal(isKeyPressedSync('w'), true, 'Resuming must restore normal dispatch');
+    assert.equal(appHotkeyEvents, 1, 'Resumed keys dispatch app-hotkey-keydown again');
+
+    window.removeEventListener('app-hotkey-keydown', countAppHotkey);
+    hotkeyStore.getState().clearKeys();
+    cleanup();
+});
+
+test('Hotkey Registry: resuming clears modifiers held during recording', () => {
+    hotkeyStore.getState().clearKeys();
+    const cleanup = setupHotkeyListeners();
+
+    const divTarget = new (global as any).HTMLElement('DIV');
+    dispatchWindowEvent('keydown', { key: 'Shift', target: divTarget });
+    assert.equal(isKeyPressedSync('Shift'), true);
+
+    // The keyup that ends a recording never reaches the store, so the modifier
+    // would stay latched forever if resuming did not clear it.
+    suspendHotkeyDispatch();
+    resumeHotkeyDispatch();
+
+    assert.equal(isKeyPressedSync('Shift'), false, 'Held modifiers must not survive a recording');
 
     cleanup();
 });

--- a/src/hotkeys/hotkeyConfig.ts
+++ b/src/hotkeys/hotkeyConfig.ts
@@ -1,23 +1,5 @@
 // Centralized configuration for application hotkeys
 
-// Universal hotkeys are hardcoded system standards and are not intended to be customizable.
-export const UNIVERSAL_HOTKEYS = {
-    DELETE: {
-        keys: ['Delete', 'Backspace'],
-        description: 'Delete selected item'
-    },
-    UNDO: {
-        key: 'z',
-        modifier: 'ctrl', // or meta
-        description: 'Undo last action'
-    },
-    REDO: {
-        key: 'z',
-        modifier: 'ctrl+shift',
-        description: 'Redo last action'
-    }
-} as const;
-
 // Default keybindings for application features.
 // These are intended to be customizable by the user in the future.
 export interface HotkeyBinding {
@@ -171,7 +153,9 @@ export const DEFAULT_KEYBINDINGS: HotkeyConfig = {
     },
     GLOBAL: {
         DELETE: {
-            key: 'Delete',
+            // `Delete` is always available as a fixed secondary delete key (see
+            // useDeleteHotkey); this configurable binding defaults to `Backspace`.
+            key: 'Backspace',
             description: 'Delete selected item'
         },
         UNDO: {

--- a/src/hotkeys/hotkeyLabels.ts
+++ b/src/hotkeys/hotkeyLabels.ts
@@ -1,0 +1,30 @@
+import type { HotkeyBinding } from './hotkeyConfig';
+
+// Turning a binding into keycaps is display-only, but it must agree with how the
+// store resolves that binding at runtime: hotkeyStore maps a configured `ctrl`
+// onto the platform's primary modifier, which is Cmd on macOS. Labelling it
+// "Ctrl" there would advertise a shortcut that does not exist.
+export function toModifierLabel(modifier: string, primaryModifierLabel: string): string {
+    const normalized = modifier.trim().toLowerCase();
+    if (normalized === 'ctrl') return primaryModifierLabel;
+    if (normalized === 'shift') return 'Shift';
+    if (normalized === 'alt') return 'Alt';
+    // `meta` is physically Cmd on macOS, and the Windows/Super key elsewhere.
+    if (normalized === 'meta') return primaryModifierLabel === 'Cmd' ? 'Cmd' : 'Meta';
+    return modifier;
+}
+
+export function toKeyLabel(key: string): string {
+    // Space first: it is one character long, so an upper-case pass would render it
+    // as a blank keycap and the branch below would never be reached.
+    if (key === ' ') return 'Space';
+    if (key.length === 1) return key.toUpperCase();
+    return key;
+}
+
+export function getBindingTokens(binding: HotkeyBinding, primaryModifierLabel: string): string[] {
+    const modifierTokens = binding.modifier
+        ? binding.modifier.split('+').map((modifier) => toModifierLabel(modifier, primaryModifierLabel))
+        : [];
+    return [...modifierTokens, toKeyLabel(binding.key)];
+}

--- a/src/hotkeys/useUndoRedoHotkeys.ts
+++ b/src/hotkeys/useUndoRedoHotkeys.ts
@@ -1,38 +1,29 @@
 import { useEffect } from 'react';
 import { redo, undo } from '@/history/historyStore';
-import { hotkeyStore, isPrimaryModifierPressed } from './hotkeyStore';
+import { hotkeyStore, isActionActiveSync } from './hotkeyStore';
 
 export function useUndoRedoHotkeys({ disabled = false }: { disabled?: boolean } = {}) {
   useEffect(() => {
     if (disabled) return;
 
-    let wasZPressed = false;
-    let wasYPressed = false;
+    let wasUndoActive = false;
+    let wasRedoActive = false;
 
-    const unsubscribe = hotkeyStore.subscribe((state) => {
-      const active = state.activeKeys;
-      const hasPrimaryModifier = isPrimaryModifierPressed(active);
-      const hasShift = active.has('shift');
-      const hasZ = active.has('z');
-      const hasY = active.has('y');
+    const unsubscribe = hotkeyStore.subscribe(() => {
+      // Undo/Redo are user-configurable via GLOBAL.UNDO / GLOBAL.REDO. Redo is a
+      // strict superset of Undo (adds Shift by default), so it is checked first;
+      // isActionActiveSync also suppresses Undo whenever Redo is the active match.
+      const isUndoActive = isActionActiveSync('GLOBAL', 'UNDO');
+      const isRedoActive = isActionActiveSync('GLOBAL', 'REDO');
 
-      const isZJustPressed = hasZ && !wasZPressed;
-      const isYJustPressed = hasY && !wasYPressed;
-
-      if (hasPrimaryModifier) {
-        if (isYJustPressed) {
-          redo();
-        } else if (isZJustPressed) {
-          if (hasShift) {
-            redo();
-          } else {
-            undo();
-          }
-        }
+      if (isRedoActive && !wasRedoActive) {
+        redo();
+      } else if (isUndoActive && !wasUndoActive) {
+        undo();
       }
 
-      wasZPressed = hasZ;
-      wasYPressed = hasY;
+      wasUndoActive = isUndoActive;
+      wasRedoActive = isRedoActive;
     });
 
     return unsubscribe;


### PR DESCRIPTION
We were still maintaining a UNIVERSAL_HOTKEYS table that completely
ignored GLOBAL bindings, so Delete/Undo/Redo shortcuts couldn't be remapped.
Now even the Delete action can be remapped, but left the `Delete` keypress as an
immutable secondary hotkey, which closes #435.

While at it, I added a per-card Reset to defaults button, fixed that Esc took you
out of Settings entirely instead of the recording modal, and showed Cmd instead
of Ctrl on macOS.

Added some unit tests and verified that everything passes.