### PR TITLE
fix(voxl): VOXL autosave and decimated vs original mesh handling in VOXL format saves

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test": "node --import tsx --test 'src/**/*.test.{ts,tsx}'",
     "test:watch": "node --import tsx --test --watch 'src/**/*.test.{ts,tsx}'",
     "bench:support-drag": "node --import tsx scripts/support-drag-perf.ts",
+    "bench:voxl-tick": "node --max-old-space-size=8192 --import tsx scripts/bench-voxl-tick.ts",
     "i18n:extract": "lingui extract --clean",
     "i18n:compile": "lingui compile",
     "i18n:update": "lingui extract --clean && lingui compile"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "macos:thumbnails": "node scripts/macos-thumbnails.mjs",
     "guard:plugin-boundaries": "node scripts/check-plugin-boundaries.mjs",
     "lint": "eslint",
+    "pretest": "npm run generate:plugin-registry && npm run generate:builtin-simple-plugins",
     "test": "node --import tsx --test 'src/**/*.test.{ts,tsx}'",
     "test:watch": "node --import tsx --test --watch 'src/**/*.test.{ts,tsx}'",
     "bench:support-drag": "node --import tsx scripts/support-drag-perf.ts",

--- a/rust/dragonfruit-cli/Cargo.lock
+++ b/rust/dragonfruit-cli/Cargo.lock
@@ -301,12 +301,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
 name = "dragonfruit-cli"
 version = "0.1.0"
 dependencies = [
  "clap",
  "dragonfruit-islands",
  "dragonfruit-slicing-engine",
+ "flate2",
  "proptest",
  "serde",
  "serde_json",
@@ -342,6 +353,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sysinfo",
  "thiserror",
  "time",
  "time-core",
@@ -578,6 +590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +611,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -876,6 +954,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,16 +1118,142 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]

--- a/rust/dragonfruit-cli/Cargo.toml
+++ b/rust/dragonfruit-cli/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
+flate2 = "1"
 
 [dev-dependencies]
 proptest = "1.9.0"

--- a/rust/dragonfruit-cli/src/io.rs
+++ b/rust/dragonfruit-cli/src/io.rs
@@ -577,44 +577,86 @@ pub fn load_voxl_triangles(path: &Path) -> Result<(Vec<f32>, bool), String> {
     let orig_chunk_indices: Vec<u16> = entries.iter().filter(|e| &e.type_tag == b"ORIG").map(|e| e.index).collect();
     let mesh_chunk_indices: Vec<u16> = entries.iter().filter(|e| &e.type_tag == b"MESH").map(|e| e.index).collect();
 
-    let model_indices = if !orig_chunk_indices.is_empty() {
+    // 1. If embedded ORIG chunks are present, load them
+    if !orig_chunk_indices.is_empty() {
         let mut idxs = orig_chunk_indices;
         idxs.sort();
         idxs.dedup();
-        idxs
-    } else {
-        let mut idxs = mesh_chunk_indices;
-        idxs.sort();
-        idxs.dedup();
-        idxs
-    };
+        let mut all_positions = Vec::new();
+        for &idx in &idxs {
+            if let Some(entry) = entries.iter().find(|e| &e.type_tag == b"ORIG" && e.index == idx) {
+                let chunk_bytes = read_chunk_data(entry)?;
+                let pos = parse_binary_stl_bytes(&chunk_bytes)?;
+                all_positions.extend_from_slice(&pos);
+            }
+        }
+        return Ok((all_positions, true));
+    }
 
-    if model_indices.is_empty() {
+    // 2. Check for originalRef / sidecar file references in MODL chunk if no embedded ORIG chunk exists
+    if let Some(modl_entry) = entries.iter().find(|e| &e.type_tag == b"MODL") {
+        if let Ok(modl_bytes) = read_chunk_data(modl_entry) {
+            if let Ok(modl_str) = std::str::from_utf8(&modl_bytes) {
+                if let Ok(models) = serde_json::from_str::<serde_json::Value>(modl_str) {
+                    if let Some(model_list) = models.as_array() {
+                        let mut sidecar_positions = Vec::new();
+                        let mut loaded_sidecars = 0;
+
+                        for model in model_list {
+                            let file_name = model.get("originalRef")
+                                .and_then(|r| r.get("fileName"))
+                                .and_then(|v| v.as_str())
+                                .or_else(|| model.get("sourcePath").and_then(|v| v.as_str()));
+
+                            if let Some(fname) = file_name {
+                                let fname_trimmed = fname.trim();
+                                if !fname_trimmed.is_empty() {
+                                    let rel_path = Path::new(fname_trimmed);
+                                    let sidecar_path = if rel_path.is_absolute() {
+                                        rel_path.to_path_buf()
+                                    } else {
+                                        path.parent().unwrap_or_else(|| Path::new("")).join(rel_path)
+                                    };
+
+                                    if sidecar_path.exists() {
+                                        if let Ok(pos) = load_binary_stl(&sidecar_path) {
+                                            sidecar_positions.extend_from_slice(&pos);
+                                            loaded_sidecars += 1;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        if loaded_sidecars > 0 && !sidecar_positions.is_empty() {
+                            return Ok((sidecar_positions, true));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // 3. Fallback: load MESH chunks (decimated preview)
+    let mut idxs = mesh_chunk_indices;
+    idxs.sort();
+    idxs.dedup();
+
+    if idxs.is_empty() {
         return Err("No MESH or ORIG geometry chunks found in VOXL file".into());
     }
 
-    let mut used_orig = false;
     let mut all_positions = Vec::new();
 
-    for &idx in &model_indices {
-        let (entry, is_orig) = if let Some(e) = entries.iter().find(|e| &e.type_tag == b"ORIG" && e.index == idx) {
-            (e, true)
-        } else if let Some(e) = entries.iter().find(|e| &e.type_tag == b"MESH" && e.index == idx) {
-            (e, false)
-        } else {
-            continue;
-        };
-
-        if is_orig {
-            used_orig = true;
+    for &idx in &idxs {
+        if let Some(entry) = entries.iter().find(|e| &e.type_tag == b"MESH" && e.index == idx) {
+            let chunk_bytes = read_chunk_data(entry)?;
+            let pos = parse_binary_stl_bytes(&chunk_bytes)?;
+            all_positions.extend_from_slice(&pos);
         }
-
-        let chunk_bytes = read_chunk_data(entry)?;
-        let pos = parse_binary_stl_bytes(&chunk_bytes)?;
-        all_positions.extend_from_slice(&pos);
     }
 
-    Ok((all_positions, used_orig))
+    Ok((all_positions, false))
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/dragonfruit-cli/src/io.rs
+++ b/rust/dragonfruit-cli/src/io.rs
@@ -7,8 +7,10 @@ use std::path::Path;
 
 use serde::{de::DeserializeOwned, Serialize};
 
-use dragonfruit_slicing_engine::geometry::{parse_triangles, Triangle};
-use dragonfruit_islands::model::{ComponentInfo, RleLabels, RleMask};
+use dragonfruit_slicing_engine::geometry::Triangle;
+#[cfg(test)]
+use dragonfruit_slicing_engine::geometry::parse_triangles;
+use dragonfruit_islands::model::{RleLabels, RleMask};
 
 // ---------------------------------------------------------------------------
 // STL Loading

--- a/rust/dragonfruit-cli/src/io.rs
+++ b/rust/dragonfruit-cli/src/io.rs
@@ -441,6 +441,183 @@ pub fn write_3mf(path: &Path, positions: &[f32]) -> Result<(), String> {
 }
 
 // ---------------------------------------------------------------------------
+// VOXL Loading (V2 binary + ORIG full-res chunk preference)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct VoxlChunkEntry {
+    type_tag: [u8; 4],
+    index: u16,
+    compression: u16,
+    offset: usize,
+    compressed_size: usize,
+    uncompressed_size: usize,
+}
+
+/// Helper function to parse binary STL buffer from memory.
+pub fn parse_binary_stl_bytes(data: &[u8]) -> Result<Vec<f32>, String> {
+    if data.len() < 84 {
+        return Err("STL byte buffer too small (< 84 bytes)".into());
+    }
+    let num_triangles = u32::from_le_bytes([data[80], data[81], data[82], data[83]]) as usize;
+    let expected = 84 + num_triangles * 50;
+    if data.len() < expected {
+        return Err(format!(
+            "STL bytes truncated: expected {} bytes for {} triangles, got {}",
+            expected, num_triangles, data.len()
+        ));
+    }
+    let mut flat = Vec::with_capacity(num_triangles * 9);
+    let mut offset = 84;
+    for _ in 0..num_triangles {
+        offset += 12; // skip normal
+        for _ in 0..3 {
+            flat.push(f32::from_le_bytes([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ]));
+            flat.push(f32::from_le_bytes([
+                data[offset + 4],
+                data[offset + 5],
+                data[offset + 6],
+                data[offset + 7],
+            ]));
+            flat.push(f32::from_le_bytes([
+                data[offset + 8],
+                data[offset + 9],
+                data[offset + 10],
+                data[offset + 11],
+            ]));
+            offset += 12;
+        }
+        offset += 2; // attribute byte count
+    }
+    Ok(flat)
+}
+
+/// Check if file starts with VOXL V2 binary header.
+pub fn is_voxl_file(path: &Path) -> bool {
+    if let Ok(mut file) = std::fs::File::open(path) {
+        let mut header = [0u8; 6];
+        if std::io::Read::read_exact(&mut file, &mut header).is_ok() {
+            if &header[0..4] == b"VOXL" {
+                let ver = u16::from_le_bytes([header[4], header[5]]);
+                return ver >= 2;
+            }
+        }
+    }
+    false
+}
+
+/// Load triangles from a VOXL binary file.
+/// Prefers `ORIG` (full-resolution) chunks over `MESH` (preview) chunks.
+/// Returns `(positions_f32, used_orig_chunk)`.
+pub fn load_voxl_triangles(path: &Path) -> Result<(Vec<f32>, bool), String> {
+    use flate2::read::ZlibDecoder;
+
+    let data = std::fs::read(path).map_err(|e| format!("Failed to read VOXL file: {e}"))?;
+    if data.len() < 16 {
+        return Err("VOXL file too small (< 16 bytes)".into());
+    }
+    if &data[0..4] != b"VOXL" {
+        return Err("Invalid VOXL magic header".into());
+    }
+    let ver = u16::from_le_bytes([data[4], data[5]]);
+    if ver < 2 {
+        return Err(format!("Unsupported VOXL container version: {ver}"));
+    }
+    let chunk_count = u32::from_le_bytes([data[8], data[9], data[10], data[11]]) as usize;
+    let dir_end = 16 + chunk_count * 20;
+    if data.len() < dir_end {
+        return Err("VOXL file truncated: incomplete chunk directory".into());
+    }
+
+    let mut entries = Vec::with_capacity(chunk_count);
+    for i in 0..chunk_count {
+        let b = 16 + i * 20;
+        let mut type_tag = [0u8; 4];
+        type_tag.copy_from_slice(&data[b..b + 4]);
+        let index = u16::from_le_bytes([data[b + 4], data[b + 5]]);
+        let compression = u16::from_le_bytes([data[b + 6], data[b + 7]]);
+        let offset = u32::from_le_bytes([data[b + 8], data[b + 9], data[b + 10], data[b + 11]]) as usize;
+        let compressed_size = u32::from_le_bytes([data[b + 12], data[b + 13], data[b + 14], data[b + 15]]) as usize;
+        let uncompressed_size = u32::from_le_bytes([data[b + 16], data[b + 17], data[b + 18], data[b + 19]]) as usize;
+
+        if offset + compressed_size > data.len() {
+            return Err("VOXL chunk extends beyond file boundary".into());
+        }
+
+        entries.push(VoxlChunkEntry {
+            type_tag,
+            index,
+            compression,
+            offset,
+            compressed_size,
+            uncompressed_size,
+        });
+    }
+
+    let read_chunk_data = |entry: &VoxlChunkEntry| -> Result<Vec<u8>, String> {
+        let raw = &data[entry.offset..entry.offset + entry.compressed_size];
+        match entry.compression {
+            0 => Ok(raw.to_vec()),
+            1 => {
+                let mut decoder = ZlibDecoder::new(raw);
+                let mut out = Vec::with_capacity(entry.uncompressed_size);
+                std::io::Read::read_to_end(&mut decoder, &mut out)
+                    .map_err(|e| format!("Decompress chunk failed: {e}"))?;
+                Ok(out)
+            }
+            c => Err(format!("Unsupported compression mode {c}")),
+        }
+    };
+
+    let orig_chunk_indices: Vec<u16> = entries.iter().filter(|e| &e.type_tag == b"ORIG").map(|e| e.index).collect();
+    let mesh_chunk_indices: Vec<u16> = entries.iter().filter(|e| &e.type_tag == b"MESH").map(|e| e.index).collect();
+
+    let model_indices = if !orig_chunk_indices.is_empty() {
+        let mut idxs = orig_chunk_indices;
+        idxs.sort();
+        idxs.dedup();
+        idxs
+    } else {
+        let mut idxs = mesh_chunk_indices;
+        idxs.sort();
+        idxs.dedup();
+        idxs
+    };
+
+    if model_indices.is_empty() {
+        return Err("No MESH or ORIG geometry chunks found in VOXL file".into());
+    }
+
+    let mut used_orig = false;
+    let mut all_positions = Vec::new();
+
+    for &idx in &model_indices {
+        let (entry, is_orig) = if let Some(e) = entries.iter().find(|e| &e.type_tag == b"ORIG" && e.index == idx) {
+            (e, true)
+        } else if let Some(e) = entries.iter().find(|e| &e.type_tag == b"MESH" && e.index == idx) {
+            (e, false)
+        } else {
+            continue;
+        };
+
+        if is_orig {
+            used_orig = true;
+        }
+
+        let chunk_bytes = read_chunk_data(entry)?;
+        let pos = parse_binary_stl_bytes(&chunk_bytes)?;
+        all_positions.extend_from_slice(&pos);
+    }
+
+    Ok((all_positions, used_orig))
+}
+
+// ---------------------------------------------------------------------------
 // Ensure directory exists
 // ---------------------------------------------------------------------------
 

--- a/rust/dragonfruit-cli/src/main.rs
+++ b/rust/dragonfruit-cli/src/main.rs
@@ -446,6 +446,12 @@ fn cmd_mesh_read_stl(input: &PathBuf, output: &PathBuf) -> Result<(), String> {
 fn cmd_mesh_info(input: &PathBuf, json_output: bool) -> Result<(), String> {
     let (flat, source) = if input.is_dir() {
         (read_positions_bin(&input.join("positions.bin"))?, "directory")
+    } else if is_voxl_file(input) {
+        let (positions, used_orig) = load_voxl_triangles(input)?;
+        if !json_output {
+            eprintln!("voxl info: used_orig_chunk={}", used_orig);
+        }
+        (positions, "voxl")
     } else {
         (load_binary_stl(input)?, "stl")
     };
@@ -632,7 +638,8 @@ fn cmd_track(input: &PathBuf, output: &PathBuf, overlap: i32, neighborhood: i32)
         let components: Vec<ComponentInfo> = read_json(&input.join("layers").join(format!("{:03}.components.json", l)))?;
 
         let prev_labels = if l > 0 { Some(&island_labels_all[l - 1]) } else { None };
-        let island_labels = tracker.process_layer(l as u32, &candidates, &components, prev_labels, &mask);
+        let is_top = l == num_layers.saturating_sub(1);
+        let island_labels = tracker.process_layer(l as u32, &candidates, &components, prev_labels, &mask, is_top);
 
         write_rle_labels_json(
             &output.join("layers").join(format!("{:03}.island-labels.rle.json", l)),
@@ -763,7 +770,8 @@ fn cmd_island_full(
 
     for (l, lr) in layer_results.iter().enumerate() {
         let prev_labels = if l > 0 { Some(&island_labels_all[l - 1]) } else { None };
-        let island_labels = tracker.process_layer(l as u32, &lr.labels, &lr.components, prev_labels, &lr.solid_mask);
+        let is_top = l == layer_results.len().saturating_sub(1);
+        let island_labels = tracker.process_layer(l as u32, &lr.labels, &lr.components, prev_labels, &lr.solid_mask, is_top);
         write_rle_labels_json(&output.join("layers").join(format!("{:03}.island-labels.rle.json", l)), &island_labels)?;
         let snap = tracker.get_islands();
         write_json(&output.join("tracker-state").join(format!("{:03}.islands.json", l)), &snap)?;
@@ -881,7 +889,8 @@ fn cmd_island_bench(
         let mut island_labels: Vec<RleLabels> = Vec::with_capacity(nl);
         for (l, lr) in layer_results.iter().enumerate() {
             let prev = if l > 0 { Some(&island_labels[l - 1]) } else { None };
-            let il = tracker.process_layer(l as u32, &lr.labels, &lr.components, prev, &lr.solid_mask);
+            let is_top = l == nl.saturating_sub(1);
+            let il = tracker.process_layer(l as u32, &lr.labels, &lr.components, prev, &lr.solid_mask, is_top);
             island_labels.push(il);
         }
         tracker.finalize_islands(nl.saturating_sub(1) as u32);
@@ -1064,9 +1073,16 @@ fn cmd_slice_run(
         .and_then(|e| e.to_str())
         .map(|e| e == "bin")
         .unwrap_or(false);
+    let is_voxl = is_voxl_file(input);
 
     let flat = if is_positions_bin {
         read_positions_bin(input)?
+    } else if is_voxl {
+        let (positions, used_orig) = load_voxl_triangles(input)?;
+        if !json_output {
+            eprintln!("slice: read VOXL file with {} triangles (used_orig_chunk={})", positions.len() / 9, used_orig);
+        }
+        positions
     } else {
         load_binary_stl(input)?
     };
@@ -1106,7 +1122,12 @@ fn cmd_slice_run(
         anti_aliasing_level: anti_aliasing.to_string(),
         anti_aliasing_mode: anti_aliasing_mode.to_string(),
         blur_brush_radius_px: 1,
+        blur_brush_kernel: "gaussian".to_string(),
+        blur_brush_sigma_x: 0.5,
+        blur_brush_sigma_y: 0.5,
         z_blur_radius_layers: 0,
+        z_blur_kernel: "box".to_string(),
+        z_blur_sigma: 0.5,
         aa_on_supports: false,
         model_triangle_count: (flat.len() / 9) as u32,
         mirror_x,
@@ -1118,6 +1139,9 @@ fn cmd_slice_run(
         zaa_kernel: None,
         zaa_pattern: None,
         zaa_duplicate_z: None,
+        dither_enabled: false,
+        dither_bit_depth: None,
+        dither_device_gamma: 3.0,
         triangles_xyz: flat,
         metadata_json: metadata_json.to_string(),
         format_version: format_version.clone(),
@@ -1534,6 +1558,7 @@ fn cmd_benchmark(
         anti_aliasing_mode: "Blur".to_string(),
         blur_brush_radius_px: 1,
         minimum_aa_alpha_percent: 35.0,
+        dither_enabled: false,
     };
 
     if !json_output {

--- a/rust/dragonfruit-cli/src/main.rs
+++ b/rust/dragonfruit-cli/src/main.rs
@@ -1075,16 +1075,17 @@ fn cmd_slice_run(
         .unwrap_or(false);
     let is_voxl = is_voxl_file(input);
 
-    let flat = if is_positions_bin {
-        read_positions_bin(input)?
+    let (flat, mesh_encoding) = if is_positions_bin {
+        (read_positions_bin(input)?, "positions_bin".to_string())
     } else if is_voxl {
         let (positions, used_orig) = load_voxl_triangles(input)?;
         if !json_output {
             eprintln!("slice: read VOXL file with {} triangles (used_orig_chunk={})", positions.len() / 9, used_orig);
         }
-        positions
+        let encoding = if used_orig { "voxl_orig" } else { "voxl_mesh" };
+        (positions, encoding.to_string())
     } else {
-        load_binary_stl(input)?
+        (load_binary_stl(input)?, "stl".to_string())
     };
     if flat.len() % 9 != 0 {
         return Err(format!("Invalid triangle buffer length: {}", flat.len()));
@@ -1161,6 +1162,8 @@ fn cmd_slice_run(
         "build_width_mm": build_width_mm,
         "build_depth_mm": build_depth_mm,
         "resolution_px": [source_width_px, source_height_px],
+        "model_triangle_count": job.model_triangle_count,
+        "mesh_encoding": mesh_encoding,
         "total_s": perf.total_s(),
         "wall_s": wall_s,
         "layers_per_second": perf.layers_per_second(),

--- a/scripts/bench-voxl-tick.ts
+++ b/scripts/bench-voxl-tick.ts
@@ -1,0 +1,97 @@
+/**
+ * Ph0.1 sub-phase C + E perf gate: the steady-state autosave tick.
+ *
+ * Reproduces the COW design's §1.4 corpus so the numbers stay comparable:
+ * synthetic binary STL at `84 + 50 x tri` with realistic float entropy
+ * (displaced-sphere tessellation — a zero-filled buffer compresses absurdly well
+ * and would understate the result), through the app's own fflate at zlib level 6
+ * plus SHA-256.
+ *
+ * Reports, for a 3 x 4M-tri plate:
+ *   - the one-time bake cost (paid on the operation the user is waiting for);
+ *   - the steady-state tick with BUFFERED assembly (post-C, pre-E);
+ *   - the steady-state tick with STREAMING assembly (post-E), plus the largest
+ *     contiguous allocation each path makes.
+ *
+ * Run: `npm run bench:voxl-tick`
+ */
+import { performance } from 'node:perf_hooks';
+import {
+  serializeVoxlDocumentV2,
+  serializeVoxlDocumentV2Streaming,
+  resetVoxlCodecStats,
+  voxlCodecStats,
+} from '@/features/scene/voxl/codec-v2';
+import { MeshChunkStore } from '@/features/scene/voxl/meshChunkStore';
+import type { BuildVoxlDocumentInput, VoxlModelRuntimeLike } from '@/features/scene/voxl/types';
+import type { DragonfruitImportFormat } from '@/supports/types';
+
+const EMPTY_SUPPORTS = { version: 1, meta: { source: 'bench', objectCenter: { x: 0, y: 0, z: 0 } }, roots: [] } as unknown as DragonfruitImportFormat;
+
+function stl(triangles: number, seed: number): Uint8Array {
+  const bytes = new Uint8Array(84 + 50 * triangles);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(80, triangles, true);
+  let x = seed >>> 0 || 1;
+  const rnd = () => { x ^= x << 13; x >>>= 0; x ^= x >> 17; x ^= x << 5; x >>>= 0; return x / 0xffffffff; };
+  let off = 84;
+  for (let t = 0; t < triangles; t += 1) {
+    const theta = (t / triangles) * Math.PI * 2 * 137.5;
+    const phi = Math.acos(1 - (2 * (t % 4096)) / 4096);
+    const r = 30 + Math.sin(theta * 7) * 2 + rnd() * 0.35;
+    for (let v = 0; v < 4; v += 1) {
+      const dt = v * 0.0021 + rnd() * 0.0009;
+      view.setFloat32(off, r * Math.sin(phi + dt) * Math.cos(theta + dt), true);
+      view.setFloat32(off + 4, r * Math.sin(phi + dt) * Math.sin(theta + dt), true);
+      view.setFloat32(off + 8, r * Math.cos(phi + dt), true);
+      off += 12;
+    }
+    off += 2;
+  }
+  return bytes;
+}
+
+function model(id: string): VoxlModelRuntimeLike {
+  return { id, name: id, visible: true, color: '#fff', polygonCount: 4000000,
+    transform: { position: { x: 0, y: 0, z: 0 }, rotation: { x: 0, y: 0, z: 0 }, scale: { x: 1, y: 1, z: 1 } },
+    mesh: { mode: 'embedded-file', fileName: id + '.stl', mimeType: 'model/stl' } };
+}
+
+async function main() {
+  const TRI = Number(process.env.TRI ?? 4000000);
+  const ids = ['m0', 'm1', 'm2'];
+  const meshes = ids.map((_, i) => stl(TRI, i + 1));
+
+  const store = new MeshChunkStore();
+  const sha = new Map<number, string>();
+  const precompressed = new Map<number, { data: Uint8Array; compression: number; uncompressedSize: number }>();
+
+  const bakeStart = performance.now();
+  for (let i = 0; i < meshes.length; i += 1) {
+    const baked = await store.bake({ modelId: ids[i], signature: 'geo-' + i, encode: () => meshes[i] });
+    sha.set(i, baked.sha256);
+    precompressed.set(i, { data: baked.data, compression: baked.compression, uncompressedSize: baked.uncompressedSize });
+  }
+  console.log('bake total (paid ONCE, at finalization): ' + (performance.now() - bakeStart).toFixed(0) + ' ms');
+
+  const input: BuildVoxlDocumentInput = { models: ids.map(model), activeModelId: 'm0', selectedModelIds: [], supports: EMPTY_SUPPORTS };
+
+  resetVoxlCodecStats();
+  let t0 = performance.now();
+  const buffered = await serializeVoxlDocumentV2(input, new Map(), sha, { precompressed });
+  console.log('\nsteady-state tick, BUFFERED assembly: ' + (performance.now() - t0).toFixed(1) + ' ms');
+  console.log('  mesh compressions ' + voxlCodecStats.meshChunkCompressions + ', json ' + voxlCodecStats.jsonChunkCompressions);
+  console.log('  largest contiguous allocation: ' + (voxlCodecStats.largestContiguousAllocation / 2 ** 20).toFixed(0) + ' MiB');
+
+  resetVoxlCodecStats();
+  let emitted = 0; let largest = 0;
+  t0 = performance.now();
+  const streamed = await serializeVoxlDocumentV2Streaming(input, new Map(), sha, (b) => { emitted += b.length; largest = Math.max(largest, b.length); }, { precompressed });
+  console.log('\nsteady-state tick, STREAMING assembly: ' + (performance.now() - t0).toFixed(1) + ' ms');
+  console.log('  mesh compressions ' + voxlCodecStats.meshChunkCompressions + ', json ' + voxlCodecStats.jsonChunkCompressions);
+  console.log('  largest contiguous allocation: ' + (voxlCodecStats.largestContiguousAllocation / 2 ** 20).toFixed(0) + ' MiB');
+  console.log('  document ' + (streamed.totalSize / 2 ** 20).toFixed(0) + ' MiB, largest single emission ' + (largest / 2 ** 20).toFixed(0) + ' MiB');
+  console.log('  byte count matches buffered: ' + (emitted === buffered.length));
+}
+
+void main();

--- a/scripts/test_synthetic_dual_payload.ts
+++ b/scripts/test_synthetic_dual_payload.ts
@@ -1,0 +1,173 @@
+import { writeFileSync, unlinkSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { execSync } from 'node:child_process';
+import { serializeVoxlDocumentV2 } from '@/features/scene/voxl/codec-v2';
+import type { BuildVoxlDocumentInput, VoxlModelRuntimeLike } from '@/features/scene/voxl/types';
+import type { DragonfruitImportFormat } from '@/supports/types';
+
+const EMPTY_SUPPORTS = {
+  version: 1,
+  meta: { source: 'test', objectCenter: { x: 0, y: 0, z: 0 } },
+  roots: [],
+} as unknown as DragonfruitImportFormat;
+
+/**
+ * Creates a valid binary STL payload with specified triangle count.
+ */
+function createSyntheticStl(numTriangles: number): Uint8Array {
+  const bufferLength = 84 + numTriangles * 50;
+  const buffer = new Uint8Array(bufferLength);
+  const view = new DataView(buffer.buffer);
+
+  // 80-byte header
+  const headerText = `Synthetic STL ${numTriangles} triangles`;
+  const encoder = new TextEncoder();
+  buffer.set(encoder.encode(headerText), 0);
+
+  // 4-byte uint32 LE triangle count
+  view.setUint32(80, numTriangles, true);
+
+  // Write triangles
+  let offset = 84;
+  for (let i = 0; i < numTriangles; i++) {
+    // Normal (0, 0, 1)
+    view.setFloat32(offset + 0, 0.0, true);
+    view.setFloat32(offset + 4, 0.0, true);
+    view.setFloat32(offset + 8, 1.0, true);
+
+    // Vertex 1: (0, 0, 0)
+    view.setFloat32(offset + 12, 0.0, true);
+    view.setFloat32(offset + 16, 0.0, true);
+    view.setFloat32(offset + 20, 0.0, true);
+
+    // Vertex 2: (10, 0, 0)
+    view.setFloat32(offset + 24, 10.0, true);
+    view.setFloat32(offset + 28, 0.0, true);
+    view.setFloat32(offset + 32, 0.0, true);
+
+    // Vertex 3: (0, 10, 10)
+    view.setFloat32(offset + 36, 0.0, true);
+    view.setFloat32(offset + 40, 10.0, true);
+    view.setFloat32(offset + 44, 10.0, true);
+
+    // Attribute byte count (0)
+    view.setUint16(offset + 48, 0, true);
+
+    offset += 50;
+  }
+
+  return buffer;
+}
+
+async function main() {
+  console.log('--- Dual-Payload VOXL Verification Test ---');
+
+  const voxlFile = resolve(process.cwd(), 'synthetic_dual_payload.voxl');
+  const outFile = resolve(process.cwd(), 'synthetic_out.nanodlp');
+
+  try {
+    // Step 2: Generate 512-triangle preview MESH chunk and 8192-triangle ORIG chunk
+    console.log('1. Generating synthetic STL payloads (MESH=512 tris, ORIG=8192 tris)...');
+    const previewStl = createSyntheticStl(512);
+    const originalStl = createSyntheticStl(8192);
+
+    const model: VoxlModelRuntimeLike = {
+      id: 'model-dual-payload-0',
+      name: 'synthetic_model',
+      visible: true,
+      color: '#00ffaa',
+      polygonCount: 8192,
+      transform: {
+        position: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+      },
+      mesh: {
+        mode: 'embedded-chunk',
+        fileName: 'synthetic_model.stl',
+        mimeType: 'model/stl',
+        uncompressedSizeBytes: previewStl.length,
+      },
+    };
+
+    const input: BuildVoxlDocumentInput = {
+      models: [model],
+      activeModelId: model.id,
+      selectedModelIds: [],
+      supports: EMPTY_SUPPORTS,
+    };
+
+    const meshBytesMap = new Map<number, Uint8Array>([[0, previewStl]]);
+    const originalMeshBytesMap = new Map<number, Uint8Array>([[0, originalStl]]);
+
+    // Step 3: Serialize to VOXL V2 document with embedOriginalMesh: true
+    console.log('2. Serializing dual-payload VOXL file...');
+    const voxlBytes = await serializeVoxlDocumentV2(
+      input,
+      meshBytesMap,
+      undefined,
+      {
+        originalMeshBytes: originalMeshBytesMap,
+        embedOriginalMesh: true,
+      }
+    );
+
+    writeFileSync(voxlFile, voxlBytes);
+    console.log(`Saved ${voxlFile} (${voxlBytes.length} bytes)`);
+
+    // Step 4: Run cargo CLI slicer command
+    console.log('3. Running Rust CLI slicer command...');
+    const cargoCmd = `cargo run --manifest-path rust/dragonfruit-cli/Cargo.toml -- slice run "${voxlFile}" -o "${outFile}" --json`;
+    console.log(`Executing: ${cargoCmd}`);
+    const stdout = execSync(cargoCmd, { cwd: process.cwd(), encoding: 'utf-8' });
+
+    console.log('CLI Slicer Output JSON:');
+    console.log(stdout.trim());
+
+    // Step 5: Verify JSON output
+    const jsonResult = JSON.parse(stdout.trim());
+
+    console.log('\n--- Verification Checks ---');
+    console.log(`model_triangle_count: ${jsonResult.model_triangle_count} (expected: 8192)`);
+    console.log(`mesh_encoding: ${jsonResult.mesh_encoding} (expected: voxl_orig)`);
+    console.log(`slice layers: ${jsonResult.layers}`);
+    console.log(`output file exists: ${existsSync(outFile)}`);
+
+    let passed = true;
+    if (jsonResult.model_triangle_count !== 8192) {
+      console.error('FAILED: model_triangle_count does not equal 8192!');
+      passed = false;
+    }
+    if (jsonResult.mesh_encoding !== 'voxl_orig') {
+      console.error('FAILED: mesh_encoding does not equal voxl_orig!');
+      passed = false;
+    }
+    if (!existsSync(outFile)) {
+      console.error('FAILED: Output file synthetic_out.nanodlp was not created!');
+      passed = false;
+    }
+
+    if (passed) {
+      console.log('\nSUCCESS: All dual-payload VOXL verification assertions passed!');
+    } else {
+      process.exitCode = 1;
+    }
+
+  } catch (err) {
+    console.error('Error during verification:', err);
+    process.exitCode = 1;
+  } finally {
+    // Step 6: Clean up temporary test files
+    console.log('\nCleaning up temporary files...');
+    if (existsSync(voxlFile)) {
+      unlinkSync(voxlFile);
+      console.log(`Removed ${voxlFile}`);
+    }
+    if (existsSync(outFile)) {
+      unlinkSync(outFile);
+      console.log(`Removed ${outFile}`);
+    }
+  }
+}
+
+main();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -93,6 +93,237 @@ fn temp_artifact_path(extension: &str) -> std::path::PathBuf {
     path
 }
 
+/// Marker that identifies a scene-file commit temp. Must stay byte-identical:
+/// `is_scene_commit_temp_path` gates the discard command on it, so an arbitrary
+/// caller-supplied path can never be deleted through that seam.
+const SCENE_COMMIT_TEMP_MARKER: &str = ".tmp-";
+
+/// Allocates the staging file for an atomic scene-file commit, as a **sibling**
+/// of the target: `<target>.tmp-<pid>-<seq>`.
+///
+/// Sibling by construction is what makes the commit atomic — `fs::rename` is
+/// only guaranteed atomic within a volume, and a temp-dir staging file can
+/// easily be on a different one (a project on D:, `%TEMP%` on C:).
+///
+/// pid + a process-wide counter, the same idiom as
+/// `allocate_mesh_stage_file_path` / `temp_artifact_path` above: nanos alone are
+/// NOT unique because Windows `SystemTime` granularity lets two concurrent
+/// allocations land in the same tick, and the consumer opens with
+/// `truncate(true)` — two in-flight saves sharing a name would let one overwrite
+/// the other's staging bytes and then rename the wrong content over the user's
+/// project. Unlike those two helpers the nanos stamp is deliberately **omitted**
+/// here: these temps live next to the user's project rather than in `%TEMP%`,
+/// and a bounded per-process name space means a hard crash leaves at most one
+/// residue file per concurrent write (reused and truncated by a later run)
+/// instead of an unbounded pile of dead files in the user's folder.
+fn sibling_commit_temp_path(target: &std::path::Path) -> Result<std::path::PathBuf, String> {
+    static COMMIT_TEMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    let file_name = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            format!(
+                "Cannot stage an atomic commit for '{}': no UTF-8 file name",
+                target.display()
+            )
+        })?;
+
+    let parent = target.parent().unwrap_or_else(|| std::path::Path::new("."));
+    if !parent.as_os_str().is_empty() {
+        std::fs::create_dir_all(parent).map_err(|err| {
+            format!(
+                "Failed creating destination directory '{}': {err}",
+                parent.display()
+            )
+        })?;
+    }
+
+    Ok(parent.join(format!(
+        "{file_name}{SCENE_COMMIT_TEMP_MARKER}{}-{}",
+        std::process::id(),
+        COMMIT_TEMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+    )))
+}
+
+fn is_scene_commit_temp_path(path: &std::path::Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| {
+            let Some((_, suffix)) = name.rsplit_once(SCENE_COMMIT_TEMP_MARKER) else {
+                return false;
+            };
+            let mut parts = suffix.split('-');
+            let pid_ok = parts
+                .next()
+                .map(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()))
+                .unwrap_or(false);
+            let seq_ok = parts
+                .next()
+                .map(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()))
+                .unwrap_or(false);
+            pid_ok && seq_ok && parts.next().is_none()
+        })
+        .unwrap_or(false)
+}
+
+const SCENE_COMMIT_RENAME_BACKOFF_MS: [u64; 3] = [50, 150, 300];
+
+/// Commits a fully-written staging file over `target` atomically: fsync the
+/// temp, then rename it into place. Either the reader sees the previous good
+/// file or it sees the new one — never a truncated prefix of either.
+///
+/// The bounded retry is a Windows concession: a rename can transiently fail with
+/// `ERROR_ACCESS_DENIED` / `ERROR_SHARING_VIOLATION` while an antivirus scanner
+/// or an Explorer thumbnailer holds the destination open.
+///
+/// On terminal failure the temp is removed and the **previous good target is
+/// left untouched** — strictly better than the pre-Ph0.1 writer, which had
+/// already destroyed it by the time anything could fail.
+fn commit_scene_file_atomic(
+    temp: &std::path::Path,
+    target: &std::path::Path,
+) -> Result<(), String> {
+    if !temp.exists() {
+        return Err(format!(
+            "Atomic commit staging file is missing: {}",
+            temp.display()
+        ));
+    }
+
+    // fsync the payload BEFORE the rename, or a power loss can leave the
+    // rename durable while the bytes it points at are not.
+    //
+    // Opened for write rather than read-only (the obvious choice on unix):
+    // Windows `FlushFileBuffers` requires write access to the handle, so a
+    // read-only handle would fail with ERROR_ACCESS_DENIED on the platform this
+    // ships to first.
+    let sync_result = std::fs::OpenOptions::new()
+        .write(true)
+        .open(temp)
+        .and_then(|file| file.sync_all());
+    if let Err(err) = sync_result {
+        let _ = std::fs::remove_file(temp);
+        return Err(format!(
+            "Failed flushing '{}' to disk before commit: {err}",
+            temp.display()
+        ));
+    }
+
+    let mut last_error: Option<String> = None;
+    for (attempt, backoff_ms) in SCENE_COMMIT_RENAME_BACKOFF_MS.iter().enumerate() {
+        match std::fs::rename(temp, target) {
+            Ok(()) => {
+                // Best-effort directory fsync so the rename itself is durable.
+                // No portable Windows equivalent (a directory cannot be opened
+                // as a file), where NTFS metadata journalling covers it.
+                #[cfg(unix)]
+                {
+                    if let Some(parent) = target.parent() {
+                        if let Ok(dir) = std::fs::File::open(parent) {
+                            let _ = dir.sync_all();
+                        }
+                    }
+                }
+                return Ok(());
+            }
+            Err(err) => {
+                last_error = Some(err.to_string());
+                if attempt + 1 < SCENE_COMMIT_RENAME_BACKOFF_MS.len() {
+                    std::thread::sleep(std::time::Duration::from_millis(*backoff_ms));
+                }
+            }
+        }
+    }
+
+    let _ = std::fs::remove_file(temp);
+    Err(format!(
+        "Failed committing '{}' over '{}' after {} attempts: {}",
+        temp.display(),
+        target.display(),
+        SCENE_COMMIT_RENAME_BACKOFF_MS.len(),
+        last_error.unwrap_or_else(|| "unknown error".to_string()),
+    ))
+}
+
+/// **User invariant: autosave ALWAYS writes `.voxl`.**
+///
+/// Deliberately NOT `is_scene_file_path`, which also accepts every plugin scene
+/// extension (`BUILTIN_PLUGIN_SCENE_EXTENSIONS`). Autosave emits VOXL bytes, so
+/// a plugin-format project must never be handed back as the autosave target —
+/// that would write VOXL into a file whose extension promises a foreign format.
+/// Such projects fall back to the generic recovery location, which is a `.voxl`
+/// by construction. (Sub-phase B replaces the fallback with a proper
+/// `<stem>_autosave.voxl` sidecar; this invariant holds either way.)
+fn is_voxl_autosave_target(path: &std::path::Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.trim().trim_start_matches('.').eq_ignore_ascii_case("voxl"))
+        .unwrap_or(false)
+}
+
+/// Allocates the sibling staging path for an atomic scene-file write.
+#[tauri::command]
+async fn scene_file_begin_atomic_write(target_path: String) -> Result<String, String> {
+    let trimmed = target_path.trim().to_string();
+    if trimmed.is_empty() {
+        return Err("scene_file_begin_atomic_write requires a non-empty target path".into());
+    }
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let temp = sibling_commit_temp_path(std::path::Path::new(&trimmed))?;
+        Ok(temp.to_string_lossy().to_string())
+    })
+    .await
+    .map_err(|err| format!("scene_file_begin_atomic_write task failed: {err}"))?
+}
+
+/// fsync + atomic rename of a staged scene file over its destination.
+#[tauri::command]
+async fn scene_file_commit_atomic(temp_path: String, target_path: String) -> Result<(), String> {
+    let temp = temp_path.trim().to_string();
+    let target = target_path.trim().to_string();
+    if temp.is_empty() || target.is_empty() {
+        return Err("scene_file_commit_atomic requires non-empty temp and target paths".into());
+    }
+
+    tauri::async_runtime::spawn_blocking(move || {
+        commit_scene_file_atomic(std::path::Path::new(&temp), std::path::Path::new(&target))
+    })
+    .await
+    .map_err(|err| format!("scene_file_commit_atomic task failed: {err}"))?
+}
+
+/// Removes an abandoned commit staging file (the write failed before commit),
+/// so a failed save does not litter the user's project folder.
+///
+/// Gated on `is_scene_commit_temp_path`: this command can only ever delete a
+/// path this process's own allocator could have produced, never an arbitrary
+/// caller-supplied file.
+#[tauri::command]
+async fn scene_file_discard_atomic_temp(temp_path: String) -> Result<(), String> {
+    let temp = temp_path.trim().to_string();
+    if temp.is_empty() {
+        return Err("scene_file_discard_atomic_temp requires a non-empty path".into());
+    }
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let path = std::path::Path::new(&temp);
+        if !is_scene_commit_temp_path(path) {
+            return Err(format!(
+                "Refusing to discard '{temp}': not a scene-file commit temp"
+            ));
+        }
+        if path.exists() {
+            std::fs::remove_file(path)
+                .map_err(|err| format!("Failed discarding commit temp '{temp}': {err}"))?;
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|err| format!("scene_file_discard_atomic_temp task failed: {err}"))?
+}
+
 fn is_dragonfruit_temp_artifact(path: &std::path::Path) -> bool {
     let file_name_ok = path
         .file_name()
@@ -1022,9 +1253,53 @@ async fn append_mesh_stage_chunk(request: tauri::ipc::Request<'_>) -> Result<u64
         None => false,
     };
 
+    stage_append_chunk(path_text, bytes, is_first_chunk)
+}
+
+/// Body of `append_mesh_stage_chunk`, extracted from the `#[tauri::command]`
+/// wrapper so the writer's crash-safety and contention contracts can be driven
+/// directly from unit tests (a `tauri::ipc::Request` cannot be constructed in
+/// one). Behaviour is byte-for-byte the pre-extraction behaviour apart from the
+/// explicitly-documented contention backstop below.
+pub(crate) fn stage_append_chunk(
+    path_text: &str,
+    bytes: &[u8],
+    is_first_chunk: bool,
+) -> Result<u64, String> {
+    let path = std::path::PathBuf::from(path_text);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("Failed creating mesh stage directory: {err}"))?;
+    }
+
     let mut appender_lock = staged_mesh_file_appender()
         .lock()
         .map_err(|e| format!("staged mesh file appender lock poisoned: {e}"))?;
+
+    // Contention backstop (Ph0.1 A / finding N2). There is exactly ONE
+    // process-global appender. A mid-sequence chunk (offset != 0) that arrives
+    // while a *different* path owns the appender means two chunked writes are
+    // interleaving: the previous code silently evicted the other writer and
+    // re-opened with truncate(true), so this chunk landed at offset 0 and the
+    // other writer's bytes were destroyed — both files corrupt, no error.
+    // The frontend single-flight queue (`runExclusiveNativeWrite` in
+    // nativeSlicerBridge.ts) makes this unreachable for callers that go through
+    // it; this backstop covers the one caller that streams chunks directly
+    // (`sliceExportOrchestrator.handleMeshFileChunk`). A loud error beats two
+    // silently corrupt files.
+    //
+    // Deliberately NOT extended to the `None` case: `handleMeshFileChunk` sends
+    // no `x-mesh-stage-offset` header at all, so *every* chunk of a slice stage
+    // is `is_first_chunk == false` and relies on the `None` branch to open its
+    // file. Erroring there would break slicing outright.
+    if let Some(existing) = appender_lock.as_ref() {
+        if !is_first_chunk && existing.path != path_text {
+            return Err(format!(
+                "concurrent mesh-stage write detected: '{}' is mid-write while a chunk arrived for '{}'",
+                existing.path, path_text
+            ));
+        }
+    }
 
     let needs_new_appender = match appender_lock.as_ref() {
         Some(existing) => is_first_chunk || existing.path != path_text,
@@ -1071,6 +1346,12 @@ async fn append_mesh_stage_chunk(request: tauri::ipc::Request<'_>) -> Result<u64
 
 #[tauri::command]
 async fn finish_mesh_stage_write(path: String) -> Result<u64, String> {
+    finish_stage_write(&path)
+}
+
+/// Body of `finish_mesh_stage_write`, extracted for the same reason as
+/// `stage_append_chunk`.
+pub(crate) fn finish_stage_write(path: &str) -> Result<u64, String> {
     let trimmed = path.trim();
     if trimmed.is_empty() {
         return Err("finish_mesh_stage_write requires a non-empty path".into());
@@ -2294,13 +2575,19 @@ async fn scene_autosave_get_paths(
 
         // Determine VOXL autosave path: if user has explicitly saved to a .voxl file,
         // autosave directly to that file. Otherwise use the generic recovery location.
+        //
+        // The predicate is `is_voxl_autosave_target`, NOT `is_scene_file_path`:
+        // autosave emits VOXL bytes, and `is_scene_file_path` also accepts every
+        // plugin scene extension, so a project saved as e.g. `MyPrint.lys` used
+        // to be returned verbatim and then filled with VOXL. Autosave ALWAYS
+        // writes `.voxl` — see `is_voxl_autosave_target` and its test.
         let voxl_path = if let Some(preferred) = preferred_save_path {
             let path = std::path::Path::new(&preferred);
-            if is_scene_file_path(path) && path.exists() {
-                // User has explicitly saved; autosave directly to that file
+            if is_voxl_autosave_target(path) && path.exists() {
+                // User has explicitly saved to a VOXL project; autosave to it
                 preferred
             } else {
-                // Not a valid scene file or doesn't exist; fall back to generic recovery
+                // Not a VOXL scene file or doesn't exist; fall back to generic recovery
                 dir.join(SCENE_AUTOSAVE_VOXL_FILE)
                     .to_string_lossy()
                     .to_string()
@@ -3291,6 +3578,9 @@ fn main() {
             allocate_mesh_stage_path,
             append_mesh_stage_chunk,
             finish_mesh_stage_write,
+            scene_file_begin_atomic_write,
+            scene_file_commit_atomic,
+            scene_file_discard_atomic_temp,
             stage_mesh_file_path,
             stage_mesh_binary_set,
             stage_mesh_binary_chunk,
@@ -3386,4 +3676,356 @@ fn main() {
                 window_state::save(app_handle);
             }
         });
+}
+
+#[cfg(test)]
+mod tests {
+    // -----------------------------------------------------------------------
+    // Shared writer-test scaffolding (Ph0.1 sub-phase A)
+    // -----------------------------------------------------------------------
+
+    /// `append_mesh_stage_chunk` owns ONE process-global appender, so every test
+    /// that drives the writer must run alone. `cargo test` runs tests on
+    /// parallel threads by default; without this they would evict each other's
+    /// appenders and go flaky for the very reason sub-phase A exists.
+    static WRITER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_writer_tests() -> std::sync::MutexGuard<'static, ()> {
+        let guard = WRITER_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // A test that simulated a crash leaves the appender open; start clean.
+        *super::staged_mesh_file_appender()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        guard
+    }
+
+    /// pid + process-wide sequence, same rationale as
+    /// `allocate_mesh_stage_file_path`: nanos alone collide on Windows.
+    fn unique_test_dir(tag: &str) -> std::path::PathBuf {
+        static TEST_DIR_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "dragonfruit-test-{tag}-{}-{}",
+            std::process::id(),
+            TEST_DIR_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("failed creating test dir");
+        dir
+    }
+
+    /// Mirrors the frontend's native VOXL write seam
+    /// (`ExportManager.downloadFile` → `writeFileAtomicToNativePath`, which both
+    /// autosave and explicit save funnel through) so the crash-safety invariant
+    /// is asserted against the real writer rather than a paraphrase of it.
+    /// `interrupt_after_bytes` models the process dying mid-write: chunks stop
+    /// and nothing commits, exactly as a kill would leave things.
+    fn voxl_write_seam(
+        target: &std::path::Path,
+        bytes: &[u8],
+        interrupt_after_bytes: Option<usize>,
+    ) -> Result<(), String> {
+        let temp = super::sibling_commit_temp_path(target)?;
+        let temp_text = temp.to_string_lossy().to_string();
+        let cut = interrupt_after_bytes.unwrap_or(bytes.len()).min(bytes.len());
+
+        super::stage_append_chunk(&temp_text, &bytes[..cut], true)?;
+        if interrupt_after_bytes.is_some() {
+            // Process dies here: no further chunks, no finish, no commit.
+            return Ok(());
+        }
+        super::stage_append_chunk(&temp_text, &bytes[cut..], false)?;
+        super::finish_stage_write(&temp_text)?;
+        super::commit_scene_file_atomic(&temp, target)
+    }
+
+    /// **The data-loss regression.** Before sub-phase A the seam wrote straight
+    /// to the destination with `truncate(true)` on chunk 0
+    /// (`append_mesh_stage_chunk`), so a crash between truncate and the last
+    /// chunk left a truncated scene file and no fallback — the user's project
+    /// destroyed by an autosave tick or a Ctrl+S that never finished.
+    #[test]
+    fn interrupted_voxl_write_preserves_previous_good_file() {
+        let _guard = lock_writer_tests();
+        let dir = unique_test_dir("atomic-commit");
+        let target = dir.join("MyPrint.voxl");
+
+        let good: Vec<u8> = (0..64u32).flat_map(|i| i.to_le_bytes()).collect();
+        voxl_write_seam(&target, &good, None).expect("initial good write failed");
+        assert_eq!(
+            std::fs::read(&target).expect("good file unreadable"),
+            good,
+            "the baseline write did not produce the expected file"
+        );
+
+        let replacement = vec![0xABu8; 4096];
+        let _ = voxl_write_seam(&target, &replacement, Some(1024));
+
+        assert_eq!(
+            std::fs::read(&target).expect("previous good file no longer exists"),
+            good,
+            "an interrupted write destroyed the previous good scene file"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The happy path of the commit: the target becomes the temp's bytes and no
+    /// `.tmp-` residue is left beside the user's project.
+    #[test]
+    fn commit_atomic_replaces_target_and_removes_temp() {
+        let _guard = lock_writer_tests();
+        let dir = unique_test_dir("atomic-replace");
+        let target = dir.join("MyPrint.voxl");
+        std::fs::write(&target, b"old contents").expect("seed write failed");
+
+        let temp = super::sibling_commit_temp_path(&target).expect("temp alloc failed");
+        std::fs::write(&temp, b"new contents").expect("temp write failed");
+        super::commit_scene_file_atomic(&temp, &target).expect("commit failed");
+
+        assert_eq!(std::fs::read(&target).unwrap(), b"new contents");
+        assert!(!temp.exists(), "commit left a temp file beside the project");
+        let residue: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|n| n.contains(".tmp-"))
+            .collect();
+        assert!(residue.is_empty(), "temp residue left behind: {residue:?}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Terminal failure must be strictly better than the old behaviour: the
+    /// previous good target survives, the temp is cleaned up, and the caller
+    /// gets an `Err` instead of a silently destroyed file.
+    #[test]
+    fn commit_atomic_leaves_target_intact_when_rename_fails() {
+        let _guard = lock_writer_tests();
+        let dir = unique_test_dir("atomic-fail");
+        // A directory can never be replaced by a file rename on any platform.
+        let target = dir.join("MyPrint.voxl");
+        std::fs::create_dir_all(&target).expect("failed creating blocking directory");
+        std::fs::write(target.join("sentinel.txt"), b"still here").expect("sentinel write failed");
+
+        let temp = super::sibling_commit_temp_path(&target).expect("temp alloc failed");
+        std::fs::write(&temp, b"new contents").expect("temp write failed");
+
+        let result = super::commit_scene_file_atomic(&temp, &target);
+        assert!(result.is_err(), "commit onto a directory should fail");
+        assert_eq!(
+            std::fs::read(target.join("sentinel.txt")).unwrap(),
+            b"still here",
+            "a failed commit damaged the previous target"
+        );
+        assert!(!temp.exists(), "a failed commit left its temp behind");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Same collision geometry as the two allocator races already pinned below:
+    /// the commit temp is created with truncate, so two same-tick allocations
+    /// sharing a name would let one in-flight save overwrite another's staging
+    /// file and then rename the wrong bytes over the user's project.
+    #[test]
+    fn sibling_commit_temp_paths_are_unique_under_concurrent_allocation() {
+        const THREADS: usize = 8;
+        const ALLOCS_PER_THREAD: usize = 64;
+
+        let dir = unique_test_dir("temp-uniqueness");
+        let target = std::sync::Arc::new(dir.join("MyPrint.voxl"));
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(THREADS));
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let barrier = std::sync::Arc::clone(&barrier);
+                let target = std::sync::Arc::clone(&target);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    (0..ALLOCS_PER_THREAD)
+                        .map(|_| {
+                            super::sibling_commit_temp_path(&target)
+                                .expect("commit temp allocation failed")
+                        })
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+
+        let mut all_paths = std::collections::HashSet::new();
+        for handle in handles {
+            for path in handle.join().expect("allocator thread panicked") {
+                assert_eq!(
+                    path.parent(),
+                    target.parent(),
+                    "commit temp must be a sibling of the target, or the rename is not atomic"
+                );
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .expect("commit temp path has a UTF-8 file name")
+                    .to_string();
+                assert!(
+                    name.starts_with("MyPrint.voxl.tmp-"),
+                    "commit temp name lost its contract: {name}"
+                );
+                assert!(
+                    super::is_scene_commit_temp_path(&path),
+                    "discard guard no longer recognizes its own temp: {name}"
+                );
+                assert!(all_paths.insert(path), "duplicate commit temp allocated");
+            }
+        }
+        assert_eq!(all_paths.len(), THREADS * ALLOCS_PER_THREAD);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// **Finding N2.** Two chunked writes to different paths used to evict each
+    /// other from the single process-global appender and re-truncate on every
+    /// switch-back — writer A's committed chunks destroyed, its next chunk
+    /// landing at offset 0, both files corrupt, and no error anywhere.
+    #[test]
+    fn concurrent_stage_writes_error_instead_of_truncating() {
+        let _guard = lock_writer_tests();
+        let dir = unique_test_dir("stage-contention");
+        let path_a = dir.join("a.bin").to_string_lossy().to_string();
+        let path_b = dir.join("b.bin").to_string_lossy().to_string();
+
+        // Writer A opens and writes its first chunk.
+        super::stage_append_chunk(&path_a, &[0xAA; 512], true).expect("writer A chunk 0 failed");
+        // Writer B interleaves with its own first chunk (evicts A's appender).
+        super::stage_append_chunk(&path_b, &[0xBB; 512], true).expect("writer B chunk 0 failed");
+        // A resumes mid-sequence. This is the corruption point.
+        let resumed = super::stage_append_chunk(&path_a, &[0xAA; 512], false);
+
+        assert!(
+            resumed.is_err(),
+            "an interleaved mid-sequence chunk was accepted — it silently re-truncated '{path_a}'"
+        );
+        let message = resumed.unwrap_err();
+        assert!(
+            message.contains("concurrent mesh-stage write detected"),
+            "contention error lost its identity: {message}"
+        );
+
+        *super::staged_mesh_file_appender()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Guard on the contention backstop itself: it must not fire on the ordinary
+    /// sequence of a *second* stage write.
+    ///
+    /// `stage_mesh_file_path` flushes the appender but deliberately does not
+    /// close it, and an aborted slice never reaches that call at all — so the
+    /// previous stage file's appender is routinely still open when the next
+    /// slice's first chunk arrives. That chunk must truncate its own new file,
+    /// not be rejected as an interleave, or the second slice of every session
+    /// (and every slice after an abort) would fail.
+    ///
+    /// This is what `sliceExportOrchestrator.handleMeshFileChunk`'s
+    /// `x-mesh-stage-offset` header buys: chunk 0 is identifiable.
+    #[test]
+    fn sequential_stage_writes_after_an_abandoned_one_still_succeed() {
+        let _guard = lock_writer_tests();
+        let dir = unique_test_dir("stage-sequential");
+        let first = dir.join("stage-1.bin").to_string_lossy().to_string();
+        let second = dir.join("stage-2.bin").to_string_lossy().to_string();
+
+        // Slice 1 streams and is abandoned (aborted) — appender left open.
+        super::stage_append_chunk(&first, &[0x11; 256], true).expect("stage 1 chunk 0 failed");
+        super::stage_append_chunk(&first, &[0x11; 256], false).expect("stage 1 chunk 1 failed");
+
+        // Slice 2 starts a brand-new stage file while that appender is open.
+        super::stage_append_chunk(&second, &[0x22; 256], true).expect(
+            "a new stage write was rejected as an interleave — the backstop is too aggressive",
+        );
+        super::stage_append_chunk(&second, &[0x22; 256], false).expect("stage 2 chunk 1 failed");
+        super::finish_stage_write(&second).expect("stage 2 finish failed");
+
+        assert_eq!(
+            std::fs::read(&second).unwrap().len(),
+            512,
+            "chunk 0 of a new stage file must truncate, not append to stale bytes"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// **User invariant: autosave ALWAYS writes `.voxl`.** `is_scene_file_path`
+    /// also accepts the plugin scene extensions, so a project saved in a plugin
+    /// format used to be handed back verbatim as the autosave target — VOXL
+    /// bytes written into a file whose extension promises a foreign format.
+    #[test]
+    fn autosave_target_is_always_voxl_for_plugin_scene_extensions() {
+        for ext in super::BUILTIN_PLUGIN_SCENE_EXTENSIONS {
+            let candidate = std::path::PathBuf::from(format!("C:/projects/MyPrint.{ext}"));
+            assert!(
+                super::is_scene_file_path(&candidate),
+                "test fixture is not a recognised scene file: {}",
+                candidate.display()
+            );
+            assert!(
+                !super::is_voxl_autosave_target(&candidate),
+                "autosave would have written VOXL bytes into a .{ext} file"
+            );
+        }
+
+        assert!(super::is_voxl_autosave_target(std::path::Path::new(
+            "C:/projects/MyPrint.voxl"
+        )));
+        assert!(super::is_voxl_autosave_target(std::path::Path::new(
+            "C:/projects/MyPrint.VOXL"
+        )));
+        assert!(!super::is_voxl_autosave_target(std::path::Path::new(
+            "C:/projects/MyPrint.stl"
+        )));
+        assert!(!super::is_voxl_autosave_target(std::path::Path::new(
+            "C:/projects/MyPrint"
+        )));
+    }
+
+    /// **RED — NOT OWNED BY Ph0.1. DO NOT "FIX" BY LOOSENING TRUNCATE.**
+    ///
+    /// Corollary of finding N2. `writeChunkedToNativePath`'s `finally` always
+    /// calls `finish_mesh_stage_write` (nativeSlicerBridge.ts:597-607), which
+    /// drops the appender, and every call restarts at offset 0 — so *every*
+    /// call re-opens with `truncate(true)`. `streamZipToNativePath`
+    /// (ExportManager.ts:655-706) makes three sequential calls to the same path
+    /// and its docstring (:642-654) asserts append-on-subsequent. That
+    /// assertion is false: native 3MF export emits only its postamble.
+    ///
+    /// This test reproduces that call shape exactly and asserts the docstring's
+    /// contract, so it fails. It is `#[ignore]`d rather than deleted so the
+    /// suite stays green while the defect stays on the record.
+    ///
+    /// Owner: the 3MF export team — fix in `streamZipToNativePath` (e.g. a
+    /// single write sequence, or an explicit append mode), NOT by weakening
+    /// `append_mesh_stage_chunk`'s truncate-on-fresh-appender semantics, which
+    /// mesh staging and Ph0.1's atomic commit both depend on.
+    #[test]
+    #[ignore = "RED: pins the known native-3MF truncation defect (N2 corollary); owned by the 3MF export team, not Ph0.1"]
+    fn native_3mf_sequential_writes_append_instead_of_truncating() {
+        let _guard = lock_writer_tests();
+        let dir = unique_test_dir("3mf-corollary");
+        let path = dir.join("model.3mf").to_string_lossy().to_string();
+
+        // Exactly what streamZipToNativePath does: three separate
+        // writeChunkedToNativePath calls to one path, each starting at offset 0
+        // and each closing the appender in its `finally`.
+        for payload in [b"PREAMBLE".as_slice(), b"XMLXMLXML", b"POSTAMBLE"] {
+            super::stage_append_chunk(&path, payload, true).expect("3mf chunk write failed");
+            super::finish_stage_write(&path).expect("3mf finish failed");
+        }
+
+        let written = std::fs::read(&path).expect("3mf output unreadable");
+        assert_eq!(
+            written, b"PREAMBLEXMLXMLXMLPOSTAMBLE",
+            "native 3MF export is emitting only its last write — the ZIP has no local headers and no model data"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -252,9 +252,10 @@ fn commit_scene_file_atomic(
 /// extension (`BUILTIN_PLUGIN_SCENE_EXTENSIONS`). Autosave emits VOXL bytes, so
 /// a plugin-format project must never be handed back as the autosave target —
 /// that would write VOXL into a file whose extension promises a foreign format.
-/// Such projects fall back to the generic recovery location, which is a `.voxl`
-/// by construction. (Sub-phase B replaces the fallback with a proper
-/// `<stem>_autosave.voxl` sidecar; this invariant holds either way.)
+/// Since sub-phase B such a project gets a correctly-named
+/// `<stem>_autosave.voxl` sidecar instead of being handed back verbatim, and
+/// `resolve_scene_autosave_target` uses this predicate to check its own output
+/// before returning it.
 fn is_voxl_autosave_target(path: &std::path::Path) -> bool {
     path.extension()
         .and_then(|ext| ext.to_str())
@@ -2536,21 +2537,440 @@ async fn local_backup_restore_history_item(
 // ---------------------------------------------------------------------------
 
 const SCENE_AUTOSAVE_DIR_NAME: &str = "autosave";
-const SCENE_AUTOSAVE_VOXL_FILE: &str = "scene.voxl";
+/// The generic-recovery payload name. It carries the `_autosave` marker so the
+/// **third** target invariant holds without an exception: every path autosave
+/// writes is self-describing, whether it is a sidecar or the fallback. The
+/// directory is unchanged, so this is still "the existing generic recovery
+/// location"; only the file name gained the marker.
+const SCENE_AUTOSAVE_VOXL_FILE: &str = "scene_autosave.voxl";
+/// The pre-Ph0.1 generic payload name. Never written any more, always searched:
+/// an autosave a user already has on disk must stay recoverable.
+const SCENE_AUTOSAVE_LEGACY_VOXL_FILE: &str = "scene.voxl";
 const SCENE_AUTOSAVE_MANIFEST_FILE: &str = "manifest.json";
 
+/// Every field added after `saved_at` / `clean` is `#[serde(default)]` so a
+/// manifest written by a pre-Ph0.1 build still parses â€” losing recovery for the
+/// autosave a user already has on disk would be a worse bug than the one this
+/// sub-phase fixes.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 struct SceneAutosaveManifest {
     saved_at: String,
     clean: bool,
+    /// Absolute path of the payload actually committed. **Authoritative**: the
+    /// manifest is written only after the atomic rename, so this can only ever
+    /// name a fully-committed file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    voxl_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    origin: Option<String>,
+    /// The project the sidecar belongs to; lets recovery re-derive the sidecar
+    /// when `voxl_path` has gone stale.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    project_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    payload_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    fallback_reason: Option<String>,
+    /// Reserved for sub-phase D (finding N4). Carried here so the manifest
+    /// schema settles in one change.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_error: Option<String>,
 }
+
+// ---------------------------------------------------------------------------
+// Sidecar naming, writability, and payload identity
+// ---------------------------------------------------------------------------
+
+/// The marker that makes a recovery file self-describing in Explorer and gates
+/// every deletion seam below.
+const SCENE_AUTOSAVE_SIDECAR_MARKER: &str = "_autosave";
+
+/// **THE ONE PLACE THE SIDECAR FILE NAME IS BUILT.**
+///
+/// Every target, every discovery candidate, and every deletion guard routes
+/// through this function, so the naming scheme has exactly one definition.
+///
+/// *Open decision, deliberately left as a one-line change:* a per-process name
+/// (`<stem>_<pid>_autosave.voxl`) would make two instances editing the same
+/// project unable to collide. It is **not** the default, because the pid is
+/// gone by the time it matters: after a crash â€” the one case clean-exit
+/// deletion cannot cover â€” recovery would face several `MyPrint_1234_autosave`
+/// files with no way to say which is current, and the orphans accumulate
+/// forever. A single well-known name is unambiguous at recovery time, which is
+/// the moment the file exists for. To switch, change only this format string
+/// (and `is_sidecar_autosave_file`'s suffix test to a marker `contains`).
+fn sidecar_autosave_file_name(project_stem: &str) -> String {
+    format!("{project_stem}{SCENE_AUTOSAVE_SIDECAR_MARKER}.voxl")
+}
+
+/// `<dir>/<stem>_autosave.voxl` for a project file. `None` when the path has no
+/// usable stem (the caller falls back to the recovery directory).
+fn sidecar_autosave_path_for_project(project: &std::path::Path) -> Option<std::path::PathBuf> {
+    let stem = project.file_stem().and_then(|s| s.to_str())?.trim();
+    if stem.is_empty() {
+        return None;
+    }
+    let parent = project.parent().unwrap_or_else(|| std::path::Path::new(""));
+    Some(parent.join(sidecar_autosave_file_name(stem)))
+}
+
+/// Windows paths are case-insensitive; a candidate-list check that missed
+/// `C:\Projects\...` vs `c:\projects\...` would reject a legitimate recovery.
+fn autosave_paths_equal(a: &std::path::Path, b: &std::path::Path) -> bool {
+    if a == b {
+        return true;
+    }
+    a.to_string_lossy().to_ascii_lowercase() == b.to_string_lossy().to_ascii_lowercase()
+}
+
+fn is_sidecar_autosave_file(path: &std::path::Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    let suffix = format!("{SCENE_AUTOSAVE_SIDECAR_MARKER}.voxl");
+    let lower = name.to_ascii_lowercase();
+    // Strictly longer than the suffix: a file called exactly `_autosave.voxl`
+    // belongs to no project and is not ours to delete.
+    lower.ends_with(&suffix) && lower.len() > suffix.len()
+}
+
+/// The deletion gate. Only a file this policy could itself have produced â€” a
+/// `<stem>_autosave.voxl` sidecar, or the generic recovery payload â€” may be
+/// removed through any of the cleanup seams. The user's project never qualifies.
+fn is_deletable_autosave_payload(
+    recovery_dir: &std::path::Path,
+    path: &std::path::Path,
+) -> bool {
+    is_sidecar_autosave_file(path)
+        || autosave_paths_equal(path, &recovery_dir.join(SCENE_AUTOSAVE_LEGACY_VOXL_FILE))
+}
+
+/// Deletes the sidecar belonging to `project`, if there is one.
+///
+/// Used on Save As, where the sidecar beside the **old** project would otherwise
+/// be orphaned â€” a `_autosave.voxl` next to a file the user no longer edits
+/// implies unsaved work that does not exist.
+fn delete_sidecar_for_project(project: &std::path::Path) -> Result<(), String> {
+    let Some(sidecar) = sidecar_autosave_path_for_project(project) else {
+        return Ok(());
+    };
+    if !is_sidecar_autosave_file(&sidecar) {
+        return Err(format!(
+            "Refusing to delete '{}': not an autosave sidecar",
+            sidecar.display()
+        ));
+    }
+    if !sidecar.exists() {
+        return Ok(());
+    }
+    std::fs::remove_file(&sidecar)
+        .map_err(|err| format!("Failed deleting sidecar '{}': {err}", sidecar.display()))
+}
+
+/// Real-syscall writability probe for a prospective sidecar location.
+///
+/// Deliberately not a metadata/permissions guess: read-only volumes,
+/// permission-denied folders, and unreachable network shares all present
+/// differently in metadata but identically to an actual create. Reuses sub-phase
+/// A's `sibling_commit_temp_path` so the probe exercises the very mechanism the
+/// real commit will use, rather than a lookalike.
+///
+/// Returns `None` when the directory is usable, or the `fallback_reason` to
+/// record in the manifest when it is not.
+fn probe_directory_writable(sidecar: &std::path::Path) -> Option<&'static str> {
+    let parent = sidecar.parent().unwrap_or_else(|| std::path::Path::new("."));
+    if !parent.as_os_str().is_empty() && !parent.is_dir() {
+        return Some("parent-missing");
+    }
+
+    let probe = sibling_commit_temp_path(sidecar).ok()?;
+    let writable = std::fs::write(&probe, b"").is_ok();
+    let _ = std::fs::remove_file(&probe);
+    if writable {
+        None
+    } else {
+        Some("parent-unwritable")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Recovery discovery
+// ---------------------------------------------------------------------------
+
+const VOXL_FILE_MAGIC: &[u8; 4] = b"VOXL";
+
+/// A candidate is only advertised if it exists, is non-empty, and actually
+/// starts with the VOXL magic â€” a truncated or foreign file must never be
+/// offered as a recoverable scene.
+fn is_readable_voxl_payload(path: &std::path::Path) -> bool {
+    use std::io::Read;
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut magic = [0u8; 4];
+    file.read_exact(&mut magic).is_ok() && &magic == VOXL_FILE_MAGIC
+}
+
+/// The ordered recovery candidate list â€” and the **only** paths the recovery
+/// reader will ever open.
+///
+/// 1. `manifest.voxlPath` â€” authoritative: the manifest is written only after
+///    the atomic rename, so it can only name a fully-committed payload.
+/// 2. the sidecar derived from `manifest.projectPath` â€” covers a project that
+///    moved, and manifests from builds older than this change.
+/// 3. the legacy generic `<app_data>/autosave/scene.voxl` â€” every autosave
+///    written before sub-phase B; back-compat is free and mandatory.
+fn scene_autosave_recovery_candidates(
+    recovery_dir: &std::path::Path,
+    manifest: Option<&SceneAutosaveManifest>,
+) -> Vec<std::path::PathBuf> {
+    let mut candidates: Vec<std::path::PathBuf> = Vec::new();
+
+    if let Some(manifest) = manifest {
+        if let Some(voxl_path) = manifest
+            .voxl_path
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            candidates.push(std::path::PathBuf::from(voxl_path));
+        }
+        if let Some(project) = manifest
+            .project_path
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            if let Some(sidecar) = sidecar_autosave_path_for_project(std::path::Path::new(project)) {
+                candidates.push(sidecar);
+            }
+        }
+    }
+
+    candidates.push(recovery_dir.join(SCENE_AUTOSAVE_VOXL_FILE));
+    candidates.push(recovery_dir.join(SCENE_AUTOSAVE_LEGACY_VOXL_FILE));
+
+    let mut deduped: Vec<std::path::PathBuf> = Vec::with_capacity(candidates.len());
+    for candidate in candidates {
+        if !deduped
+            .iter()
+            .any(|existing| autosave_paths_equal(existing, &candidate))
+        {
+            deduped.push(candidate);
+        }
+    }
+    deduped
+}
+
+/// The read gate: `scene_autosave_read_voxl_bytes` accepts a path **only** if
+/// the resolver itself produced it. Same discipline as
+/// `scene_file_discard_atomic_temp` â€” an arbitrary caller-supplied path can
+/// never be turned into a file read through this seam.
+fn is_allowed_recovery_read(candidates: &[std::path::PathBuf], path: &std::path::Path) -> bool {
+    candidates
+        .iter()
+        .any(|candidate| autosave_paths_equal(candidate, path))
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SceneAutosaveRecoveryCandidate {
+    voxl_path: std::path::PathBuf,
+    origin: String,
+    saved_at: Option<String>,
+    clean: bool,
+    project_path: Option<String>,
+    payload_bytes: u64,
+    fallback_reason: Option<String>,
+}
+
+fn resolve_scene_autosave_recovery(
+    recovery_dir: &std::path::Path,
+    manifest: Option<&SceneAutosaveManifest>,
+) -> Option<SceneAutosaveRecoveryCandidate> {
+    let generic = recovery_dir.join(SCENE_AUTOSAVE_VOXL_FILE);
+    let legacy_generic = recovery_dir.join(SCENE_AUTOSAVE_LEGACY_VOXL_FILE);
+
+    for candidate in scene_autosave_recovery_candidates(recovery_dir, manifest) {
+        if !is_readable_voxl_payload(&candidate) {
+            continue;
+        }
+
+        let origin = if autosave_paths_equal(&candidate, &generic)
+            || autosave_paths_equal(&candidate, &legacy_generic)
+        {
+            SCENE_AUTOSAVE_ORIGIN_RECOVERY_DIR.to_string()
+        } else {
+            manifest
+                .and_then(|m| m.origin.clone())
+                .unwrap_or_else(|| SCENE_AUTOSAVE_ORIGIN_SIDECAR.to_string())
+        };
+
+        let payload_bytes = std::fs::metadata(&candidate).map(|m| m.len()).unwrap_or(0);
+
+        return Some(SceneAutosaveRecoveryCandidate {
+            voxl_path: candidate,
+            origin,
+            saved_at: manifest.map(|m| m.saved_at.clone()),
+            clean: manifest.map(|m| m.clean).unwrap_or(false),
+            project_path: manifest.and_then(|m| m.project_path.clone()),
+            payload_bytes,
+            fallback_reason: manifest.and_then(|m| m.fallback_reason.clone()),
+        });
+    }
+
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Stale commit-temp sweep (inherited from sub-phase A)
+// ---------------------------------------------------------------------------
+
+/// The pid segment of a `<target>.tmp-<pid>-<seq>` name.
+fn scene_commit_temp_pid(path: &std::path::Path) -> Option<u32> {
+    let name = path.file_name().and_then(|n| n.to_str())?;
+    let (_, suffix) = name.rsplit_once(SCENE_COMMIT_TEMP_MARKER)?;
+    suffix.split('-').next()?.parse::<u32>().ok()
+}
+
+/// Removes commit temps abandoned by a crashed write.
+///
+/// Conservative by construction, because these live in the user's own project
+/// folder: only names `is_scene_commit_temp_path` recognises (sub-phase A's
+/// exact pattern), only in a directory autosave already writes to, never this
+/// process's own temps (they may be in flight â€” `scene_file_discard_atomic_temp`
+/// owns those), and only past an age gate so another instance's in-flight write
+/// is never deleted out from under it.
+fn sweep_stale_scene_commit_temps(dir: &std::path::Path, min_age_seconds: u64) -> u32 {
+    let cutoff = std::time::SystemTime::now()
+        .checked_sub(std::time::Duration::from_secs(min_age_seconds))
+        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+    let current_pid = std::process::id();
+
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+
+    let mut removed = 0u32;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !is_scene_commit_temp_path(&path) {
+            continue;
+        }
+        if scene_commit_temp_pid(&path) == Some(current_pid) {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .map(|modified| modified <= cutoff)
+            .unwrap_or(false);
+        if stale && std::fs::remove_file(&path).is_ok() {
+            removed += 1;
+        }
+    }
+    removed
+}
+
+/// Crash residue can be minutes old for a large scene; anything younger than
+/// this may still be an in-flight write from a second instance.
+const SCENE_COMMIT_TEMP_SWEEP_MIN_AGE_SECONDS: u64 = 30 * 60;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SceneAutosavePaths {
     voxl_path: String,
     manifest_path: String,
+    origin: String,
+    project_path: Option<String>,
+    fallback_reason: Option<String>,
+}
+
+/// Where an autosave tick will land, and why.
+///
+/// Pure and app-handle-free on purpose: the recovery directory is passed in, so
+/// the whole target policy â€” including the three invariants the user pinned â€”
+/// is testable without a Tauri runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SceneAutosaveTarget {
+    voxl_path: std::path::PathBuf,
+    origin: &'static str,
+    project_path: Option<String>,
+    fallback_reason: Option<&'static str>,
+}
+
+const SCENE_AUTOSAVE_ORIGIN_SIDECAR: &str = "sidecar";
+const SCENE_AUTOSAVE_ORIGIN_RECOVERY_DIR: &str = "recovery-dir";
+
+/// Resolves where an autosave tick lands.
+///
+/// **User item 5.** A project that has been saved or opened gets its recovery
+/// copy *beside it* as `<stem>_autosave.voxl` â€” local and obvious, not a hidden
+/// app-data path the user would have to hunt for. Untitled scenes keep the
+/// generic recovery location exactly as before.
+///
+/// **Binding fallback directive.** Any failure of the sidecar target â€” folder
+/// gone, read-only volume, permission denied, unreachable network share â€” falls
+/// back to the generic recovery location with a `fallback_reason` recorded in
+/// the manifest. Never fail an autosave over a folder-policy question, and never
+/// lie about where the payload actually went.
+///
+/// Three invariants hold for every input, each with its own test: the result
+/// never equals the project path, always ends in `.voxl`, and always carries the
+/// `_autosave` marker.
+fn resolve_scene_autosave_target(
+    recovery_dir: &std::path::Path,
+    preferred_project_path: Option<&str>,
+) -> SceneAutosaveTarget {
+    let fallback = |project: Option<&str>, reason: &'static str| SceneAutosaveTarget {
+        voxl_path: recovery_dir.join(SCENE_AUTOSAVE_VOXL_FILE),
+        origin: SCENE_AUTOSAVE_ORIGIN_RECOVERY_DIR,
+        project_path: project.map(str::to_string),
+        fallback_reason: Some(reason),
+    };
+
+    let Some(project) = preferred_project_path
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return fallback(None, "no-project");
+    };
+
+    let path = std::path::Path::new(project);
+    // `is_scene_file_path`, not `is_voxl_autosave_target`: a project saved in a
+    // plugin scene format is still a project and still deserves a sidecar. It
+    // gets a correctly-named `.voxl` one, so VOXL bytes never land in a file
+    // whose extension promises a foreign format (invariant b).
+    if !is_scene_file_path(path) {
+        return fallback(Some(project), "not-a-scene-file");
+    }
+
+    let Some(sidecar) = sidecar_autosave_path_for_project(path) else {
+        return fallback(Some(project), "not-a-scene-file");
+    };
+
+    // Invariants (a) and (b), enforced rather than assumed: the target is never
+    // the file the user saves to, and it always ends in `.voxl`. Both are
+    // unreachable by construction â€” `sidecar_autosave_file_name` inserts the
+    // marker before a hard-coded `.voxl` â€” but they are the locks this whole
+    // sub-phase exists for, so the resolver checks its own output instead of
+    // trusting that the naming helper is never changed carelessly.
+    if autosave_paths_equal(&sidecar, path) || !is_voxl_autosave_target(&sidecar) {
+        return fallback(Some(project), "not-a-scene-file");
+    }
+
+    if let Some(reason) = probe_directory_writable(&sidecar) {
+        return fallback(Some(project), reason);
+    }
+
+    SceneAutosaveTarget {
+        voxl_path: sidecar,
+        origin: SCENE_AUTOSAVE_ORIGIN_SIDECAR,
+        project_path: Some(project.to_string()),
+        fallback_reason: None,
+    }
 }
 
 fn scene_autosave_resolve_dir(app: &DragonFruitAppHandle) -> Result<std::path::PathBuf, String> {
@@ -2572,63 +2992,132 @@ async fn scene_autosave_get_paths(
 ) -> Result<SceneAutosavePaths, String> {
     tauri::async_runtime::spawn_blocking(move || {
         let dir = scene_autosave_resolve_dir(&app)?;
+        let target = resolve_scene_autosave_target(&dir, preferred_save_path.as_deref());
 
-        // Determine VOXL autosave path: if user has explicitly saved to a .voxl file,
-        // autosave directly to that file. Otherwise use the generic recovery location.
-        //
-        // The predicate is `is_voxl_autosave_target`, NOT `is_scene_file_path`:
-        // autosave emits VOXL bytes, and `is_scene_file_path` also accepts every
-        // plugin scene extension, so a project saved as e.g. `MyPrint.lys` used
-        // to be returned verbatim and then filled with VOXL. Autosave ALWAYS
-        // writes `.voxl` — see `is_voxl_autosave_target` and its test.
-        let voxl_path = if let Some(preferred) = preferred_save_path {
-            let path = std::path::Path::new(&preferred);
-            if is_voxl_autosave_target(path) && path.exists() {
-                // User has explicitly saved to a VOXL project; autosave to it
-                preferred
-            } else {
-                // Not a VOXL scene file or doesn't exist; fall back to generic recovery
-                dir.join(SCENE_AUTOSAVE_VOXL_FILE)
-                    .to_string_lossy()
-                    .to_string()
-            }
-        } else {
-            // No preferred path; use generic recovery location
-            dir.join(SCENE_AUTOSAVE_VOXL_FILE)
-                .to_string_lossy()
-                .to_string()
-        };
+        // Sweep crash residue from the directory we are about to write to, and
+        // only that one. A `<project>.voxl.tmp-<pid>-<seq>` left by a killed
+        // write is confusing clutter sitting next to the user's project.
+        if let Some(parent) = target.voxl_path.parent() {
+            sweep_stale_scene_commit_temps(parent, SCENE_COMMIT_TEMP_SWEEP_MIN_AGE_SECONDS);
+        }
 
         Ok(SceneAutosavePaths {
-            voxl_path,
+            voxl_path: target.voxl_path.to_string_lossy().to_string(),
             manifest_path: dir
                 .join(SCENE_AUTOSAVE_MANIFEST_FILE)
                 .to_string_lossy()
                 .to_string(),
+            origin: target.origin.to_string(),
+            project_path: target.project_path,
+            fallback_reason: target.fallback_reason.map(str::to_string),
         })
     })
     .await
     .map_err(|err| format!("scene_autosave_get_paths task failed: {err}"))?
 }
 
+/// Writes the recovery manifest â€” **always after** the payload has been
+/// committed by sub-phase A's atomic rename. That ordering is what makes
+/// `voxl_path` authoritative: the manifest can only ever name a file that is
+/// already complete on disk.
+///
+/// `delete_payload` is the cleanup seam. It removes the payload the *previous*
+/// manifest advertised (plus the legacy generic location), gated on
+/// `is_deletable_autosave_payload` so the user's project can never be reached
+/// through it. Callers use it only after a successful save, restore, or an
+/// explicit discard â€” never while unsaved work exists.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 async fn scene_autosave_write_manifest(
     app: DragonFruitAppHandle,
     saved_at: String,
     clean: bool,
+    voxl_path: Option<String>,
+    origin: Option<String>,
+    project_path: Option<String>,
+    payload_bytes: Option<u64>,
+    fallback_reason: Option<String>,
+    delete_payload: Option<bool>,
 ) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         let dir = scene_autosave_resolve_dir(&app)?;
-        let manifest = SceneAutosaveManifest { saved_at, clean };
+        let path = dir.join(SCENE_AUTOSAVE_MANIFEST_FILE);
+
+        let previous: Option<SceneAutosaveManifest> = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|content| serde_json::from_str(&content).ok());
+
+        if delete_payload.unwrap_or(false) {
+            let mut targets: Vec<std::path::PathBuf> =
+                vec![dir.join(SCENE_AUTOSAVE_LEGACY_VOXL_FILE), dir.join(SCENE_AUTOSAVE_VOXL_FILE)];
+            for advertised in [
+                previous.as_ref().and_then(|m| m.voxl_path.clone()),
+                voxl_path.clone(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                targets.push(std::path::PathBuf::from(advertised));
+            }
+            if let Some(project) = previous
+                .as_ref()
+                .and_then(|m| m.project_path.clone())
+                .or_else(|| project_path.clone())
+            {
+                if let Some(sidecar) =
+                    sidecar_autosave_path_for_project(std::path::Path::new(&project))
+                {
+                    targets.push(sidecar);
+                }
+            }
+
+            for target in targets {
+                if !is_deletable_autosave_payload(&dir, &target) {
+                    continue;
+                }
+                if target.exists() {
+                    let _ = std::fs::remove_file(&target);
+                }
+            }
+        }
+
+        let manifest = SceneAutosaveManifest {
+            saved_at,
+            clean,
+            // A cleaned manifest must not keep advertising a payload it just
+            // deleted, or recovery would offer a file that is gone.
+            voxl_path: if delete_payload.unwrap_or(false) { None } else { voxl_path },
+            origin,
+            project_path,
+            payload_bytes,
+            fallback_reason,
+            last_error: None,
+        };
         let json = serde_json::to_string(&manifest)
             .map_err(|err| format!("Failed serializing autosave manifest: {err}"))?;
-        let path = dir.join(SCENE_AUTOSAVE_MANIFEST_FILE);
         std::fs::write(&path, json.as_bytes())
             .map_err(|err| format!("Failed writing autosave manifest: {err}"))?;
         Ok(())
     })
     .await
     .map_err(|err| format!("scene_autosave_write_manifest task failed: {err}"))?
+}
+
+/// Deletes the sidecar belonging to a specific project.
+///
+/// Save As uses this on the **old** project path, so a successful Save As never
+/// orphans a `_autosave.voxl` beside a file the user has stopped editing.
+#[tauri::command]
+async fn scene_autosave_delete_sidecar(project_path: String) -> Result<(), String> {
+    let trimmed = project_path.trim().to_string();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+    tauri::async_runtime::spawn_blocking(move || {
+        delete_sidecar_for_project(std::path::Path::new(&trimmed))
+    })
+    .await
+    .map_err(|err| format!("scene_autosave_delete_sidecar task failed: {err}"))?
 }
 
 #[tauri::command]
@@ -2651,15 +3140,67 @@ async fn scene_autosave_read_manifest(
     .map_err(|err| format!("scene_autosave_read_manifest task failed: {err}"))?
 }
 
+fn scene_autosave_read_manifest_from_dir(dir: &std::path::Path) -> Option<SceneAutosaveManifest> {
+    let path = dir.join(SCENE_AUTOSAVE_MANIFEST_FILE);
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// **Recovery-discovery parity.** Without this, sidecar path control would be a
+/// regression rather than a fix: the manifest would advertise a payload beside
+/// the project and the reader â€” hard-wired to the generic location before this
+/// change â€” could not open it.
 #[tauri::command]
-async fn scene_autosave_read_voxl_bytes(app: DragonFruitAppHandle) -> Result<Response, String> {
+async fn scene_autosave_resolve_recovery(
+    app: DragonFruitAppHandle,
+) -> Result<Option<SceneAutosaveRecoveryCandidate>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let dir = scene_autosave_resolve_dir(&app)?;
+        let manifest = scene_autosave_read_manifest_from_dir(&dir);
+        Ok(resolve_scene_autosave_recovery(&dir, manifest.as_ref()))
+    })
+    .await
+    .map_err(|err| format!("scene_autosave_resolve_recovery task failed: {err}"))?
+}
+
+/// Reads a recovery payload. `path` is accepted **only** when it appears in the
+/// resolver's own candidate list â€” never an arbitrary caller-supplied path.
+/// Omitting it keeps the pre-Ph0.1 behaviour of reading the generic location.
+#[tauri::command]
+async fn scene_autosave_read_voxl_bytes(
+    app: DragonFruitAppHandle,
+    path: Option<String>,
+) -> Result<Response, String> {
     let bytes = tauri::async_runtime::spawn_blocking(move || {
         let dir = scene_autosave_resolve_dir(&app)?;
-        let path = dir.join(SCENE_AUTOSAVE_VOXL_FILE);
-        if !path.exists() {
+        let manifest = scene_autosave_read_manifest_from_dir(&dir);
+        let candidates = scene_autosave_recovery_candidates(&dir, manifest.as_ref());
+
+        let requested = path
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(std::path::PathBuf::from);
+
+        let target = match requested {
+            Some(requested) => {
+                if !is_allowed_recovery_read(&candidates, &requested) {
+                    return Err(format!(
+                        "Refusing to read '{}': not an autosave recovery candidate",
+                        requested.display()
+                    ));
+                }
+                requested
+            }
+            None => resolve_scene_autosave_recovery(&dir, manifest.as_ref())
+                .map(|candidate| candidate.voxl_path)
+                .ok_or_else(|| "No autosaved scene file found".to_string())?,
+        };
+
+        if !target.exists() {
             return Err("No autosaved scene file found".to_string());
         }
-        std::fs::read(&path).map_err(|err| format!("Failed reading autosaved scene: {err}"))
+        std::fs::read(&target).map_err(|err| format!("Failed reading autosaved scene: {err}"))
     })
     .await
     .map_err(|err| format!("scene_autosave_read_voxl_bytes task failed: {err}"))??;
@@ -3621,6 +4162,8 @@ fn main() {
             scene_autosave_write_manifest,
             scene_autosave_read_manifest,
             scene_autosave_read_voxl_bytes,
+            scene_autosave_resolve_recovery,
+            scene_autosave_delete_sidecar,
             reveal_in_file_manager,
             open_external_url,
             launch_external_process,
@@ -4028,4 +4571,468 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&dir);
     }
+
+    // -----------------------------------------------------------------------
+    // Ph0.1 sub-phase B â€” sidecar target policy + recovery-discovery parity
+    // -----------------------------------------------------------------------
+
+    /// Builds a project folder with a real scene file in it, plus a separate
+    /// recovery dir, mirroring the two real locations at runtime.
+    fn autosave_fixture(tag: &str, project_file: &str) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+        let root = unique_test_dir(tag);
+        let project_dir = root.join("projects");
+        let recovery_dir = root.join("recovery");
+        std::fs::create_dir_all(&project_dir).expect("failed creating project dir");
+        std::fs::create_dir_all(&recovery_dir).expect("failed creating recovery dir");
+        let project = project_dir.join(project_file);
+        std::fs::write(&project, voxl_payload(b"project")).expect("failed seeding project file");
+        (root, recovery_dir, project)
+    }
+
+    /// A minimally-valid VOXL payload: the 4-byte magic plus filler. The
+    /// recovery resolver magic-checks every candidate, so fixtures must carry it.
+    fn voxl_payload(tail: &[u8]) -> Vec<u8> {
+        let mut bytes = b"VOXL".to_vec();
+        bytes.extend_from_slice(tail);
+        bytes
+    }
+
+    /// **User item 5, the lock.** An autosave tick must never target the file the
+    /// user saves to. Before sub-phase B `scene_autosave_get_paths` returned the
+    /// project path verbatim, so every tick overwrote the user's project with a
+    /// scene state they never asked to save.
+    #[test]
+    fn autosave_target_never_equals_the_project_path() {
+        let (root, recovery_dir, project) = autosave_fixture("b-never-project", "MyPrint.voxl");
+        let project_text = project.to_string_lossy().to_string();
+
+        for candidate in [
+            project_text.as_str(),
+            // Already-sidecar-shaped names must not collapse onto themselves.
+            root.join("projects/MyPrint_autosave.voxl")
+                .to_string_lossy()
+                .to_string()
+                .as_str(),
+        ] {
+            let target = super::resolve_scene_autosave_target(&recovery_dir, Some(candidate));
+            assert_ne!(
+                target.voxl_path,
+                std::path::Path::new(candidate),
+                "autosave targeted the user's own project file: {candidate}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// **Invariant (b).** Whatever the project's extension, the autosave target
+    /// ends in `.voxl` â€” autosave emits VOXL bytes and must never put them in a
+    /// file whose extension promises a foreign format.
+    #[test]
+    fn autosave_target_always_ends_in_voxl() {
+        let root = unique_test_dir("b-always-voxl");
+        let project_dir = root.join("projects");
+        std::fs::create_dir_all(&project_dir).expect("failed creating project dir");
+
+        let mut names: Vec<String> = vec!["MyPrint.voxl".to_string(), "MyPrint.VOXL".to_string()];
+        names.extend(
+            super::BUILTIN_PLUGIN_SCENE_EXTENSIONS
+                .iter()
+                .map(|ext| format!("MyPrint.{ext}")),
+        );
+
+        for name in names {
+            let project = project_dir.join(&name);
+            std::fs::write(&project, voxl_payload(b"p")).expect("seed failed");
+            let target = super::resolve_scene_autosave_target(
+                &root.join("recovery"),
+                Some(project.to_string_lossy().as_ref()),
+            );
+            let ext = target
+                .voxl_path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+            assert_eq!(
+                ext,
+                "voxl",
+                "autosave target for '{name}' does not end in .voxl: {}",
+                target.voxl_path.display()
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// **Invariant (c).** The target always carries the `_autosave` marker, so a
+    /// recovery file is self-describing in Explorer and can never be mistaken for
+    /// a project. It is also what gates payload deletion
+    /// (`is_deletable_autosave_payload`).
+    #[test]
+    fn autosave_target_always_contains_the_autosave_marker() {
+        let (root, recovery_dir, project) = autosave_fixture("b-marker", "MyPrint.voxl");
+
+        for preferred in [
+            Some(project.to_string_lossy().to_string()),
+            Some("   ".to_string()),
+            None,
+        ] {
+            let target =
+                super::resolve_scene_autosave_target(&recovery_dir, preferred.as_deref());
+            let name = target
+                .voxl_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default()
+                .to_string();
+            assert!(
+                name.contains("_autosave"),
+                "autosave target is not self-describing: {name}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// **User item 5, the payoff.** A saved/opened project gets its recovery copy
+    /// beside it â€” local and obvious â€” not in a hidden app-data path.
+    #[test]
+    fn sidecar_lands_beside_the_project_as_stem_autosave_voxl() {
+        let (root, recovery_dir, project) = autosave_fixture("b-sidecar", "MyPrint.voxl");
+
+        let target = super::resolve_scene_autosave_target(
+            &recovery_dir,
+            Some(project.to_string_lossy().as_ref()),
+        );
+
+        assert_eq!(target.origin, super::SCENE_AUTOSAVE_ORIGIN_SIDECAR);
+        assert_eq!(target.fallback_reason, None);
+        assert_eq!(
+            target.voxl_path,
+            project.parent().unwrap().join("MyPrint_autosave.voxl"),
+            "the sidecar did not land beside the project"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A plugin-format project still gets a correctly-named VOXL sidecar in its
+    /// own folder rather than being exiled to the recovery dir.
+    #[test]
+    fn sidecar_is_derived_for_plugin_scene_extensions_too() {
+        let ext = super::BUILTIN_PLUGIN_SCENE_EXTENSIONS
+            .first()
+            .expect("no plugin scene extensions registered");
+        let (root, recovery_dir, project) =
+            autosave_fixture("b-plugin-ext", &format!("MyPrint.{ext}"));
+
+        let target = super::resolve_scene_autosave_target(
+            &recovery_dir,
+            Some(project.to_string_lossy().as_ref()),
+        );
+
+        assert_eq!(target.origin, super::SCENE_AUTOSAVE_ORIGIN_SIDECAR);
+        assert_eq!(
+            target.voxl_path,
+            project.parent().unwrap().join("MyPrint_autosave.voxl"),
+            "a plugin-format project did not get a .voxl sidecar beside it"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// **Binding user directive.** Any failure of the sidecar target falls back
+    /// to the default recovery location and says why â€” never fail an autosave
+    /// over a folder-permission question, and never lie about where it went.
+    #[test]
+    fn sidecar_falls_back_to_recovery_dir_when_the_project_folder_is_unusable() {
+        let root = unique_test_dir("b-fallback");
+        let recovery_dir = root.join("recovery");
+        std::fs::create_dir_all(&recovery_dir).expect("failed creating recovery dir");
+        let generic = recovery_dir.join(super::SCENE_AUTOSAVE_VOXL_FILE);
+
+        // Parent directory does not exist (deleted folder / unreachable share).
+        let missing = root.join("gone/MyPrint.voxl");
+        let target =
+            super::resolve_scene_autosave_target(&recovery_dir, Some(missing.to_string_lossy().as_ref()));
+        assert_eq!(target.voxl_path, generic);
+        assert_eq!(target.origin, super::SCENE_AUTOSAVE_ORIGIN_RECOVERY_DIR);
+        assert_eq!(target.fallback_reason, Some("parent-missing"));
+
+        // Not a scene file at all.
+        let not_scene = root.join("notes.txt");
+        std::fs::write(&not_scene, b"hi").expect("seed failed");
+        let target = super::resolve_scene_autosave_target(
+            &recovery_dir,
+            Some(not_scene.to_string_lossy().as_ref()),
+        );
+        assert_eq!(target.voxl_path, generic);
+        assert_eq!(target.fallback_reason, Some("not-a-scene-file"));
+
+        // No project at all (untitled scene) keeps today's behaviour exactly.
+        let target = super::resolve_scene_autosave_target(&recovery_dir, None);
+        assert_eq!(target.voxl_path, generic);
+        assert_eq!(target.fallback_reason, Some("no-project"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The writability probe must use a real syscall â€” a metadata guess passes on
+    /// read-only volumes and on network shares that deny writes.
+    #[test]
+    fn writability_probe_rejects_a_directory_that_cannot_be_written() {
+        let root = unique_test_dir("b-probe");
+        let usable = root.join("usable");
+        std::fs::create_dir_all(&usable).expect("failed creating dir");
+
+        assert!(
+            super::probe_directory_writable(&usable.join("MyPrint_autosave.voxl")).is_none(),
+            "a writable folder was reported unusable"
+        );
+        assert!(
+            !usable.join("MyPrint_autosave.voxl").exists(),
+            "the probe left its scratch file behind"
+        );
+        let residue: Vec<_> = std::fs::read_dir(&usable)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        assert!(residue.is_empty(), "the probe left residue: {residue:?}");
+
+        assert_eq!(
+            super::probe_directory_writable(&root.join("absent/MyPrint_autosave.voxl")),
+            Some("parent-missing"),
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// **The parity requirement.** Path control without discovery is a
+    /// regression: a manifest would advertise a sidecar the reader could not
+    /// open. Resolution order is manifest â†’ sidecar-from-project â†’ legacy generic.
+    #[test]
+    fn recovery_discovery_prefers_manifest_then_sidecar_then_generic() {
+        let (root, recovery_dir, project) = autosave_fixture("b-discovery", "MyPrint.voxl");
+        let sidecar = project.parent().unwrap().join("MyPrint_autosave.voxl");
+        let generic = recovery_dir.join(super::SCENE_AUTOSAVE_VOXL_FILE);
+        std::fs::write(&sidecar, voxl_payload(b"sidecar")).expect("sidecar seed failed");
+        std::fs::write(&generic, voxl_payload(b"generic")).expect("generic seed failed");
+
+        let manifest = super::SceneAutosaveManifest {
+            saved_at: "2026-07-26T00:00:00.000Z".to_string(),
+            clean: false,
+            voxl_path: Some(sidecar.to_string_lossy().to_string()),
+            origin: Some(super::SCENE_AUTOSAVE_ORIGIN_SIDECAR.to_string()),
+            project_path: Some(project.to_string_lossy().to_string()),
+            payload_bytes: None,
+            fallback_reason: None,
+            last_error: None,
+        };
+
+        // 1. The manifest is authoritative.
+        let found = super::resolve_scene_autosave_recovery(&recovery_dir, Some(&manifest))
+            .expect("no recovery candidate found");
+        assert_eq!(found.voxl_path, sidecar);
+        assert_eq!(found.origin, super::SCENE_AUTOSAVE_ORIGIN_SIDECAR);
+
+        // 2. A manifest whose `voxlPath` no longer resolves falls through to the
+        //    sidecar derived from `projectPath` (project moved, or an older build
+        //    wrote no `voxlPath` at all).
+        let mut stale = manifest.clone();
+        stale.voxl_path = Some(root.join("gone/MyPrint_autosave.voxl").to_string_lossy().to_string());
+        let found = super::resolve_scene_autosave_recovery(&recovery_dir, Some(&stale))
+            .expect("no recovery candidate found via project path");
+        assert_eq!(found.voxl_path, sidecar);
+
+        // 3. With neither, the legacy generic location still recovers.
+        let mut legacy = manifest.clone();
+        legacy.voxl_path = None;
+        legacy.project_path = None;
+        let found = super::resolve_scene_autosave_recovery(&recovery_dir, Some(&legacy))
+            .expect("no recovery candidate found in the legacy location");
+        assert_eq!(found.voxl_path, generic);
+
+        // 4. Nothing on disk â‡’ no prompt.
+        std::fs::remove_file(&generic).expect("generic cleanup failed");
+        assert!(super::resolve_scene_autosave_recovery(&recovery_dir, Some(&legacy)).is_none());
+        assert!(super::resolve_scene_autosave_recovery(&recovery_dir, None).is_none());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Back-compat lock: a manifest written before sub-phase B has none of the
+    /// new fields and must still parse and still recover from the generic path.
+    #[test]
+    fn recovery_discovery_reads_a_legacy_pre_sidecar_manifest() {
+        let root = unique_test_dir("b-legacy-manifest");
+        let recovery_dir = root.join("recovery");
+        std::fs::create_dir_all(&recovery_dir).expect("failed creating recovery dir");
+        // The pre-Ph0.1 payload name, which is never written any more.
+        let legacy = recovery_dir.join(super::SCENE_AUTOSAVE_LEGACY_VOXL_FILE);
+        std::fs::write(&legacy, voxl_payload(b"legacy")).expect("legacy seed failed");
+
+        let legacy_json = r#"{"savedAt":"2026-07-01T12:00:00.000Z","clean":false}"#;
+        let manifest: super::SceneAutosaveManifest =
+            serde_json::from_str(legacy_json).expect("a pre-Ph0.1 manifest no longer parses");
+        assert_eq!(manifest.voxl_path, None);
+
+        let found = super::resolve_scene_autosave_recovery(&recovery_dir, Some(&manifest))
+            .expect("a pre-Ph0.1 autosave became unrecoverable");
+        assert_eq!(found.voxl_path, legacy);
+        assert_eq!(found.origin, super::SCENE_AUTOSAVE_ORIGIN_RECOVERY_DIR);
+        assert_eq!(found.saved_at.as_deref(), Some("2026-07-01T12:00:00.000Z"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A payload that is not VOXL (truncated, foreign, or a leftover of some
+    /// other tool) must not be advertised as recoverable.
+    #[test]
+    fn recovery_discovery_skips_candidates_that_are_not_voxl() {
+        let (root, recovery_dir, project) = autosave_fixture("b-magic", "MyPrint.voxl");
+        let sidecar = project.parent().unwrap().join("MyPrint_autosave.voxl");
+        let generic = recovery_dir.join(super::SCENE_AUTOSAVE_VOXL_FILE);
+        std::fs::write(&sidecar, b"NOPE-not-a-voxl").expect("sidecar seed failed");
+        std::fs::write(&generic, voxl_payload(b"generic")).expect("generic seed failed");
+
+        let manifest = super::SceneAutosaveManifest {
+            saved_at: "2026-07-26T00:00:00.000Z".to_string(),
+            clean: false,
+            voxl_path: Some(sidecar.to_string_lossy().to_string()),
+            origin: Some(super::SCENE_AUTOSAVE_ORIGIN_SIDECAR.to_string()),
+            project_path: Some(project.to_string_lossy().to_string()),
+            payload_bytes: None,
+            fallback_reason: None,
+            last_error: None,
+        };
+
+        let found = super::resolve_scene_autosave_recovery(&recovery_dir, Some(&manifest))
+            .expect("recovery gave up instead of falling through a bad payload");
+        assert_eq!(
+            found.voxl_path, generic,
+            "a non-VOXL payload was advertised as recoverable"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The reader accepts only paths the resolver itself produced â€” never an
+    /// arbitrary caller-supplied path. Same discipline as
+    /// `scene_file_discard_atomic_temp`'s guard.
+    #[test]
+    fn recovery_read_rejects_paths_outside_the_candidate_list() {
+        let (root, recovery_dir, project) = autosave_fixture("b-candidate-guard", "MyPrint.voxl");
+        let sidecar = project.parent().unwrap().join("MyPrint_autosave.voxl");
+        std::fs::write(&sidecar, voxl_payload(b"sidecar")).expect("sidecar seed failed");
+
+        let manifest = super::SceneAutosaveManifest {
+            saved_at: "2026-07-26T00:00:00.000Z".to_string(),
+            clean: false,
+            voxl_path: Some(sidecar.to_string_lossy().to_string()),
+            origin: Some(super::SCENE_AUTOSAVE_ORIGIN_SIDECAR.to_string()),
+            project_path: Some(project.to_string_lossy().to_string()),
+            payload_bytes: None,
+            fallback_reason: None,
+            last_error: None,
+        };
+
+        let candidates = super::scene_autosave_recovery_candidates(&recovery_dir, Some(&manifest));
+        assert!(super::is_allowed_recovery_read(&candidates, &sidecar));
+        // The user's own project is never a recovery candidate.
+        assert!(!super::is_allowed_recovery_read(&candidates, &project));
+        assert!(!super::is_allowed_recovery_read(
+            &candidates,
+            std::path::Path::new("C:/Windows/System32/config/SAM")
+        ));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Cleanup gate: only a file this policy could have produced may be deleted
+    /// through the payload-deletion seam.
+    #[test]
+    fn only_autosave_payloads_are_deletable() {
+        let recovery_dir = std::path::Path::new("C:/appdata/autosave");
+        assert!(super::is_deletable_autosave_payload(
+            recovery_dir,
+            std::path::Path::new("C:/projects/MyPrint_autosave.voxl")
+        ));
+        assert!(super::is_deletable_autosave_payload(
+            recovery_dir,
+            &recovery_dir.join(super::SCENE_AUTOSAVE_VOXL_FILE)
+        ));
+        // The pre-Ph0.1 payload name has no marker; it is deletable only because
+        // it sits at the one well-known legacy location.
+        assert!(super::is_deletable_autosave_payload(
+            recovery_dir,
+            &recovery_dir.join(super::SCENE_AUTOSAVE_LEGACY_VOXL_FILE)
+        ));
+        assert!(!super::is_deletable_autosave_payload(
+            recovery_dir,
+            std::path::Path::new("C:/projects/scene.voxl")
+        ));
+        // The user's project, and anything else, never.
+        assert!(!super::is_deletable_autosave_payload(
+            recovery_dir,
+            std::path::Path::new("C:/projects/MyPrint.voxl")
+        ));
+        assert!(!super::is_deletable_autosave_payload(
+            recovery_dir,
+            std::path::Path::new("C:/projects/MyPrint_autosave.stl")
+        ));
+    }
+
+    /// **Save-As cleanup (user item 6).** A sidecar left beside the *old* project
+    /// after Save As is an orphan that implies unsaved work which does not exist.
+    #[test]
+    fn sidecar_for_a_project_is_deleted_by_name_and_nothing_else_is() {
+        let (root, _recovery, project) = autosave_fixture("b-saveas-cleanup", "MyPrint.voxl");
+        let sidecar = project.parent().unwrap().join("MyPrint_autosave.voxl");
+        let neighbour = project.parent().unwrap().join("OtherPrint_autosave.voxl");
+        std::fs::write(&sidecar, voxl_payload(b"s")).expect("sidecar seed failed");
+        std::fs::write(&neighbour, voxl_payload(b"n")).expect("neighbour seed failed");
+
+        super::delete_sidecar_for_project(&project).expect("sidecar deletion failed");
+
+        assert!(!sidecar.exists(), "the orphaned sidecar was not deleted");
+        assert!(project.exists(), "deletion touched the user's project");
+        assert!(neighbour.exists(), "deletion touched an unrelated sidecar");
+
+        // Idempotent: a project that never autosaved is not an error.
+        super::delete_sidecar_for_project(&project).expect("second deletion should be a no-op");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// **Inherited from sub-phase A.** A crashed write leaves a
+    /// `<target>.tmp-<pid>-<seq>` sibling beside the user's project. Sweep them,
+    /// but only files matching A's exact pattern and only where we already write.
+    #[test]
+    fn stale_commit_temps_are_swept_conservatively() {
+        let root = unique_test_dir("b-temp-sweep");
+        let stale = root.join("MyPrint.voxl.tmp-424242-7");
+        let ours = root.join(format!("MyPrint.voxl.tmp-{}-0", std::process::id()));
+        let innocent = root.join("MyPrint.voxl");
+        let lookalike = root.join("MyPrint.voxl.tmp-notapid-0");
+        for path in [&stale, &ours, &innocent, &lookalike] {
+            std::fs::write(path, b"x").expect("seed failed");
+        }
+
+        // Nothing is old enough yet, so a fresh crash residue is left alone â€”
+        // an in-flight write from another instance must never be deleted.
+        assert_eq!(super::sweep_stale_scene_commit_temps(&root, 3600), 0);
+        assert!(stale.exists());
+
+        // With the age gate satisfied, only other processes' temps go.
+        assert_eq!(super::sweep_stale_scene_commit_temps(&root, 0), 1);
+        assert!(!stale.exists(), "a stale foreign temp survived the sweep");
+        assert!(ours.exists(), "the sweep deleted this process's own live temp");
+        assert!(innocent.exists(), "the sweep deleted a real scene file");
+        assert!(lookalike.exists(), "the sweep deleted a non-matching file");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2572,10 +2572,93 @@ struct SceneAutosaveManifest {
     payload_bytes: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     fallback_reason: Option<String>,
-    /// Reserved for sub-phase D (finding N4). Carried here so the manifest
-    /// schema settles in one change.
+    /// Failure message from the most recent tick, or None while autosave is healthy (D3).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     last_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SceneAutosaveManifestWrite {
+    pub saved_at: String,
+    pub clean: bool,
+    pub voxl_path: Option<String>,
+    pub origin: Option<String>,
+    pub project_path: Option<String>,
+    pub payload_bytes: Option<u64>,
+    pub fallback_reason: Option<String>,
+    pub last_error: Option<String>,
+    pub delete_payload: bool,
+}
+
+/**
+ * Builds the manifest to persist for a tick (finding N4, sub-phase D3).
+ *
+ * Failure honesty requires that **a failed tick must not overwrite the pointer
+ * to the last committed payload nor advance `saved_at` past what is on disk.** A
+ * naive write that serialized `saved_at: now` on every attempt turned a transient
+ * (antivirus locking the file, a share blinking) into a false recovery prompt
+ * offering an old payload labeled with a fresh timestamp — turning a
+ * *reported* problem into a real one. So on a failure write every
+ * payload-describing field, `saved_at` included, falls back to the previous
+ * manifest's value. Conversely a successful write clears `last_error`: the
+ * condition is over, and a stale error in the settings tab is its own small
+ * dishonesty.
+ */
+pub(crate) fn build_scene_autosave_manifest(
+    previous: Option<&SceneAutosaveManifest>,
+    write: SceneAutosaveManifestWrite,
+) -> SceneAutosaveManifest {
+    if write.last_error.is_some() {
+        return SceneAutosaveManifest {
+            saved_at: previous
+                .map(|m| m.saved_at.clone())
+                .unwrap_or(write.saved_at),
+            clean: write.clean,
+            voxl_path: write
+                .voxl_path
+                .or_else(|| previous.and_then(|m| m.voxl_path.clone())),
+            origin: write.origin.or_else(|| previous.and_then(|m| m.origin.clone())),
+            project_path: write
+                .project_path
+                .or_else(|| previous.and_then(|m| m.project_path.clone())),
+            payload_bytes: write
+                .payload_bytes
+                .or_else(|| previous.and_then(|m| m.payload_bytes)),
+            fallback_reason: write
+                .fallback_reason
+                .or_else(|| previous.and_then(|m| m.fallback_reason.clone())),
+            last_error: write.last_error,
+        };
+    }
+
+    SceneAutosaveManifest {
+        saved_at: write.saved_at,
+        clean: write.clean,
+        voxl_path: if write.delete_payload {
+            None
+        } else {
+            write
+                .voxl_path
+                .or_else(|| previous.and_then(|m| m.voxl_path.clone()))
+        },
+        origin: write
+            .origin
+            .or_else(|| previous.and_then(|m| m.origin.clone())),
+        project_path: write
+            .project_path
+            .or_else(|| previous.and_then(|m| m.project_path.clone())),
+        payload_bytes: if write.delete_payload {
+            None
+        } else {
+            write
+                .payload_bytes
+                .or_else(|| previous.and_then(|m| m.payload_bytes))
+        },
+        fallback_reason: write
+            .fallback_reason
+            .or_else(|| previous.and_then(|m| m.fallback_reason.clone())),
+        last_error: None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -3037,6 +3120,7 @@ async fn scene_autosave_write_manifest(
     project_path: Option<String>,
     payload_bytes: Option<u64>,
     fallback_reason: Option<String>,
+    last_error: Option<String>,
     delete_payload: Option<bool>,
 ) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
@@ -3081,18 +3165,20 @@ async fn scene_autosave_write_manifest(
             }
         }
 
-        let manifest = SceneAutosaveManifest {
-            saved_at,
-            clean,
-            // A cleaned manifest must not keep advertising a payload it just
-            // deleted, or recovery would offer a file that is gone.
-            voxl_path: if delete_payload.unwrap_or(false) { None } else { voxl_path },
-            origin,
-            project_path,
-            payload_bytes,
-            fallback_reason,
-            last_error: None,
-        };
+        let manifest = build_scene_autosave_manifest(
+            previous.as_ref(),
+            SceneAutosaveManifestWrite {
+                saved_at,
+                clean,
+                voxl_path,
+                origin,
+                project_path,
+                payload_bytes,
+                fallback_reason,
+                last_error,
+                delete_payload: delete_payload.unwrap_or(false),
+            },
+        );
         let json = serde_json::to_string(&manifest)
             .map_err(|err| format!("Failed serializing autosave manifest: {err}"))?;
         std::fs::write(&path, json.as_bytes())
@@ -5035,4 +5121,116 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    fn committed_manifest() -> super::SceneAutosaveManifest {
+        super::SceneAutosaveManifest {
+            saved_at: "2026-07-26T11:00:00.000Z".to_string(),
+            clean: false,
+            voxl_path: Some("C:/projects/MyPrint_autosave.voxl".to_string()),
+            origin: Some("sidecar".to_string()),
+            project_path: Some("C:/projects/MyPrint.voxl".to_string()),
+            payload_bytes: Some(12345),
+            fallback_reason: None,
+            last_error: None,
+        }
+    }
+
+    fn failure_write(error: &str) -> super::SceneAutosaveManifestWrite {
+        super::SceneAutosaveManifestWrite {
+            saved_at: "2026-07-26T12:00:00.000Z".to_string(),
+            clean: false,
+            voxl_path: None,
+            origin: None,
+            project_path: None,
+            payload_bytes: None,
+            fallback_reason: None,
+            last_error: Some(error.to_string()),
+            delete_payload: false,
+        }
+    }
+
+    /// Failure honesty (sub-phase D3, finding N4): an error must be recorded without
+    /// advancing `saved_at` past what is actually on disk or dropping the pointer
+    /// to the last committed payload. A naive write that updated `saved_at` turned a
+    /// transient (antivirus on destination, share blinking) into a false recovery prompt
+    /// offering old work labeled with a fresh timestamp — turning a *reported* problem into
+    /// a real one.
+    #[test]
+    fn autosave_failure_is_recorded_without_disturbing_the_last_good_payload() {
+        let previous = committed_manifest();
+        let next = super::build_scene_autosave_manifest(
+            Some(&previous),
+            failure_write("This scene is 4.3 GB compressed and exceeds the VOXL 4 GB limit."),
+        );
+
+        assert_eq!(
+            next.last_error.as_deref(),
+            Some("This scene is 4.3 GB compressed and exceeds the VOXL 4 GB limit.")
+        );
+        assert_eq!(
+            next.saved_at, previous.saved_at,
+            "a failed tick advanced the timestamp the recovery prompt shows"
+        );
+        assert_eq!(
+            next.voxl_path, previous.voxl_path,
+            "a failed tick erased the pointer to the last committed payload"
+        );
+        assert_eq!(next.origin, previous.origin);
+        assert_eq!(next.project_path, previous.project_path);
+        assert_eq!(next.payload_bytes, previous.payload_bytes);
+    }
+
+    #[test]
+    fn a_first_ever_failure_still_produces_a_readable_manifest() {
+        let next = super::build_scene_autosave_manifest(None, failure_write("disk full"));
+        assert_eq!(next.last_error.as_deref(), Some("disk full"));
+        assert_eq!(next.saved_at, "2026-07-26T12:00:00.000Z");
+        assert_eq!(next.voxl_path, None);
+    }
+
+    #[test]
+    fn a_successful_write_clears_a_recorded_failure() {
+        let mut previous = committed_manifest();
+        previous.last_error = Some("disk full".to_string());
+
+        let next = super::build_scene_autosave_manifest(
+            Some(&previous),
+            super::SceneAutosaveManifestWrite {
+                saved_at: "2026-07-26T12:00:00.000Z".to_string(),
+                clean: false,
+                voxl_path: Some("C:/projects/MyPrint_autosave.voxl".to_string()),
+                origin: Some("sidecar".to_string()),
+                project_path: Some("C:/projects/MyPrint.voxl".to_string()),
+                payload_bytes: Some(999),
+                fallback_reason: None,
+                last_error: None,
+                delete_payload: false,
+            },
+        );
+
+        assert_eq!(next.last_error, None, "a healthy autosave kept reporting a stale error");
+        assert_eq!(next.saved_at, "2026-07-26T12:00:00.000Z");
+        assert_eq!(next.payload_bytes, Some(999));
+    }
+
+    #[test]
+    fn clearing_the_manifest_drops_the_payload_pointer_it_just_deleted() {
+        let previous = committed_manifest();
+        let next = super::build_scene_autosave_manifest(
+            Some(&previous),
+            super::SceneAutosaveManifestWrite {
+                saved_at: "2026-07-26T12:00:00.000Z".to_string(),
+                clean: true,
+                voxl_path: previous.voxl_path.clone(),
+                origin: previous.origin.clone(),
+                project_path: previous.project_path.clone(),
+                payload_bytes: None,
+                fallback_reason: None,
+                last_error: None,
+                delete_payload: true,
+            },
+        );
+
+        assert!(next.clean);
+        assert_eq!(next.voxl_path, None, "a cleaned manifest advertised a file it had deleted");
+    }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -316,7 +316,13 @@ import { resolveCompositeMaterialLabel } from '@/utils/materialLabel';
 
 import { type MeshShaderType } from '@/features/shaders/mesh';
 import type { ModelTransform, TransformMode } from '@/hooks/useModelTransform';
-import { useSceneAutosave, suppressSceneAutosave } from '@/hooks/useSceneAutosave';
+import {
+  useSceneAutosave,
+  suppressSceneAutosave,
+  resolveAutosaveRecovery,
+  readAutosaveRecoveryBytes,
+  deleteAutosaveSidecarForProject,
+} from '@/hooks/useSceneAutosave';
 import { SceneAutosaveRecoveryModal } from '@/components/scene/SceneAutosaveRecoveryModal';
 import { MeshRepairReportModal } from '@/components/scene/MeshRepairReportModal';
 import { MeshRepairConfirmModal } from '@/components/scene/MeshRepairConfirmModal';
@@ -776,7 +782,12 @@ export default function Home() {
   const [showSceneSaveChoiceModal, setShowSceneSaveChoiceModal] = React.useState(false);
   const [sceneSaveChoiceFileName, setSceneSaveChoiceFileName] = React.useState<string | null>(null);
   const [sceneSaveChoicePath, setSceneSaveChoicePath] = React.useState<string | null>(null);
-  const [autosaveRecovery, setAutosaveRecovery] = React.useState<{ savedAt: string } | null>(null);
+  const [autosaveRecovery, setAutosaveRecovery] = React.useState<{
+    savedAt: string;
+    /** The payload discovery resolved — the restore reads this exact file. */
+    voxlPath: string;
+    origin: string;
+  } | null>(null);
   const [showCloseUnsavedChangesModal, setShowCloseUnsavedChangesModal] = React.useState(false);
   const [closeUnsavedChangesBusy, setCloseUnsavedChangesBusy] = React.useState<'none' | 'save_and_close' | 'discard_and_close'>('none');
   const [hasUnsavedSceneChanges, setHasUnsavedSceneChanges] = React.useState(false);
@@ -823,7 +834,15 @@ export default function Home() {
     enabled: sceneAutosaveEnabled,
     debounceMs: sceneAutosaveSettings.debounceMs,
     capMs: sceneAutosaveSettings.capMs,
-    preferredSavePath: preferredOverwriteScenePathRef.current,
+    // **Finding N3.** This used to read `preferredOverwriteScenePathRef.current`
+    // — a ref, read during render. Mutating a ref does not re-render, so the
+    // hook kept whatever value happened to be captured at the last unrelated
+    // render. Harmless while autosave wrote to one fixed location; under
+    // sidecars it is a correctness bug, because after a Save As the recovery
+    // file would keep landing beside the *old* project. `activeSceneFilePath` is
+    // state (set on every successful save and on every scene open), so the
+    // sidecar follows the project.
+    preferredSavePath: activeSceneFilePath,
   });
 
   // Editor toast/notification subsystem (state, refs, fade/show effects,
@@ -4001,6 +4020,9 @@ export default function Home() {
   }, [printingArtifact]);
 
   const performTopBarSaveScene = React.useCallback(async (options?: { nativePathOverride?: string | null }) => {
+    // Captured before the save so a Save As can clean up the sidecar beside the
+    // project the user just moved away from.
+    const previousScenePath = activeSceneFilePath;
     const visibleModels = scene.models.filter((model) => model.visible);
     const scopeModels = visibleModels.length > 0 ? visibleModels : scene.models;
     const resolvedNativePath = options?.nativePathOverride !== undefined
@@ -4058,6 +4080,16 @@ export default function Home() {
       // Once a scene has been successfully saved to a concrete VOXL path,
       // future Ctrl+S should keep saving in-place without prompting again.
       preferredOverwriteScenePathRef.current = nextActiveScenePath;
+
+      // Save As moved the project. The recovery file beside the old one is now
+      // an orphan that implies unsaved work which does not exist — and the new
+      // sidecar is about to be written beside the new project. Safe to remove
+      // here specifically because the save above succeeded.
+      if (previousScenePath && previousScenePath !== nextActiveScenePath) {
+        void deleteAutosaveSidecarForProject(previousScenePath).catch((error) => {
+          console.warn('[SceneAutosave] Failed removing the sidecar beside the previous project.', error);
+        });
+      }
     }
     if (savedPath) {
       setExportSuccessToast({ id: Date.now(), path: savedPath });
@@ -4093,8 +4125,10 @@ export default function Home() {
     });
 
     try {
-      const { invoke } = await import('@tauri-apps/api/core');
-      const bytes = await invoke<ArrayBuffer>('scene_autosave_read_voxl_bytes');
+      // Read exactly the payload discovery resolved — the sidecar beside the
+      // project, or the generic location if that is where the tick fell back to.
+      // The backend re-validates the path against its own candidate list.
+      const bytes = await readAutosaveRecoveryBytes(recoverySnapshot?.voxlPath ?? null);
       const uint8 = new Uint8Array(bytes);
       if (uint8.byteLength === 0) {
         throw new Error('Autosaved VOXL file is empty.');
@@ -4320,10 +4354,18 @@ export default function Home() {
     let cancelled = false;
     void (async () => {
       try {
-        const { invoke } = await import('@tauri-apps/api/core');
-        const manifest = await invoke<{ savedAt: string; clean: boolean } | null>('scene_autosave_read_manifest');
-        if (!cancelled && manifest && !manifest.clean) {
-          setAutosaveRecovery({ savedAt: manifest.savedAt });
+        // Discovery, not a bare manifest read: the payload may be a sidecar
+        // beside the project, the generic location, or a legacy `scene.voxl`
+        // from before Ph0.1. `resolveAutosaveRecovery` validates that whichever
+        // it finds actually exists and really is a VOXL file, so the prompt is
+        // never offered for a payload that cannot be restored.
+        const candidate = await resolveAutosaveRecovery();
+        if (!cancelled && candidate && !candidate.clean) {
+          setAutosaveRecovery({
+            savedAt: candidate.savedAt ?? new Date().toISOString(),
+            voxlPath: candidate.voxlPath,
+            origin: candidate.origin,
+          });
         }
       } catch {
         // Non-fatal: no autosave recovery available.
@@ -4355,13 +4397,27 @@ export default function Home() {
     }
   }, [isDesktopRuntime]);
 
+  /**
+   * Clean exit. The recovery file is deleted **only** when there is nothing left
+   * to recover.
+   *
+   * The unsaved-changes branch deliberately keeps the sidecar: a user who closes
+   * the app and declines to save has still, on the next launch, a right to the
+   * autosaved copy. Deleting it here would turn "don't save" into "destroy my
+   * recovery too". `handleDiscardAndCloseProgram` retains it for the same
+   * reason; `handleSaveAndCloseProgram` deletes it via `clearAutosave`, but only
+   * after the save has actually succeeded.
+   */
   const handleRequestProgramClose = React.useCallback(() => {
     if (hasUnsavedSceneChangesRef.current) {
       setShowCloseUnsavedChangesModal(true);
       return;
     }
-    void closeDesktopWindowNow();
-  }, [closeDesktopWindowNow]);
+    void (async () => {
+      await clearAutosave();
+      await closeDesktopWindowNow();
+    })();
+  }, [clearAutosave, closeDesktopWindowNow]);
 
   const handleDiscardAndCloseProgram = React.useCallback(() => {
     void (async () => {
@@ -4423,6 +4479,15 @@ export default function Home() {
           }
 
           if (!hasUnsavedSceneChangesRef.current) {
+            // Clean exit with nothing outstanding: take the close over so the
+            // recovery file is actually gone before the process ends. A
+            // fire-and-forget delete here would race the window teardown and
+            // leave a `_autosave.voxl` beside a fully-saved project.
+            event.preventDefault();
+            void (async () => {
+              await clearAutosave();
+              await closeDesktopWindowNow();
+            })();
             return;
           }
 
@@ -4445,7 +4510,7 @@ export default function Home() {
         unlisten();
       }
     };
-  }, [isDesktopRuntime]);
+  }, [clearAutosave, closeDesktopWindowNow, isDesktopRuntime]);
 
   React.useEffect(() => {
     if (!isDesktopRuntime()) return;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -316,12 +316,14 @@ import { resolveCompositeMaterialLabel } from '@/utils/materialLabel';
 
 import { type MeshShaderType } from '@/features/shaders/mesh';
 import type { ModelTransform, TransformMode } from '@/hooks/useModelTransform';
+import { VoxlSizeLimitError } from '@/features/scene/voxl';
 import {
   useSceneAutosave,
   suppressSceneAutosave,
   resolveAutosaveRecovery,
   readAutosaveRecoveryBytes,
   deleteAutosaveSidecarForProject,
+  SCENE_AUTOSAVE_FAILED_EVENT,
 } from '@/hooks/useSceneAutosave';
 import { SceneAutosaveRecoveryModal } from '@/components/scene/SceneAutosaveRecoveryModal';
 import { MeshRepairReportModal } from '@/components/scene/MeshRepairReportModal';
@@ -844,6 +846,46 @@ export default function Home() {
     // sidecar follows the project.
     preferredSavePath: activeSceneFilePath,
   });
+
+  /**
+   * User-facing scene-save failure (Ph0.1 sub-phase D).
+   *
+   * Two producers, one surface: the 4 GiB VOXL guard rejecting an explicit save
+   * (D1), and a persistently failing autosave (D3 / finding N4). Both were
+   * previously `console.error` into a console the user never opens — and in the
+   * 4 GiB case the alternative was worse than silence, because the writer
+   * wrapped its `u32` offsets and produced a file that parsed and was wrong.
+   */
+  const [sceneSaveError, setSceneSaveError] = React.useState<{
+    title: string;
+    message: string;
+    detail?: string | null;
+  } | null>(null);
+
+  /**
+   * Persistent autosave failure (Ph0.1 D3, finding N4).
+   *
+   * Fires once per outage, after two consecutive failures — one failure is a
+   * transient (antivirus on the destination, a share blinking), two across a
+   * 30 s debounce is a condition. Before this the user's only signal was a
+   * recovery prompt at next launch showing an hour-old timestamp.
+   */
+  React.useEffect(() => {
+    const onAutosaveFailed = (event: Event) => {
+      const detail = (event as CustomEvent<{ message?: string; lastSuccessAt?: string | null }>).detail;
+      setSceneSaveError({
+        title: 'Autosave is not working',
+        message: detail?.message ?? 'The background recovery save failed repeatedly.',
+        detail: detail?.lastSuccessAt
+          ? `Last successful autosave: ${new Date(detail.lastSuccessAt).toLocaleString()}. Save your project manually.`
+          : 'No autosave has succeeded this session. Save your project manually.',
+      });
+    };
+    window.addEventListener(SCENE_AUTOSAVE_FAILED_EVENT, onAutosaveFailed);
+    return () => window.removeEventListener(SCENE_AUTOSAVE_FAILED_EVENT, onAutosaveFailed);
+  }, []);
+
+  const dismissSceneSaveError = React.useCallback(() => setSceneSaveError(null), []);
 
   // Editor toast/notification subsystem (state, refs, fade/show effects,
   // helpers). Triggers stay in Home and call these returned setters; the
@@ -4207,6 +4249,26 @@ export default function Home() {
       void performTopBarSaveScene({ nativePathOverride: queuedNativePathOverride })
         .catch((error) => {
           console.error('[SceneSave] Save operation failed.', error);
+          // The 4 GiB ceiling is the case that must never be silent: without a
+          // guard the writer wrapped its u32 offsets and wrote a file that
+          // parsed and was wrong. The typed error carries the measured size and
+          // the per-model breakdown, so the message can say what to remove.
+          setSceneSaveError(
+            error instanceof VoxlSizeLimitError
+              ? {
+                  title: 'Scene is too large to save',
+                  message: error.userMessage,
+                  detail: error.perModelBreakdown
+                    .slice(0, 5)
+                    .map((row) => `${row.name}: ${(row.compressedBytes / (1024 * 1024)).toFixed(0)} MB compressed`)
+                    .join('\n'),
+                }
+              : {
+                  title: 'Could not save the scene',
+                  message: error instanceof Error ? error.message : String(error),
+                  detail: null,
+                },
+          );
         })
         .finally(() => {
           sceneSaveInFlightRef.current = false;
@@ -9924,6 +9986,8 @@ export default function Home() {
         showPluginImportWarningModal={showPluginImportWarningModal}
         showSceneSaveChoiceModal={showSceneSaveChoiceModal}
         supportsInfoModelId={supportsInfoModelId}
+        sceneSaveError={sceneSaveError}
+        dismissSceneSaveError={dismissSceneSaveError}
         zipPickerResolveRef={zipPickerResolveRef}
         zipPickerState={zipPickerState}
       />

--- a/src/components/organisms/modals/SceneFileModals.tsx
+++ b/src/components/organisms/modals/SceneFileModals.tsx
@@ -10,7 +10,7 @@ export type SceneFileModalsProps = {
   arrangeOverlayContent: { title: string; detailLines: string[]; };
   arrangeOverlayElapsedLabel: string;
   arrangeOverlayModelCount: number | null;
-  autosaveRecovery: { savedAt: string; } | null;
+  autosaveRecovery: { savedAt: string; voxlPath: string; origin: string } | null;
   closeUnsavedChangesBusy: "none" | "save_and_close" | "discard_and_close";
   handleAutosaveDiscard: () => Promise<void>;
   handleAutosaveRestore: () => Promise<void>;
@@ -176,6 +176,8 @@ export function SceneFileModals({
       {autosaveRecovery && (
         <SceneAutosaveRecoveryModal
           savedAt={autosaveRecovery.savedAt}
+          voxlPath={autosaveRecovery.voxlPath}
+          origin={autosaveRecovery.origin}
           onRestore={handleAutosaveRestore}
           onDiscard={handleAutosaveDiscard}
         />

--- a/src/components/organisms/modals/SceneFileModals.tsx
+++ b/src/components/organisms/modals/SceneFileModals.tsx
@@ -24,6 +24,8 @@ export type SceneFileModalsProps = {
   scene: ReturnType<typeof useSceneCollectionManager>;
   sceneSaveChoiceFileName: string | null;
   sceneSaveChoicePath: string | null;
+  sceneSaveError?: { title: string; message: string; detail?: string | null } | null;
+  dismissSceneSaveError?: () => void;
   setPluginImportWarningSkipFuture: React.Dispatch<React.SetStateAction<boolean>>;
   setShowCloseUnsavedChangesModal: React.Dispatch<React.SetStateAction<boolean>>;
   setSupportsInfoModelId: React.Dispatch<React.SetStateAction<string | null>>;
@@ -37,7 +39,7 @@ export type SceneFileModalsProps = {
   zipPickerState: { zipName: string; files: File[]; category: "mesh" | "scene" | "mixed"; defaultSelectionCategory: "mesh" | "scene"; } | null;
 };
 
-/** Editor modal organism: ModelSupportsModal, sceneImportPlacementPrompt, autosaveRecovery, pluginImportWarning, zipPicker, StructuredDialog_closeUnsaved, sceneSaveChoice, arrangeBlockingOverlay. */
+/** Editor modal organism: ModelSupportsModal, sceneImportPlacementPrompt, autosaveRecovery, pluginImportWarning, zipPicker, StructuredDialog_closeUnsaved, sceneSaveChoice, arrangeBlockingOverlay, sceneSaveError. */
 export function SceneFileModals({
   arrangeOverlayContent,
   arrangeOverlayElapsedLabel,
@@ -56,6 +58,8 @@ export function SceneFileModals({
   scene,
   sceneSaveChoiceFileName,
   sceneSaveChoicePath,
+  sceneSaveError = null,
+  dismissSceneSaveError,
   setPluginImportWarningSkipFuture,
   setShowCloseUnsavedChangesModal,
   setSupportsInfoModelId,
@@ -70,6 +74,33 @@ export function SceneFileModals({
 }: SceneFileModalsProps) {
   return (
     <>
+      <StructuredDialogModal
+        open={sceneSaveError !== null}
+        onClose={() => dismissSceneSaveError?.()}
+        ariaLabel="Save Error"
+        icon={<AlertTriangle className="h-5 w-5 text-amber-400" />}
+        title={sceneSaveError?.title ?? 'Save error'}
+        actions={
+          <button
+            type="button"
+            className="ui-button ui-button-accent !h-9 px-4 text-xs font-semibold"
+            onClick={() => dismissSceneSaveError?.()}
+          >
+            OK
+          </button>
+        }
+      >
+        <div className="space-y-2 text-xs" style={{ color: 'var(--text-muted)' }}>
+          <p className="font-medium text-sm" style={{ color: 'var(--text-strong)' }}>
+            {sceneSaveError?.message}
+          </p>
+          {sceneSaveError?.detail && (
+            <pre className="mt-2 overflow-x-auto rounded bg-black/30 p-2 text-[11px] font-mono whitespace-pre-wrap">
+              {sceneSaveError.detail}
+            </pre>
+          )}
+        </div>
+      </StructuredDialogModal>
       <ModelSupportsModal
         isOpen={supportsInfoModelId !== null}
         onClose={() => setSupportsInfoModelId(null)}

--- a/src/components/scene/SceneAutosaveRecoveryModal.tsx
+++ b/src/components/scene/SceneAutosaveRecoveryModal.tsx
@@ -5,11 +5,15 @@ import { AlertTriangle, ArchiveRestore, Trash2, X } from 'lucide-react';
 
 type Props = {
   savedAt: string;
+  /** The exact payload recovery resolved; shown so the restore is never a guess. */
+  voxlPath?: string | null;
+  /** `sidecar` (beside the project) or `recovery-dir` (the fallback location). */
+  origin?: string | null;
   onRestore: () => Promise<void> | void;
   onDiscard: () => Promise<void> | void;
 };
 
-export function SceneAutosaveRecoveryModal({ savedAt, onRestore, onDiscard }: Props) {
+export function SceneAutosaveRecoveryModal({ savedAt, voxlPath, origin, onRestore, onDiscard }: Props) {
   const [busy, setBusy] = React.useState<'none' | 'restore' | 'discard'>('none');
 
   const formattedDate = React.useMemo(() => {
@@ -118,6 +122,20 @@ export function SceneAutosaveRecoveryModal({ savedAt, onRestore, onDiscard }: Pr
             <div className="mt-1 text-sm font-semibold leading-tight" style={{ color: 'var(--text-strong)' }}>
               {formattedDate}
             </div>
+            {voxlPath && (
+              <>
+                <div className="mt-2.5 text-[11px] uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+                  {origin === 'sidecar' ? 'Saved beside your project' : 'Saved in the recovery folder'}
+                </div>
+                <div
+                  className="mt-1 break-all text-[11px] leading-snug"
+                  style={{ color: 'var(--text-muted)' }}
+                  title={voxlPath}
+                >
+                  {voxlPath}
+                </div>
+              </>
+            )}
           </div>
 
           <div className="flex shrink-0 items-center justify-end gap-2 pt-1">

--- a/src/components/settings/SceneAutosaveSettingsTab.tsx
+++ b/src/components/settings/SceneAutosaveSettingsTab.tsx
@@ -12,11 +12,18 @@ import {
 type AutosavePaths = {
   voxlPath: string;
   manifestPath: string;
+  origin: string;
+  projectPath: string | null;
+  fallbackReason: string | null;
 };
 
 type AutosaveManifest = {
   savedAt: string;
   clean: boolean;
+  voxlPath?: string | null;
+  origin?: string | null;
+  projectPath?: string | null;
+  fallbackReason?: string | null;
 };
 
 function isDesktopRuntime(): boolean {
@@ -82,9 +89,14 @@ export function SceneAutosaveSettingsTab() {
     setMessage({ kind: 'idle', text: '' });
 
     try {
+      // This is the settings-level explicit discard, so it deletes the payload
+      // as well as clearing the flag — the same rule as the recovery prompt's
+      // Discard. A `_autosave.voxl` the user has just declared stale should not
+      // stay on disk next to their project.
       await invokeDesktop('scene_autosave_write_manifest', {
         savedAt: manifest?.savedAt ?? new Date().toISOString(),
         clean: true,
+        deletePayload: true,
       });
       await loadStatus();
       setMessage({ kind: 'success', text: 'Autosave recovery state marked clean.' });
@@ -95,18 +107,29 @@ export function SceneAutosaveSettingsTab() {
     }
   }, [desktopAvailable, loadStatus, manifest?.savedAt]);
 
+  /**
+   * The manifest wins over the path probe. `scene_autosave_get_paths` is called
+   * here without a project, so it can only ever answer with the generic
+   * fallback — while the last tick may well have written a sidecar beside the
+   * open project. The manifest records the payload that was actually committed,
+   * so it is the honest answer to "where is my autosave".
+   */
+  const resolvedAutosavePath = manifest?.voxlPath ?? paths?.voxlPath ?? null;
+  const resolvedAutosaveOrigin = manifest?.origin ?? paths?.origin ?? null;
+  const resolvedFallbackReason = manifest?.fallbackReason ?? paths?.fallbackReason ?? null;
+
   const handleRevealAutosave = React.useCallback(async () => {
-    if (!desktopAvailable || !paths?.voxlPath) return;
+    if (!desktopAvailable || !resolvedAutosavePath) return;
 
     setBusy('reveal');
     try {
-      await invokeDesktop('reveal_in_file_manager', { path: paths.voxlPath });
+      await invokeDesktop('reveal_in_file_manager', { path: resolvedAutosavePath });
     } catch (error) {
       setMessage({ kind: 'error', text: error instanceof Error ? error.message : 'Failed to open autosave location.' });
     } finally {
       setBusy('none');
     }
-  }, [desktopAvailable, paths?.voxlPath]);
+  }, [desktopAvailable, resolvedAutosavePath]);
 
   const debounceSeconds = Math.round(settings.debounceMs / 1000);
   const capMinutes = Math.round(settings.capMs / 60_000);
@@ -307,7 +330,15 @@ export function SceneAutosaveSettingsTab() {
               <div className="rounded-md border px-2.5 py-2 sm:col-span-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
                 <div className="text-[10px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}>Autosave scene file</div>
                 <div className="mt-1 text-xs break-all" style={{ color: 'var(--text-strong)' }}>
-                  {paths?.voxlPath ?? 'Unavailable'}
+                  {resolvedAutosavePath ?? 'Unavailable'}
+                </div>
+                <div className="mt-1.5 text-[11px] leading-snug" style={{ color: 'var(--text-muted)' }}>
+                  {resolvedAutosaveOrigin === 'sidecar'
+                    ? 'A recovery copy is written beside each saved project, as <name>_autosave.voxl. It uses roughly as much disk as the project itself.'
+                    : 'Recovery copies are written to the app data folder above.'}
+                  {resolvedFallbackReason
+                    ? ` Could not write beside the project (${resolvedFallbackReason}), so the default location is being used.`
+                    : ''}
                 </div>
               </div>
             </div>
@@ -327,7 +358,7 @@ export function SceneAutosaveSettingsTab() {
           <button
             type="button"
             onClick={() => { void handleRevealAutosave(); }}
-            disabled={!desktopAvailable || !paths?.voxlPath || busy !== 'none'}
+            disabled={!desktopAvailable || !resolvedAutosavePath || busy !== 'none'}
             className="ui-button ui-button-secondary !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
           >
             {busy === 'reveal' ? <Loader2 className="h-4 w-4 animate-spin" /> : <HardDrive className="h-4 w-4" />}

--- a/src/components/settings/SceneAutosaveSettingsTab.tsx
+++ b/src/components/settings/SceneAutosaveSettingsTab.tsx
@@ -24,6 +24,7 @@ type AutosaveManifest = {
   origin?: string | null;
   projectPath?: string | null;
   fallbackReason?: string | null;
+  lastError?: string | null;
 };
 
 function isDesktopRuntime(): boolean {
@@ -326,6 +327,13 @@ export function SceneAutosaveSettingsTab() {
                   {manifest?.savedAt ? new Date(manifest.savedAt).toLocaleString() : 'Unknown'}
                 </div>
               </div>
+
+              {manifest?.lastError && (
+                <div className="rounded-md border px-2.5 py-2 sm:col-span-2 border-amber-500/40 bg-amber-500/10">
+                  <div className="text-[10px] uppercase tracking-wide font-semibold text-amber-400">Standing Autosave Error</div>
+                  <div className="mt-1 text-xs text-amber-200">{manifest.lastError}</div>
+                </div>
+              )}
 
               <div className="rounded-md border px-2.5 py-2 sm:col-span-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
                 <div className="text-[10px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}>Autosave scene file</div>

--- a/src/features/export/logic/ExportManager.ts
+++ b/src/features/export/logic/ExportManager.ts
@@ -28,6 +28,7 @@ export interface ExportOptions {
   includeRaft: boolean;
   includeSupports: boolean;
   includeModel: boolean;
+  embedOriginalMesh?: boolean;
 }
 
 export interface ExportSceneContext {
@@ -1206,6 +1207,7 @@ export class ExportManager {
     const meshBytesMap = new Map<number, Uint8Array>();
     const sha256Map = new Map<number, string>();
     const precompressedMap = new Map<number, PrecompressedChunk>();
+    const precompressedOriginalMap = new Map<number, PrecompressedChunk>();
     const staleModelIds = new Set<string>();
 
     const models = options.includeModel
@@ -1254,6 +1256,15 @@ export class ExportManager {
                 uncompressedSize: resolvedChunk.chunk.uncompressedSize,
               });
               if (resolvedChunk.stale) staleModelIds.add(model.id);
+            }
+
+            const origChunk = meshChunkStore.lastCommitted(model.id, 'original');
+            if (origChunk) {
+              precompressedOriginalMap.set(index, {
+                data: origChunk.data,
+                compression: origChunk.compression,
+                uncompressedSize: origChunk.uncompressedSize,
+              });
             }
 
             exportedModels.push({
@@ -1334,7 +1345,11 @@ export class ExportManager {
       },
       extensions: voxlExtensions,
     };
-    const serializeOptions = { precompressed: precompressedMap };
+    const serializeOptions = {
+      precompressed: precompressedMap,
+      precompressedOriginal: precompressedOriginalMap,
+      embedOriginalMesh: options.embedOriginalMesh ?? true,
+    };
 
     // Native path: stream straight into the atomic writer's temp file, so the
     // 172–515 MiB contiguous document buffer never exists (Ph0.1 sub-phase E).

--- a/src/features/export/logic/ExportManager.ts
+++ b/src/features/export/logic/ExportManager.ts
@@ -4,9 +4,10 @@ import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import type { ModelMeshModifiers } from '@/features/mesh-modifiers/types';
 import { resolveModelMeshModifiers } from '@/features/mesh-modifiers/meshModifierStore';
 import { KNOWN_SOURCE_EXTENSION_STRIP_RE } from '@/features/plugins/pluginFileTypeExtensions';
-import { buildSupportExportFromStores, serializeVoxlDocumentV2 } from '@/features/scene/voxl';
+import { buildSupportExportFromStores, serializeVoxlDocumentV2, serializeVoxlDocumentV2Streaming, VoxlSizeLimitError, type PrecompressedChunk } from '@/features/scene/voxl';
+import { type BakedChunk, meshChunkStore } from '@/features/scene/voxl/meshChunkStore';
 import { buildScopedSupportExportDocument, buildScopedSupportGeometryGroup } from '@/features/export/logic/supportExportReconstruction';
-import { allocateMeshStagePath, exportMeshFile, pickSavePathWithNativeDialog, writeChunkedToNativePath, writeFileAtomicToNativePath } from '@/features/slicing/tauri/nativeSlicerBridge';
+import { allocateMeshStagePath, exportMeshFile, pickSavePathWithNativeDialog, writeChunkedToNativePath, writeFileAtomicToNativePath, writeFileAtomicStreamedToNativePath } from '@/features/slicing/tauri/nativeSlicerBridge';
 import { getKickstandSnapshot } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 import { getSnapshot } from '@/supports/state';
 import { getRaftSettings, getRaftSettingsForModel } from '@/supports/Rafts/Crenelated/RaftState';
@@ -41,6 +42,8 @@ export interface ExportSceneSaveTarget {
 }
 
 export class ExportManager {
+  private static readonly BAKE_WAIT_MS = 2_000;
+
   private static readonly embeddedBinaryStlCache = new Map<string, {
     geometrySignature: string;
     rawBytes: Uint8Array;
@@ -144,7 +147,20 @@ export class ExportManager {
     return new Uint8Array(bytes);
   }
 
-  private static computeModelGeometrySignature(model: LoadedModel): string {
+  /**
+   * The dirty primitive for the COW chunk store (Ph0.1 sub-phase C).
+   *
+   * Derived entirely from the geometry object — `uuid` changes when
+   * `replaceModelGeometry` swaps in a new `BufferGeometry` (hollow, punch,
+   * mirror, repair), and `position.version` / `index.version` change on an
+   * in-place edit. That is why this, and not a boolean `dirty` flag, is the
+   * authority: a flag depends on every present and future mutation path
+   * remembering to set it, whereas a signature cannot drift from the object it
+   * is read out of. The cost of getting it wrong is asymmetric — a missed flag
+   * writes stale geometry into the user's recovery file; a missed bake hook only
+   * costs one lazy re-bake.
+   */
+  static computeModelGeometrySignature(model: LoadedModel): string {
     const geometry = model.geometry.geometry;
     const position = geometry.getAttribute('position');
     const index = geometry.getIndex();
@@ -156,28 +172,75 @@ export class ExportManager {
     return `${geometry.uuid}:${positionVersion}:${indexVersion}:${vertexCount}`;
   }
 
-  private static async getEmbeddedBinaryStlWithSha(model: LoadedModel): Promise<{
-    rawBytes: Uint8Array;
-    sha256: string;
-  }> {
-    const geometrySignature = this.computeModelGeometrySignature(model);
-    const cached = this.embeddedBinaryStlCache.get(model.id);
-    if (cached && cached.geometrySignature === geometrySignature) {
-      return {
-        rawBytes: cached.rawBytes,
-        sha256: cached.sha256,
-      };
+  /**
+   * Encode → SHA → zlib-6 → store, once, for this model's current geometry.
+   *
+   * Call it at finalization (`replaceModelGeometry`, import completion, both
+   * split paths) so the work lands on the operation the user is already waiting
+   * for rather than on the next autosave tick. Idempotent and cheap on a hit, so
+   * the tick calls it too as a lazy fallback — that is what makes the hooks an
+   * optimization rather than a correctness dependency.
+   *
+   * **Ph5:** the original-mesh embed baked with `slot: 'original'` goes through
+   * this same seam; nothing about the tick or the writer changes to accommodate
+   * it, because the writer consumes the store rather than the geometry.
+   */
+  static async bakeModelGeometryChunk(model: LoadedModel): Promise<BakedChunk> {
+    return meshChunkStore.bake({
+      modelId: model.id,
+      signature: this.computeModelGeometrySignature(model),
+      encode: () => this.exportModelAsEmbeddedBinaryStlBytes(model),
+    });
+  }
+
+  /**
+   * Resolves this model's chunk for a tick.
+   *
+   * Waits a bounded {@link BAKE_WAIT_MS} for a bake that is already in flight;
+   * if that expires, falls back to whatever chunk the store last committed for
+   * this model and reports `stale`. Losing the tick entirely would be worse than
+   * writing one-operation-old geometry — but presenting it as current would be a
+   * lie, so the caller stamps `geometryStale` on the MODL entry (D2).
+   */
+  static async resolveModelChunkForTick(model: LoadedModel): Promise<{
+    chunk: BakedChunk;
+    stale: boolean;
+  } | null> {
+    const signature = this.computeModelGeometrySignature(model);
+
+    const cached = meshChunkStore.lookup(model.id, signature);
+    if (cached) return { chunk: cached, stale: false };
+
+    const inFlight = meshChunkStore.pending(model.id, signature);
+    if (inFlight) {
+      const timeout = new Promise<null>((resolve) => {
+        setTimeout(() => resolve(null), this.BAKE_WAIT_MS);
+      });
+      const settled = await Promise.race([inFlight, timeout]);
+      if (settled) return { chunk: settled, stale: false };
+
+      const lastCommitted = meshChunkStore.lastCommitted(model.id);
+      if (lastCommitted) return { chunk: lastCommitted, stale: true };
     }
 
-    const rawBytes = this.exportModelAsEmbeddedBinaryStlBytes(model);
-    const sha256 = await this.sha256Hex(rawBytes);
-    this.embeddedBinaryStlCache.set(model.id, {
-      geometrySignature,
-      rawBytes,
-      sha256,
-    });
+    return { chunk: await this.bakeModelGeometryChunk(model), stale: false };
+  }
 
-    return { rawBytes, sha256 };
+  /**
+   * Eviction hook (Ph0.1 sub-phase C2). Called from `deleteModels`.
+   *
+   * Before this the encode memo had exactly one `.get` and one `.set` and no
+   * eviction anywhere, so deleting a 4M-tri model left ~191 MiB of raw STL
+   * resident for the rest of the session. Releasing every slot the model owns
+   * also covers Ph5's original embed without a second hook.
+   */
+  static releaseModelChunks(modelIds: Iterable<string>): void {
+    for (const id of modelIds) meshChunkStore.release(id);
+  }
+
+  /** Backstop for paths that drop models without going through `deleteModels`. */
+  static retainModelChunks(modelIds: Iterable<string>): void {
+    meshChunkStore.retainOnly(modelIds);
   }
 
   private static encodeRleU8(input: Uint8Array): Uint8Array {
@@ -1135,8 +1198,15 @@ export class ExportManager {
       supports.kickstands = [];
     }
 
+    // Post-C the writer is fed from the chunk store, so `meshBytesMap` stays
+    // empty on this path: the raw STL bytes exist only inside the bake and are
+    // dropped immediately after. `precompressedMap` carries the payload, its
+    // compression tag, and its uncompressed length — everything the directory
+    // and the MODL entries need.
     const meshBytesMap = new Map<number, Uint8Array>();
     const sha256Map = new Map<number, string>();
+    const precompressedMap = new Map<number, PrecompressedChunk>();
+    const staleModelIds = new Set<string>();
 
     const models = options.includeModel
       ? await (async () => {
@@ -1148,6 +1218,14 @@ export class ExportManager {
             color: string;
             polygonCount: number;
             fileSizeBytes: number;
+            sourcePath?: string;
+            nativePreview?: {
+              originalTriangleCount: number;
+              previewTriangleCount: number;
+              cPre?: [number, number, number];
+              sourceFingerprint?: { sizeBytes: number; mtimeMs: number };
+            };
+            geometryStale?: boolean;
             transform: {
               position: { x: number; y: number; z: number };
               rotation: { x: number; y: number; z: number };
@@ -1167,9 +1245,16 @@ export class ExportManager {
 
           for (let index = 0; index < sourceModels.length; index += 1) {
             const model = sourceModels[index];
-            const { rawBytes, sha256 } = await this.getEmbeddedBinaryStlWithSha(model);
-            meshBytesMap.set(index, rawBytes);
-            sha256Map.set(index, sha256);
+            const resolvedChunk = await this.resolveModelChunkForTick(model);
+            if (resolvedChunk) {
+              sha256Map.set(index, resolvedChunk.chunk.sha256);
+              precompressedMap.set(index, {
+                data: resolvedChunk.chunk.data,
+                compression: resolvedChunk.chunk.compression,
+                uncompressedSize: resolvedChunk.chunk.uncompressedSize,
+              });
+              if (resolvedChunk.stale) staleModelIds.add(model.id);
+            }
 
             exportedModels.push({
               id: model.id,
@@ -1178,6 +1263,17 @@ export class ExportManager {
               color: model.color,
               polygonCount: model.polygonCount,
               fileSizeBytes: model.fileSizeBytes ?? 0,
+              // Preserves sourcePath / nativePreview if present on model
+              ...(typeof model.sourcePath === 'string' && model.sourcePath.trim().length > 0
+                ? { sourcePath: model.sourcePath }
+                : {}),
+              ...(model.geometry.nativePreview
+                ? { nativePreview: { ...model.geometry.nativePreview } }
+                : {}),
+              // Honesty flag (Ph0.1 D2): this model's embedded mesh is the last
+              // committed bake, not the geometry currently on screen, because a
+              // mutation was still baking when the bounded wait expired.
+              ...(staleModelIds.has(model.id) ? { geometryStale: true as const } : {}),
               transform: {
                 position: {
                   x: model.transform.position.x,
@@ -1228,20 +1324,46 @@ export class ExportManager {
         }
       : undefined;
 
+    const documentInput = {
+      models,
+      activeModelId: sceneContext?.activeModelId ?? null,
+      selectedModelIds: sceneContext?.selectedModelIds ?? [],
+      supports,
+      meta: {
+        generator: 'DragonFruit',
+      },
+      extensions: voxlExtensions,
+    };
+    const serializeOptions = { precompressed: precompressedMap };
+
+    // Native path: stream straight into the atomic writer's temp file, so the
+    // 172–515 MiB contiguous document buffer never exists (Ph0.1 sub-phase E).
+    // A pre-picked destination is the autosave and in-place Ctrl+S case — the
+    // one that runs unattended and the one that most needed the buffer gone.
+    if (useNativeWrite && prePickedNativePath && this.requiresAtomicCommit('voxl')) {
+      try {
+        await writeFileAtomicStreamedToNativePath(prePickedNativePath, async (emit) => {
+          await serializeVoxlDocumentV2Streaming(
+            documentInput,
+            meshBytesMap,
+            sha256Map,
+            emit,
+            serializeOptions,
+          );
+        });
+        return prePickedNativePath;
+      } catch (error) {
+        if (error instanceof VoxlSizeLimitError) throw error;
+        console.warn('[ExportManager] Streamed VOXL write failed, retrying buffered.', error);
+      }
+    }
+
     // serializeVoxlDocumentV2 is async — compression runs off the main thread.
     const binary = await serializeVoxlDocumentV2(
-      {
-        models,
-        activeModelId: sceneContext?.activeModelId ?? null,
-        selectedModelIds: sceneContext?.selectedModelIds ?? [],
-        supports,
-        meta: {
-          generator: 'DragonFruit',
-        },
-        extensions: voxlExtensions,
-      },
+      documentInput,
       meshBytesMap,
       sha256Map,
+      serializeOptions,
     );
 
     return this.downloadFile(

--- a/src/features/export/logic/ExportManager.ts
+++ b/src/features/export/logic/ExportManager.ts
@@ -6,7 +6,7 @@ import { resolveModelMeshModifiers } from '@/features/mesh-modifiers/meshModifie
 import { KNOWN_SOURCE_EXTENSION_STRIP_RE } from '@/features/plugins/pluginFileTypeExtensions';
 import { buildSupportExportFromStores, serializeVoxlDocumentV2 } from '@/features/scene/voxl';
 import { buildScopedSupportExportDocument, buildScopedSupportGeometryGroup } from '@/features/export/logic/supportExportReconstruction';
-import { allocateMeshStagePath, exportMeshFile, pickSavePathWithNativeDialog, writeChunkedToNativePath } from '@/features/slicing/tauri/nativeSlicerBridge';
+import { allocateMeshStagePath, exportMeshFile, pickSavePathWithNativeDialog, writeChunkedToNativePath, writeFileAtomicToNativePath } from '@/features/slicing/tauri/nativeSlicerBridge';
 import { getKickstandSnapshot } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 import { getSnapshot } from '@/supports/state';
 import { getRaftSettings, getRaftSettingsForModel } from '@/supports/Rafts/Crenelated/RaftState';
@@ -1254,6 +1254,19 @@ export class ExportManager {
     );
   }
 
+  /**
+   * Which exported formats must be committed atomically rather than written in
+   * place. A scene file IS the user's document — losing it to an interrupted
+   * overwrite is unrecoverable data loss — whereas a mesh export is a
+   * regenerable artifact.
+   *
+   * Exported for the shared-seam test: this predicate, not the caller, decides
+   * whether a given save is crash-safe.
+   */
+  static requiresAtomicCommit(extension: string): boolean {
+    return extension.trim().toLowerCase() === 'voxl';
+  }
+
   private static async downloadFile(
     data: DataView | Uint8Array | string,
     filename: string,
@@ -1273,12 +1286,31 @@ export class ExportManager {
         ? data
         : new TextEncoder().encode(data);
 
+    // The shared write seam (Ph0.1 sub-phase A, finding N1).
+    //
+    // Scene files go through the atomic writer: temp → fsync → rename. The
+    // truncate-first chunked writer destroyed the destination before the first
+    // byte of the new payload landed, so a crash mid-write left a truncated file
+    // with no fallback.
+    //
+    // Autosave and explicit save BOTH arrive here — autosave via
+    // `useSceneAutosave.performAutosave` → `exportScene({nativePath})`, Ctrl+S
+    // via the same `exportScene` with a picked path — so this one branch is what
+    // makes both crash-safe. Do not fork them into separate writers.
+    //
+    // STL/3MF keep the raw chunked writer: they are new-file exports rather than
+    // overwrites of the working document, and 3MF's native path additionally
+    // depends on the existing truncate-on-fresh-appender semantics.
+    const writeNative = this.requiresAtomicCommit(extension)
+      ? writeFileAtomicToNativePath
+      : writeChunkedToNativePath;
+
     // If a native path was already picked before heavy work started, write directly.
     let nativeDestinationPath = prePickedNativePath;
 
     if (nativeDestinationPath && useNativeWrite) {
       try {
-        await writeChunkedToNativePath(nativeDestinationPath, bytes);
+        await writeNative(nativeDestinationPath, bytes);
         return nativeDestinationPath;
       } catch (error) {
         console.warn('[ExportManager] Chunked write failed, retrying with a fresh save destination.', error);
@@ -1290,7 +1322,7 @@ export class ExportManager {
       // Fallback: try native dialog + write (e.g. VOXL path that doesn't pre-pick)
       try {
         const destinationPath = await pickSavePathWithNativeDialog(resolvedFilename);
-        await writeChunkedToNativePath(destinationPath, bytes);
+        await writeNative(destinationPath, bytes);
         return destinationPath;
       } catch (error) {
         const message = this.getErrorMessage(error);

--- a/src/features/export/logic/ExportManager.ts
+++ b/src/features/export/logic/ExportManager.ts
@@ -1281,6 +1281,11 @@ export class ExportManager {
               ...(model.geometry.nativePreview
                 ? { nativePreview: { ...model.geometry.nativePreview } }
                 : {}),
+              ...(model.originalRef
+                ? { originalRef: model.originalRef }
+                : (!options.embedOriginalMesh && typeof model.sourcePath === 'string' && model.sourcePath.trim().length > 0
+                  ? { originalRef: { mode: 'external-file' as const, fileName: model.sourcePath } }
+                  : {})),
               // Honesty flag (Ph0.1 D2): this model's embedded mesh is the last
               // committed bake, not the geometry currently on screen, because a
               // mutation was still baking when the bounded wait expired.

--- a/src/features/export/logic/__tests__/voxlWriteIsAtomic.test.ts
+++ b/src/features/export/logic/__tests__/voxlWriteIsAtomic.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ExportManager } from '../ExportManager';
+import { writeFileAtomicUnlocked, type NativeWriteInvoke } from '@/features/slicing/tauri/nativeSlicerBridge';
+
+/**
+ * Crash-safe scene-file commit (Ph0.1 sub-phase A, findings N1 + user item 2).
+ *
+ * The pre-Ph0.1 seam wrote scene bytes straight to the destination and the first
+ * chunk truncated it, so a crash mid-write left a truncated `.voxl` with no
+ * fallback — for autosave AND for an explicit Ctrl+S overwrite, which share the
+ * seam. These tests pin that scene writes never touch the destination until a
+ * complete payload is on disk.
+ */
+
+type InvokeRecord = { cmd: string; path?: string };
+
+const TEMP_PATH = 'C:/projects/MyPrint.voxl.tmp-4242-0';
+const TARGET_PATH = 'C:/projects/MyPrint.voxl';
+
+function createRecordingInvoke(options?: { failChunks?: boolean }): {
+  invoke: NativeWriteInvoke;
+  calls: InvokeRecord[];
+} {
+  const calls: InvokeRecord[] = [];
+
+  const invoke = (async (
+    cmd: string,
+    args?: Record<string, unknown> | ArrayBuffer | Uint8Array,
+    opts?: { headers: HeadersInit },
+  ) => {
+    const headers = (opts?.headers ?? {}) as Record<string, string>;
+    const record = args && !(args instanceof Uint8Array) && !(args instanceof ArrayBuffer)
+      ? (args as Record<string, string>)
+      : {};
+    calls.push({
+      cmd,
+      path: headers['x-mesh-stage-path'] ?? record.path ?? record.tempPath ?? record.targetPath,
+    });
+
+    if (cmd === 'scene_file_begin_atomic_write') return TEMP_PATH as never;
+    if (cmd === 'append_mesh_stage_chunk' && options?.failChunks) {
+      throw new Error('disk full');
+    }
+    return undefined as never;
+  }) as NativeWriteInvoke;
+
+  return { invoke, calls };
+}
+
+describe('VOXL writes are committed atomically', () => {
+  it('routes scene files, and only scene files, to the atomic writer', () => {
+    assert.equal(ExportManager.requiresAtomicCommit('voxl'), true);
+    assert.equal(ExportManager.requiresAtomicCommit('VOXL'), true);
+    assert.equal(ExportManager.requiresAtomicCommit('stl'), false);
+    assert.equal(ExportManager.requiresAtomicCommit('3mf'), false);
+  });
+
+  it('stages to a temp and commits, never writing to the destination directly', async () => {
+    const { invoke, calls } = createRecordingInvoke();
+
+    await writeFileAtomicUnlocked(invoke, TARGET_PATH, new Uint8Array(10), 4);
+
+    const chunkTargets = calls
+      .filter((call) => call.cmd === 'append_mesh_stage_chunk')
+      .map((call) => call.path);
+    assert.ok(chunkTargets.length > 0, 'no payload was written at all');
+    assert.ok(
+      chunkTargets.every((path) => path === TEMP_PATH),
+      `scene bytes were written straight to the destination: ${chunkTargets.join(', ')}`,
+    );
+
+    assert.deepEqual(
+      calls.map((call) => call.cmd),
+      [
+        'scene_file_begin_atomic_write',
+        'append_mesh_stage_chunk',
+        'append_mesh_stage_chunk',
+        'append_mesh_stage_chunk',
+        'finish_mesh_stage_write',
+        'scene_file_commit_atomic',
+      ],
+      'the commit must be the last step, after the full payload is on disk',
+    );
+  });
+
+  it('discards the staging file and never commits when the payload fails', async () => {
+    const { invoke, calls } = createRecordingInvoke({ failChunks: true });
+
+    await assert.rejects(
+      writeFileAtomicUnlocked(invoke, TARGET_PATH, new Uint8Array(10), 4),
+      /disk full/,
+    );
+
+    assert.equal(
+      calls.some((call) => call.cmd === 'scene_file_commit_atomic'),
+      false,
+      'a failed write must never reach the destination',
+    );
+    assert.equal(
+      calls.some((call) => call.cmd === 'scene_file_discard_atomic_temp' && call.path === TEMP_PATH),
+      true,
+      'a failed write left its staging file beside the user project',
+    );
+  });
+});

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -4,7 +4,7 @@ import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js
 import { loadMeshGeometry, load3mfGeometryMergedWithSplitData, processGeometry, type GeometryWithBounds, type ProcessGeometryOptions } from '@/hooks/useStlGeometry';
 import type { MeshHealthReport, MeshAnalysisJson } from '@/utils/meshRepair';
 import { computeFlatteningPlanes, type FlatteningPlane } from '@/features/placeOnFace/logic/computeFlatteningPlanes';
-import { isVoxlBinaryV2, parseVoxlBinaryV2, parseVoxlDocument, type VoxlDocumentV1, type VoxlMeshRef } from '@/features/scene/voxl';
+import { isVoxlBinaryV2, meshChunkStore, parseVoxlBinaryV2, parseVoxlDocument, type VoxlDocumentV1, type VoxlMeshRef } from '@/features/scene/voxl';
 import { clearPaintToBase } from '@/components/analysis/MeshPainter';
 import { getSnapshot, loadFromImportFormat, mergeFromImportFormat, reassignAllSupportModelIds, setSnapshot as setSupportSnapshot, transformAllSupportsForSingleModel, transformSupportsForModel } from '@/supports/state';
 import type { SelectionHighlightMode } from '@/components/selection';
@@ -4214,11 +4214,13 @@ export function useSceneCollectionManager() {
 
       let document: VoxlDocumentV1;
       let resolvedMeshBytes: Map<string, Uint8Array>;
+      let resolvedOriginalMeshBytes: Map<string, Uint8Array> | undefined;
 
       if (isV2) {
         const r = parseVoxlBinaryV2(new Uint8Array(await file.arrayBuffer()));
         document = r.document;
         resolvedMeshBytes = r.meshBytes;
+        resolvedOriginalMeshBytes = r.originalMeshBytes;
       } else {
         document = parseVoxlDocument(await file.text());
         resolvedMeshBytes = new Map();
@@ -4358,6 +4360,16 @@ export function useSceneCollectionManager() {
           }
           existingIds.add(resolvedId);
           idMap.set(model.id, resolvedId);
+
+          const origMeshBytes = resolvedOriginalMeshBytes?.get(model.id);
+          if (origMeshBytes) {
+            void meshChunkStore.bake({
+              modelId: resolvedId,
+              slot: 'original',
+              signature: `original:${resolvedId}`,
+              encode: () => origMeshBytes,
+            });
+          }
 
           const polygonCount = geometry.geometry.getAttribute('position').count / 3;
           const color = clampHexColor(model.color, DEFAULT_MESH_COLOR);

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -4,7 +4,7 @@ import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js
 import { loadMeshGeometry, load3mfGeometryMergedWithSplitData, processGeometry, type GeometryWithBounds, type ProcessGeometryOptions } from '@/hooks/useStlGeometry';
 import type { MeshHealthReport, MeshAnalysisJson } from '@/utils/meshRepair';
 import { computeFlatteningPlanes, type FlatteningPlane } from '@/features/placeOnFace/logic/computeFlatteningPlanes';
-import { isVoxlBinaryV2, meshChunkStore, parseVoxlBinaryV2, parseVoxlDocument, type VoxlDocumentV1, type VoxlMeshRef } from '@/features/scene/voxl';
+import { isVoxlBinaryV2, meshChunkStore, parseVoxlBinaryV2, parseVoxlDocument, readSidecarFileBytes, resolveOriginalRefSidecar, type VoxlDocumentV1, type VoxlMeshRef } from '@/features/scene/voxl';
 import { clearPaintToBase } from '@/components/analysis/MeshPainter';
 import { getSnapshot, loadFromImportFormat, mergeFromImportFormat, reassignAllSupportModelIds, setSnapshot as setSupportSnapshot, transformAllSupportsForSingleModel, transformSupportsForModel } from '@/supports/state';
 import type { SelectionHighlightMode } from '@/components/selection';
@@ -876,6 +876,8 @@ export interface LoadedModel {
   fileUrl: string;
   /** Original on-disk mesh retained when `geometry` is a reduced native preview. */
   sourcePath?: string | null;
+  /** Original mesh sidecar reference when not embedded in ORIG chunk. */
+  originalRef?: VoxlMeshRef;
   fileSizeBytes?: number;
   geometry: GeometryWithBounds;
   transform: ModelTransform;
@@ -4369,6 +4371,32 @@ export function useSceneCollectionManager() {
               signature: `original:${resolvedId}`,
               encode: () => origMeshBytes,
             });
+          } else {
+            const voxlFilePath = (file as File & { path?: string; filePath?: string }).path
+              || (file as File & { filePath?: string }).filePath
+              || options?.sourcePath;
+            const origRefToResolve = model.originalRef ?? (
+              typeof model.sourcePath === 'string' && model.sourcePath.trim().length > 0
+                ? { mode: 'external-file' as const, fileName: model.sourcePath }
+                : undefined
+            );
+            const sidecarPath = resolveOriginalRefSidecar(origRefToResolve, voxlFilePath || undefined);
+
+            if (sidecarPath) {
+              try {
+                const sidecarBytes = await readSidecarFileBytes(sidecarPath);
+                if (sidecarBytes) {
+                  void meshChunkStore.bake({
+                    modelId: resolvedId,
+                    slot: 'original',
+                    signature: `original:${resolvedId}`,
+                    encode: () => sidecarBytes,
+                  });
+                }
+              } catch (err) {
+                console.warn(`[SceneCollection] Unreadable sidecar file at "${sidecarPath}", falling back to preview:`, err);
+              }
+            }
           }
 
           const polygonCount = geometry.geometry.getAttribute('position').count / 3;
@@ -4378,6 +4406,8 @@ export function useSceneCollectionManager() {
             id: resolvedId,
             name: sanitizeImportedModelDisplayName(model.name),
             fileUrl: '',
+            sourcePath: model.sourcePath ?? undefined,
+            originalRef: model.originalRef,
             fileSizeBytes: model.fileSizeBytes,
             geometry,
             transform: {

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -984,6 +984,85 @@ type ModelClipboardEntry = {
   supportClipboard: SupportClipboardPayload | null;
 };
 
+// ---------------------------------------------------------------------------
+// COW chunk-store hooks (Ph0.1 sub-phase C2 / C3)
+// ---------------------------------------------------------------------------
+
+/**
+ * `ExportManager` is loaded lazily here. It is a heavy module that pulls in the
+ * STL exporter, the support stores and the raft geometry generators, and this
+ * file is on the app's critical path — a static import would drag all of it into
+ * the initial scene bundle for work that is, by construction, deferrable.
+ */
+async function exportManager() {
+  const { ExportManager } = await import('@/features/export/logic/ExportManager');
+  return ExportManager;
+}
+
+const scheduleIdleTask = (task: () => void, timeout = 500): void => {
+  if (typeof window !== 'undefined' && typeof (window as unknown as {
+    requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => void;
+  }).requestIdleCallback === 'function') {
+    (window as unknown as {
+      requestIdleCallback: (cb: () => void, opts?: { timeout: number }) => void;
+    }).requestIdleCallback(task, { timeout });
+    return;
+  }
+  setTimeout(task, 0);
+};
+
+/**
+ * Bakes one model's mesh chunk after a finalized geometry mutation.
+ *
+ * Idle-scheduled so React commits the new geometry to the screen first: the bake
+ * is an encode + SHA + zlib-6 over the whole mesh, and the user is looking at
+ * the result of the operation that produced it.
+ *
+ * Failures are logged, never thrown. The geometry SIGNATURE is the authority, so
+ * a bake that does not land costs the next autosave tick one lazy re-bake — it
+ * can never cause a stale write.
+ */
+function scheduleModelChunkBake(model: LoadedModel | undefined): void {
+  if (!model) return;
+  scheduleIdleTask(() => {
+    void exportManager()
+      .then((manager) => manager.bakeModelGeometryChunk(model))
+      .catch((error) => {
+        console.warn('[SceneCollection] Mesh chunk bake failed; the next autosave will bake lazily.', error);
+      });
+  });
+}
+
+/**
+ * Coalesced sweep over the whole scene: bakes anything not yet in the store and
+ * releases anything that has left it.
+ *
+ * This is deliberately a sweep rather than a hook per entry point. Models arrive
+ * from import, both split paths, paste, undo/redo and autosave recovery, and a
+ * per-path hook set would need every one of those — and every future one — to
+ * remember. The sweep is derived from the model list itself, which is the same
+ * reasoning that made the geometry signature preferable to a dirty flag.
+ */
+let chunkStoreSweepPending = false;
+function scheduleChunkStoreSweep(getModels: () => LoadedModel[]): void {
+  if (chunkStoreSweepPending) return;
+  chunkStoreSweepPending = true;
+  scheduleIdleTask(() => {
+    chunkStoreSweepPending = false;
+    const models = getModels();
+    void exportManager()
+      .then(async (manager) => {
+        manager.retainModelChunks(models.map((m) => m.id));
+        for (const model of models) {
+          await manager.bakeModelGeometryChunk(model);
+        }
+      })
+      .catch((error) => {
+        console.warn('[SceneCollection] Mesh chunk sweep failed; the next autosave will bake lazily.', error);
+      });
+  }, 1_500);
+}
+
 export function useSceneCollectionManager() {
   type ScenePluginImportEntry = {
     pluginId: string;
@@ -1054,6 +1133,15 @@ export function useSceneCollectionManager() {
   modelsRef.current = models;
   activeModelIdRef.current = activeModelId;
   selectedModelIdsRef.current = selectedModelIds;
+
+  // Keep the COW chunk store in step with the scene (Ph0.1 sub-phase C).
+  // Coalesced and idle-scheduled, so a burst of imports or an Auto-Arrange
+  // sweeps once. See `scheduleChunkStoreSweep` for why this is a sweep rather
+  // than a hook on every model-producing path.
+  useEffect(() => {
+    if (models.length === 0) return;
+    scheduleChunkStoreSweep(() => modelsRef.current);
+  }, [models]);
   const [modelClipboard, setModelClipboard] = useState<ModelClipboardEntry[]>([]);
   const [recentOpenedFiles, setRecentOpenedFiles] = useState<RecentOpenedFileEntry[]>([]);
   const [importProgress, setImportProgress] = useState<ImportProgressState>({
@@ -2638,7 +2726,15 @@ export function useSceneCollectionManager() {
     const after = captureSceneSnapshot(nextModels, currentActiveModelId, currentSelectedModelIds, {
       includeSupportState: includeSupportHistory,
     });
-    pushSceneSnapshotHistory(before, after, historyDescription);
+    // COW chunk-store bake (Ph0.1 sub-phase C3). This is the VERIFIED sole
+    // finalization point for hollow, hole-punch, mirror and repair, so baking
+    // here moves the encode+SHA+zlib-6 onto the operation the user is already
+    // waiting for and off the next autosave tick.
+    //
+    // Fire-and-forget on purpose: the geometry SIGNATURE is the authority, so if
+    // this bake never lands the next tick simply bakes lazily instead. It can
+    // cost a slow tick; it can never write stale geometry.
+    void scheduleModelChunkBake(nextModels.find((m) => m.id === id));
 
     return true;
   }, [pushSceneSnapshotHistory, deferAccelerateGeometry]);
@@ -2992,6 +3088,18 @@ export function useSceneCollectionManager() {
 
     const existing = modelsRef.current.filter((m) => ids.has(m.id));
     if (existing.length === 0) return;
+
+    // Release the deleted models' compressed mesh chunks (Ph0.1 sub-phase C2).
+    // The encode cache this replaced had exactly one `.get` and one `.set` and
+    // no eviction anywhere: a deleted 4M-tri model kept ~191 MiB of raw STL
+    // resident for the remainder of the session, and repeated import → delete
+    // cycles grew the heap without bound. Refcounted, so instances that still
+    // share the blob keep it alive.
+    void exportManager()
+      .then((manager) => manager.releaseModelChunks(ids))
+      .catch((error) => {
+        console.warn('[SceneCollection] Failed releasing mesh chunks for deleted models.', error);
+      });
 
     const supportStateBeforeDelete = getSnapshot();
     const kickstandSnapshotBefore = getKickstandSnapshot();

--- a/src/features/scene/voxl/__tests__/meshChunkStore.test.ts
+++ b/src/features/scene/voxl/__tests__/meshChunkStore.test.ts
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict';
+import test, { describe, beforeEach } from 'node:test';
+
+import { MeshChunkStore } from '../meshChunkStore';
+
+/**
+ * COW compressed-chunk store (Ph0.1 sub-phase C).
+ *
+ * The defect this pins: the per-model encode memo stored RAW STL bytes and threw
+ * the compressed result away, so zlib-6 re-ran over every model's entire
+ * geometry on every 30 s autosave tick — 3 589 ms / 172 MiB for one 4M-tri
+ * model, 11 125 ms / 515 MiB for a 3-model plate — and nothing was ever evicted,
+ * so a deleted 4M-tri model kept ~191 MiB resident for the rest of the session.
+ *
+ * Two properties carry the whole design:
+ *
+ *  - **Dirty tracking is by geometry SIGNATURE, not by a boolean flag.** The
+ *    signature is derived from the geometry object, so it cannot drift the way a
+ *    flag missed by a future mutation path would. A missed bake hook therefore
+ *    costs a lazy re-bake, never a stale write.
+ *  - **The store is content-addressed** (`owner → sha`, `sha → compressed`), so
+ *    cross-tick reuse, multi-instance dedup, and eviction are one mechanism.
+ */
+
+const RAW_A = new Uint8Array(4096).fill(0xa1);
+const RAW_B = new Uint8Array(4096).fill(0xb2);
+
+function countingEncoder(bytes: Uint8Array) {
+  const state = { calls: 0 };
+  return {
+    state,
+    encode: () => {
+      state.calls += 1;
+      return bytes;
+    },
+  };
+}
+
+describe('the COW compressed-chunk store', () => {
+  let store: MeshChunkStore;
+
+  beforeEach(() => {
+    store = new MeshChunkStore();
+  });
+
+  test('an unchanged model is NOT re-encoded or re-compressed on a second tick', async () => {
+    const a = countingEncoder(RAW_A);
+
+    const first = await store.bake({ modelId: 'm0', signature: 'sig-1', encode: a.encode });
+    const second = await store.bake({ modelId: 'm0', signature: 'sig-1', encode: a.encode });
+
+    assert.equal(a.state.calls, 1, 'the STL encoder ran again for unchanged geometry');
+    assert.equal(store.stats().compressions, 1, 'zlib re-ran over unchanged geometry (the 3 589 ms defect)');
+    assert.equal(store.stats().hits, 1);
+    assert.equal(second.sha256, first.sha256);
+    assert.equal(second.data, first.data, 'the second tick must hand back the SAME blob, not a copy');
+  });
+
+  test('lookup by signature is the dirty primitive — no flag is consulted', async () => {
+    const a = countingEncoder(RAW_A);
+    await store.bake({ modelId: 'm0', signature: 'sig-1', encode: a.encode });
+
+    assert.ok(store.lookup('m0', 'sig-1'), 'a matching signature must resolve without a bake');
+    assert.equal(store.lookup('m0', 'sig-2'), null, 'a changed signature must read as dirty');
+  });
+
+  test('a geometry mutation re-bakes exactly that model and zero neighbours', async () => {
+    const a = countingEncoder(RAW_A);
+    const b = countingEncoder(RAW_B);
+
+    await store.bake({ modelId: 'm0', signature: 'sig-1', encode: a.encode });
+    await store.bake({ modelId: 'm1', signature: 'sig-1', encode: b.encode });
+
+    // m0 is hollowed: `replaceModelGeometry` produces a new BufferGeometry, so
+    // its signature changes. m1 is untouched.
+    const mutated = new Uint8Array(4096).fill(0xc3);
+    const c = countingEncoder(mutated);
+    await store.bake({ modelId: 'm0', signature: 'sig-2', encode: c.encode });
+    await store.bake({ modelId: 'm1', signature: 'sig-1', encode: b.encode });
+
+    assert.equal(c.state.calls, 1, 'the mutated model must re-bake exactly once');
+    assert.equal(b.state.calls, 1, 'an untouched neighbour must NOT re-bake');
+    assert.equal(store.stats().compressions, 3, 'expected 2 initial bakes + 1 re-bake');
+  });
+
+  test('N models with identical geometry hold ONE blob', async () => {
+    const a = countingEncoder(RAW_A);
+
+    // Distinct signatures (different BufferGeometry uuids) but identical bytes —
+    // exactly what Fill Plate produces.
+    await store.bake({ modelId: 'm0', signature: 'geo-0', encode: a.encode });
+    await store.bake({ modelId: 'm1', signature: 'geo-1', encode: a.encode });
+    await store.bake({ modelId: 'm2', signature: 'geo-2', encode: a.encode });
+
+    const stats = store.stats();
+    assert.equal(stats.blobs, 1, 'three identical meshes must share one compressed blob');
+    assert.equal(stats.owners, 3);
+    assert.equal(stats.compressions, 1, 'only the first identical mesh may pay for compression');
+    assert.equal(stats.retainedBytes, store.lookup('m0', 'geo-0')!.data.length);
+  });
+
+  test('deleting a model releases its bytes', async () => {
+    const a = countingEncoder(RAW_A);
+    await store.bake({ modelId: 'm0', signature: 'sig-1', encode: a.encode });
+    assert.ok(store.stats().retainedBytes > 0);
+
+    store.release('m0');
+
+    const stats = store.stats();
+    assert.equal(stats.blobs, 0, 'a deleted model retained its compressed bytes forever');
+    assert.equal(stats.owners, 0);
+    assert.equal(stats.retainedBytes, 0);
+    assert.equal(stats.evictions, 1);
+    assert.equal(store.lookup('m0', 'sig-1'), null);
+  });
+
+  test('refcounting: releasing one of two sharers keeps the blob alive', async () => {
+    const a = countingEncoder(RAW_A);
+    await store.bake({ modelId: 'm0', signature: 'geo-0', encode: a.encode });
+    await store.bake({ modelId: 'm1', signature: 'geo-1', encode: a.encode });
+
+    store.release('m0');
+    assert.equal(store.stats().blobs, 1, 'the surviving sharer lost its bytes');
+    assert.ok(store.lookup('m1', 'geo-1'));
+
+    store.release('m1');
+    assert.equal(store.stats().blobs, 0);
+  });
+
+  test('re-baking releases the superseded blob instead of leaking it', async () => {
+    const a = countingEncoder(RAW_A);
+    const b = countingEncoder(RAW_B);
+
+    await store.bake({ modelId: 'm0', signature: 'sig-1', encode: a.encode });
+    await store.bake({ modelId: 'm0', signature: 'sig-2', encode: b.encode });
+
+    assert.equal(store.stats().blobs, 1, 'the pre-mutation blob was retained after the mutation');
+    assert.equal(store.stats().evictions, 1);
+  });
+
+  test('retainOnly evicts every model that has left the scene', async () => {
+    const a = countingEncoder(RAW_A);
+    const b = countingEncoder(RAW_B);
+    await store.bake({ modelId: 'm0', signature: 'sig-1', encode: a.encode });
+    await store.bake({ modelId: 'm1', signature: 'sig-1', encode: b.encode });
+
+    store.retainOnly(['m1']);
+
+    assert.equal(store.stats().owners, 1);
+    assert.equal(store.lookup('m0', 'sig-1'), null);
+    assert.ok(store.lookup('m1', 'sig-1'));
+  });
+
+  /**
+   * Ph5 forward-compat. The original-mesh embed is a SECOND chunk for the same
+   * model, so the store is keyed on (modelId, slot) rather than modelId alone.
+   * Ph5 bakes it once at import with `slot: 'original'`; every tick and every
+   * explicit save then references it, and a deletion releases both slots in one
+   * call. Nothing about that path is implemented here — this test only pins the
+   * key shape so it does not have to be retrofitted.
+   */
+  test('slots are independent, and deleting a model releases all of them', async () => {
+    const preview = countingEncoder(RAW_A);
+    const original = countingEncoder(RAW_B);
+
+    await store.bake({ modelId: 'm0', slot: 'preview', signature: 'sig-1', encode: preview.encode });
+    await store.bake({ modelId: 'm0', slot: 'original', signature: 'file-1', encode: original.encode });
+
+    assert.equal(store.stats().owners, 2);
+    assert.ok(store.lookup('m0', 'sig-1', 'preview'));
+    assert.ok(store.lookup('m0', 'file-1', 'original'));
+    assert.equal(store.lookup('m0', 'sig-1', 'original'), null, 'slots must not alias each other');
+
+    store.release('m0');
+    assert.equal(store.stats().owners, 0, 'deleting a model must release every slot it owns');
+    assert.equal(store.stats().blobs, 0);
+  });
+
+  test('concurrent bakes of the same key collapse into one compression', async () => {
+    const a = countingEncoder(RAW_A);
+    const [first, second] = await Promise.all([
+      store.bake({ modelId: 'm0', signature: 'sig-1', encode: a.encode }),
+      store.bake({ modelId: 'm0', signature: 'sig-1', encode: a.encode }),
+    ]);
+
+    assert.equal(store.stats().compressions, 1, 'a coalesced bake ran zlib twice');
+    assert.equal(first.data, second.data);
+  });
+
+  test('payloads too small or too incompressible to shrink are stored raw', async () => {
+    const tiny = new Uint8Array([1, 2, 3, 4]);
+    const t = countingEncoder(tiny);
+    const baked = await store.bake({ modelId: 'm0', signature: 'sig-1', encode: t.encode });
+
+    // Mirrors the codec's own policy (`raw.length > 64` and only if it shrinks),
+    // which is what keeps the emitted bytes identical to the pre-store writer.
+    assert.equal(baked.compression, 0, 'a 4-byte payload must not be zlib-wrapped');
+    assert.deepEqual([...baked.data], [...tiny]);
+    assert.equal(baked.uncompressedSize, tiny.length);
+  });
+});

--- a/src/features/scene/voxl/__tests__/voxlOriginalEmbed.test.ts
+++ b/src/features/scene/voxl/__tests__/voxlOriginalEmbed.test.ts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import test, { describe, beforeEach } from 'node:test';
+
+import {
+  parseVoxlBinaryV2,
+  resetVoxlCodecStats,
+  serializeVoxlDocumentV2,
+} from '../codec-v2';
+import { MeshChunkStore } from '../meshChunkStore';
+import {
+  countVoxlChunks,
+  meshLike,
+  testInput,
+  withFrozenClock,
+} from './voxlTestSupport';
+
+const PREVIEW_MESH = meshLike(1, 2048);
+const ORIGINAL_MESH = meshLike(99, 8192);
+
+describe('Full-Resolution Mesh Embedding (ORIG Chunk)', () => {
+  beforeEach(() => {
+    resetVoxlCodecStats();
+  });
+
+  test('embeds ORIG chunk and extracts originalMeshBytes upon parsing', async () => {
+    await withFrozenClock(async () => {
+      const store = new MeshChunkStore();
+
+      const previewBaked = await store.bake({
+        modelId: 'm0',
+        slot: 'preview',
+        signature: 'sig:preview:m0',
+        encode: () => PREVIEW_MESH,
+      });
+
+      const origBaked = await store.bake({
+        modelId: 'm0',
+        slot: 'original',
+        signature: 'sig:orig:m0',
+        encode: () => ORIGINAL_MESH,
+      });
+
+      const meshBytesMap = new Map<number, Uint8Array>([[0, PREVIEW_MESH]]);
+      const sha256Map = new Map<number, string>([[0, previewBaked.sha256]]);
+
+      const precompressed = new Map<number, { data: Uint8Array; compression: number; uncompressedSize: number }>([
+        [0, { data: previewBaked.data, compression: previewBaked.compression, uncompressedSize: previewBaked.uncompressedSize }],
+      ]);
+      const precompressedOriginal = new Map<number, { data: Uint8Array; compression: number; uncompressedSize: number }>([
+        [0, { data: origBaked.data, compression: origBaked.compression, uncompressedSize: origBaked.uncompressedSize }],
+      ]);
+
+      const bin = await serializeVoxlDocumentV2(
+        testInput(['m0']),
+        meshBytesMap,
+        sha256Map,
+        {
+          precompressed,
+          precompressedOriginal,
+          embedOriginalMesh: true,
+        },
+      );
+
+      assert.equal(countVoxlChunks(bin, 'MESH'), 1, 'must contain 1 MESH chunk');
+      assert.equal(countVoxlChunks(bin, 'ORIG'), 1, 'must contain 1 ORIG chunk');
+
+      const parsed = parseVoxlBinaryV2(bin);
+      assert.ok(parsed.meshBytes.has('m0'), 'meshBytes must contain m0');
+      assert.deepEqual([...parsed.meshBytes.get('m0')!], [...PREVIEW_MESH], 'preview mesh bytes must match');
+
+      assert.ok(parsed.originalMeshBytes, 'originalMeshBytes must be defined');
+      assert.ok(parsed.originalMeshBytes.has('m0'), 'originalMeshBytes must contain m0');
+      assert.deepEqual([...parsed.originalMeshBytes.get('m0')!], [...ORIGINAL_MESH], 'original mesh bytes must match');
+    });
+  });
+
+  test('legacy reader compatibility: ignores ORIG chunk without throwing error', async () => {
+    const store = new MeshChunkStore();
+    const previewBaked = await store.bake({
+      modelId: 'm0',
+      slot: 'preview',
+      signature: 'sig:preview:m0',
+      encode: () => PREVIEW_MESH,
+    });
+    const origBaked = await store.bake({
+      modelId: 'm0',
+      slot: 'original',
+      signature: 'sig:orig:m0',
+      encode: () => ORIGINAL_MESH,
+    });
+
+    const precompressed = new Map([[0, { data: previewBaked.data, compression: previewBaked.compression, uncompressedSize: previewBaked.uncompressedSize }]]);
+    const precompressedOriginal = new Map([[0, { data: origBaked.data, compression: origBaked.compression, uncompressedSize: origBaked.uncompressedSize }]]);
+
+    const bin = await serializeVoxlDocumentV2(
+      testInput(['m0']),
+      new Map([[0, PREVIEW_MESH]]),
+      new Map([[0, previewBaked.sha256]]),
+      { precompressed, precompressedOriginal, embedOriginalMesh: true },
+    );
+
+    const parsed = parseVoxlBinaryV2(bin);
+    assert.equal(parsed.document.models.length, 1);
+    assert.equal(parsed.document.models[0].name, 'm0');
+    assert.deepEqual([...parsed.meshBytes.get('m0')!], [...PREVIEW_MESH]);
+  });
+
+  test('embedOriginalMesh: false omits ORIG chunk from binary output', async () => {
+    const store = new MeshChunkStore();
+    const previewBaked = await store.bake({
+      modelId: 'm0',
+      slot: 'preview',
+      signature: 'sig:preview:m0',
+      encode: () => PREVIEW_MESH,
+    });
+    const origBaked = await store.bake({
+      modelId: 'm0',
+      slot: 'original',
+      signature: 'sig:orig:m0',
+      encode: () => ORIGINAL_MESH,
+    });
+
+    const precompressed = new Map([[0, { data: previewBaked.data, compression: previewBaked.compression, uncompressedSize: previewBaked.uncompressedSize }]]);
+    const precompressedOriginal = new Map([[0, { data: origBaked.data, compression: origBaked.compression, uncompressedSize: origBaked.uncompressedSize }]]);
+
+    const bin = await serializeVoxlDocumentV2(
+      testInput(['m0']),
+      new Map([[0, PREVIEW_MESH]]),
+      new Map([[0, previewBaked.sha256]]),
+      {
+        precompressed,
+        precompressedOriginal,
+        embedOriginalMesh: false,
+      },
+    );
+
+    assert.equal(countVoxlChunks(bin, 'MESH'), 1);
+    assert.equal(countVoxlChunks(bin, 'ORIG'), 0, 'ORIG chunk must be omitted when embedOriginalMesh is false');
+
+    const parsed = parseVoxlBinaryV2(bin);
+    assert.equal(parsed.originalMeshBytes, undefined, 'originalMeshBytes must be undefined when ORIG chunk is absent');
+  });
+
+  test('refcount eviction releases both preview and original chunks on release(modelId)', async () => {
+    const store = new MeshChunkStore();
+
+    await store.bake({
+      modelId: 'm0',
+      slot: 'preview',
+      signature: 'sig:p:m0',
+      encode: () => PREVIEW_MESH,
+    });
+
+    await store.bake({
+      modelId: 'm0',
+      slot: 'original',
+      signature: 'sig:o:m0',
+      encode: () => ORIGINAL_MESH,
+    });
+
+    const statsBefore = store.stats();
+    assert.equal(statsBefore.owners, 2, 'store must track 2 owners (preview and original)');
+    assert.equal(statsBefore.blobs, 2, 'store must hold 2 blobs');
+
+    store.release('m0');
+
+    const statsAfter = store.stats();
+    assert.equal(statsAfter.owners, 0, 'releasing modelId must drop all owner mappings');
+    assert.equal(statsAfter.blobs, 0, 'releasing modelId must evict all blobs when refcount reaches 0');
+    assert.equal(statsAfter.evictions, 2, 'both preview and original blobs must be evicted');
+  });
+});

--- a/src/features/scene/voxl/__tests__/voxlOriginalRef.test.ts
+++ b/src/features/scene/voxl/__tests__/voxlOriginalRef.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import test, { describe } from 'node:test';
+
+import {
+  parseVoxlDocumentV2,
+  readSidecarFileBytes,
+  resolveOriginalRefSidecar,
+  serializeVoxlDocumentV2,
+} from '../codec-v2';
+import type { VoxlMeshRef } from '../types';
+import { meshLike, testInput, withFrozenClock } from './voxlTestSupport';
+
+const PREVIEW_MESH = meshLike(1, 1024);
+
+describe('VOXL originalRef Sidecar Resolution & Serialization', () => {
+  test('serializes and parses originalRef sidecar reference in V2 document', async () => {
+    await withFrozenClock(async () => {
+      const originalRef: VoxlMeshRef = {
+        mode: 'external-file',
+        fileName: 'sidecars/my_model_orig.stl',
+        uncompressedSizeBytes: 543210,
+        sha256: 'a'.repeat(64),
+      };
+
+      const input = testInput(['m0']);
+      input.models[0].originalRef = originalRef;
+
+      const meshBytesMap = new Map<number, Uint8Array>([[0, PREVIEW_MESH]]);
+      const bin = await serializeVoxlDocumentV2(
+        input,
+        meshBytesMap,
+        undefined,
+        { embedOriginalMesh: false },
+      );
+
+      const parsed = parseVoxlDocumentV2(bin);
+      assert.equal(parsed.document.models.length, 1);
+      const parsedModel = parsed.document.models[0];
+      assert.ok(parsedModel.originalRef, 'parsed model must carry originalRef');
+      assert.equal(parsedModel.originalRef.mode, 'external-file');
+      assert.equal(parsedModel.originalRef.fileName, 'sidecars/my_model_orig.stl');
+      assert.equal(parsedModel.originalRef.uncompressedSizeBytes, 543210);
+      assert.equal(parsedModel.originalRef.sha256, 'a'.repeat(64));
+    });
+  });
+
+  test('resolveOriginalRefSidecar resolves relative path relative to .voxl project path', () => {
+    const ref: VoxlMeshRef = {
+      mode: 'external-file',
+      fileName: 'models/my_part_orig.stl',
+    };
+
+    // Windows project path
+    const resolvedWin = resolveOriginalRefSidecar(ref, 'C:/Users/aaron/Projects/my_scene.voxl');
+    assert.equal(resolvedWin, 'C:/Users/aaron/Projects/models/my_part_orig.stl');
+
+    // POSIX project path
+    const resolvedPosix = resolveOriginalRefSidecar(ref, '/home/user/projects/my_scene.voxl');
+    assert.equal(resolvedPosix, '/home/user/projects/models/my_part_orig.stl');
+
+    // Simple filename in same directory
+    const simpleRef: VoxlMeshRef = {
+      mode: 'external-file',
+      fileName: 'part_orig.stl',
+    };
+    const resolvedSameDir = resolveOriginalRefSidecar(simpleRef, 'C:/Projects/my_scene.voxl');
+    assert.equal(resolvedSameDir, 'C:/Projects/part_orig.stl');
+  });
+
+  test('resolveOriginalRefSidecar preserves absolute sidecar file paths', () => {
+    const winAbsRef: VoxlMeshRef = {
+      mode: 'external-file',
+      fileName: 'D:/Assets/HighRes/part_orig.stl',
+    };
+    const resolvedWinAbs = resolveOriginalRefSidecar(winAbsRef, 'C:/Projects/my_scene.voxl');
+    assert.equal(resolvedWinAbs, 'D:/Assets/HighRes/part_orig.stl');
+
+    const posixAbsRef: VoxlMeshRef = {
+      mode: 'external-file',
+      fileName: '/var/data/part_orig.stl',
+    };
+    const resolvedPosixAbs = resolveOriginalRefSidecar(posixAbsRef, '/home/user/projects/my_scene.voxl');
+    assert.equal(resolvedPosixAbs, '/var/data/part_orig.stl');
+  });
+
+  test('resolveOriginalRefSidecar returns null for invalid or non-external references', () => {
+    assert.equal(resolveOriginalRefSidecar(undefined, 'C:/Projects/my_scene.voxl'), null);
+
+    const embeddedChunkRef: VoxlMeshRef = { mode: 'embedded-chunk', chunkIndex: 0 };
+    assert.equal(resolveOriginalRefSidecar(embeddedChunkRef, 'C:/Projects/my_scene.voxl'), null);
+
+    const emptyFileRef: VoxlMeshRef = { mode: 'external-file', fileName: '' };
+    assert.equal(resolveOriginalRefSidecar(emptyFileRef, 'C:/Projects/my_scene.voxl'), null);
+  });
+
+  test('readSidecarFileBytes returns null gracefully when sidecar file is unreadable or missing', async () => {
+    const nonExistentPath = 'X:/invalid_path_does_not_exist_12345/missing.stl';
+    const bytes = await readSidecarFileBytes(nonExistentPath);
+    assert.equal(bytes, null, 'must return null when file does not exist');
+  });
+});

--- a/src/features/scene/voxl/__tests__/voxlPrecompressedChunks.test.ts
+++ b/src/features/scene/voxl/__tests__/voxlPrecompressedChunks.test.ts
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import test, { describe, beforeEach } from 'node:test';
+
+import { serializeVoxlDocumentV2, parseVoxlBinaryV2, resetVoxlCodecStats, voxlCodecStats } from '../codec-v2';
+import { MeshChunkStore } from '../meshChunkStore';
+import {
+  countVoxlChunks,
+  meshLike,
+  readVoxlVersion,
+  testInput,
+  withFrozenClock,
+} from './voxlTestSupport';
+
+/**
+ * The store → codec seam (Ph0.1 sub-phase C).
+ *
+ * `serializeVoxlDocumentV2` gains an additive `precompressed` option so a tick
+ * can hand it chunks that were already encoded, hashed and zlib-6'd at
+ * finalization time. The scope fence for this sub-phase is byte-identity: a
+ * document assembled from the store must be indistinguishable from one the
+ * pre-store writer would have produced.
+ */
+
+const MESH_A = meshLike(1);
+const MESH_B = meshLike(2);
+
+async function bakeAll(store: MeshChunkStore, meshes: Array<[string, Uint8Array]>) {
+  const meshBytes = new Map<number, Uint8Array>();
+  const sha256Map = new Map<number, string>();
+  const precompressed = new Map<number, { data: Uint8Array; compression: number; uncompressedSize: number }>();
+
+  for (let i = 0; i < meshes.length; i += 1) {
+    const [modelId, bytes] = meshes[i];
+    const baked = await store.bake({ modelId, signature: `sig:${modelId}`, encode: () => bytes });
+    meshBytes.set(i, bytes);
+    sha256Map.set(i, baked.sha256);
+    precompressed.set(i, {
+      data: baked.data,
+      compression: baked.compression,
+      uncompressedSize: baked.uncompressedSize,
+    });
+  }
+
+  return { meshBytes, sha256Map, precompressed };
+}
+
+describe('pre-compressed chunk payloads', () => {
+  beforeEach(() => {
+    resetVoxlCodecStats();
+  });
+
+  test('a document serialized from the store is byte-identical to one serialized from raw input', async () => {
+    await withFrozenClock(async () => {
+      const store = new MeshChunkStore();
+      const { meshBytes, sha256Map, precompressed } = await bakeAll(store, [
+        ['m0', MESH_A],
+        ['m1', MESH_B],
+      ]);
+
+      const fromRaw = await serializeVoxlDocumentV2(testInput(['m0', 'm1']), meshBytes, sha256Map);
+      const fromStore = await serializeVoxlDocumentV2(
+        testInput(['m0', 'm1']),
+        meshBytes,
+        sha256Map,
+        { precompressed },
+      );
+
+      assert.deepEqual([...fromStore], [...fromRaw], 'the store path changed the on-disk bytes');
+    });
+  });
+
+  test('supplying pre-compressed MESH payloads performs ZERO mesh compressions', async () => {
+    const store = new MeshChunkStore();
+    const { meshBytes, sha256Map, precompressed } = await bakeAll(store, [
+      ['m0', MESH_A],
+      ['m1', MESH_B],
+    ]);
+
+    resetVoxlCodecStats();
+    await serializeVoxlDocumentV2(testInput(['m0', 'm1']), meshBytes, sha256Map, { precompressed });
+
+    assert.equal(
+      voxlCodecStats.meshChunkCompressions,
+      0,
+      'zlib-6 re-ran over geometry the store had already compressed',
+    );
+    assert.ok(voxlCodecStats.jsonChunkCompressions > 0, 'the JSON chunks still compress per tick, by design');
+  });
+
+  /**
+   * The trigger-hygiene lock (sub-phase D5). A 0.1 mm nudge schedules a full
+   * autosave and that is deliberately NOT filtered: post-C the tick's cost is
+   * the KB-scale JSON chunks plus the disk write, so a drift-prone "which
+   * history entries matter" classifier would buy nothing. This test is what
+   * makes that acceptable — if a future change reintroduces per-tick mesh
+   * compression, it fails here rather than in a user's 3 589 ms stall.
+   */
+  test('a transform-only tick compresses no MESH chunks at all', async () => {
+    const store = new MeshChunkStore();
+    const { meshBytes, sha256Map } = await bakeAll(store, [['m0', MESH_A], ['m1', MESH_B]]);
+
+    // Tick 2: only the transform changed, so every signature still matches.
+    const precompressed = new Map<number, { data: Uint8Array; compression: number; uncompressedSize: number }>();
+    for (const [i, modelId] of ['m0', 'm1'].entries()) {
+      const cached = store.lookup(modelId, `sig:${modelId}`);
+      assert.ok(cached, 'an unchanged model must still be resolvable from the store');
+      precompressed.set(i, {
+        data: cached.data,
+        compression: cached.compression,
+        uncompressedSize: cached.uncompressedSize,
+      });
+    }
+
+    resetVoxlCodecStats();
+    const moved = testInput(['m0', 'm1']);
+    moved.models[0].transform.position.x = 0.1;
+    await serializeVoxlDocumentV2(moved, meshBytes, sha256Map, { precompressed });
+
+    assert.equal(voxlCodecStats.meshChunkCompressions, 0);
+    assert.equal(store.stats().compressions, 2, 'the nudge must not have re-baked anything');
+  });
+
+  test('pre-compressed payloads still dedup identical meshes to one chunk', async () => {
+    const store = new MeshChunkStore();
+    const { meshBytes, sha256Map, precompressed } = await bakeAll(store, [
+      ['m0', MESH_A],
+      ['m1', MESH_A],
+      ['m2', MESH_B],
+    ]);
+
+    const bin = await serializeVoxlDocumentV2(
+      testInput(['m0', 'm1', 'm2']),
+      meshBytes,
+      sha256Map,
+      { precompressed },
+    );
+
+    assert.equal(countVoxlChunks(bin, 'MESH'), 2, 'the two identical meshes must share one chunk');
+    assert.equal(readVoxlVersion(bin), 3);
+
+    const { meshBytes: out } = parseVoxlBinaryV2(bin);
+    assert.deepEqual([...out.get('m0')!], [...MESH_A]);
+    assert.deepEqual([...out.get('m1')!], [...MESH_A]);
+    assert.deepEqual([...out.get('m2')!], [...MESH_B]);
+  });
+
+  test('a pre-compressed document round-trips to the original mesh bytes', async () => {
+    const store = new MeshChunkStore();
+    const { meshBytes, sha256Map, precompressed } = await bakeAll(store, [['m0', MESH_A]]);
+
+    const bin = await serializeVoxlDocumentV2(testInput(['m0']), meshBytes, sha256Map, { precompressed });
+    const { document, meshBytes: out } = parseVoxlBinaryV2(bin);
+
+    assert.deepEqual([...out.get('m0')!], [...MESH_A]);
+    assert.equal(document.models[0].mesh.sha256, sha256Map.get(0));
+    assert.equal(document.models[0].mesh.uncompressedSizeBytes, MESH_A.length);
+  });
+});

--- a/src/features/scene/voxl/__tests__/voxlSizeGuard.test.ts
+++ b/src/features/scene/voxl/__tests__/voxlSizeGuard.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import test, { describe, beforeEach } from 'node:test';
+
+import {
+  serializeVoxlDocumentV2,
+  assertVoxlSizeLimits,
+  resetVoxlCodecStats,
+  voxlCodecStats,
+  VoxlSizeLimitError,
+  VOXL_SIZE_LIMIT_BYTES,
+  VOXL_SIZE_SOFT_WARN_BYTES,
+} from '../codec-v2';
+import { meshLike, testInput } from './voxlTestSupport';
+
+/** `assert.throws` is typed `void`, so capture the error explicitly. */
+function captureSizeLimitError(fn: () => void): VoxlSizeLimitError {
+  try {
+    fn();
+  } catch (error) {
+    assert.ok(error instanceof VoxlSizeLimitError, `expected VoxlSizeLimitError, got ${String(error)}`);
+    return error;
+  }
+  throw new assert.AssertionError({ message: 'expected the size guard to reject, but it passed' });
+}
+
+/**
+ * The 4 GiB ceiling (Ph0.1 sub-phase D1).
+ *
+ * Chunk offsets, `compressedSize` and `uncompressedSize` are all `setUint32`.
+ * There was NO writer guard: a scene past the ceiling wrapped its offsets and
+ * produced a file that parsed and was silently wrong. The guard is wired
+ * **pre-flight** — the directory layout is computed before assembly, so every
+ * length is known before a single byte is allocated, and the failure must
+ * therefore happen before the allocation rather than as a failed 4 GiB `new
+ * ArrayBuffer`.
+ */
+
+const OVER_U32 = 0x1_0000_0000;
+
+describe('the VOXL 4 GiB pre-flight guard', () => {
+  beforeEach(() => {
+    resetVoxlCodecStats();
+  });
+
+  test('the limit is the u32 ceiling and the soft warning sits below it', () => {
+    assert.equal(VOXL_SIZE_LIMIT_BYTES, 0xFFFF_FFFF);
+    assert.ok(
+      VOXL_SIZE_SOFT_WARN_BYTES < VOXL_SIZE_LIMIT_BYTES,
+      'the soft warning must fire before the hard failure',
+    );
+  });
+
+  test('a total past the ceiling raises VoxlSizeLimitError instead of wrapping', () => {
+    const entries = [
+      { type: 'MODL', index: 0, compressedSize: 1024, uncompressedSize: 4096 },
+      { type: 'MESH', index: 0, compressedSize: 0xFFFF_0000, uncompressedSize: 0xFFFF_0000 },
+      { type: 'MESH', index: 1, compressedSize: 0x0002_0000, uncompressedSize: 0x0002_0000 },
+    ];
+    const total = entries.reduce((n, e) => n + e.compressedSize, 16 + entries.length * 20);
+
+    assert.throws(
+      () => assertVoxlSizeLimits(entries, total),
+      (error: unknown) => {
+        assert.ok(error instanceof VoxlSizeLimitError);
+        assert.equal(error.totalBytes, total);
+        assert.equal(error.limitBytes, VOXL_SIZE_LIMIT_BYTES);
+        return true;
+      },
+    );
+  });
+
+  test('a single oversize chunk is rejected even when the total fits', () => {
+    // A chunk that compressed under the ceiling but whose RAW size does not fit
+    // the u32 `rawSize` field: the reader would allocate the wrong buffer and
+    // fail the post-inflate size check with a meaningless message.
+    const entries = [
+      { type: 'MESH', index: 0, compressedSize: 4096, uncompressedSize: OVER_U32 },
+    ];
+
+    const error = captureSizeLimitError(() => assertVoxlSizeLimits(entries, 8192));
+
+    assert.equal(error.oversizeChunks.length, 1);
+    assert.equal(error.oversizeChunks[0].type, 'MESH');
+  });
+
+  test('a scene inside the ceiling passes cleanly', () => {
+    assert.doesNotThrow(() =>
+      assertVoxlSizeLimits(
+        [{ type: 'MESH', index: 0, compressedSize: 1_000_000, uncompressedSize: 8_000_000 }],
+        1_000_100,
+      ),
+    );
+  });
+
+  test('the serializer fails pre-flight — no contiguous buffer is ever allocated', async () => {
+    // A pre-compressed payload declaring a raw size past u32 is the cheapest
+    // honest way to drive the writer past the ceiling without materialising
+    // 4 GiB in the test process.
+    const mesh = meshLike(7);
+    const precompressed = new Map([
+      [0, { data: mesh, compression: 0, uncompressedSize: OVER_U32 }],
+    ]);
+
+    await assert.rejects(
+      () => serializeVoxlDocumentV2(
+        testInput(['m0']),
+        new Map([[0, mesh]]),
+        new Map([[0, 'sha-0']]),
+        { precompressed },
+      ),
+      VoxlSizeLimitError,
+    );
+
+    assert.equal(
+      voxlCodecStats.largestContiguousAllocation,
+      0,
+      'the writer allocated the output buffer before checking whether it could address it',
+    );
+  });
+
+  test('the error carries a user-facing message naming the size and the cause', () => {
+    // 2 × 2.15 GiB → 4.3 GiB total, each chunk individually inside u32.
+    const entries = [
+      { type: 'MESH', index: 0, compressedSize: 2_308_544_922, uncompressedSize: 2_308_544_922 },
+      { type: 'MESH', index: 1, compressedSize: 2_308_544_922, uncompressedSize: 2_308_544_922 },
+    ];
+    const total = 4_617_089_844;
+
+    const error = captureSizeLimitError(
+      () => assertVoxlSizeLimits(entries, total, { modelNames: ['Dragon', 'Castle'] }),
+    );
+
+    // The message the modal shows. It must state the measured size, the limit,
+    // and what the user can actually do about it — never a bare stack trace.
+    assert.match(error.userMessage, /4\.3 GB/);
+    assert.match(error.userMessage, /4 GB limit/);
+    assert.match(error.userMessage, /Remove a model/i);
+    assert.ok(
+      error.perModelBreakdown.some((row) => row.name === 'Dragon'),
+      'the breakdown must name the models so the user knows which one to remove',
+    );
+  });
+});

--- a/src/features/scene/voxl/__tests__/voxlStreamingAssembly.test.ts
+++ b/src/features/scene/voxl/__tests__/voxlStreamingAssembly.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test, { describe, beforeEach } from 'node:test';
+
+import {
+  serializeVoxlDocumentV2,
+  serializeVoxlDocumentV2Streaming,
+  parseVoxlBinaryV2,
+  resetVoxlCodecStats,
+  voxlCodecStats,
+} from '../codec-v2';
+import { meshLike, testInput, withFrozenClock } from './voxlTestSupport';
+
+/**
+ * Streaming assembly (Ph0.1 sub-phase E).
+ *
+ * The writer allocated ONE contiguous `ArrayBuffer` the size of the whole
+ * document and memcpy'd every chunk into it on the MAIN thread — 172 MiB for a
+ * single 4M-tri model, 515 MiB for a 3-model plate — on the one code path that
+ * runs unattended every 30 seconds. It is both a jank source and an OOM
+ * candidate, and Ph5's original-mesh embed roughly triples it.
+ *
+ * It is removable because the chunk directory is computed BEFORE assembly: every
+ * chunk's offset is already known when the first byte is emitted, so nothing
+ * needs a second pass.
+ */
+
+const MESH_A = meshLike(11);
+const MESH_B = meshLike(12);
+
+function collectingSink() {
+  const parts: Uint8Array[] = [];
+  return {
+    parts,
+    sink: async (bytes: Uint8Array) => {
+      // Copy: the streaming writer is allowed to reuse a scratch buffer for the
+      // header/directory, and a sink that retained it would see it mutated.
+      parts.push(new Uint8Array(bytes));
+    },
+    concat(): Uint8Array {
+      const total = parts.reduce((n, p) => n + p.length, 0);
+      const out = new Uint8Array(total);
+      let cursor = 0;
+      for (const part of parts) {
+        out.set(part, cursor);
+        cursor += part.length;
+      }
+      return out;
+    },
+  };
+}
+
+describe('the streaming VOXL serializer', () => {
+  beforeEach(() => {
+    resetVoxlCodecStats();
+  });
+
+  test('emits bytes identical to the buffered serializer (all-unique scene)', async () => {
+    await withFrozenClock(async () => {
+      const meshBytes = new Map([[0, MESH_A], [1, MESH_B]]);
+      const sha = new Map([[0, 'sha-a'], [1, 'sha-b']]);
+
+      const buffered = await serializeVoxlDocumentV2(testInput(['m0', 'm1']), meshBytes, sha);
+      const streamed = collectingSink();
+      await serializeVoxlDocumentV2Streaming(testInput(['m0', 'm1']), meshBytes, sha, streamed.sink);
+
+      assert.deepEqual([...streamed.concat()], [...buffered], 'streaming changed the on-disk bytes');
+    });
+  });
+
+  test('emits bytes identical to the buffered serializer (deduped scene)', async () => {
+    await withFrozenClock(async () => {
+      const meshBytes = new Map([[0, MESH_A], [1, MESH_A], [2, MESH_B]]);
+      const sha = new Map([[0, 'sha-a'], [1, 'sha-a'], [2, 'sha-b']]);
+
+      const buffered = await serializeVoxlDocumentV2(testInput(['m0', 'm1', 'm2']), meshBytes, sha);
+      const streamed = collectingSink();
+      await serializeVoxlDocumentV2Streaming(testInput(['m0', 'm1', 'm2']), meshBytes, sha, streamed.sink);
+
+      const bytes = streamed.concat();
+      assert.deepEqual([...bytes], [...buffered]);
+
+      // And it is a real file, not just an equal byte string.
+      const { meshBytes: out } = parseVoxlBinaryV2(bytes);
+      assert.deepEqual([...out.get('m1')!], [...MESH_A]);
+    });
+  });
+
+  test('never allocates a buffer the size of the document', async () => {
+    const meshBytes = new Map([[0, MESH_A], [1, MESH_B]]);
+    const sha = new Map([[0, 'sha-a'], [1, 'sha-b']]);
+
+    const streamed = collectingSink();
+    const result = await serializeVoxlDocumentV2Streaming(
+      testInput(['m0', 'm1']),
+      meshBytes,
+      sha,
+      streamed.sink,
+    );
+
+    assert.ok(result.totalSize > MESH_A.length, 'sanity: the document is bigger than one mesh');
+    assert.ok(
+      voxlCodecStats.largestContiguousAllocation < result.totalSize,
+      'the streaming path still allocated the whole document contiguously',
+    );
+    assert.ok(
+      streamed.parts.length > 2,
+      'the payload must arrive as separate chunks, not one buffer handed to the sink',
+    );
+    assert.equal(
+      streamed.concat().length,
+      result.totalSize,
+      'the reported total must match what actually reached the sink',
+    );
+  });
+
+  test('the buffered serializer remains available for the browser download path', async () => {
+    const bytes = await serializeVoxlDocumentV2(
+      testInput(['m0']),
+      new Map([[0, MESH_A]]),
+      new Map([[0, 'sha-a']]),
+    );
+    assert.ok(bytes instanceof Uint8Array);
+    assert.equal(voxlCodecStats.largestContiguousAllocation, bytes.length);
+  });
+
+  test('a sink failure propagates instead of producing a half-written file', async () => {
+    await assert.rejects(
+      () => serializeVoxlDocumentV2Streaming(
+        testInput(['m0']),
+        new Map([[0, MESH_A]]),
+        new Map([[0, 'sha-a']]),
+        async () => {
+          throw new Error('disk full');
+        },
+      ),
+      /disk full/,
+    );
+  });
+});

--- a/src/features/scene/voxl/__tests__/voxlTestSupport.ts
+++ b/src/features/scene/voxl/__tests__/voxlTestSupport.ts
@@ -1,0 +1,94 @@
+import type { BuildVoxlDocumentInput, VoxlModelRuntimeLike } from '../types';
+import type { DragonfruitImportFormat } from '@/supports/types';
+
+export const EMPTY_SUPPORTS: DragonfruitImportFormat = {
+  version: 1,
+  meta: { source: 'unit-test', objectCenter: { x: 0, y: 0, z: 0 } },
+  roots: [],
+} as unknown as DragonfruitImportFormat;
+
+export function testModel(id: string, overrides: Partial<VoxlModelRuntimeLike> = {}): VoxlModelRuntimeLike {
+  return {
+    id,
+    name: id,
+    visible: true,
+    color: '#ffffff',
+    polygonCount: 1,
+    transform: {
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      scale: { x: 1, y: 1, z: 1 },
+    },
+    mesh: { mode: 'embedded-file', fileName: `${id}.stl`, mimeType: 'model/stl' },
+    ...overrides,
+  };
+}
+
+export function testInput(
+  models: Array<string | VoxlModelRuntimeLike>,
+): BuildVoxlDocumentInput {
+  const resolved = models.map((m) => (typeof m === 'string' ? testModel(m) : m));
+  return {
+    models: resolved,
+    activeModelId: resolved[0]?.id ?? null,
+    selectedModelIds: [],
+    supports: EMPTY_SUPPORTS,
+  };
+}
+
+/**
+ * The META chunk embeds `new Date().toISOString()`, so two serializations of the
+ * same scene differ by however many milliseconds elapsed between them. Every
+ * byte-identity assertion in this suite is about the CODEC, not the clock —
+ * freeze it so the comparison means what it says.
+ */
+export async function withFrozenClock<T>(fn: () => Promise<T>): Promise<T> {
+  const RealDate = globalThis.Date;
+  const frozen = RealDate.parse('2026-07-26T00:00:00.000Z');
+
+  class FrozenDate extends RealDate {
+    constructor(...args: unknown[]) {
+      if (args.length === 0) super(frozen);
+      else super(...(args as [number]));
+    }
+
+    static now(): number {
+      return frozen;
+    }
+  }
+
+  globalThis.Date = FrozenDate as unknown as DateConstructor;
+  try {
+    return await fn();
+  } finally {
+    globalThis.Date = RealDate;
+  }
+}
+
+/** Reads the container version from a serialized VOXL document. */
+export const readVoxlVersion = (bytes: Uint8Array): number =>
+  new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint16(4, true);
+
+/** Counts chunks of a given 4-char type in a serialized VOXL document. */
+export function countVoxlChunks(bytes: Uint8Array, type: string): number {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const chunkCount = view.getUint32(8, true);
+  let n = 0;
+  for (let i = 0; i < chunkCount; i += 1) {
+    const base = 16 + i * 20;
+    const tag = String.fromCharCode(bytes[base], bytes[base + 1], bytes[base + 2], bytes[base + 3]);
+    if (tag === type) n += 1;
+  }
+  return n;
+}
+
+/** Deterministic pseudo-random bytes — compressible enough to exercise zlib. */
+export function meshLike(seed: number, length = 8192): Uint8Array {
+  const out = new Uint8Array(length);
+  let x = seed >>> 0 || 1;
+  for (let i = 0; i < length; i += 1) {
+    x = (x * 1664525 + 1013904223) >>> 0;
+    out[i] = (x >>> 24) & 0x1f; // low entropy → zlib actually shrinks it
+  }
+  return out;
+}

--- a/src/features/scene/voxl/codec-v2.ts
+++ b/src/features/scene/voxl/codec-v2.ts
@@ -26,6 +26,16 @@
  */
 
 import { unzlibSync, zlib as zlibAsync } from 'fflate';
+import {
+  VOXL_MAGIC,
+  type BuildVoxlDocumentInput,
+  type ParsedVoxlResult,
+  type VoxlMeshRef,
+  type VoxlMeta,
+  type VoxlModelEntry,
+  type VoxlSceneState,
+} from './types';
+import type { DragonfruitImportFormat } from '@/supports/types';
 
 type ZlibCompressionLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
@@ -37,16 +47,6 @@ const compressAsync = (data: Uint8Array, level: ZlibCompressionLevel): Promise<U
       else resolve(result);
     });
   });
-import {
-  VOXL_MAGIC,
-  type BuildVoxlDocumentInput,
-  type ParsedVoxlResult,
-  type VoxlMeshRef,
-  type VoxlMeta,
-  type VoxlModelEntry,
-  type VoxlSceneState,
-} from './types';
-import type { DragonfruitImportFormat } from '@/supports/types';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -94,21 +94,198 @@ interface ChunkDirEntry {
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
+// ─── Size limits (Ph0.1 sub-phase D1) ─────────────────────────────────────────
+
+/**
+ * The container addresses chunk offsets, `compSize` and `rawSize` with `u32`
+ * (`:290-292`). Past this, offsets wrap and the writer emits a file that parses
+ * and is silently wrong. There was no writer guard at all.
+ */
+export const VOXL_SIZE_LIMIT_BYTES = 0xFFFF_FFFF;
+
+/**
+ * Explicit saves warn here rather than failing. The ceiling is approached fast
+ * once Ph5 embeds originals — one 4M preview plus one 11.24M original is
+ * ~654 MiB, so six such models reach it.
+ */
+export const VOXL_SIZE_SOFT_WARN_BYTES = Math.floor(3.5 * 1024 * 1024 * 1024);
+
+export interface VoxlChunkSizeInfo {
+  type: string;
+  index: number;
+  compressedSize: number;
+  uncompressedSize: number;
+}
+
+export interface VoxlSizeBreakdownRow {
+  index: number;
+  name: string;
+  compressedBytes: number;
+  uncompressedBytes: number;
+}
+
+const formatGb = (bytes: number): string => `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+
+/** Latch so the soft warning fires once per approach, not once per 30 s tick. */
+let softLimitWarned = false;
+
+/**
+ * Thrown **before** any allocation. Carries the measured total and the per-model
+ * breakdown so the caller can tell the user which model to remove rather than
+ * reporting a bare failure.
+ */
+export class VoxlSizeLimitError extends Error {
+  readonly totalBytes: number;
+
+  readonly limitBytes: number;
+
+  readonly oversizeChunks: VoxlChunkSizeInfo[];
+
+  readonly perModelBreakdown: VoxlSizeBreakdownRow[];
+
+  /** The sentence a modal / toast shows verbatim. */
+  readonly userMessage: string;
+
+  constructor(args: {
+    totalBytes: number;
+    oversizeChunks: VoxlChunkSizeInfo[];
+    perModelBreakdown: VoxlSizeBreakdownRow[];
+    userMessage: string;
+  }) {
+    super(args.userMessage);
+    this.name = 'VoxlSizeLimitError';
+    this.totalBytes = args.totalBytes;
+    this.limitBytes = VOXL_SIZE_LIMIT_BYTES;
+    this.oversizeChunks = args.oversizeChunks;
+    this.perModelBreakdown = args.perModelBreakdown;
+    this.userMessage = args.userMessage;
+  }
+}
+
+/**
+ * Pre-flight size check. Wired to the computed directory rather than to the
+ * assembly step: every chunk's length is known once the layout is calculated
+ * (`:246-266`), which is *before* `new ArrayBuffer` — so the failure is a clean
+ * typed error, never a silent wrap and never a failed 4 GiB allocation.
+ */
+export function assertVoxlSizeLimits(
+  entries: VoxlChunkSizeInfo[],
+  totalSize: number,
+  options?: { modelNames?: string[] },
+): void {
+  const oversizeChunks = entries.filter(
+    (e) => e.compressedSize > VOXL_SIZE_LIMIT_BYTES || e.uncompressedSize > VOXL_SIZE_LIMIT_BYTES,
+  );
+  const totalOver = totalSize > VOXL_SIZE_LIMIT_BYTES;
+
+  if (!totalOver && oversizeChunks.length === 0) {
+    // Soft warning. The headroom below the ceiling disappears fast once Ph5
+    // embeds originals — one 4M preview plus one 11.24M original is ~654 MiB, so
+    // six such models reach it. Latched so a 30 s autosave tick cannot spam, and
+    // reset when the scene drops back under, so it fires again next time.
+    if (totalSize >= VOXL_SIZE_SOFT_WARN_BYTES) {
+      if (!softLimitWarned) {
+        softLimitWarned = true;
+        console.warn(
+          `[VOXL] This scene is ${formatGb(totalSize)} — approaching the 4 GB format limit. `
+          + 'Saves will fail past it; remove a model or reduce embedded originals.',
+        );
+      }
+    } else {
+      softLimitWarned = false;
+    }
+    return;
+  }
+
+  const names = options?.modelNames ?? [];
+  const perModelBreakdown: VoxlSizeBreakdownRow[] = entries
+    .filter((e) => e.type === CHUNK_MESH)
+    .map((e) => ({
+      index: e.index,
+      name: names[e.index] ?? `Model ${e.index + 1}`,
+      compressedBytes: e.compressedSize,
+      uncompressedBytes: e.uncompressedSize,
+    }))
+    .sort((a, b) => b.compressedBytes - a.compressedBytes);
+
+  const remedy = 'Remove a model, or turn off “Save original model along with decimated”.';
+  const userMessage = totalOver
+    ? `This scene is ${formatGb(totalSize)} compressed and exceeds the VOXL 4 GB limit. ${remedy}`
+    : `“${names[oversizeChunks[0].index] ?? `Model ${oversizeChunks[0].index + 1}`}” is `
+      + `${formatGb(Math.max(oversizeChunks[0].compressedSize, oversizeChunks[0].uncompressedSize))} on its own, `
+      + `which exceeds the VOXL 4 GB limit for a single mesh. ${remedy}`;
+
+  throw new VoxlSizeLimitError({ totalBytes: totalSize, oversizeChunks, perModelBreakdown, userMessage });
+}
+
+// ─── Codec instrumentation ────────────────────────────────────────────────────
+
+/**
+ * Counters the perf and honesty tests assert against. `meshChunkCompressions`
+ * is the one that mattered: it was N-per-tick, and post-store it must be zero
+ * for an unchanged scene. `largestContiguousAllocation` pins sub-phase E's
+ * claim that the streaming writer never allocates the whole document.
+ */
+export const voxlCodecStats = {
+  meshChunkCompressions: 0,
+  jsonChunkCompressions: 0,
+  largestContiguousAllocation: 0,
+};
+
+export function resetVoxlCodecStats(): void {
+  voxlCodecStats.meshChunkCompressions = 0;
+  voxlCodecStats.jsonChunkCompressions = 0;
+  voxlCodecStats.largestContiguousAllocation = 0;
+}
+
 // ─── V2 Binary Writer ─────────────────────────────────────────────────────────
 
 /**
- * Serialize a VOXL scene to the V2 binary container format.
- *
- * @param input       - Scene data (models, supports, extensions, etc.)
- * @param meshBytes   - Map of model index → raw mesh binary (e.g. STL bytes)
- * @param sha256Map   - Optional map of model index → hex SHA-256 digest
- * @returns           - Complete VOXL V2 binary as Uint8Array
+ * A chunk payload the caller already encoded, hashed and compressed — supplied
+ * by the COW chunk store (Ph0.1 sub-phase C). `compression` uses the container's
+ * own tags (0 = none, 1 = zlib), and the store applies the identical
+ * `>64 bytes and only if it shrinks` policy the writer used to apply inline, so
+ * the emitted bytes are unchanged.
  */
-export async function serializeVoxlDocumentV2(
+export interface PrecompressedChunk {
+  data: Uint8Array;
+  compression: number;
+  uncompressedSize: number;
+}
+
+export interface VoxlSerializeOptions {
+  /** Model index → already-compressed MESH payload. */
+  precompressed?: Map<number, PrecompressedChunk>;
+}
+
+interface ResolvedChunk {
+  type: string;
+  index: number;
+  compression: number;
+  data: Uint8Array;
+  uncompressedSize: number;
+}
+
+interface PreparedDocument {
+  resolved: ResolvedChunk[];
+  directory: ChunkDirEntry[];
+  totalSize: number;
+  version: number;
+}
+
+/**
+ * Everything up to (but not including) assembly: chunk construction, dedup,
+ * compression, layout, and the pre-flight size guard. Shared by the buffered and
+ * streaming writers so they cannot drift — the byte-identity gate between them
+ * is the whole point of sub-phase E.
+ */
+async function prepareVoxlDocumentV2(
   input: BuildVoxlDocumentInput,
   meshBytes: Map<number, Uint8Array>,
   sha256Map?: Map<number, string>,
-): Promise<Uint8Array> {
+  options?: VoxlSerializeOptions,
+): Promise<PreparedDocument> {
+  const precompressed = options?.precompressed;
   const nowIso = new Date().toISOString();
 
   // ── Build chunk payloads ──────────────────────────────────────────────
@@ -133,11 +310,22 @@ export async function serializeVoxlDocumentV2(
   // chunks are written, so a Fill-Plate bed of N copies stores 1 mesh, not N.
   // Falls back to 1:1 when a SHA is missing (dedup is best-effort, never
   // wrong: without a hash we cannot prove two meshes are identical).
+  //
+  // A model's payload may arrive raw (`meshBytes`) or already baked
+  // (`precompressed`, from the chunk store). Both are legitimate sources of "this
+  // model has a chunk"; everything downstream goes through these two accessors
+  // so the dedup, the directory, and the MODL entries cannot disagree about it.
+  const hasChunkFor = (i: number): boolean => meshBytes.has(i) || (precompressed?.has(i) ?? false);
+  const rawSizeFor = (i: number): number =>
+    meshBytes.get(i)?.length ?? precompressed?.get(i)?.uncompressedSize ?? 0;
+
   const chunkOwnerByModelIndex = new Map<number, number>(); // model i → owning chunk index
   const ownerBySha = new Map<string, number>();
-  const dedupedMeshBytes = new Map<number, Uint8Array>();
+  const dedupedChunkIndices: number[] = [];
+  let chunkCandidateCount = 0;
   for (let i = 0; i < input.models.length; i += 1) {
-    if (!meshBytes.has(i)) continue;
+    if (!hasChunkFor(i)) continue;
+    chunkCandidateCount += 1;
     const sha = sha256Map?.get(i);
     const existingOwner = sha !== undefined ? ownerBySha.get(sha) : undefined;
     if (existingOwner !== undefined) {
@@ -145,20 +333,20 @@ export async function serializeVoxlDocumentV2(
     } else {
       chunkOwnerByModelIndex.set(i, i); // owner → keeps its own chunk
       if (sha !== undefined) ownerBySha.set(sha, i);
-      dedupedMeshBytes.set(i, meshBytes.get(i)!);
+      dedupedChunkIndices.push(i);
     }
   }
-  const dedupRemovedChunks = meshBytes.size > dedupedMeshBytes.size;
+  const dedupRemovedChunks = chunkCandidateCount > dedupedChunkIndices.length;
 
   const models: VoxlModelEntry[] = input.models.map((m, i) => {
-    const hasChunk = meshBytes.has(i);
+    const hasChunk = hasChunkFor(i);
     const ownerIndex = chunkOwnerByModelIndex.get(i);
     const meshRef: VoxlMeshRef = hasChunk
       ? {
           mode: 'embedded-chunk',
           fileName: m.mesh?.fileName ?? m.name,
           mimeType: m.mesh?.mimeType ?? 'model/stl',
-          uncompressedSizeBytes: meshBytes.get(i)!.length,
+          uncompressedSizeBytes: rawSizeFor(i),
           sha256: sha256Map?.get(i),
           // Only duplicates carry an explicit pointer; owners default to `i`,
           // keeping V2 files byte-identical to before when no dedup occurs.
@@ -178,6 +366,18 @@ export async function serializeVoxlDocumentV2(
         typeof m.fileSizeBytes === 'number' && Number.isFinite(m.fileSizeBytes)
           ? Math.max(0, Math.floor(m.fileSizeBytes))
           : undefined,
+      // Phase-1 full-res linkage (STL-import remediation): additive JSON
+      // fields inside the MODL chunk — no container-version bump needed
+      // (older readers ignore unknown fields; the versioning convention
+      // reserves bumps for changes that would make old readers WRONG, like
+      // the dedup chunk sharing above).
+      ...(typeof m.sourcePath === 'string' && m.sourcePath.trim().length > 0
+        ? { sourcePath: m.sourcePath }
+        : {}),
+      ...(m.nativePreview ? { nativePreview: m.nativePreview } : {}),
+      // Written only when true (Ph0.1 D2): a scene with nothing stale must
+      // serialize to exactly the bytes it did before the flag existed.
+      ...(m.geometryStale === true ? { geometryStale: true } : {}),
       transform: {
         position: { x: m.transform.position.x, y: m.transform.position.y, z: m.transform.position.z },
         rotation: { x: m.transform.rotation.x, y: m.transform.rotation.y, z: m.transform.rotation.z },
@@ -190,7 +390,13 @@ export async function serializeVoxlDocumentV2(
 
   // ── Collect pending chunks ────────────────────────────────────────────
 
-  type PendingChunk = { type: string; index: number; raw: Uint8Array; compress: boolean };
+  type PendingChunk = {
+    type: string;
+    index: number;
+    raw?: Uint8Array;
+    pre?: PrecompressedChunk;
+    compress: boolean;
+  };
   const pending: PendingChunk[] = [];
 
   pending.push({ type: CHUNK_META, index: 0, raw: textEncoder.encode(JSON.stringify(meta)), compress: false });
@@ -199,9 +405,13 @@ export async function serializeVoxlDocumentV2(
 
   // One MESH chunk per UNIQUE mesh (owner index), sorted by index. Duplicates
   // reference an owner via meshRef.chunkIndex and get no chunk of their own.
-  const sortedMeshEntries = [...dedupedMeshBytes.entries()].sort((a, b) => a[0] - b[0]);
-  for (const [modelIndex, bytes] of sortedMeshEntries) {
-    pending.push({ type: CHUNK_MESH, index: modelIndex, raw: bytes, compress: true });
+  for (const modelIndex of [...dedupedChunkIndices].sort((a, b) => a - b)) {
+    const pre = precompressed?.get(modelIndex);
+    if (pre) {
+      pending.push({ type: CHUNK_MESH, index: modelIndex, pre, compress: true });
+    } else {
+      pending.push({ type: CHUNK_MESH, index: modelIndex, raw: meshBytes.get(modelIndex)!, compress: true });
+    }
   }
 
   pending.push({ type: CHUNK_SUPP, index: 0, raw: textEncoder.encode(JSON.stringify(input.supports)), compress: true });
@@ -211,17 +421,35 @@ export async function serializeVoxlDocumentV2(
   }
 
   // ── Compress (async – does not block the main thread) ─────────────────
+  //
+  // A chunk that arrives pre-compressed skips this entirely. That is the whole
+  // sub-phase-C win: for an unchanged scene, every MESH chunk takes this branch
+  // and the per-tick zlib cost collapses to the KB-scale JSON chunks.
 
-  const resolved = await Promise.all(pending.map(async (chunk) => {
-    if (chunk.compress && chunk.raw.length > 64) {
-      const compressed = await compressAsync(chunk.raw, 6);
-      if (compressed.length < chunk.raw.length) {
+  const resolved: ResolvedChunk[] = await Promise.all(pending.map(async (chunk): Promise<ResolvedChunk> => {
+    if (chunk.pre) {
+      return {
+        type: chunk.type,
+        index: chunk.index,
+        compression: chunk.pre.compression,
+        data: chunk.pre.data,
+        uncompressedSize: chunk.pre.uncompressedSize,
+      };
+    }
+
+    const raw = chunk.raw!;
+    if (chunk.compress && raw.length > 64) {
+      if (chunk.type === CHUNK_MESH) voxlCodecStats.meshChunkCompressions += 1;
+      else voxlCodecStats.jsonChunkCompressions += 1;
+
+      const compressed = await compressAsync(raw, 6);
+      if (compressed.length < raw.length) {
         return {
           type: chunk.type,
           index: chunk.index,
           compression: COMPRESSION_ZLIB,
           data: compressed,
-          uncompressedSize: chunk.raw.length,
+          uncompressedSize: raw.length,
         };
       }
     }
@@ -229,8 +457,8 @@ export async function serializeVoxlDocumentV2(
       type: chunk.type,
       index: chunk.index,
       compression: COMPRESSION_NONE,
-      data: chunk.raw,
-      uncompressedSize: chunk.raw.length,
+      data: raw,
+      uncompressedSize: raw.length,
     };
   }));
 
@@ -250,32 +478,46 @@ export async function serializeVoxlDocumentV2(
       compressedSize: chunk.data.length,
       uncompressedSize: chunk.uncompressedSize,
     };
+
     cursor += chunk.data.length;
     return entry;
   });
 
   const totalSize = cursor;
 
-  // ── Assemble binary ───────────────────────────────────────────────────
+  // Pre-flight, before any assembly buffer exists (Ph0.1 D1). Every offset and
+  // length is already known here, so a scene past the u32 ceiling fails with a
+  // typed, user-readable error instead of wrapping its offsets silently.
+  assertVoxlSizeLimits(directory, totalSize, { modelNames: input.models.map((m) => m.name) });
 
-  const buffer = new ArrayBuffer(totalSize);
-  const view = new DataView(buffer);
-  const out = new Uint8Array(buffer);
+  return {
+    resolved,
+    directory,
+    totalSize,
+    // Version bumps to 3 only when dedup removed chunks, so old readers reject
+    // deduped files cleanly rather than losing the shared-chunk models;
+    // non-deduped scenes stay V2 and remain readable by older builds.
+    version: dedupRemovedChunks ? VOXL_V3 : VOXL_V2,
+  };
+}
 
-  // Header. Version bumps to 3 only when dedup removed chunks, so old readers
-  // reject deduped files cleanly rather than losing the shared-chunk models;
-  // non-deduped scenes stay V2 and remain readable by older builds.
-  out.set(MAGIC_BYTES, 0);
-  view.setUint16(4, dedupRemovedChunks ? VOXL_V3 : VOXL_V2, true);
+/** Header + directory. Identical in both writers; ~16 + 20N bytes, never scene-sized. */
+function buildVoxlPreamble(prepared: PreparedDocument): Uint8Array {
+  const { directory, version } = prepared;
+  const chunkCount = directory.length;
+  const preamble = new Uint8Array(HEADER_SIZE + chunkCount * DIR_ENTRY_SIZE);
+  const view = new DataView(preamble.buffer);
+
+  preamble.set(MAGIC_BYTES, 0);
+  view.setUint16(4, version, true);
   view.setUint16(6, 0, true);
   view.setUint32(8, chunkCount, true);
   view.setUint32(12, 0, true);
 
-  // Directory
   for (let i = 0; i < chunkCount; i += 1) {
     const entry = directory[i];
     const base = HEADER_SIZE + i * DIR_ENTRY_SIZE;
-    out.set(textEncoder.encode(entry.type), base);
+    preamble.set(textEncoder.encode(entry.type), base);
     view.setUint16(base + 4, entry.index, true);
     view.setUint16(base + 6, entry.compression, true);
     view.setUint32(base + 8, entry.offset, true);
@@ -283,12 +525,79 @@ export async function serializeVoxlDocumentV2(
     view.setUint32(base + 16, entry.uncompressedSize, true);
   }
 
-  // Chunk data
-  for (let i = 0; i < resolved.length; i += 1) {
-    out.set(resolved[i].data, directory[i].offset);
+  return preamble;
+}
+
+/**
+ * Serialize a VOXL scene to the V2 binary container format.
+ *
+ * Buffered form: allocates the whole document contiguously. Kept for the browser
+ * `<a download>` fallback, which genuinely needs a Blob, and for every existing
+ * caller. Native writes should prefer `serializeVoxlDocumentV2Streaming` — see
+ * its docstring for why the contiguous buffer is worth avoiding.
+ *
+ * @param input       - Scene data (models, supports, extensions, etc.)
+ * @param meshBytes   - Map of model index → raw mesh binary (e.g. STL bytes)
+ * @param sha256Map   - Optional map of model index → hex SHA-256 digest
+ * @param options     - Additional serialization options (e.g. precompressed chunks)
+ * @returns           - Complete VOXL V2 binary as Uint8Array
+ */
+export async function serializeVoxlDocumentV2(
+  input: BuildVoxlDocumentInput,
+  meshBytes: Map<number, Uint8Array>,
+  sha256Map?: Map<number, string>,
+  options?: VoxlSerializeOptions,
+): Promise<Uint8Array> {
+  const prepared = await prepareVoxlDocumentV2(input, meshBytes, sha256Map, options);
+
+  const out = new Uint8Array(prepared.totalSize);
+  voxlCodecStats.largestContiguousAllocation = Math.max(
+    voxlCodecStats.largestContiguousAllocation,
+    prepared.totalSize,
+  );
+
+  out.set(buildVoxlPreamble(prepared), 0);
+  for (let i = 0; i < prepared.resolved.length; i += 1) {
+    out.set(prepared.resolved[i].data, prepared.directory[i].offset);
   }
 
   return out;
+}
+
+/**
+ * Streaming form (Ph0.1 sub-phase E).
+ *
+ * The buffered writer allocated ONE contiguous `ArrayBuffer` the size of the
+ * whole document and memcpy'd every chunk into it on the MAIN thread —
+ * 172 MiB for a single 4M-tri model, 515 MiB for a 3-model plate — on the one
+ * code path that runs unattended every 30 seconds. It is both a jank source and
+ * an OOM candidate, and Ph5's original-mesh embed roughly triples it.
+ *
+ * Removing it is cheap because the directory is computed **before** assembly:
+ * every chunk's offset is known when the first byte is emitted, so the writer
+ * emits the preamble and then each chunk's payload in directory order, with no
+ * second pass and no copy. Peak residency per tick drops from
+ * `raw + compressed + contiguous` to `compressed` (the store's own retention)
+ * plus one sink chunk.
+ *
+ * The sink is awaited per emission, so a write failure aborts immediately rather
+ * than after the whole document has been produced.
+ */
+export async function serializeVoxlDocumentV2Streaming(
+  input: BuildVoxlDocumentInput,
+  meshBytes: Map<number, Uint8Array>,
+  sha256Map: Map<number, string> | undefined,
+  sink: (bytes: Uint8Array) => void | Promise<void>,
+  options?: VoxlSerializeOptions,
+): Promise<{ totalSize: number; version: number }> {
+  const prepared = await prepareVoxlDocumentV2(input, meshBytes, sha256Map, options);
+
+  await sink(buildVoxlPreamble(prepared));
+  for (const chunk of prepared.resolved) {
+    await sink(chunk.data);
+  }
+
+  return { totalSize: prepared.totalSize, version: prepared.version };
 }
 
 // ─── V2 Binary Reader ─────────────────────────────────────────────────────────

--- a/src/features/scene/voxl/codec-v2.ts
+++ b/src/features/scene/voxl/codec-v2.ts
@@ -75,6 +75,7 @@ const CHUNK_META = 'META';
 const CHUNK_SCNE = 'SCNE';
 const CHUNK_MODL = 'MODL';
 const CHUNK_MESH = 'MESH';
+export const CHUNK_ORIG = 'ORIG';
 const CHUNK_SUPP = 'SUPP';
 const CHUNK_EXTD = 'EXTD';
 
@@ -256,6 +257,11 @@ export interface PrecompressedChunk {
 export interface VoxlSerializeOptions {
   /** Model index → already-compressed MESH payload. */
   precompressed?: Map<number, PrecompressedChunk>;
+  /** Model index → already-compressed ORIG payload. */
+  precompressedOriginal?: Map<number, PrecompressedChunk>;
+  /** Model index → raw uncompressed ORIG payload. */
+  originalMeshBytes?: Map<number, Uint8Array>;
+  embedOriginalMesh?: boolean;
 }
 
 interface ResolvedChunk {
@@ -286,6 +292,9 @@ async function prepareVoxlDocumentV2(
   options?: VoxlSerializeOptions,
 ): Promise<PreparedDocument> {
   const precompressed = options?.precompressed;
+  const precompressedOriginal = options?.precompressedOriginal;
+  const originalMeshBytes = options?.originalMeshBytes;
+  const embedOriginalMesh = options?.embedOriginalMesh ?? true;
   const nowIso = new Date().toISOString();
 
   // ── Build chunk payloads ──────────────────────────────────────────────
@@ -410,7 +419,23 @@ async function prepareVoxlDocumentV2(
     if (pre) {
       pending.push({ type: CHUNK_MESH, index: modelIndex, pre, compress: true });
     } else {
-      pending.push({ type: CHUNK_MESH, index: modelIndex, raw: meshBytes.get(modelIndex)!, compress: true });
+      const raw = meshBytes.get(modelIndex);
+      if (raw) {
+        pending.push({ type: CHUNK_MESH, index: modelIndex, raw, compress: true });
+      }
+    }
+  }
+
+  // Additive ORIG chunks for full-res original mesh embedding
+  if (embedOriginalMesh) {
+    for (const modelIndex of [...dedupedChunkIndices].sort((a, b) => a - b)) {
+      const preOrig = precompressedOriginal?.get(modelIndex);
+      const rawOrig = originalMeshBytes?.get(modelIndex);
+      if (preOrig) {
+        pending.push({ type: CHUNK_ORIG, index: modelIndex, pre: preOrig, compress: true });
+      } else if (rawOrig) {
+        pending.push({ type: CHUNK_ORIG, index: modelIndex, raw: rawOrig, compress: true });
+      }
     }
   }
 
@@ -721,6 +746,27 @@ export function parseVoxlBinaryV2(data: Uint8Array): ParsedVoxlResult {
     }
   }
 
+  // ── Resolve ORIG chunks (additive full-res mesh) ──────────────────────
+
+  const originalMeshBytesMap = new Map<string, Uint8Array>();
+  const origBytesByIndex = new Map<number, Uint8Array>();
+
+  for (let i = 0; i < models.length; i += 1) {
+    const model = models[i];
+    const chunkIdx = typeof model.mesh?.chunkIndex === 'number' ? model.mesh.chunkIndex : i;
+    let bytes = origBytesByIndex.get(chunkIdx);
+    if (!bytes) {
+      const origEntry = entries.find((e) => e.type === CHUNK_ORIG && e.index === chunkIdx);
+      if (origEntry) {
+        bytes = readChunk(origEntry);
+        origBytesByIndex.set(chunkIdx, bytes);
+      }
+    }
+    if (bytes) {
+      originalMeshBytesMap.set(model.id, bytes);
+    }
+  }
+
   return {
     document: {
       magic: VOXL_MAGIC,
@@ -732,6 +778,7 @@ export function parseVoxlBinaryV2(data: Uint8Array): ParsedVoxlResult {
       extensions,
     },
     meshBytes: meshBytesMap,
+    ...(originalMeshBytesMap.size > 0 ? { originalMeshBytes: originalMeshBytesMap } : {}),
     sourceVersion: VOXL_V2_SEMANTIC_REVISION,
   };
 }

--- a/src/features/scene/voxl/codec-v2.ts
+++ b/src/features/scene/voxl/codec-v2.ts
@@ -384,6 +384,7 @@ async function prepareVoxlDocumentV2(
         ? { sourcePath: m.sourcePath }
         : {}),
       ...(m.nativePreview ? { nativePreview: m.nativePreview } : {}),
+      ...(m.originalRef ? { originalRef: m.originalRef } : {}),
       // Written only when true (Ph0.1 D2): a scene with nothing stale must
       // serialize to exactly the bytes it did before the flag existed.
       ...(m.geometryStale === true ? { geometryStale: true } : {}),
@@ -783,6 +784,11 @@ export function parseVoxlBinaryV2(data: Uint8Array): ParsedVoxlResult {
   };
 }
 
+/**
+ * Alias for `parseVoxlBinaryV2` for V2 container documents.
+ */
+export const parseVoxlDocumentV2 = parseVoxlBinaryV2;
+
 // ─── Format Detection ─────────────────────────────────────────────────────────
 
 /**
@@ -794,3 +800,86 @@ export function isVoxlBinaryV2(data: Uint8Array): boolean {
   const version = data[4] | (data[5] << 8); // uint16 LE
   return version >= 2;
 }
+
+// ─── Sidecar Mesh Resolution ──────────────────────────────────────────────────
+
+/**
+ * Locate and resolve external original mesh files referenced by `originalRef`
+ * relative to the `.voxl` project path.
+ *
+ * If `originalRef` is missing or mode is not 'external-file' (or fileName is empty), returns null.
+ * If `originalRef.fileName` is an absolute path, returns it directly.
+ * If `originalRef.fileName` is relative and `projectPath` is provided, returns
+ * the resolved absolute path relative to the directory containing `projectPath`.
+ */
+export function resolveOriginalRefSidecar(
+  originalRef?: VoxlMeshRef,
+  projectPath?: string,
+): string | null {
+  if (!originalRef || originalRef.mode !== 'external-file' || !originalRef.fileName) {
+    return null;
+  }
+
+  const rawFileName = originalRef.fileName.trim();
+  if (!rawFileName) return null;
+
+  const isAbsolute = /^(?:[a-zA-Z]:[/\\]|\\\\|\/)/.test(rawFileName);
+  if (isAbsolute) {
+    return rawFileName.replace(/\\/g, '/');
+  }
+
+  if (!projectPath) {
+    return rawFileName.replace(/\\/g, '/');
+  }
+
+  const normalizedProject = projectPath.replace(/\\/g, '/');
+  const lastSlashIndex = normalizedProject.lastIndexOf('/');
+  const baseDir = lastSlashIndex >= 0 ? normalizedProject.slice(0, lastSlashIndex) : normalizedProject;
+
+  const normalizedRelative = rawFileName.replace(/\\/g, '/').replace(/^\.\//, '');
+  const resolved = baseDir ? `${baseDir}/${normalizedRelative}` : normalizedRelative;
+  return resolved;
+}
+
+/**
+ * Helper to read raw bytes from a sidecar file path across environments (Node/Tauri/Browser).
+ * Returns null if the file cannot be read or is missing.
+ */
+export async function readSidecarFileBytes(filePath: string): Promise<Uint8Array | null> {
+  try {
+    if (typeof process !== 'undefined' && process.versions?.node) {
+      try {
+        const fs = await import('fs');
+        if (fs.existsSync(filePath)) {
+          const buf = fs.readFileSync(filePath);
+          return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+        }
+      } catch {
+        // Fall through
+      }
+    }
+
+    if (typeof window !== 'undefined' && '__TAURI_IPC__' in window) {
+      try {
+        const { invoke } = await import('@tauri-apps/api/core');
+        const ab = await invoke<ArrayBuffer>('read_print_file_bytes', { path: filePath });
+        if (ab) return new Uint8Array(ab);
+      } catch {
+        // Fall through
+      }
+    }
+
+    if (typeof fetch === 'function') {
+      const response = await fetch(filePath);
+      if (response.ok) {
+        const ab = await response.arrayBuffer();
+        return new Uint8Array(ab);
+      }
+    }
+  } catch {
+    // Ignore and return null
+  }
+
+  return null;
+}
+

--- a/src/features/scene/voxl/codec.ts
+++ b/src/features/scene/voxl/codec.ts
@@ -196,6 +196,9 @@ function mapModelToVoxl(model: VoxlModelRuntimeLike): VoxlModelEntry {
     fileSizeBytes: typeof model.fileSizeBytes === 'number' && Number.isFinite(model.fileSizeBytes)
       ? Math.max(0, Math.floor(model.fileSizeBytes))
       : undefined,
+    ...(model.sourcePath ? { sourcePath: model.sourcePath } : {}),
+    ...(model.nativePreview ? { nativePreview: model.nativePreview } : {}),
+    ...(model.originalRef ? { originalRef: model.originalRef } : {}),
     transform: {
       position: toVec3(model.transform.position),
       rotation: toVec3(model.transform.rotation),

--- a/src/features/scene/voxl/index.ts
+++ b/src/features/scene/voxl/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './codec';
 export * from './codec-v2';
+export * from './meshChunkStore';

--- a/src/features/scene/voxl/meshChunkStore.ts
+++ b/src/features/scene/voxl/meshChunkStore.ts
@@ -1,0 +1,359 @@
+/**
+ * COW compressed-chunk store (Ph0.1 sub-phase C).
+ *
+ * ## The defect this replaces
+ *
+ * The VOXL writer memoised each model's **raw** binary STL bytes keyed on a
+ * geometry signature, then threw the compressed result away. Every 30 s autosave
+ * tick therefore re-ran zlib-6 over every model's entire geometry — measured at
+ * **3 589 ms / 172 MiB for one 4M-tri model** and **11 125 ms / 515 MiB for a
+ * 3-model plate** — even when nothing but a camera transform had changed. The
+ * memo also had exactly one `.get` and one `.set` and no eviction anywhere, so a
+ * deleted 4M-tri model kept ~191 MiB of raw STL resident for the rest of the
+ * session.
+ *
+ * ## The two properties that carry the design
+ *
+ * **1. Dirty tracking is by geometry SIGNATURE, not by a boolean flag.**
+ * `ExportManager.computeModelGeometrySignature` is promoted from a private cache
+ * key to the dirty primitive. It is derived from the geometry object itself
+ * (`uuid : position.version : index.version : vertexCount`), so it cannot drift
+ * the way a flag missed by a future mutation path would. The consequence worth
+ * stating: because the signature is the authority and the bake hooks are merely
+ * *when*, a missed hook costs a lazy re-bake on the next tick — **never a stale
+ * write**. That makes the hook placement an optimization, not a correctness
+ * dependency.
+ *
+ * **2. The store is content-addressed, two levels deep.**
+ *
+ * ```
+ *   owner (modelId + slot)  →  { signature, sha256 }
+ *   sha256                  →  { data, compression, uncompressedSize, refs }
+ * ```
+ *
+ * One mechanism buys three things: cross-tick reuse (level 1 hit), memory-side
+ * dedup across instances of the same geometry (level 2 collision), and
+ * refcounted eviction (level 2 `refs` reaching zero).
+ *
+ * ## Ph5 forward-compat (design only — not implemented here)
+ *
+ * The coming VOXL original-mesh embed must be written **through** this store.
+ * That is why owners are keyed on `(modelId, slot)` rather than `modelId`: Ph5
+ * bakes the original once at import with `slot: 'original'`, every subsequent
+ * tick and explicit save references the same blob, a second import of the same
+ * file collides on SHA and costs nothing, and `release(modelId)` still frees
+ * both slots in one call from `deleteModels`.
+ */
+
+import { zlib as zlibAsync } from 'fflate';
+
+/** Mirrors the codec's own chunk compression tags. */
+export const CHUNK_COMPRESSION_NONE = 0;
+export const CHUNK_COMPRESSION_ZLIB = 1;
+
+/**
+ * The codec's compression policy, restated here because the store now decides it
+ * at bake time. Both halves matter for the byte-identity gate: payloads at or
+ * below 64 bytes are never zlib-wrapped, and a payload that does not actually
+ * shrink is stored raw.
+ */
+const MIN_COMPRESSIBLE_BYTES = 64;
+const ZLIB_LEVEL = 6;
+
+const compressAsync = (data: Uint8Array): Promise<Uint8Array> =>
+  new Promise((resolve, reject) => {
+    zlibAsync(data, { level: ZLIB_LEVEL }, (err, result) => {
+      if (err) reject(err);
+      else resolve(result);
+    });
+  });
+
+/**
+ * Which payload a chunk holds for a model. `preview` is the live scene geometry
+ * the writer embeds today; `original` is reserved for Ph5's full-resolution
+ * embed and is already routable so the embed does not have to retrofit the key.
+ */
+export type ChunkSlot = 'preview' | 'original';
+
+export interface BakedChunk {
+  readonly sha256: string;
+  /** Compressed bytes, or the raw bytes when `compression === 0`. */
+  readonly data: Uint8Array;
+  readonly compression: number;
+  readonly uncompressedSize: number;
+}
+
+export interface BakeRequest {
+  modelId: string;
+  /** Defaults to `'preview'`. */
+  slot?: ChunkSlot;
+  /** The geometry signature this payload corresponds to. */
+  signature: string;
+  /** Produces the raw bytes. Called only on a miss. */
+  encode: () => Uint8Array | Promise<Uint8Array>;
+}
+
+export interface MeshChunkStoreStats {
+  /** Payloads encoded + hashed + compressed (i.e. real work performed). */
+  compressions: number;
+  /** Ticks served from level 1 without touching the encoder. */
+  hits: number;
+  /** Blobs deleted when their refcount reached zero. */
+  evictions: number;
+  /** Distinct SHAs currently held. */
+  blobs: number;
+  /** Distinct (modelId, slot) owners currently mapped. */
+  owners: number;
+  /** Bytes currently retained across all blobs. */
+  retainedBytes: number;
+}
+
+interface BlobEntry {
+  data: Uint8Array;
+  compression: number;
+  uncompressedSize: number;
+  refs: number;
+}
+
+interface OwnerEntry {
+  signature: string;
+  sha256: string;
+}
+
+const ownerKey = (modelId: string, slot: ChunkSlot): string => `${slot}:${modelId}`;
+
+export class MeshChunkStore {
+  private readonly contentByOwner = new Map<string, OwnerEntry>();
+
+  private readonly chunkStore = new Map<string, BlobEntry>();
+
+  /**
+   * In-flight bakes keyed on owner+signature. Two ticks racing the same model —
+   * an explicit save landing on top of an autosave, say — must produce one
+   * compression, not two.
+   */
+  private readonly inFlight = new Map<string, Promise<BakedChunk>>();
+
+  private compressions = 0;
+
+  private hits = 0;
+
+  private evictions = 0;
+
+  /**
+   * Returns true if any geometry bake operation is currently running in-flight.
+   */
+  isBakeInFlight(): boolean {
+    return this.inFlight.size > 0;
+  }
+
+  /**
+   * Returns the baked chunk for this owner **iff** its recorded signature still
+   * matches. A mismatch reads as dirty; that is the whole dirty-tracking
+   * mechanism.
+   */
+  lookup(modelId: string, signature: string, slot: ChunkSlot = 'preview'): BakedChunk | null {
+    const owner = this.contentByOwner.get(ownerKey(modelId, slot));
+    if (!owner || owner.signature !== signature) return null;
+    const blob = this.chunkStore.get(owner.sha256);
+    if (!blob) return null;
+    return {
+      sha256: owner.sha256,
+      data: blob.data,
+      compression: blob.compression,
+      uncompressedSize: blob.uncompressedSize,
+    };
+  }
+
+  /**
+   * The in-flight bake for this exact owner+signature, if one is running.
+   *
+   * Exposed so a tick can *wait* on a bake that a finalization hook already
+   * started rather than starting a second one — which is what makes the bounded
+   * wait and the `geometryStale` fallback (D2) possible without a second
+   * coalescing mechanism living outside the store.
+   */
+  pending(modelId: string, signature: string, slot: ChunkSlot = 'preview'): Promise<BakedChunk> | null {
+    return this.inFlight.get(`${ownerKey(modelId, slot)}@${signature}`) ?? null;
+  }
+
+  /**
+   * The chunk this owner last committed, **whatever its signature**. Used only
+   * by the stale-geometry fallback (D2): a tick whose bounded wait expired
+   * writes these bytes and flags the model rather than losing the tick.
+   */
+  lastCommitted(modelId: string, slot: ChunkSlot = 'preview'): BakedChunk | null {
+    const owner = this.contentByOwner.get(ownerKey(modelId, slot));
+    if (!owner) return null;
+    const blob = this.chunkStore.get(owner.sha256);
+    if (!blob) return null;
+    return {
+      sha256: owner.sha256,
+      data: blob.data,
+      compression: blob.compression,
+      uncompressedSize: blob.uncompressedSize,
+    };
+  }
+
+  /**
+   * Resolve this owner's chunk, encoding + hashing + compressing only if the
+   * signature has moved. Safe to call on every tick and from every finalization
+   * hook — a hit is a map lookup.
+   */
+  async bake(request: BakeRequest): Promise<BakedChunk> {
+    const slot = request.slot ?? 'preview';
+    const key = ownerKey(request.modelId, slot);
+
+    const cached = this.lookup(request.modelId, request.signature, slot);
+    if (cached) {
+      this.hits += 1;
+      return cached;
+    }
+
+    const flightKey = `${key}@${request.signature}`;
+    const existing = this.inFlight.get(flightKey);
+    if (existing) return existing;
+
+    const flight = (async (): Promise<BakedChunk> => {
+      const raw = await request.encode();
+      const sha256 = await sha256Hex(raw);
+
+      let blob = this.chunkStore.get(sha256);
+      if (!blob) {
+        // Level-2 miss: this content has never been seen. This is the only place
+        // zlib runs.
+        let data = raw;
+        let compression = CHUNK_COMPRESSION_NONE;
+        if (raw.length > MIN_COMPRESSIBLE_BYTES) {
+          const compressed = await compressAsync(raw);
+          if (compressed.length < raw.length) {
+            data = compressed;
+            compression = CHUNK_COMPRESSION_ZLIB;
+          }
+        }
+        blob = { data, compression, uncompressedSize: raw.length, refs: 0 };
+        this.chunkStore.set(sha256, blob);
+        this.compressions += 1;
+      }
+
+      this.adopt(key, request.signature, sha256);
+
+      return { sha256, data: blob.data, compression: blob.compression, uncompressedSize: blob.uncompressedSize };
+    })();
+
+    this.inFlight.set(flightKey, flight);
+    try {
+      return await flight;
+    } finally {
+      this.inFlight.delete(flightKey);
+    }
+  }
+
+  /**
+   * Drops this model's chunks. With no `slot`, every slot the model owns is
+   * released — which is what `deleteModels` wants, and what keeps Ph5's embed
+   * from leaking when a model is deleted.
+   */
+  release(modelId: string, slot?: ChunkSlot): void {
+    if (slot) {
+      this.releaseOwner(ownerKey(modelId, slot));
+      return;
+    }
+    for (const candidate of ['preview', 'original'] as const) {
+      this.releaseOwner(ownerKey(modelId, candidate));
+    }
+  }
+
+  /**
+   * Releases every owner whose model is no longer in the scene. A backstop for
+   * paths that remove models without going through `deleteModels`; cheap enough
+   * to call on a tick.
+   */
+  retainOnly(modelIds: Iterable<string>): void {
+    const keep = new Set(modelIds);
+    for (const key of [...this.contentByOwner.keys()]) {
+      const modelId = key.slice(key.indexOf(':') + 1);
+      if (!keep.has(modelId)) this.releaseOwner(key);
+    }
+  }
+
+  clear(): void {
+    this.contentByOwner.clear();
+    this.chunkStore.clear();
+    this.inFlight.clear();
+    this.compressions = 0;
+    this.hits = 0;
+    this.evictions = 0;
+  }
+
+  stats(): MeshChunkStoreStats {
+    let retainedBytes = 0;
+    for (const blob of this.chunkStore.values()) retainedBytes += blob.data.length;
+    return {
+      compressions: this.compressions,
+      hits: this.hits,
+      evictions: this.evictions,
+      blobs: this.chunkStore.size,
+      owners: this.contentByOwner.size,
+      retainedBytes,
+    };
+  }
+
+  private adopt(key: string, signature: string, sha256: string): void {
+    const previous = this.contentByOwner.get(key);
+    if (previous?.sha256 === sha256) {
+      // Same content under a new signature (e.g. a mutation that happened to be
+      // a no-op). Re-point without disturbing the refcount.
+      this.contentByOwner.set(key, { signature, sha256 });
+      return;
+    }
+
+    this.chunkStore.get(sha256)!.refs += 1;
+    this.contentByOwner.set(key, { signature, sha256 });
+    if (previous) this.decRef(previous.sha256);
+  }
+
+  private releaseOwner(key: string): void {
+    const owner = this.contentByOwner.get(key);
+    if (!owner) return;
+    this.contentByOwner.delete(key);
+    this.decRef(owner.sha256);
+  }
+
+  private decRef(sha256: string): void {
+    const blob = this.chunkStore.get(sha256);
+    if (!blob) return;
+    blob.refs -= 1;
+    if (blob.refs <= 0) {
+      this.chunkStore.delete(sha256);
+      this.evictions += 1;
+    }
+  }
+}
+
+/**
+ * Hex SHA-256. Kept here rather than in `ExportManager` because the store is now
+ * the only steady-state caller: post-bake the raw bytes are dropped, so the
+ * transient full-buffer copy this makes no longer happens on every tick.
+ */
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('SHA-256 hashing is unavailable in this environment.');
+  }
+  const digestInput = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(digestInput).set(bytes);
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', digestInput);
+  const digestBytes = new Uint8Array(digest);
+  let hex = '';
+  for (let i = 0; i < digestBytes.length; i += 1) {
+    hex += digestBytes[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+/**
+ * The process-wide store. A single instance is correct here: the webview runs
+ * one scene, and content addressing means a second scene's identical geometry is
+ * a free hit rather than a collision.
+ */
+export const meshChunkStore = new MeshChunkStore();

--- a/src/features/scene/voxl/types.ts
+++ b/src/features/scene/voxl/types.ts
@@ -40,6 +40,27 @@ export type VoxlMeshRef = {
   chunkIndex?: number;
 };
 
+/**
+ * Native-preview linkage persisted with a model entry (STL-import
+ * decimation remediation Phase 1). The embedded mesh payload of a >6M
+ * import is the reduced preview; these fields let a reload re-link the
+ * ORIGINAL on-disk source so output paths (slicing, mesh export) can stage
+ * full resolution again. Additive + optional: files without them (and
+ * older readers, which ignore unknown JSON fields) are unaffected.
+ */
+export type VoxlNativePreviewRef = {
+  originalTriangleCount: number;
+  previewTriangleCount: number;
+  /** Import-time pre-centering bbox center (raw-file frame) — the frame
+   *  datum for `w = M · (v_raw − cPre)` reprojection. */
+  cPre?: [number, number, number];
+  /** Import-time staleness fingerprint of the source file. */
+  sourceFingerprint?: {
+    sizeBytes: number;
+    mtimeMs: number;
+  };
+};
+
 export type VoxlModelEntry = {
   id: string;
   name: string;
@@ -47,6 +68,17 @@ export type VoxlModelEntry = {
   color: string;
   polygonCount: number;
   fileSizeBytes?: number;
+  /** Absolute on-disk path of the original import (native-preview models). */
+  sourcePath?: string;
+  nativePreview?: VoxlNativePreviewRef;
+  /**
+   * Set when the writer had to fall back to this model's last committed mesh
+   * chunk because a geometry bake was still in flight when the tick's bounded
+   * wait expired (Ph0.1 sub-phase D2). The bytes are one operation behind, and
+   * recovery says so instead of presenting them as current. Omitted — never
+   * written as `false` — so an ordinary scene's bytes are unchanged.
+   */
+  geometryStale?: boolean;
   transform: VoxlModelTransform;
   mesh: VoxlMeshRef;
   meshModifiers?: ModelMeshModifiers;
@@ -100,6 +132,10 @@ export type VoxlModelRuntimeLike = {
   color: string;
   polygonCount: number;
   fileSizeBytes?: number;
+  sourcePath?: string;
+  nativePreview?: VoxlNativePreviewRef;
+  /** See `VoxlModelEntry.geometryStale` (Ph0.1 sub-phase D2). */
+  geometryStale?: boolean;
   transform: {
     position: { x: number; y: number; z: number };
     rotation: { x: number; y: number; z: number };

--- a/src/features/scene/voxl/types.ts
+++ b/src/features/scene/voxl/types.ts
@@ -71,6 +71,8 @@ export type VoxlModelEntry = {
   /** Absolute on-disk path of the original import (native-preview models). */
   sourcePath?: string;
   nativePreview?: VoxlNativePreviewRef;
+  /** Reference to original full-resolution sidecar mesh file when not embedded directly in ORIG chunk. */
+  originalRef?: VoxlMeshRef;
   /**
    * Set when the writer had to fall back to this model's last committed mesh
    * chunk because a geometry bake was still in flight when the tick's bounded
@@ -135,6 +137,7 @@ export type VoxlModelRuntimeLike = {
   fileSizeBytes?: number;
   sourcePath?: string;
   nativePreview?: VoxlNativePreviewRef;
+  originalRef?: VoxlMeshRef;
   /** See `VoxlModelEntry.geometryStale` (Ph0.1 sub-phase D2). */
   geometryStale?: boolean;
   transform: {

--- a/src/features/scene/voxl/types.ts
+++ b/src/features/scene/voxl/types.ts
@@ -123,6 +123,7 @@ export type VoxlCompressedDocumentEnvelopeV1 = {
 
 export type SerializeVoxlOptions = {
   compression?: 'none' | 'auto' | 'rle-u8' | 'zlib';
+  embedOriginalMesh?: boolean;
 };
 
 export type VoxlModelRuntimeLike = {
@@ -165,6 +166,8 @@ export type ParsedVoxlResult = {
   document: VoxlDocumentV1;
   /** Pre-decoded mesh bytes keyed by model ID (populated for V2 files). */
   meshBytes: Map<string, Uint8Array>;
+  /** Pre-decoded original full-res mesh bytes keyed by model ID (if ORIG chunk present). */
+  originalMeshBytes?: Map<string, Uint8Array>;
   /** The VOXL format version that was read (e.g. 1, 2.1). */
   sourceVersion: number;
 };

--- a/src/features/slicing/sliceExportOrchestrator.ts
+++ b/src/features/slicing/sliceExportOrchestrator.ts
@@ -580,6 +580,9 @@ export async function runSliceExportOrchestrator(options: SliceExportOrchestrato
         stageMeshIpcMs += performance.now() - chunkInvokeStart;
     };
 
+    /** Byte offset of the next chunk in the file-backed stage sequence. */
+    let meshStageFileOffset = 0;
+
     const handleMeshFileChunk = async (chunk: Uint8Array) => {
         throwIfAborted(options.abortSignal);
         if (!meshStageFilePath) {
@@ -594,11 +597,15 @@ export async function runSliceExportOrchestrator(options: SliceExportOrchestrato
         stageMeshChunkCount += 1;
         maybeEmitStageProgress();
 
+        const chunkOffset = meshStageFileOffset;
+        meshStageFileOffset += transportChunk.byteLength;
+
         const appendStart = performance.now();
         const appendedLen = await invoke<number>('append_mesh_stage_chunk', transportChunk, {
             headers: {
                 'Content-Type': 'application/octet-stream',
                 'x-mesh-stage-path': meshStageFilePath,
+                'x-mesh-stage-offset': String(chunkOffset),
             },
         });
         stageMeshIpcMs += performance.now() - appendStart;

--- a/src/features/slicing/tauri/__tests__/chunkedWritesAreSerialized.test.ts
+++ b/src/features/slicing/tauri/__tests__/chunkedWritesAreSerialized.test.ts
@@ -1,0 +1,114 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  runExclusiveNativeWrite,
+  writeChunkedUnlocked,
+  type NativeWriteInvoke,
+} from '../nativeSlicerBridge';
+
+/**
+ * Writer single-flight (Ph0.1 sub-phase A, finding N2).
+ *
+ * Rust keeps ONE process-global chunk appender. Two chunk sequences to different
+ * paths evict each other and re-truncate on every switch-back, so writer A's
+ * committed chunks are destroyed and its next chunk lands at offset 0 — both
+ * files corrupt, no error. These tests pin that the frontend never emits that
+ * interleaving in the first place.
+ */
+
+type InvokeRecord = { cmd: string; path?: string; offset?: string };
+
+/**
+ * Fake `invoke` that records the command stream and yields to the microtask
+ * queue on every call, which is exactly where a real IPC round-trip would let
+ * another writer in.
+ */
+function createRecordingInvoke(): { invoke: NativeWriteInvoke; calls: InvokeRecord[] } {
+  const calls: InvokeRecord[] = [];
+
+  const invoke = (async (
+    cmd: string,
+    args?: Record<string, unknown> | ArrayBuffer | Uint8Array,
+    options?: { headers: HeadersInit },
+  ) => {
+    const headers = (options?.headers ?? {}) as Record<string, string>;
+    calls.push({
+      cmd,
+      path: headers['x-mesh-stage-path']
+        ?? (args && !(args instanceof Uint8Array) && !(args instanceof ArrayBuffer)
+          ? (args as Record<string, string>).path
+          : undefined),
+      offset: headers['x-mesh-stage-offset'],
+    });
+    // Two ticks: enough for an unserialized competitor to interleave.
+    await Promise.resolve();
+    await Promise.resolve();
+    return 0 as never;
+  }) as NativeWriteInvoke;
+
+  return { invoke, calls };
+}
+
+/** Splits the recorded stream into per-path append runs, in arrival order. */
+function appendRuns(calls: InvokeRecord[]): string[] {
+  const runs: string[] = [];
+  for (const call of calls) {
+    if (call.cmd !== 'append_mesh_stage_chunk') continue;
+    const path = call.path ?? '<none>';
+    if (runs[runs.length - 1] !== path) runs.push(path);
+  }
+  return runs;
+}
+
+describe('native chunked writes are serialized', () => {
+  it('does not interleave two overlapping writes to different paths', async () => {
+    const { invoke, calls } = createRecordingInvoke();
+    const bytes = new Uint8Array(12);
+
+    // Both writes start before either finishes — the real autosave-vs-save race.
+    await Promise.all([
+      runExclusiveNativeWrite(() => writeChunkedUnlocked(invoke, 'A.voxl', bytes, 4)),
+      runExclusiveNativeWrite(() => writeChunkedUnlocked(invoke, 'B.voxl', bytes, 4)),
+    ]);
+
+    const runs = appendRuns(calls);
+    assert.deepEqual(
+      runs,
+      ['A.voxl', 'B.voxl'],
+      `chunk sequences interleaved — each switch-back re-truncates: ${runs.join(' → ')}`,
+    );
+
+    // Each sequence must also be complete and in offset order.
+    const perPath = new Map<string, string[]>();
+    for (const call of calls) {
+      if (call.cmd !== 'append_mesh_stage_chunk') continue;
+      const list = perPath.get(call.path!) ?? [];
+      list.push(call.offset!);
+      perPath.set(call.path!, list);
+    }
+    assert.deepEqual(perPath.get('A.voxl'), ['0', '4', '8']);
+    assert.deepEqual(perPath.get('B.voxl'), ['0', '4', '8']);
+  });
+
+  it('keeps serializing after a write rejects', async () => {
+    const { invoke, calls } = createRecordingInvoke();
+    const failing: NativeWriteInvoke = (async (cmd: string) => {
+      if (cmd === 'append_mesh_stage_chunk') throw new Error('disk full');
+      return 0 as never;
+    }) as NativeWriteInvoke;
+
+    const first = runExclusiveNativeWrite(() =>
+      writeChunkedUnlocked(failing, 'A.voxl', new Uint8Array(4), 4),
+    );
+    const second = runExclusiveNativeWrite(() =>
+      writeChunkedUnlocked(invoke, 'B.voxl', new Uint8Array(8), 4),
+    );
+
+    await assert.rejects(first, /disk full/);
+    await second;
+
+    // A rejected write must not wedge the queue for every later write.
+    assert.deepEqual(appendRuns(calls), ['B.voxl']);
+  });
+});

--- a/src/features/slicing/tauri/nativeSlicerBridge.ts
+++ b/src/features/slicing/tauri/nativeSlicerBridge.ts
@@ -566,26 +566,69 @@ export async function writeBytesToNativePath(
 }
 
 /**
- * Writes `bytes` to `destinationPath` using the raw-binary `append_mesh_stage_chunk` IPC command,
- * sending the data in chunks to avoid JSON-encoding the entire buffer over IPC.
- * Each call sequences through chunks of `chunkSize` bytes (default 4 MB).
- * The first chunk truncates/creates the file; subsequent chunks append to it.
+ * Minimal `invoke` surface the native write seam needs. Declared separately so
+ * the write functions can be driven by a recorder in tests without mocking the
+ * `@tauri-apps/api/core` module.
  */
-export async function writeChunkedToNativePath(
+export type NativeWriteInvoke = TauriCoreModule['invoke'];
+
+/**
+ * Writer single-flight (Ph0.1 sub-phase A, finding N2).
+ *
+ * Rust keeps exactly ONE process-global chunk appender. Two chunk sequences to
+ * different paths therefore evict each other and re-truncate on every
+ * switch-back, destroying both files with no error. The live pairs are autosave,
+ * explicit save, mesh staging for hollow/punch/repair/mirror, and native 3MF —
+ * only slicing and printing were guarded (`page.tsx:811-813`).
+ *
+ * The lock is a module-level promise chain rather than a Rust-side mutex or a
+ * per-path appender map because it is the least invasive mechanism that is
+ * actually correct here: the webview runs one JS thread, so every caller of
+ * every native write funnels through this one module and a promise chain *is* a
+ * true process-wide mutex for them — with no change to
+ * `append_mesh_stage_chunk`'s truncate-on-fresh-appender semantics, which mesh
+ * staging, 3MF, and the atomic commit all depend on. A second writer defers
+ * (queues) rather than failing, so no caller needs to learn to retry.
+ *
+ * It is a lock, not a fix for reentrancy: never call a queued function from
+ * inside another queued function — compose at the `…Unlocked` layer instead
+ * (see `writeFileAtomicWithInvoke`).
+ *
+ * The one native-write caller that does not funnel through here is
+ * `sliceExportOrchestrator.handleMeshFileChunk`, which streams
+ * `append_mesh_stage_chunk` directly from a geometry-collection callback. It is
+ * covered instead by the Rust-side backstop in `stage_append_chunk`, which turns
+ * an interleave into a loud error rather than two corrupt files.
+ */
+let nativeWriteQueue: Promise<unknown> = Promise.resolve();
+
+export function runExclusiveNativeWrite<T>(task: () => Promise<T>): Promise<T> {
+  const run = nativeWriteQueue.then(task, task);
+  // Keep the chain alive after a rejection so one failed write cannot wedge
+  // every subsequent one.
+  nativeWriteQueue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+/**
+ * Chunked write with an explicit `invoke`, **without** taking the single-flight
+ * lock. Internal composition seam — exported for the write-seam tests and for
+ * `writeFileAtomicWithInvoke`, which holds the lock across its whole sequence.
+ */
+export async function writeChunkedUnlocked(
+  invoke: NativeWriteInvoke,
   destinationPath: string,
   bytes: Uint8Array,
   chunkSize = 4 * 1024 * 1024,
 ): Promise<void> {
-  const core = await loadTauriCore();
-  if (!core) {
-    throw new Error('Chunked file writing is only available in DragonFruit Desktop (Tauri runtime).');
-  }
-
   try {
     let offset = 0;
     while (offset < bytes.length) {
       const chunk = bytes.subarray(offset, Math.min(offset + chunkSize, bytes.length));
-      await core.invoke<number>('append_mesh_stage_chunk', chunk, {
+      await invoke<number>('append_mesh_stage_chunk', chunk, {
         headers: {
           'Content-Type': 'application/octet-stream',
           'x-mesh-stage-path': destinationPath,
@@ -598,13 +641,102 @@ export async function writeChunkedToNativePath(
     // Always close the backend writer for this path so the destination file
     // handle is released immediately (important for Explorer thumbnail reads).
     try {
-      await core.invoke<number>('finish_mesh_stage_write', {
+      await invoke<number>('finish_mesh_stage_write', {
         path: destinationPath,
       });
     } catch (error) {
       console.warn('[nativeSlicerBridge] Failed finishing chunked write appender.', error);
     }
   }
+}
+
+/**
+ * Writes `bytes` to `destinationPath` using the raw-binary `append_mesh_stage_chunk` IPC command,
+ * sending the data in chunks to avoid JSON-encoding the entire buffer over IPC.
+ * Each call sequences through chunks of `chunkSize` bytes (default 4 MB).
+ * The first chunk truncates/creates the file; subsequent chunks append to it.
+ *
+ * **Not crash-safe on its own** — the first chunk truncates the destination, so
+ * an interrupted sequence leaves a truncated file with no fallback. Callers
+ * writing a file the user would miss (scene files) must use
+ * `writeFileAtomicToNativePath` instead. This raw form stays for staging files
+ * and for formats written straight to a scratch destination.
+ *
+ * Serialized process-wide by `runExclusiveNativeWrite` — see its docs.
+ */
+export async function writeChunkedToNativePath(
+  destinationPath: string,
+  bytes: Uint8Array,
+  chunkSize = 4 * 1024 * 1024,
+): Promise<void> {
+  const core = await loadTauriCore();
+  if (!core) {
+    throw new Error('Chunked file writing is only available in DragonFruit Desktop (Tauri runtime).');
+  }
+
+  return runExclusiveNativeWrite(() =>
+    writeChunkedUnlocked(core.invoke, destinationPath, bytes, chunkSize),
+  );
+}
+
+/**
+ * Crash-safe write with an explicit `invoke`, **without** taking the
+ * single-flight lock. Exported for the write-seam tests.
+ *
+ * Write-to-temp → fsync → atomic rename. The destination is never opened for
+ * write until the payload is complete on disk, so a crash, OOM-kill, or power
+ * loss at any point leaves the previous good file exactly as it was.
+ */
+export async function writeFileAtomicUnlocked(
+  invoke: NativeWriteInvoke,
+  destinationPath: string,
+  bytes: Uint8Array,
+  chunkSize = 4 * 1024 * 1024,
+): Promise<void> {
+  const tempPath = await invoke<string>('scene_file_begin_atomic_write', {
+    targetPath: destinationPath,
+  });
+
+  try {
+    await writeChunkedUnlocked(invoke, tempPath, bytes, chunkSize);
+  } catch (error) {
+    // The destination has not been touched; clean up the staging file so a
+    // failed save does not litter the user's project folder.
+    try {
+      await invoke<void>('scene_file_discard_atomic_temp', { tempPath });
+    } catch (discardError) {
+      console.warn('[nativeSlicerBridge] Failed discarding atomic-write staging file.', discardError);
+    }
+    throw error;
+  }
+
+  await invoke<void>('scene_file_commit_atomic', {
+    tempPath,
+    targetPath: destinationPath,
+  });
+}
+
+/**
+ * Crash-safe replacement for `writeChunkedToNativePath` on files the user would
+ * miss if they were destroyed (scene files).
+ *
+ * This is the **shared seam**: both autosave and explicit save reach it through
+ * `ExportManager.downloadFile`, so neither can regress to a truncate-first
+ * overwrite without the other noticing.
+ */
+export async function writeFileAtomicToNativePath(
+  destinationPath: string,
+  bytes: Uint8Array,
+  chunkSize = 4 * 1024 * 1024,
+): Promise<void> {
+  const core = await loadTauriCore();
+  if (!core) {
+    throw new Error('Atomic file writing is only available in DragonFruit Desktop (Tauri runtime).');
+  }
+
+  return runExclusiveNativeWrite(() =>
+    writeFileAtomicUnlocked(core.invoke, destinationPath, bytes, chunkSize),
+  );
 }
 
 /**

--- a/src/features/slicing/tauri/nativeSlicerBridge.ts
+++ b/src/features/slicing/tauri/nativeSlicerBridge.ts
@@ -717,6 +717,93 @@ export async function writeFileAtomicUnlocked(
 }
 
 /**
+ * Streaming counterpart of {@link writeFileAtomicUnlocked} (Ph0.1 sub-phase E),
+ * **without** the single-flight lock. Exported for the write-seam tests.
+ *
+ * `produce` is handed an `emit` function and calls it as many times as it likes;
+ * emissions are re-chunked at `chunkSize` and appended in order against a single
+ * open appender, so the caller never has to materialise the whole payload. Only
+ * the first IPC call carries offset 0, which is what tells Rust to open fresh —
+ * every later emission appends.
+ *
+ * The atomic contract is unchanged: temp → fsync → rename, destination untouched
+ * until the payload is complete.
+ */
+export async function writeFileAtomicStreamedUnlocked(
+  invoke: NativeWriteInvoke,
+  destinationPath: string,
+  produce: (emit: (bytes: Uint8Array) => Promise<void>) => Promise<void>,
+  chunkSize = 4 * 1024 * 1024,
+): Promise<number> {
+  const tempPath = await invoke<string>('scene_file_begin_atomic_write', {
+    targetPath: destinationPath,
+  });
+
+  let written = 0;
+  try {
+    try {
+      await produce(async (bytes: Uint8Array) => {
+        let local = 0;
+        while (local < bytes.length) {
+          const chunk = bytes.subarray(local, Math.min(local + chunkSize, bytes.length));
+          await invoke<number>('append_mesh_stage_chunk', chunk, {
+            headers: {
+              'Content-Type': 'application/octet-stream',
+              'x-mesh-stage-path': tempPath,
+              'x-mesh-stage-offset': String(written),
+            },
+          });
+          local += chunk.length;
+          written += chunk.length;
+        }
+      });
+    } finally {
+      // Always close the backend writer for this path, exactly as the buffered
+      // form does — the handle must be released before the commit renames it.
+      try {
+        await invoke<number>('finish_mesh_stage_write', { path: tempPath });
+      } catch (error) {
+        console.warn('[nativeSlicerBridge] Failed finishing streamed write appender.', error);
+      }
+    }
+  } catch (error) {
+    try {
+      await invoke<void>('scene_file_discard_atomic_temp', { tempPath });
+    } catch (discardError) {
+      console.warn('[nativeSlicerBridge] Failed discarding atomic-write staging file.', discardError);
+    }
+    throw error;
+  }
+
+  await invoke<void>('scene_file_commit_atomic', {
+    tempPath,
+    targetPath: destinationPath,
+  });
+
+  return written;
+}
+
+/**
+ * Crash-safe streaming write. Same seam and same guarantees as
+ * {@link writeFileAtomicToNativePath}; use it when the payload can be produced
+ * incrementally, so no contiguous copy of the document ever exists.
+ */
+export async function writeFileAtomicStreamedToNativePath(
+  destinationPath: string,
+  produce: (emit: (bytes: Uint8Array) => Promise<void>) => Promise<void>,
+  chunkSize = 4 * 1024 * 1024,
+): Promise<number> {
+  const core = await loadTauriCore();
+  if (!core) {
+    throw new Error('Atomic file writing is only available in DragonFruit Desktop (Tauri runtime).');
+  }
+
+  return runExclusiveNativeWrite(() =>
+    writeFileAtomicStreamedUnlocked(core.invoke, destinationPath, produce, chunkSize),
+  );
+}
+
+/**
  * Crash-safe replacement for `writeChunkedToNativePath` on files the user would
  * miss if they were destroyed (scene files).
  *

--- a/src/hooks/__tests__/autosaveFailureHonesty.test.ts
+++ b/src/hooks/__tests__/autosaveFailureHonesty.test.ts
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+import test, { describe } from 'node:test';
+
+import {
+  AutosaveFailureTracker,
+  decideAutosaveGate,
+  AUTOSAVE_FAILURE_NOTIFY_THRESHOLD,
+} from '../useSceneAutosave';
+
+/**
+ * Failure honesty and contention policy (Ph0.1 sub-phase D3 + D4).
+ *
+ * **N4.** Autosave failures were swallowed with a `console.warn`, and the
+ * manifest was written only on success. An autosave that had been failing for an
+ * hour presented as a stale "unsaved changes from <time>" prompt with no signal
+ * at all — and that is precisely the surface the 4 GiB guard fails into. A
+ * failure must now leave a durable record (`last_error`, with `saved_at` still
+ * pointing at the last *successful* payload) and tell the user.
+ *
+ * **D4.** Sub-phase A's single-flight lock made an overlapping write SAFE; this
+ * decides whether it is worth attempting at all. The policy is explicit here
+ * rather than implied by control flow, because the interesting half is not
+ * "when do we skip" but "when we skip, does the dirtiness survive". Work done
+ * during a suppressed window that is silently forgotten is data loss with extra
+ * steps.
+ */
+
+describe('autosave failure honesty (N4)', () => {
+  test('a failure is recorded and leaves the last successful timestamp alone', () => {
+    const tracker = new AutosaveFailureTracker();
+    tracker.recordSuccess('2026-07-26T10:00:00.000Z');
+
+    const outcome = tracker.recordFailure(new Error('This scene exceeds the VOXL 4 GB limit.'));
+
+    assert.equal(outcome.consecutiveFailures, 1);
+    assert.equal(tracker.lastError, 'This scene exceeds the VOXL 4 GB limit.');
+    assert.equal(
+      tracker.lastSuccessAt,
+      '2026-07-26T10:00:00.000Z',
+      'a failed tick must not advance the timestamp recovery shows the user',
+    );
+  });
+
+  test('the user is told after two consecutive failures, and only once', () => {
+    const tracker = new AutosaveFailureTracker();
+
+    assert.equal(tracker.recordFailure(new Error('disk full')).shouldNotifyUser, false,
+      'one transient failure must not interrupt the user');
+    assert.equal(AUTOSAVE_FAILURE_NOTIFY_THRESHOLD, 2);
+
+    const second = tracker.recordFailure(new Error('disk full'));
+    assert.equal(second.consecutiveFailures, 2);
+    assert.equal(second.shouldNotifyUser, true, 'a persistently failing autosave must surface');
+
+    assert.equal(
+      tracker.recordFailure(new Error('disk full')).shouldNotifyUser,
+      false,
+      'a 30 s tick must not spam the same failure forever',
+    );
+  });
+
+  test('a success clears the streak, so the next outage notifies again', () => {
+    const tracker = new AutosaveFailureTracker();
+    tracker.recordFailure(new Error('a'));
+    tracker.recordFailure(new Error('b'));
+    tracker.recordSuccess('2026-07-26T10:00:00.000Z');
+
+    assert.equal(tracker.lastError, null, 'a successful write must clear the recorded error');
+    assert.equal(tracker.recordFailure(new Error('c')).shouldNotifyUser, false);
+    assert.equal(tracker.recordFailure(new Error('d')).shouldNotifyUser, true);
+  });
+
+  test('a non-Error rejection still yields a readable message', () => {
+    const tracker = new AutosaveFailureTracker();
+    tracker.recordFailure('scene_autosave_write_manifest task failed');
+    assert.equal(tracker.lastError, 'scene_autosave_write_manifest task failed');
+  });
+});
+
+describe('autosave contention policy (D4)', () => {
+  const base = {
+    enabled: true,
+    desktop: true,
+    suppressedUntil: 0,
+    now: 1_000,
+    modelCount: 3,
+    navigationBusy: false,
+    forced: false,
+  };
+
+  test('a quiet desktop scene with models runs', () => {
+    assert.deepEqual(decideAutosaveGate(base), { action: 'run' });
+  });
+
+  test('a suppressed window DEFERS and keeps the scene dirty', () => {
+    const decision = decideAutosaveGate({ ...base, suppressedUntil: 5_000 });
+    assert.equal(decision.action, 'defer');
+    assert.equal(decision.reason, 'suppressed');
+    assert.equal(
+      decision.retainDirty,
+      true,
+      'edits made during a long operation were being forgotten rather than deferred',
+    );
+  });
+
+  test('camera navigation defers rather than competing for the main thread', () => {
+    const decision = decideAutosaveGate({ ...base, navigationBusy: true });
+    assert.equal(decision.action, 'defer');
+    assert.equal(decision.reason, 'navigation');
+    assert.equal(decision.retainDirty, true);
+  });
+
+  test('a forced flush overrides navigation but never suppression', () => {
+    assert.equal(decideAutosaveGate({ ...base, navigationBusy: true, forced: true }).action, 'run');
+    assert.equal(
+      decideAutosaveGate({ ...base, suppressedUntil: 5_000, forced: true }).action,
+      'run',
+      'an explicit flush (quit, Ctrl+S handoff) must not be blocked by a suppression window',
+    );
+  });
+
+  test('an empty scene skips and drops the dirtiness — there is nothing to lose', () => {
+    const decision = decideAutosaveGate({ ...base, modelCount: 0 });
+    assert.equal(decision.action, 'skip');
+    assert.equal(decision.reason, 'empty-scene');
+    assert.equal(decision.retainDirty, false);
+  });
+
+  test('a disabled autosave skips but RETAINS dirtiness for when it is re-enabled', () => {
+    const decision = decideAutosaveGate({ ...base, enabled: false });
+    assert.equal(decision.action, 'skip');
+    assert.equal(decision.reason, 'disabled');
+    assert.equal(
+      decision.retainDirty,
+      true,
+      'turning autosave off and on again must not lose the edits made in between',
+    );
+  });
+
+  test('the browser build skips permanently', () => {
+    const decision = decideAutosaveGate({ ...base, desktop: false });
+    assert.equal(decision.action, 'skip');
+    assert.equal(decision.reason, 'not-desktop');
+    assert.equal(decision.retainDirty, false);
+  });
+});

--- a/src/hooks/__tests__/autosaveSidecarLifecycle.test.ts
+++ b/src/hooks/__tests__/autosaveSidecarLifecycle.test.ts
@@ -1,0 +1,122 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Sidecar lifecycle rules (Ph0.1 sub-phase B, user items 5 and 6).
+ *
+ * These are source-anchored on purpose. The rules are about *which call sites*
+ * may delete a recovery payload, and the failure they guard against — deleting
+ * one call site too many — is invisible to a behavioural test of any single
+ * function: every individual deletion is correct in isolation. What must be
+ * pinned is the set.
+ *
+ * The deletion gate itself (`is_deletable_autosave_payload`, which is what stops
+ * any of these ever reaching the user's project) is tested for real in
+ * `src-tauri/src/main.rs`.
+ */
+
+function readSource(relative: string): string {
+  return fs.readFileSync(path.join(process.cwd(), relative), 'utf8');
+}
+
+/** Extracts a `const <name> = React.useCallback(...)` body by brace matching. */
+function extractCallback(source: string, name: string): string {
+  const start = source.indexOf(`const ${name} = React.useCallback(`);
+  assert.notEqual(start, -1, `${name} no longer exists — the deletion rules moved`);
+  let depth = 0;
+  for (let i = source.indexOf('(', start); i < source.length; i += 1) {
+    if (source[i] === '(') depth += 1;
+    else if (source[i] === ')') {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error(`could not find the end of ${name}`);
+}
+
+describe('the autosave sidecar is deleted only when nothing would be lost', () => {
+  const page = readSource('src/app/page.tsx');
+
+  /**
+   * **The binding safety rule.** A user who closes the app and declines to save
+   * has still not agreed to lose their autosaved copy. Exiting cleanly with
+   * unsaved changes must RETAIN the sidecar; only an exit with nothing
+   * outstanding may delete it.
+   */
+  it('retains the sidecar when a clean exit still has unsaved changes', () => {
+    const discardAndClose = extractCallback(page, 'handleDiscardAndCloseProgram');
+    assert.equal(
+      discardAndClose.includes('clearAutosave'),
+      false,
+      'closing without saving deletes the recovery copy — the user loses the work they declined to save',
+    );
+
+    const requestClose = extractCallback(page, 'handleRequestProgramClose');
+    const unsavedBranch = requestClose.slice(
+      requestClose.indexOf('hasUnsavedSceneChangesRef.current'),
+      requestClose.indexOf('return;'),
+    );
+    assert.equal(
+      unsavedBranch.includes('clearAutosave'),
+      false,
+      'the unsaved-changes branch must open the modal, never delete the payload',
+    );
+    assert.equal(
+      requestClose.includes('clearAutosave'),
+      true,
+      'a clean exit with nothing outstanding should not leave a stale _autosave.voxl behind',
+    );
+  });
+
+  /**
+   * **Save As cleanup (item 6).** The sidecar beside the project the user just
+   * moved away from is an orphan implying unsaved work that does not exist.
+   * Deleting it is safe only because the save it follows has already succeeded.
+   */
+  it('deletes the sidecar beside the previous project after a successful Save As', () => {
+    const save = extractCallback(page, 'performTopBarSaveScene');
+
+    assert.ok(
+      /const previousScenePath = activeSceneFilePath/.test(save),
+      'the previous project path is no longer captured, so Save As cannot clean up after itself',
+    );
+    assert.ok(
+      save.includes('deleteAutosaveSidecarForProject(previousScenePath)'),
+      'a successful Save As orphans the sidecar beside the old project',
+    );
+
+    // The deletion must sit after a confirmed save, keyed on the path actually
+    // having changed — never on the plain overwrite path.
+    const deletion = save.indexOf('deleteAutosaveSidecarForProject');
+    const guard = save.lastIndexOf('previousScenePath !== nextActiveScenePath', deletion);
+    assert.notEqual(guard, -1, 'the sidecar is deleted even when the project did not move');
+    assert.ok(
+      save.lastIndexOf('const nextActiveScenePath', deletion) !== -1,
+      'the cleanup must run after the save resolved a new path, not before',
+    );
+  });
+
+  /** Restore and explicit discard are the other two moments deletion is safe. */
+  it('clears the payload after a successful restore and on an explicit discard', () => {
+    const restore = extractCallback(page, 'handleAutosaveRestore');
+    const discard = extractCallback(page, 'handleAutosaveDiscard');
+
+    assert.ok(
+      /if \(restored\) \{\s*await clearAutosave\(\);/.test(restore),
+      'the payload must only be cleared once the restore has actually succeeded',
+    );
+    assert.ok(discard.includes('clearAutosave'), 'an explicit discard should remove the payload');
+  });
+
+  /** `clearAutosave` is the only seam that deletes, and it must ask for it. */
+  it('routes every deletion through the manifest seam with deletePayload set', () => {
+    const hook = readSource('src/hooks/useSceneAutosave.ts');
+    const clear = hook.slice(hook.indexOf('const clearAutosave'));
+    assert.ok(
+      /writeManifest\([\s\S]*?\{\s*deletePayload:\s*true\s*\}\s*\)/.test(clear),
+      'clearAutosave marks the manifest clean but leaves the payload on disk',
+    );
+  });
+});

--- a/src/hooks/__tests__/autosaveTargetFollowsActiveScenePath.test.ts
+++ b/src/hooks/__tests__/autosaveTargetFollowsActiveScenePath.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  resolveAutosavePaths,
+  resetAutosavePathCache,
+  type AutosaveInvoke,
+  type AutosavePaths,
+} from '../useSceneAutosave';
+
+/**
+ * Autosave target resolution (Ph0.1 sub-phase B, finding N3 + the sidecar policy).
+ *
+ * Two defects are pinned here:
+ *
+ *  - **N3.** The hook's `preferredSavePath` was supplied from
+ *    `preferredOverwriteScenePathRef.current` — a ref, read during render.
+ *    Mutating a ref does not re-render, so the value could be a whole session
+ *    stale. That was harmless while autosave wrote to one fixed location; with
+ *    sidecars it means a Save As keeps writing the recovery file next to the
+ *    *old* project.
+ *  - **The module-level path cache**, which pinned the first resolution it ever
+ *    saw and so could outlive the project it was resolved for.
+ */
+
+const PROJECT_A = 'C:/projects/MyPrint.voxl';
+const PROJECT_B = 'D:/archive/MyPrint.voxl';
+
+function sidecarFor(project: string): AutosavePaths {
+  const dir = project.slice(0, project.lastIndexOf('/'));
+  const stem = project.slice(project.lastIndexOf('/') + 1).replace(/\.voxl$/i, '');
+  return {
+    voxlPath: `${dir}/${stem}_autosave.voxl`,
+    manifestPath: 'C:/appdata/autosave/manifest.json',
+    origin: 'sidecar',
+    projectPath: project,
+    fallbackReason: null,
+  };
+}
+
+const GENERIC_FALLBACK: AutosavePaths = {
+  voxlPath: 'C:/appdata/autosave/scene_autosave.voxl',
+  manifestPath: 'C:/appdata/autosave/manifest.json',
+  origin: 'recovery-dir',
+  projectPath: PROJECT_A,
+  fallbackReason: 'parent-unwritable',
+};
+
+function recordingInvoke(reply: (preferred: string | null) => AutosavePaths): {
+  invoke: AutosaveInvoke;
+  requested: (string | null)[];
+} {
+  const requested: (string | null)[] = [];
+  const invoke = (async (cmd: string, args?: Record<string, unknown>) => {
+    assert.equal(cmd, 'scene_autosave_get_paths');
+    const preferred = (args?.preferredSavePath as string | undefined) ?? null;
+    requested.push(preferred);
+    return reply(preferred) as never;
+  }) as AutosaveInvoke;
+  return { invoke, requested };
+}
+
+describe('the autosave target follows the active scene path', () => {
+  beforeEach(() => {
+    resetAutosavePathCache();
+  });
+
+  it('re-resolves when the project moves, instead of pinning the first path', async () => {
+    const { invoke, requested } = recordingInvoke((preferred) => sidecarFor(preferred ?? PROJECT_A));
+
+    const first = await resolveAutosavePaths(invoke, PROJECT_A);
+    assert.equal(first.voxlPath, 'C:/projects/MyPrint_autosave.voxl');
+
+    // Same project: served from cache, no second round-trip.
+    await resolveAutosavePaths(invoke, PROJECT_A);
+    assert.equal(requested.length, 1, 'an unchanged project should not re-resolve every tick');
+
+    // Save As to a new folder. The sidecar must follow the project.
+    const moved = await resolveAutosavePaths(invoke, PROJECT_B);
+    assert.equal(
+      moved.voxlPath,
+      'D:/archive/MyPrint_autosave.voxl',
+      'the recovery file is still being written beside the previous project',
+    );
+    assert.deepEqual(requested, [PROJECT_A, PROJECT_B]);
+  });
+
+  it('never caches a fallback, so the sidecar returns when the folder does', async () => {
+    let usable = false;
+    const { invoke, requested } = recordingInvoke(() => (usable ? sidecarFor(PROJECT_A) : GENERIC_FALLBACK));
+
+    const fellBack = await resolveAutosavePaths(invoke, PROJECT_A);
+    assert.equal(fellBack.origin, 'recovery-dir');
+    assert.equal(fellBack.fallbackReason, 'parent-unwritable');
+
+    // The share reconnects / the folder becomes writable again.
+    usable = true;
+    const recovered = await resolveAutosavePaths(invoke, PROJECT_A);
+    assert.equal(
+      recovered.origin,
+      'sidecar',
+      'a transient folder failure permanently exiled the autosave to the recovery dir',
+    );
+    assert.equal(requested.length, 2);
+  });
+
+  it('asks for no project at all when the scene is untitled', async () => {
+    const { invoke, requested } = recordingInvoke(() => GENERIC_FALLBACK);
+    await resolveAutosavePaths(invoke, null);
+    assert.deepEqual(requested, [null], 'an untitled scene must not claim a project path');
+  });
+
+  /**
+   * Source-anchored because the defect is *where the value comes from*, not what
+   * the hook does with it: a ref read during render type-checks and behaves
+   * identically until the moment it goes stale. `activeSceneFilePath` is state,
+   * set on every successful save (`performTopBarSaveScene`) and every scene open
+   * (`useImportExportManager`), so React re-renders and the hook sees the move.
+   */
+  it('is driven by activeSceneFilePath state, not a ref read during render', () => {
+    const pageSource = fs.readFileSync(
+      path.join(process.cwd(), 'src/app/page.tsx'),
+      'utf8',
+    );
+    const preferred = /preferredSavePath:\s*([^,\n]+)/.exec(pageSource);
+    assert.ok(preferred, 'useSceneAutosave no longer receives a preferredSavePath');
+    assert.equal(
+      preferred[1].trim(),
+      'activeSceneFilePath',
+      'the autosave target is fed from a render-time ref again (finding N3)',
+    );
+  });
+});

--- a/src/hooks/useSceneAutosave.ts
+++ b/src/hooks/useSceneAutosave.ts
@@ -107,12 +107,150 @@ async function getAutosavePaths(preferredSavePath?: string | null): Promise<Auto
   return resolveAutosavePaths(await desktopInvoke(), preferredSavePath);
 }
 
+// ---------------------------------------------------------------------------
+// Failure honesty (sub-phase D3, finding N4)
+// ---------------------------------------------------------------------------
+
+/**
+ * How many consecutive failures before the user is interrupted.
+ *
+ * One is a transient: an antivirus holding the destination, a share blinking,
+ * a rename losing a race. Two in a row across a 30 s debounce is a condition,
+ * not a blip — and a condition the user can usually act on (free disk, remove a
+ * model, save elsewhere).
+ */
+export const AUTOSAVE_FAILURE_NOTIFY_THRESHOLD = 2;
+
+export type AutosaveFailureOutcome = {
+  consecutiveFailures: number;
+  /** True exactly once per outage, at the threshold. */
+  shouldNotifyUser: boolean;
+  message: string;
+};
+
+/**
+ * Tracks the autosave's honesty state (finding N4).
+ *
+ * Before this, failures were swallowed with a `console.warn` and the manifest
+ * was written only on success. An autosave that had been failing for an hour
+ * presented as a stale "unsaved changes from <time>" prompt with no signal at
+ * all — and it is the surface the 4 GiB guard (D1) fails into, so the two had to
+ * land together.
+ *
+ * The rule the class exists to enforce: **a failed tick never advances the
+ * timestamp recovery shows the user.** `saved_at` keeps naming the last payload
+ * that actually reached disk, and the error rides alongside it.
+ */
+export class AutosaveFailureTracker {
+  private consecutive = 0;
+
+  private error: string | null = null;
+
+  private successAt: string | null = null;
+
+  get lastError(): string | null {
+    return this.error;
+  }
+
+  /** ISO timestamp of the last payload that actually committed. */
+  get lastSuccessAt(): string | null {
+    return this.successAt;
+  }
+
+  get consecutiveFailures(): number {
+    return this.consecutive;
+  }
+
+  recordSuccess(savedAt: string): void {
+    this.consecutive = 0;
+    this.error = null;
+    this.successAt = savedAt;
+  }
+
+  recordFailure(error: unknown): AutosaveFailureOutcome {
+    const message = error instanceof Error
+      ? error.message
+      : String(error ?? 'Unknown autosave failure');
+    this.consecutive += 1;
+    this.error = message;
+    return {
+      consecutiveFailures: this.consecutive,
+      // Strictly `===`, not `>=`: a 30 s tick against a persistent condition
+      // would otherwise interrupt the user twice a minute forever.
+      shouldNotifyUser: this.consecutive === AUTOSAVE_FAILURE_NOTIFY_THRESHOLD,
+      message,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Contention policy (sub-phase D4)
+// ---------------------------------------------------------------------------
+
+export type AutosaveGateInput = {
+  enabled: boolean;
+  desktop: boolean;
+  /** Epoch ms until which `suppressSceneAutosave` holds ticks off. */
+  suppressedUntil: number;
+  now: number;
+  modelCount: number;
+  navigationBusy: boolean;
+  /** An explicit flush: quit, or a hand-off from the save path. */
+  forced: boolean;
+};
+
+export type AutosaveGateDecision =
+  | { action: 'run' }
+  | { action: 'defer'; reason: 'navigation' | 'suppressed'; retainDirty: true }
+  | { action: 'skip'; reason: 'disabled' | 'not-desktop' | 'empty-scene'; retainDirty: boolean };
+
+/**
+ * Decides whether a tick runs now, later, or not at all.
+ *
+ * Sub-phase A's single-flight lock already made an overlapping native write
+ * **safe**; this makes it **cheap**, and — more importantly — makes the
+ * defer-vs-skip choice explicit rather than an emergent property of early
+ * returns.
+ *
+ * The load-bearing half is `retainDirty`. The old control flow cleared the dirty
+ * flag before every one of these checks, so edits made during a slice, a hollow,
+ * or a suppression window were silently forgotten and waited for the *next*
+ * unrelated history push to be persisted at all. Deferring keeps the scene
+ * dirty; only "there is genuinely nothing to save" (an empty scene) and "this
+ * build cannot save" (browser) drop it.
+ *
+ * A forced flush overrides both defer reasons: it is the quit path and the
+ * explicit hand-off, where waiting means losing the work outright.
+ */
+export function decideAutosaveGate(input: AutosaveGateInput): AutosaveGateDecision {
+  if (!input.desktop) return { action: 'skip', reason: 'not-desktop', retainDirty: false };
+  if (!input.enabled) return { action: 'skip', reason: 'disabled', retainDirty: true };
+  if (input.modelCount === 0) return { action: 'skip', reason: 'empty-scene', retainDirty: false };
+
+  if (!input.forced) {
+    if (input.now < input.suppressedUntil) {
+      return { action: 'defer', reason: 'suppressed', retainDirty: true };
+    }
+    if (input.navigationBusy) {
+      return { action: 'defer', reason: 'navigation', retainDirty: true };
+    }
+  }
+
+  return { action: 'run' };
+}
+
 export type WriteManifestOptions = {
   voxlPath?: string | null;
   origin?: string | null;
   projectPath?: string | null;
   payloadBytes?: number | null;
   fallbackReason?: string | null;
+  /**
+   * Records why the last tick failed (D3 / N4). When set, the backend preserves
+   * the previous manifest's `savedAt` and payload pointer, so recovery keeps
+   * naming the last file that actually committed.
+   */
+  lastError?: string | null;
   /**
    * Deletes the advertised payload as well as marking the manifest clean.
    * **Only ever passed when there is no unsaved work to lose** — after a
@@ -135,6 +273,7 @@ async function writeManifest(
     projectPath: options.projectPath ?? null,
     payloadBytes: options.payloadBytes ?? null,
     fallbackReason: options.fallbackReason ?? null,
+    lastError: options.lastError ?? null,
     deletePayload: options.deletePayload ?? false,
   });
 }
@@ -186,9 +325,18 @@ export type UseSceneAutosaveOptions = {
 export type UseSceneAutosaveResult = {
   isAutosaving: boolean;
   lastAutosaveAt: string | null;
+  /** Message from the most recent failed tick, or null while autosave is healthy (D3). */
+  lastAutosaveError: string | null;
   clearAutosave: () => Promise<void>;
   flushAutosave: () => Promise<void>;
 };
+
+/**
+ * Fired once per outage, after {@link AUTOSAVE_FAILURE_NOTIFY_THRESHOLD}
+ * consecutive failures. `page.tsx` turns it into a modal; the settings tab shows
+ * the standing state regardless.
+ */
+export const SCENE_AUTOSAVE_FAILED_EVENT = 'scene-autosave-failed';
 
 export function useSceneAutosave({
   models,
@@ -201,6 +349,8 @@ export function useSceneAutosave({
 }: UseSceneAutosaveOptions): UseSceneAutosaveResult {
   const [isAutosaving, setIsAutosaving] = React.useState(false);
   const [lastAutosaveAt, setLastAutosaveAt] = React.useState<string | null>(null);
+  const [lastAutosaveError, setLastAutosaveError] = React.useState<string | null>(null);
+  const failureTrackerRef = React.useRef(new AutosaveFailureTracker());
 
   // Keep stable refs so the debounce callback always sees fresh values
   const modelsRef = React.useRef(models);
@@ -238,12 +388,16 @@ export function useSceneAutosave({
     return navigationActiveRef.current || Date.now() < navigationQuietUntilRef.current;
   }, []);
 
-  const scheduleDeferredAutosave = React.useCallback((perform: () => void) => {
+  const scheduleDeferredAutosave = React.useCallback((perform: () => void, notBeforeMs = 0) => {
     clearDeferredAutosave();
 
+    // `notBeforeMs` lets a suppression-deferred tick wake when the window
+    // actually closes instead of re-checking every settle interval for the whole
+    // length of a long import or hollow (D4).
     const delay = Math.max(
       AUTOSAVE_NAVIGATION_SETTLE_MS,
       navigationQuietUntilRef.current - Date.now(),
+      notBeforeMs - Date.now(),
       0,
     );
 
@@ -261,19 +415,32 @@ export function useSceneAutosave({
     }
 
     const run = async () => {
-      if (!enabledRef.current) return;
-      if (!isDesktopRuntime()) return;
-      if (Date.now() < sceneAutosaveSuppressRef.current) return;
+      const currentModels = modelsRef.current;
 
-      if (!options?.force && shouldDeferAutosaveForNavigation()) {
-        scheduleDeferredAutosave(() => {
-          void performAutosave();
-        });
+      // One explicit policy decision instead of five early returns, so
+      // "does the dirtiness survive this?" is answerable by reading it (D4).
+      const decision = decideAutosaveGate({
+        enabled: enabledRef.current,
+        desktop: isDesktopRuntime(),
+        suppressedUntil: sceneAutosaveSuppressRef.current,
+        now: Date.now(),
+        modelCount: currentModels.length,
+        navigationBusy: shouldDeferAutosaveForNavigation(),
+        forced: options?.force === true,
+      });
+
+      if (decision.action !== 'run') {
+        if (!decision.retainDirty) dirtyRef.current = false;
+        if (decision.action === 'defer') {
+          // Re-arm rather than drop. `scheduleDeferredAutosave` no-ops when the
+          // scene is not dirty, so this cannot spin on a clean scene.
+          scheduleDeferredAutosave(
+            () => { void performAutosave(); },
+            decision.reason === 'suppressed' ? sceneAutosaveSuppressRef.current : 0,
+          );
+        }
         return;
       }
-
-      const currentModels = modelsRef.current;
-      if (currentModels.length === 0) return;
 
       clearDeferredAutosave();
       inFlightRef.current = true;
@@ -323,9 +490,42 @@ export function useSceneAutosave({
           projectPath: paths.projectPath,
           fallbackReason: paths.fallbackReason,
         });
+        failureTrackerRef.current.recordSuccess(savedAt);
         setLastAutosaveAt(savedAt);
+        setLastAutosaveError(null);
       } catch (err) {
+        // Failure honesty (D3 / N4). The old code was a bare `console.warn`, and
+        // because the manifest is written only after a successful payload, a
+        // failing autosave was indistinguishable from a quiet one until the user
+        // hit recovery and found hour-old work.
+        //
+        // Three things happen now: the error is recorded in the manifest beside
+        // the LAST GOOD `savedAt` (never overwriting it), it is surfaced in the
+        // autosave settings tab, and a persistent outage interrupts the user
+        // once. This is also the surface the 4 GiB guard (D1) fails into.
+        const outcome = failureTrackerRef.current.recordFailure(err);
+        setLastAutosaveError(outcome.message);
         console.warn('[SceneAutosave] Autosave failed:', err);
+
+        try {
+          await writeManifest(
+            failureTrackerRef.current.lastSuccessAt ?? new Date().toISOString(),
+            false,
+            { lastError: outcome.message },
+          );
+        } catch (manifestError) {
+          console.warn('[SceneAutosave] Could not record the autosave failure either.', manifestError);
+        }
+
+        if (outcome.shouldNotifyUser && typeof window !== 'undefined') {
+          window.dispatchEvent(new CustomEvent(SCENE_AUTOSAVE_FAILED_EVENT, {
+            detail: {
+              message: outcome.message,
+              consecutiveFailures: outcome.consecutiveFailures,
+              lastSuccessAt: failureTrackerRef.current.lastSuccessAt,
+            },
+          }));
+        }
       } finally {
         inFlightRef.current = false;
         setIsAutosaving(false);
@@ -344,8 +544,15 @@ export function useSceneAutosave({
   }, []);
 
   const scheduleSave = React.useCallback(() => {
-    if (!enabledRef.current || !isDesktopRuntime()) return;
+    if (!isDesktopRuntime()) return;
+
+    // Mark dirty BEFORE the enabled check (D4). Autosave is disabled outright
+    // during slicing and printing (`page.tsx`), and the old order meant every
+    // edit made in those windows never marked the scene dirty at all — it
+    // waited for the next unrelated history push to be persisted. Recording it
+    // here costs nothing and means the window closing is enough to fire a tick.
     dirtyRef.current = true;
+    if (!enabledRef.current) return;
 
     // Reset the debounce window
     if (debounceRef.current !== null) {
@@ -501,7 +708,7 @@ export function useSceneAutosave({
     await performAutosave({ force: true });
   }, [clearDeferredAutosave, performAutosave]);
 
-  return { isAutosaving, lastAutosaveAt, clearAutosave, flushAutosave };
+  return { isAutosaving, lastAutosaveAt, lastAutosaveError, clearAutosave, flushAutosave };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/hooks/useSceneAutosave.ts
+++ b/src/hooks/useSceneAutosave.ts
@@ -181,6 +181,14 @@ export function useSceneAutosave({
           { nativePath: voxlPath },
         );
 
+        // Ordering is load-bearing and must stay this way: payload first, then
+        // manifest. `exportScene` above commits the VOXL through the atomic
+        // writer (temp → fsync → rename, ExportManager.downloadFile), so by the
+        // time the manifest is written the file it advertises is guaranteed to
+        // be complete. A manifest written first — or written on a failed
+        // export — would point recovery at a file that may not exist or may be
+        // half a scene. Sub-phase B extends this manifest with the payload path
+        // and origin; that only stays trustworthy while this order holds.
         const savedAt = new Date().toISOString();
         await writeManifest(savedAt, false);
         setLastAutosaveAt(savedAt);

--- a/src/hooks/useSceneAutosave.ts
+++ b/src/hooks/useSceneAutosave.ts
@@ -17,30 +17,152 @@ const AUTOSAVE_NAVIGATION_SETTLE_MS = 900;
 // Tauri helpers
 // ---------------------------------------------------------------------------
 
-type AutosavePaths = { voxlPath: string; manifestPath: string };
+export type AutosaveOrigin = 'sidecar' | 'recovery-dir';
+
+export type AutosavePaths = {
+  voxlPath: string;
+  manifestPath: string;
+  origin: AutosaveOrigin;
+  projectPath: string | null;
+  /** Set only when the sidecar target was unusable. See `resolve_scene_autosave_target`. */
+  fallbackReason: string | null;
+};
+
+export type AutosaveRecoveryCandidate = {
+  voxlPath: string;
+  origin: AutosaveOrigin;
+  savedAt: string | null;
+  clean: boolean;
+  projectPath: string | null;
+  payloadBytes: number;
+  fallbackReason: string | null;
+};
+
+/** Minimal shape of `@tauri-apps/api/core`'s `invoke`, so tests can inject one. */
+export type AutosaveInvoke = <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+
+async function desktopInvoke(): Promise<AutosaveInvoke> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke as AutosaveInvoke;
+}
 
 let cachedPaths: AutosavePaths | null = null;
 let cachedPreferredSavePath: string | null | undefined;
+let warnedFallbackFor: string | null = null;
 
-async function getAutosavePaths(preferredSavePath?: string | null): Promise<AutosavePaths> {
-  // Invalidate cache if preferredSavePath changes
+/** Drops the resolved-path cache. Used by tests, which would otherwise leak it between cases. */
+export function resetAutosavePathCache(): void {
+  cachedPaths = null;
+  cachedPreferredSavePath = undefined;
+  warnedFallbackFor = null;
+}
+
+/**
+ * Resolves the autosave target at **tick time** (finding N3).
+ *
+ * The cache is keyed on the project path, so a Save As to a new folder moves the
+ * sidecar with it instead of writing next to the old project forever. A resolved
+ * *fallback* is deliberately never cached: falling back means the project folder
+ * was unusable at that moment (read-only, permission-denied, disconnected
+ * share), which is exactly the kind of condition that clears — re-probing costs
+ * one syscall per tick and lets the sidecar come back on its own.
+ */
+export async function resolveAutosavePaths(
+  invoke: AutosaveInvoke,
+  preferredSavePath?: string | null,
+): Promise<AutosavePaths> {
   if (cachedPaths && preferredSavePath !== cachedPreferredSavePath) {
     cachedPaths = null;
   }
   if (cachedPaths) return cachedPaths;
-  const { invoke } = await import('@tauri-apps/api/core');
+
   const result = await invoke<AutosavePaths>(
     'scene_autosave_get_paths',
     preferredSavePath ? { preferredSavePath } : {},
   );
+
+  if (result.fallbackReason) {
+    // Never fail an autosave over a folder-policy question — but never hide it
+    // either. Warned once per distinct project so a 30 s tick cannot spam.
+    const key = `${preferredSavePath ?? ''}:${result.fallbackReason}`;
+    if (warnedFallbackFor !== key) {
+      warnedFallbackFor = key;
+      console.warn(
+        `[SceneAutosave] Cannot write a recovery file beside this project (${result.fallbackReason}); `
+        + `using the default recovery location instead: ${result.voxlPath}`,
+      );
+    }
+    cachedPaths = null;
+    cachedPreferredSavePath = undefined;
+    return result;
+  }
+
+  warnedFallbackFor = null;
   cachedPaths = result;
   cachedPreferredSavePath = preferredSavePath;
-  return cachedPaths;
+  return result;
 }
 
-async function writeManifest(savedAt: string, clean: boolean): Promise<void> {
-  const { invoke } = await import('@tauri-apps/api/core');
-  await invoke('scene_autosave_write_manifest', { savedAt, clean });
+async function getAutosavePaths(preferredSavePath?: string | null): Promise<AutosavePaths> {
+  return resolveAutosavePaths(await desktopInvoke(), preferredSavePath);
+}
+
+export type WriteManifestOptions = {
+  voxlPath?: string | null;
+  origin?: string | null;
+  projectPath?: string | null;
+  payloadBytes?: number | null;
+  fallbackReason?: string | null;
+  /**
+   * Deletes the advertised payload as well as marking the manifest clean.
+   * **Only ever passed when there is no unsaved work to lose** — after a
+   * successful save, a successful restore, or an explicit discard.
+   */
+  deletePayload?: boolean;
+};
+
+async function writeManifest(
+  savedAt: string,
+  clean: boolean,
+  options: WriteManifestOptions = {},
+): Promise<void> {
+  const invoke = await desktopInvoke();
+  await invoke('scene_autosave_write_manifest', {
+    savedAt,
+    clean,
+    voxlPath: options.voxlPath ?? null,
+    origin: options.origin ?? null,
+    projectPath: options.projectPath ?? null,
+    payloadBytes: options.payloadBytes ?? null,
+    fallbackReason: options.fallbackReason ?? null,
+    deletePayload: options.deletePayload ?? false,
+  });
+}
+
+/**
+ * The single entry point for recovery discovery. Resolves, in order: the
+ * manifest's committed `voxlPath` → the sidecar derived from its `projectPath` →
+ * the legacy generic location → none.
+ */
+export async function resolveAutosaveRecovery(): Promise<AutosaveRecoveryCandidate | null> {
+  const invoke = await desktopInvoke();
+  return invoke<AutosaveRecoveryCandidate | null>('scene_autosave_resolve_recovery');
+}
+
+/** Reads a recovery payload. The backend accepts only its own candidates. */
+export async function readAutosaveRecoveryBytes(path: string | null): Promise<ArrayBuffer> {
+  const invoke = await desktopInvoke();
+  return invoke<ArrayBuffer>('scene_autosave_read_voxl_bytes', path ? { path } : {});
+}
+
+/**
+ * Removes the sidecar belonging to `projectPath`. Used on Save As against the
+ * **old** project, so a rename never leaves an orphaned `_autosave.voxl` implying
+ * unsaved work that does not exist.
+ */
+export async function deleteAutosaveSidecarForProject(projectPath: string): Promise<void> {
+  const invoke = await desktopInvoke();
+  await invoke('scene_autosave_delete_sidecar', { projectPath });
 }
 
 function isDesktopRuntime(): boolean {
@@ -159,7 +281,11 @@ export function useSceneAutosave({
       setIsAutosaving(true);
 
       try {
-        const { voxlPath } = await getAutosavePaths(preferredSavePathRef.current);
+        // Resolved per tick, not per render: `preferredSavePathRef` now tracks
+        // `activeSceneFilePath` state, so a Save As moves the sidecar with the
+        // project instead of stranding it beside the old one (finding N3).
+        const paths = await getAutosavePaths(preferredSavePathRef.current);
+        const { voxlPath } = paths;
 
         await ExportManager.exportScene(
           null,
@@ -187,10 +313,16 @@ export function useSceneAutosave({
         // time the manifest is written the file it advertises is guaranteed to
         // be complete. A manifest written first — or written on a failed
         // export — would point recovery at a file that may not exist or may be
-        // half a scene. Sub-phase B extends this manifest with the payload path
-        // and origin; that only stays trustworthy while this order holds.
+        // half a scene. Sub-phase B relies on exactly this: `voxlPath` below is
+        // what makes the manifest authoritative for recovery, and it is only
+        // trustworthy because it is written after the commit.
         const savedAt = new Date().toISOString();
-        await writeManifest(savedAt, false);
+        await writeManifest(savedAt, false, {
+          voxlPath,
+          origin: paths.origin,
+          projectPath: paths.projectPath,
+          fallbackReason: paths.fallbackReason,
+        });
         setLastAutosaveAt(savedAt);
       } catch (err) {
         console.warn('[SceneAutosave] Autosave failed:', err);
@@ -333,10 +465,20 @@ export function useSceneAutosave({
     };
   }, []);
 
+  /**
+   * Marks the autosave clean **and deletes the payload**.
+   *
+   * A `_autosave.voxl` lingering beside a saved project is user-visible clutter
+   * that implies unsaved work which does not exist. Deleting is safe only
+   * because every caller runs after the work is already secured — a successful
+   * explicit save, a successful restore, or an explicit discard. It is
+   * deliberately NOT called on a clean exit that still has unsaved changes; see
+   * `handleRequestProgramClose` in `page.tsx`.
+   */
   const clearAutosave = React.useCallback(async () => {
     if (!isDesktopRuntime()) return;
     try {
-      await writeManifest(new Date().toISOString(), true);
+      await writeManifest(new Date().toISOString(), true, { deletePayload: true });
     } catch (err) {
       console.warn('[SceneAutosave] Failed marking autosave clean:', err);
     }

--- a/src/hotkeys/__tests__/tripwires.test.ts
+++ b/src/hotkeys/__tests__/tripwires.test.ts
@@ -69,10 +69,14 @@ test('Static ESLint rule flags violations in forbidden paths and passes allowed 
     const forbiddenFile = join(workspaceRoot, 'src/hotkeys/temp_mock_forbidden.ts');
     const allowedFile = join(workspaceRoot, 'src/hotkeys/temp_mock_allowed.test.ts');
 
+    const eslintBin = join(workspaceRoot, 'node_modules/eslint/bin/eslint.js');
+    const runLint = (filePath: string) =>
+        execSync(`"${process.execPath}" "${eslintBin}" "${filePath}"`, { stdio: 'pipe', env: process.env });
+
     // 1. Test forbidden file (CallExpression)
     writeFileSync(forbiddenFile, "window.addEventListener('keydown', () => {});\n");
     try {
-        execSync(`npx eslint "${forbiddenFile}"`, { stdio: 'pipe' });
+        runLint(forbiddenFile);
         assert.fail('ESLint should have failed for forbidden file CallExpression');
     } catch (err: any) {
         const output = err.stdout?.toString() || err.stderr?.toString() || '';
@@ -87,7 +91,7 @@ test('Static ESLint rule flags violations in forbidden paths and passes allowed 
     // 2. Test forbidden file (AssignmentExpression)
     writeFileSync(forbiddenFile, "document.onkeyup = () => {};\n");
     try {
-        execSync(`npx eslint "${forbiddenFile}"`, { stdio: 'pipe' });
+        runLint(forbiddenFile);
         assert.fail('ESLint should have failed for forbidden file AssignmentExpression');
     } catch (err: any) {
         const output = err.stdout?.toString() || err.stderr?.toString() || '';
@@ -102,7 +106,7 @@ test('Static ESLint rule flags violations in forbidden paths and passes allowed 
     // 3. Test allowed file (CallExpression in a .test.ts file)
     writeFileSync(allowedFile, "window.addEventListener('keydown', () => {});\n");
     try {
-        execSync(`npx eslint "${allowedFile}"`, { stdio: 'pipe' });
+        runLint(allowedFile);
         // Should pass, no error thrown
     } catch (err: any) {
         const output = err.stdout?.toString() || err.stderr?.toString() || '';


### PR DESCRIPTION
- Added creation of <filename>_autosave.voxl for existing and saved VOXL files to prevent Autosave overwrites.  Creates in same folder as saved VOXL when writable.
- Added atomic saves to VOXL autosave.  Prevents stage 1 deletion of existing data. Should resolve #452, but note the #452 trigger sequence is not replicated and may not be fully covered.
- Wired startup autosave recovery to retrieve most recent autosave -- whether <filename>_autosave.voxl for an autosave for an existing VOXL file or the default autosave.voxl in appdata or similar.
- Added mesh Copy-on-Write chunk store in preparation for decimation fixes.  Autosaves should be significantly faster as unchanged files are not recompressed and rewritten to disk at every autosave interval. 
- Autosave now waits for Rust mutations to complete before firing autosave (e.g. an autosave interval which occurs during hollowing will wait until hollowing completes to fire).

Closes #452.