### PR TITLE
fix(athena): respect safety margin & NanoDLP networking fixes

### DIFF
--- a/plugins/athena/network/nanodlpHandlers.ts
+++ b/plugins/athena/network/nanodlpHandlers.ts
@@ -298,6 +298,7 @@ async function probeNanoDlp(
     }
 
     let networkFilterMatched = false;
+    let deviceHasUnknownFilter = true;
 
     if (requestedNetworkFilter) {
       const machineName = await resolveDeviceMachineName(hostOrIp, port, Math.max(1200, Math.min(timeoutMs, 4000)));
@@ -315,6 +316,7 @@ async function probeNanoDlp(
         if (normalizedMachineName !== normalizedRequestedFilter) {
           const knownNetworkFilter = resolveKnownNetworkFilter(machineName);
           const normalizedKnownNetworkFilter = knownNetworkFilter ? normalizeMachineName(knownNetworkFilter) : null;
+          deviceHasUnknownFilter = knownNetworkFilter === null;
           const explicitKnownFilterMismatch = Boolean(
             normalizedKnownNetworkFilter
             && normalizedKnownNetworkFilter !== normalizedRequestedFilter,
@@ -347,9 +349,11 @@ async function probeNanoDlp(
             normalizedRequestedFilter,
             printerModel: resolveNanoDlpPrinterModel(status),
             fallbackToModelHint: true,
+            deviceHasUnknownFilter,
           });
         } else {
           networkFilterMatched = true;
+          deviceHasUnknownFilter = false;
 
           logNanoDlpFilterDebug(debugFilter, 'probe/match', {
             hostOrIp,
@@ -362,7 +366,7 @@ async function probeNanoDlp(
     }
 
     const modelHintMatched = isSupportedAthenaModelMatch(supportedModel, requestedModelHint);
-    if (!modelHintMatched && !networkFilterMatched) {
+    if (!modelHintMatched && !networkFilterMatched && !deviceHasUnknownFilter) {
       logNanoDlpFilterDebug(debugFilter, 'probe/reject', {
         hostOrIp,
         port,
@@ -371,10 +375,23 @@ async function probeNanoDlp(
         requestedModelHint,
         modelHintMatched,
         networkFilterMatched,
+        deviceHasUnknownFilter,
         printerModel: resolveNanoDlpPrinterModel(status),
       });
       return null;
     }
+
+    logNanoDlpFilterDebug(debugFilter, deviceHasUnknownFilter && !networkFilterMatched && !modelHintMatched ? 'probe/fallback' : 'probe/accept', {
+      hostOrIp,
+      port,
+      reason: deviceHasUnknownFilter && !networkFilterMatched && !modelHintMatched ? 'unknown-filter-fallback' : undefined,
+      supportedModel,
+      requestedModelHint,
+      modelHintMatched,
+      networkFilterMatched,
+      deviceHasUnknownFilter,
+      printerModel: resolveNanoDlpPrinterModel(status),
+    });
 
     const hostName = resolveNanoDlpStatusHostName(status);
     const printerName = resolveNanoDlpPrinterName(status);
@@ -845,7 +862,13 @@ async function handleNanoDlpConnect(payload: unknown): Promise<HandlerResult> {
       && isSupportedAthenaModelMatch(supportedModel, requestedModelHint),
     );
 
-    if (!supportedModel || explicitKnownFilterMismatch || (!modelHintMatched && !networkFilterMatched)) {
+    // When a device reports a name that doesn't match any known Athena filter
+    // key (e.g. "athena" instead of "Athena2 16K"), it's likely reporting a
+    // generic/non-standard name. Allow the connection as a fallback rather than
+    // rejecting it as a model mismatch.
+    const deviceHasUnknownFilter = normalizedDeviceNetworkFilter === null;
+
+    if (!supportedModel || explicitKnownFilterMismatch || (!modelHintMatched && !networkFilterMatched && !deviceHasUnknownFilter)) {
       logNanoDlpFilterDebug(debugFilter, 'connect/reject', {
         host: parsedHost.host,
         port,
@@ -859,6 +882,7 @@ async function handleNanoDlpConnect(payload: unknown): Promise<HandlerResult> {
         modelHintMatched,
         networkFilterMatched,
         explicitKnownFilterMismatch,
+        deviceHasUnknownFilter,
         supportedModel,
         printerModel,
         deviceMachineName,
@@ -891,6 +915,18 @@ async function handleNanoDlpConnect(payload: unknown): Promise<HandlerResult> {
         },
       };
     }
+
+    logNanoDlpFilterDebug(debugFilter, deviceHasUnknownFilter && !networkFilterMatched && !modelHintMatched ? 'connect/fallback' : 'connect/accept', {
+      host: parsedHost.host,
+      port,
+      reason: deviceHasUnknownFilter && !networkFilterMatched && !modelHintMatched ? 'unknown-filter-fallback' : undefined,
+      requestedNetworkFilter,
+      deviceMachineName,
+      deviceNetworkFilter,
+      supportedModel,
+      printerModel,
+      deviceHasUnknownFilter,
+    });
 
     const hostName = resolveNanoDlpStatusHostName(status);
     const printerName = resolveNanoDlpPrinterName(status);

--- a/plugins/athena/rust/network.rs
+++ b/plugins/athena/rust/network.rs
@@ -1272,9 +1272,15 @@ async fn nanodlp_connect(payload: &Value) -> (u16, Value) {
                 .map(|model| matches_model_hint(model, requested_model_hint))
                 .unwrap_or(false);
 
+            // When a device reports a name that doesn't match any known Athena
+            // filter key (e.g. "athena" instead of "Athena2 16K"), it's likely
+            // reporting a generic/non-standard name. Allow the connection as a
+            // fallback rather than rejecting it as a model mismatch.
+            let device_has_unknown_filter = normalized_device_network_filter.is_none();
+
             if supported_model.is_none()
                 || explicit_known_filter_mismatch
-                || (!model_hint_matched && !network_filter_matched)
+                || (!model_hint_matched && !network_filter_matched && !device_has_unknown_filter)
             {
                 let reason = if supported_model.is_none() {
                     "unsupported-model"
@@ -1615,7 +1621,9 @@ async fn nanodlp_discover(payload: &Value) -> (u16, Value) {
                 .map(|known| known != normalized_expected)
                 .unwrap_or(false);
             let model_hint_fallback = device_matches_requested_model_hint(&device, requested_model_hint);
-            let accepted = matched || (!explicit_known_filter_mismatch && model_hint_fallback);
+            let device_has_unknown_filter = known_network_filter.is_none();
+            let accepted = matched
+                || (!explicit_known_filter_mismatch && (model_hint_fallback || device_has_unknown_filter));
             log_nanodlp_filter_debug(
                 if matched {
                     "discover/match"
@@ -1705,7 +1713,9 @@ async fn nanodlp_discover(payload: &Value) -> (u16, Value) {
                     .map(|known| known != normalized_expected)
                     .unwrap_or(false);
                 let model_hint_fallback = device_matches_requested_model_hint(&device, requested_model_hint);
-                let accepted = matched || (!explicit_known_filter_mismatch && model_hint_fallback);
+                let device_has_unknown_filter = known_network_filter.is_none();
+                let accepted = matched
+                    || (!explicit_known_filter_mismatch && (model_hint_fallback || device_has_unknown_filter));
                 log_nanodlp_filter_debug(
                     if matched {
                         "discover/match"
@@ -1832,7 +1842,9 @@ async fn nanodlp_discover(payload: &Value) -> (u16, Value) {
                     .map(|known| known != normalized_expected)
                     .unwrap_or(false);
                 let model_hint_fallback = device_matches_requested_model_hint(&device, requested_model_hint);
-                let accepted = matched || (!explicit_known_filter_mismatch && model_hint_fallback);
+                let device_has_unknown_filter = known_network_filter.is_none();
+                let accepted = matched
+                    || (!explicit_known_filter_mismatch && (model_hint_fallback || device_has_unknown_filter));
                 log_nanodlp_filter_debug(
                     if matched {
                         "discover/match"

--- a/src/features/plugins/pluginRegistry.ts
+++ b/src/features/plugins/pluginRegistry.ts
@@ -356,6 +356,21 @@ function resolveBuildDimensionMm(
   return fallbackMm;
 }
 
+function sanitizeSafetyMarginMm(input: unknown): PrinterPreset['safetyMarginMm'] {
+  if (!input || typeof input !== 'object') return undefined;
+  const src = input as Record<string, unknown>;
+  const clampEdge = (v: unknown) => {
+    const n = Number(v);
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  };
+  return {
+    front: clampEdge(src.front),
+    back: clampEdge(src.back),
+    left: clampEdge(src.left),
+    right: clampEdge(src.right),
+  };
+}
+
 function sanitizePrinterPreset(input: unknown): PrinterPreset | null {
   const value = (input ?? {}) as Record<string, unknown>;
 
@@ -397,6 +412,7 @@ function sanitizePrinterPreset(input: unknown): PrinterPreset | null {
       depth: resolveBuildDimensionMm((value as any).buildVolumeMm?.depth, resolutionY, pixelSize?.y, 89),
       height: sanitizeNumber((value as any).buildVolumeMm?.height, 175, 1, 10000),
     },
+    safetyMarginMm: sanitizeSafetyMarginMm((value as any).safetyMarginMm),
     display: {
       resolutionX,
       resolutionY,


### PR DESCRIPTION
This pull request introduces improvements to how devices with unknown or generic network filter names are handled during network probing and connection for NanoDLP devices, both in TypeScript and Rust code. The main effect is to allow connections to devices that do not match any known Athena network filter, treating them as a fallback rather than rejecting them outright. Additionally, the pull request adds better logging and input sanitization for printer safety margins.

**Device discovery and connection logic improvements:**

* Devices reporting unknown or generic network filter names (e.g., "athena" instead of a specific model) are now accepted as a fallback, instead of being rejected as a model mismatch. This logic is applied consistently in both the TypeScript (`nanodlpHandlers.ts`) and Rust (`network.rs`) implementations. [[1]](diffhunk://#diff-e25357c4a8027d3574918a8f6c3da44e3150f05145e19638e653a76d4c04bf48L848-R871) [[2]](diffhunk://#diff-e25357c4a8027d3574918a8f6c3da44e3150f05145e19638e653a76d4c04bf48R319) [[3]](diffhunk://#diff-e25357c4a8027d3574918a8f6c3da44e3150f05145e19638e653a76d4c04bf48L365-R369) [[4]](diffhunk://#diff-f656ea2999fd3db2c53cef02b7222148b58e6ad75dd58c0b1c4a2257418ad347R1275-R1283) [[5]](diffhunk://#diff-f656ea2999fd3db2c53cef02b7222148b58e6ad75dd58c0b1c4a2257418ad347L1618-R1626) [[6]](diffhunk://#diff-f656ea2999fd3db2c53cef02b7222148b58e6ad75dd58c0b1c4a2257418ad347L1708-R1718) [[7]](diffhunk://#diff-f656ea2999fd3db2c53cef02b7222148b58e6ad75dd58c0b1c4a2257418ad347L1835-R1847)

* The logic for rejecting connections now checks that the device does not have an unknown filter before rejecting based on model and filter mismatches. [[1]](diffhunk://#diff-e25357c4a8027d3574918a8f6c3da44e3150f05145e19638e653a76d4c04bf48L365-R369) [[2]](diffhunk://#diff-e25357c4a8027d3574918a8f6c3da44e3150f05145e19638e653a76d4c04bf48L848-R871) [[3]](diffhunk://#diff-f656ea2999fd3db2c53cef02b7222148b58e6ad75dd58c0b1c4a2257418ad347R1275-R1283)

**Debug logging enhancements:**

* Additional debug logs are added to indicate when a device is accepted as a fallback due to an unknown filter, including the reason and relevant device/model information. [[1]](diffhunk://#diff-e25357c4a8027d3574918a8f6c3da44e3150f05145e19638e653a76d4c04bf48R352-R356) [[2]](diffhunk://#diff-e25357c4a8027d3574918a8f6c3da44e3150f05145e19638e653a76d4c04bf48R378-R395) [[3]](diffhunk://#diff-e25357c4a8027d3574918a8f6c3da44e3150f05145e19638e653a76d4c04bf48R919-R930) [[4]](diffhunk://#diff-e25357c4a8027d3574918a8f6c3da44e3150f05145e19638e653a76d4c04bf48R885)

**Input sanitization improvements:**

* Added a new `sanitizeSafetyMarginMm` function to validate and clamp the `safetyMarginMm` property in printer presets, ensuring that only valid non-negative numbers are accepted for each edge.
* The `sanitizePrinterPreset` function now uses `sanitizeSafetyMarginMm` to process the `safetyMarginMm` field.