### PR TITLE
fix: Remove the non-manifold overlay from the supports tab

### DIFF
--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -5475,8 +5475,10 @@ export function SceneCanvas({
                 // The native repair/classify routines end with a manifold_csg
                 // status check on the model section. When the CSG backend reports
                 // any non-manifold status, overlay a red stripe pattern on
-                // the model to flag it.
+                // the model to flag it. Suppressed in the support tab so it
+                // doesn't obscure support editing.
                 const modelIsNonManifold =
+                  mode !== 'support' &&
                   model.geometry.meshDefects?.nativeRepairReport?.model_is_manifold === false;
 
                 return (


### PR DESCRIPTION
Users report difficulty seeing the island scanner vertex shader on non-manifold meshes, so this PR is set to remove the shader on the supports tab to allow usability.