### PR TITLE
Holes not applied properly to LYS imports + QoL fixes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6688,10 +6688,17 @@ export default function Home() {
         slicing.setLayerIndex(clamped);
       }
       preservedNonPrintingLayerIndexRef.current = null;
+    } else if (previousMode === 'export' && currentMode !== 'export') {
+      // Export mode force-selects every visible model (for tinting). Collapse
+      // back to the active model when leaving by any route, so the next tool
+      // doesn't open with all meshes selected.
+      if (scene.activeModelId) {
+        scene.setSelectedModelIds([scene.activeModelId]);
+      }
     }
 
     previousSceneModeRef.current = currentMode;
-  }, [scene.mode, slicing.layerIndex, slicing.numLayers, slicing.setLayerIndex]);
+  }, [scene.mode, scene.activeModelId, scene.setSelectedModelIds, slicing.layerIndex, slicing.numLayers, slicing.setLayerIndex]);
 
   // Invalidate printing artifact if scene changed (detected via history events after the slice marker)
   React.useEffect(() => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -978,6 +978,12 @@ export default function Home() {
   const [holePunchHoverPlacement, setHolePunchHoverPlacement] = React.useState<HolePunchPlacementState | null>(null);
   const [isApplyingHolePunch, setIsApplyingHolePunch] = React.useState(false);
   const [pendingHolePunchAutoApplyModelId, setPendingHolePunchAutoApplyModelId] = React.useState<string | null>(null);
+  // Export-tab "Apply to All": sequential bake across every visible model with
+  // unapplied holes. The ref holds the remaining model ids after the current
+  // one; progress drives the blocking-overlay label. (Orchestration glue — see
+  // docs/page-tsx-refactor-handoff.md §5.)
+  const holePunchApplyAllQueueRef = React.useRef<string[]>([]);
+  const [applyAllHolePunchProgress, setApplyAllHolePunchProgress] = React.useState<{ done: number; total: number } | null>(null);
   const {
     isFinalizing,
     beginFinalizing,
@@ -1425,7 +1431,12 @@ export default function Home() {
   } = importExport;
 
   const [isExporting, setIsExporting] = React.useState(false);
-  const showModifierApplyBlockingOverlay = isApplyingHollowing || isApplyingHolePunch || isApplyingBlockersHollowing || pendingHolePunchAutoApplyModelId !== null || isFinalizing;
+  const showModifierApplyBlockingOverlay = isApplyingHollowing || isApplyingHolePunch || isApplyingBlockersHollowing || pendingHolePunchAutoApplyModelId !== null || applyAllHolePunchProgress !== null || isFinalizing;
+  // Sub-line under the blocking-overlay title. During "Apply to All" it reports
+  // sequence progress; otherwise it's the single-model default.
+  const modifierApplyProcessingLabel = applyAllHolePunchProgress
+    ? `Applying model ${Math.min(applyAllHolePunchProgress.done + 1, applyAllHolePunchProgress.total)} of ${applyAllHolePunchProgress.total}`
+    : 'Processing 1 model';
   const [modifierApplyOverlayElapsedSec, setModifierApplyOverlayElapsedSec] = React.useState(0);
 
 
@@ -7574,17 +7585,30 @@ export default function Home() {
     scene.setMode('prepare');
   }, [scene.mode, scene.models.length, scene.setMode]);
 
+  // Visible models with unapplied hole punches. Hidden models are ignored
+  // entirely — they neither open the export warning nor get baked by
+  // "Apply to All".
+  const getVisibleModelIdsWithUnappliedHoles = React.useCallback((): string[] => {
+    return scene.models
+      .filter((model) => model.visible)
+      .filter((model) => {
+        const mm = scene.getModelMeshModifiers(model.id);
+        const punches = mm?.holePunches;
+        return Boolean(punches && punches.length > 0 && !mm?.holePunchesBakedIntoGeometry);
+      })
+      .map((model) => model.id);
+  }, [scene.models, scene.getModelMeshModifiers]);
+
   React.useEffect(() => {
     if (scene.mode !== 'export') return;
     if (scene.models.length === 0) return;
 
-    // Check for unapplied hole punches and warn the user.
-    const hasUnapplied = scene.models.some((model) => {
-      const mm = scene.getModelMeshModifiers(model.id);
-      const p = mm?.holePunches;
-      return p && p.length > 0 && !mm?.holePunchesBakedIntoGeometry;
-    });
-    if (hasUnapplied && unappliedHolePunchResolveRef.current === null) {
+    // Check for unapplied hole punches and warn the user. Suppressed while an
+    // "Apply to All" sequence is running — each bake mutates scene.models and
+    // re-runs this effect, and models still in the queue would otherwise
+    // re-open the modal on top of the progress overlay.
+    const hasUnapplied = getVisibleModelIdsWithUnappliedHoles().length > 0;
+    if (hasUnapplied && unappliedHolePunchResolveRef.current === null && applyAllHolePunchProgress === null) {
       setShowUnappliedHolePunchModal(true);
     }
 
@@ -7604,7 +7628,54 @@ export default function Home() {
 
     // Select all visible models for export workspace tinting
     scene.setSelectedModelIds(visibleIds);
-  }, [scene.mode, scene.activeModelId, scene.models, scene.setActiveModelId]);
+  }, [scene.mode, scene.activeModelId, scene.models, scene.setActiveModelId, getVisibleModelIdsWithUnappliedHoles, applyAllHolePunchProgress]);
+
+  // Export-tab "Apply to All": bake holes into every visible model that has
+  // unapplied holes, one at a time. Each model is made active and handed to the
+  // manager's auto-apply effect via pendingHolePunchAutoApplyModelId; the
+  // advance effect below walks the queue as each bake settles.
+  const handleApplyAllHolePunches = React.useCallback(() => {
+    setShowUnappliedHolePunchModal(false);
+    const queue = getVisibleModelIdsWithUnappliedHoles();
+    if (queue.length === 0) return;
+    holePunchApplyAllQueueRef.current = queue.slice(1);
+    setApplyAllHolePunchProgress({ done: 0, total: queue.length });
+    scene.setActiveModelId(queue[0]);
+    setPendingHolePunchAutoApplyModelId(queue[0]);
+  }, [getVisibleModelIdsWithUnappliedHoles, scene.setActiveModelId]);
+
+  // Guide the user to the per-model hole-punch UI (Prepare → Hollow tool).
+  const handleGoToHollowTool = React.useCallback(() => {
+    setShowUnappliedHolePunchModal(false);
+    const firstWithHoles = getVisibleModelIdsWithUnappliedHoles()[0];
+    if (firstWithHoles) {
+      scene.setActiveModelId(firstWithHoles);
+    }
+    scene.setMode('prepare');
+    setTransformModeWithMirrorFinalize('hollowing');
+  }, [getVisibleModelIdsWithUnappliedHoles, scene.setActiveModelId, scene.setMode, setTransformModeWithMirrorFinalize]);
+
+  // Advance the "Apply to All" queue once the current model's bake settles.
+  // A model is done when it is no longer applying and the auto-apply handoff
+  // has cleared (the manager sets pendingHolePunchAutoApplyModelId back to null
+  // in the same batched tick it flips isApplyingHolePunch, so this never fires
+  // mid-bake).
+  React.useEffect(() => {
+    if (!applyAllHolePunchProgress) return;
+    if (isApplyingHolePunch) return;
+    if (pendingHolePunchAutoApplyModelId !== null) return;
+
+    const nextModelId = holePunchApplyAllQueueRef.current.shift();
+    if (!nextModelId) {
+      setApplyAllHolePunchProgress(null);
+      return;
+    }
+    setApplyAllHolePunchProgress((previous) => (
+      previous ? { ...previous, done: previous.done + 1 } : previous
+    ));
+    scene.setActiveModelId(nextModelId);
+    setPendingHolePunchAutoApplyModelId(nextModelId);
+  }, [applyAllHolePunchProgress, isApplyingHolePunch, pendingHolePunchAutoApplyModelId, scene.setActiveModelId]);
 
   // When entering arrange mode with exactly one visible model, auto-select it.
   React.useEffect(() => {
@@ -10392,13 +10463,15 @@ export default function Home() {
       />
 
       <ModifierModals
-        handleApplyHolePunch={handleApplyHolePunch}
+        handleApplyAllHolePunches={handleApplyAllHolePunches}
+        handleGoToHollowTool={handleGoToHollowTool}
         handleCancelDestructiveTransform={handleCancelDestructiveTransform}
         handleConfirmBlockerReset={handleConfirmBlockerReset}
         handleConfirmDestructiveTransform={handleConfirmDestructiveTransform}
         handleConfirmModifierReset={handleConfirmModifierReset}
         modifierApplyOverlayContent={modifierApplyOverlayContent}
         modifierApplyOverlayElapsedLabel={modifierApplyOverlayElapsedLabel}
+        modifierApplyProcessingLabel={modifierApplyProcessingLabel}
         pendingBlockerResetState={pendingBlockerResetState}
         pendingDestructiveTransform={pendingDestructiveTransform}
         pendingModifierResetAction={pendingModifierResetAction}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7607,9 +7607,17 @@ export default function Home() {
     // "Apply to All" sequence is running — each bake mutates scene.models and
     // re-runs this effect, and models still in the queue would otherwise
     // re-open the modal on top of the progress overlay.
-    const hasUnapplied = getVisibleModelIdsWithUnappliedHoles().length > 0;
-    if (hasUnapplied && unappliedHolePunchResolveRef.current === null && applyAllHolePunchProgress === null) {
+    const unbakedHoleModelIds = getVisibleModelIdsWithUnappliedHoles();
+    if (unbakedHoleModelIds.length > 0 && unappliedHolePunchResolveRef.current === null && applyAllHolePunchProgress === null) {
       setShowUnappliedHolePunchModal(true);
+      // Make the first model with un-baked holes active so the modal's actions
+      // (and the user's next glance) land on a model that needs attention,
+      // rather than whichever model happened to be active on entering export.
+      // Only nudge when the active model isn't already one that needs baking, so
+      // this doesn't fight a deliberate selection or loop on re-run.
+      if (scene.activeModelId === null || !unbakedHoleModelIds.includes(scene.activeModelId)) {
+        scene.setActiveModelId(unbakedHoleModelIds[0]);
+      }
     }
 
     // In export mode, select all visible models for tinting

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1435,7 +1435,7 @@ export default function Home() {
   // Sub-line under the blocking-overlay title. During "Apply to All" it reports
   // sequence progress; otherwise it's the single-model default.
   const modifierApplyProcessingLabel = applyAllHolePunchProgress
-    ? `Applying model ${Math.min(applyAllHolePunchProgress.done + 1, applyAllHolePunchProgress.total)} of ${applyAllHolePunchProgress.total}`
+    ? `Applying to model ${Math.min(applyAllHolePunchProgress.done + 1, applyAllHolePunchProgress.total)} of ${applyAllHolePunchProgress.total}`
     : 'Processing 1 model';
   const [modifierApplyOverlayElapsedSec, setModifierApplyOverlayElapsedSec] = React.useState(0);
 

--- a/src/components/organisms/modals/ModifierModals.tsx
+++ b/src/components/organisms/modals/ModifierModals.tsx
@@ -107,8 +107,8 @@ export function ModifierModals({
           </p>
           <p className="text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
             <strong>Apply to All</strong> bakes the holes into every visible model
-            that has unapplied holes — not just the one on screen. Or open the
-            <strong> Hollow</strong> tool to review and apply them per model.
+            when applicable. Or open the <strong>Hollow</strong> tool to review and
+            apply holes individually.
           </p>
         </div>
       </StructuredDialogModal>

--- a/src/components/organisms/modals/ModifierModals.tsx
+++ b/src/components/organisms/modals/ModifierModals.tsx
@@ -6,13 +6,15 @@ import { type HollowingPanelState } from '@/features/hollowing';
 type PendingModifierResetAction = 'hollowing' | 'hole_punch' | 'clear_hollowing';
 
 export type ModifierModalsProps = {
-  handleApplyHolePunch: () => void;
+  handleApplyAllHolePunches: () => void;
+  handleGoToHollowTool: () => void;
   handleCancelDestructiveTransform: () => void;
   handleConfirmBlockerReset: () => void;
   handleConfirmDestructiveTransform: () => void;
   handleConfirmModifierReset: () => void;
   modifierApplyOverlayContent: { title: string; detailLines: string[]; };
   modifierApplyOverlayElapsedLabel: string;
+  modifierApplyProcessingLabel: string;
   pendingBlockerResetState: HollowingPanelState | null;
   pendingDestructiveTransform: { modelId: string; modelName: string; supportCount: number; operationLabel: string; } | null;
   pendingModifierResetAction: PendingModifierResetAction | null;
@@ -26,13 +28,15 @@ export type ModifierModalsProps = {
 
 /** Editor modal organism: StructuredDialog_unappliedHolePunch, StructuredDialog_modifierReset, StructuredDialog_blockerReset, DestructiveTransformModal, modifierApplyBlockingOverlay. */
 export function ModifierModals({
-  handleApplyHolePunch,
+  handleApplyAllHolePunches,
+  handleGoToHollowTool,
   handleCancelDestructiveTransform,
   handleConfirmBlockerReset,
   handleConfirmDestructiveTransform,
   handleConfirmModifierReset,
   modifierApplyOverlayContent,
   modifierApplyOverlayElapsedLabel,
+  modifierApplyProcessingLabel,
   pendingBlockerResetState,
   pendingDestructiveTransform,
   pendingModifierResetAction,
@@ -73,15 +77,24 @@ export function ModifierModals({
             </button>
             <button
               type="button"
-              className="ui-button ui-button-accent !h-9 px-3 text-xs"
+              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
               onClick={() => {
-                setShowUnappliedHolePunchModal(false);
                 unappliedHolePunchResolveRef.current = null;
-                // Defer so the modal closes before apply starts.
-                setTimeout(() => { handleApplyHolePunch(); }, 0);
+                handleGoToHollowTool();
               }}
             >
-              Apply Now
+              Go to Hollow Tool
+            </button>
+            <button
+              type="button"
+              className="ui-button ui-button-accent !h-9 px-3 text-xs"
+              onClick={() => {
+                unappliedHolePunchResolveRef.current = null;
+                // Defer so the modal closes before apply starts.
+                setTimeout(() => { handleApplyAllHolePunches(); }, 0);
+              }}
+            >
+              Apply to All
             </button>
           </>
         )}
@@ -93,7 +106,9 @@ export function ModifierModals({
             will not appear in the output.
           </p>
           <p className="text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
-            <strong>Do you want to apply them now?</strong>
+            <strong>Apply to All</strong> bakes the holes into every visible model
+            that has unapplied holes — not just the one on screen. Or open the
+            <strong> Hollow</strong> tool to review and apply them per model.
           </p>
         </div>
       </StructuredDialogModal>
@@ -222,7 +237,7 @@ export function ModifierModals({
               Elapsed: {modifierApplyOverlayElapsedLabel}
             </div>
             <div className="mt-1 text-[11px]" style={{ color: 'var(--text-muted)' }}>
-              Processing 1 model
+              {modifierApplyProcessingLabel}
             </div>
 
             <div

--- a/src/features/hole-punching/useHolePunchManager.ts
+++ b/src/features/hole-punching/useHolePunchManager.ts
@@ -1270,9 +1270,17 @@ export function useHolePunchManager({
       return;
     }
 
+    // Wait until the placement-sync effect has loaded this model's holes into
+    // activeHolePunchPlacements. When the auto-apply target is a model that was
+    // just made active (e.g. the export-tab "Apply to All" sequence), applying
+    // with stale/empty placements would take the "no placements → restore
+    // geometry" path and wipe the model's holes.
+    if (activeHolePunchPlacements.length === 0) return;
+
     setPendingHolePunchAutoApplyModelId(null);
     handleApplyHolePunch();
   }, [
+    activeHolePunchPlacements.length,
     handleApplyHolePunch,
     isApplyingHolePunch,
     isApplyingHollowing,


### PR DESCRIPTION
## Summary

Two threads on this branch:

1. **Export tab "unapplied holes" modal** — rework the warning that fires when you
   open Export with hole punches that were never baked into geometry. The modal now
   offers a real batch **Apply to All**, a **Go to Hollow Tool** path, and no longer
   leaves the scene in a weird selection state when you leave export.
2. **`lys-import` submodule** — rotation and support-anchoring fixes (submodule
   pointer bumps).

## Export-tab hole-punch changes

Unapplied hole punches are lost at slice time — they must be baked into geometry
first. When you enter the Export tab with visible models that have unbaked holes, a
warning modal now surfaces with three clear actions:

- **Apply to All** — sequentially bakes holes into *every visible model* that has
  unapplied holes, not just the active one. Progress is reported in the blocking
  overlay (`Applying model N of M`).
- **Go to Hollow Tool** — jumps to Prepare → Hollow tool with the first un-baked
  model made active, for per-model review.
- **Continue Without** — proceeds unchanged.

### Correctness fixes
- **Batch bake without wiping geometry.** "Apply to All" walks a queue, making each
  model active and handing it to the manager's auto-apply effect. The manager now
  waits until the target model's placements have actually loaded
  (`activeHolePunchPlacements.length === 0` guard) before applying — otherwise a
  just-activated model would take the "no placements → restore geometry" path and
  wipe its holes.
- **No modal storm mid-batch.** Each bake mutates `scene.models` and re-runs the
  export effect; the warning is now suppressed while an Apply-to-All sequence is in
  flight so queued models don't re-open the modal on top of the progress overlay.
- **Collapse selection on leaving export.** Export force-selects every visible model
  (for tinting). On *any* exit from export the selection now collapses back to the
  active model, so the next tool (e.g. Hollow) doesn't open with every mesh selected.
- **Focus a model that needs attention.** On entering export with unbaked holes, the
  first such model is made active (only when the current active model isn't already
  one that needs baking, so it won't fight a deliberate selection).

### Copy
Modal body reworded to explain that holes must be baked before slicing, and to
describe what **Apply to All** vs the **Hollow** tool each do.

## lys-import submodule
- Apply rotation as a delta of the surface normal, detect winding, and allow
  supports anchored to interior faces.
- Apply tip rotation when included.

## Files
- `src/app/page.tsx` — Apply-to-All queue orchestration, export-mode selection
  collapse, focus nudge, progress label.
- `src/components/organisms/modals/ModifierModals.tsx` — new actions, wiring, copy.
- `src/features/hole-punching/useHolePunchManager.ts` — placements-loaded guard.
- `plugins/lys-import` — submodule bump.

## Testing
- `npx tsc --noEmit` clean.
- Manual: enter Export with multiple visible models carrying unbaked holes; verify
  **Apply to All** bakes each without wiping geometry and the overlay counts up;
  verify **Go to Hollow Tool** opens Prepare with the first unbaked model active;
  leave Export via tab / button / keyboard and confirm only the active model stays
  selected.

depends on: https://github.com/Open-Resin-Alliance/df-plugin-lys/pull/10