### PR TITLE
Modify now can choose World or Local axes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -603,6 +603,8 @@ export default function Home() {
   // 2. Transform Management (needs geom for bounds)
   const transformMgr = useTransformManager({ geom: scene.geom });
   const [uniformScaling, setUniformScaling] = React.useState(true);
+  // Gizmo frame: world axes, or the active model's own (issue #504).
+  const [localTransformSpace, setLocalTransformSpace] = React.useState(false);
 
   // --- Hollowing manager: placed early so its state/setters are in scope for
   //     useHolePunchManager below. Late/cross deps supplied via a ref populated
@@ -7559,6 +7561,7 @@ export default function Home() {
     hasModels: scene.models.length > 0,
     transformMode: transformMgr.transformMode,
     setTransformMode: setTransformModeWithMirrorFinalize,
+    setLocalTransformSpace: setLocalTransformSpace,
     onArrangeAll: () => {
       void (arrangeLayoutMode === 'array'
         ? handleManualArrayArrangeModels('all')
@@ -9578,6 +9581,8 @@ export default function Home() {
               scheduleCommitPendingTransformHistory: scheduleCommitPendingTransformHistory,
               uniformScaling: uniformScaling,
               setUniformScaling: setUniformScaling,
+              localTransformSpace: localTransformSpace,
+              setLocalTransformSpace: setLocalTransformSpace,
               isApplyingHolePunch: isApplyingHolePunch,
               interiorView: interiorView,
               hasCavityGeometry: hasCavityGeometry,
@@ -9817,6 +9822,7 @@ export default function Home() {
             transformMode={transformMgr.transformMode}
             transform={transformMgr.transform}
             uniformScaling={uniformScaling}
+            localTransformSpace={localTransformSpace}
             autoLift={transformMgr.autoLift}
             liftDistance={transformMgr.liftDistance}
             autoSnapEnabled={transformMgr.autoSnapEnabled}

--- a/src/components/controls/TransformControls.tsx
+++ b/src/components/controls/TransformControls.tsx
@@ -36,7 +36,11 @@ interface TransformControlsProps {
   onResetScale: () => void;
   uniformScaling: boolean;
   onUniformScalingChange: (value: boolean) => void;
-  
+
+  // Gizmo space — one flag for both move and rotate, since the gizmo is one frame
+  localSpace: boolean;
+  onLocalSpaceChange: (value: boolean) => void;
+
   // Shared
   modelBBox: THREE.Box3 | null;
   
@@ -64,6 +68,8 @@ export function TransformControls({
   onResetScale,
   uniformScaling,
   onUniformScalingChange,
+  localSpace,
+  onLocalSpaceChange,
   modelBBox,
   autoLift,
   onAutoLiftChange,
@@ -107,6 +113,34 @@ export function TransformControls({
     background: 'transparent',
     color: 'var(--text-strong)',
   };
+
+  const toggleButtonClass = 'h-7 min-w-[64px] rounded-md border px-2 text-[10px] font-semibold uppercase tracking-wide transition-colors';
+
+  const toggleButtonStyle = (active: boolean): React.CSSProperties => (active
+    ? {
+        borderColor: 'color-mix(in srgb, var(--accent), white 10%)',
+        background: 'color-mix(in srgb, var(--accent), var(--surface-0) 76%)',
+        color: 'var(--accent-contrast)',
+      }
+    : {
+        borderColor: 'var(--border-subtle)',
+        background: 'var(--surface-1)',
+        color: 'var(--text-muted)',
+      });
+
+  // Move and rotate share the gizmo's frame, so they share one button: pressing
+  // either one turns both to the model's own axes.
+  const renderLocalSpaceToggle = () => (
+    <button
+      type="button"
+      onClick={() => onLocalSpaceChange(!localSpace)}
+      title="Move and rotate along the model's own axes instead of the build plate's"
+      className={toggleButtonClass}
+      style={toggleButtonStyle(localSpace)}
+    >
+      Local
+    </button>
+  );
 
   // Conversion helpers
   const toDegrees = (rad: number) => (rad * 180) / Math.PI;
@@ -180,7 +214,13 @@ export function TransformControls({
 
           {/* MOVE SECTION */}
           <div className="rounded-md border p-2" style={moveCardStyle}>
-            <SectionHeader title="Move" />
+            <div className="flex items-center">
+              <div className="flex-1" />
+              <SectionHeader title="Move" />
+              <div className="flex-1 flex justify-end">
+                {renderLocalSpaceToggle()}
+              </div>
+            </div>
               <div className="pt-1.5 space-y-2">
                 <div className="grid grid-cols-3 gap-1 min-w-0">
                   <div className="min-w-0">
@@ -302,7 +342,13 @@ export function TransformControls({
 
           {/* ROTATE SECTION */}
           <div className="rounded-md border p-2" style={rotateCardStyle}>
-            <SectionHeader title="Rotate" />
+            <div className="flex items-center">
+              <div className="flex-1" />
+              <SectionHeader title="Rotate" />
+              <div className="flex-1 flex justify-end">
+                {renderLocalSpaceToggle()}
+              </div>
+            </div>
             <div className="pt-1.5 space-y-2">
                 <div className="grid grid-cols-3 gap-1 min-w-0">
                   <div className="min-w-0">

--- a/src/components/gizmo/TransformGizmo.tsx
+++ b/src/components/gizmo/TransformGizmo.tsx
@@ -689,6 +689,7 @@ export function TransformGizmo({
               interactionsEnabled={partIsInteractable('scale-x')}
               isUniform={uniformScaling}
               gizmoPosition={posVec}
+              worldAxisDir={worldAxisDirs.x}
               onDragStart={(isUniform: boolean) => handleDragStart('scale-x', isUniform)}
               onDrag={(factor: number, isUniform: boolean) => handleScaleDrag('x', factor, isUniform)}
               onDragEnd={handleDragEnd}
@@ -708,6 +709,7 @@ export function TransformGizmo({
               interactionsEnabled={partIsInteractable('scale-y')}
               isUniform={uniformScaling}
               gizmoPosition={posVec}
+              worldAxisDir={worldAxisDirs.y}
               onDragStart={(isUniform: boolean) => handleDragStart('scale-y', isUniform)}
               onDrag={(factor: number, isUniform: boolean) => handleScaleDrag('y', factor, isUniform)}
               onDragEnd={handleDragEnd}
@@ -727,6 +729,7 @@ export function TransformGizmo({
               interactionsEnabled={partIsInteractable('scale-z')}
               isUniform={uniformScaling}
               gizmoPosition={posVec}
+              worldAxisDir={worldAxisDirs.z}
               onDragStart={(isUniform: boolean) => handleDragStart('scale-z', isUniform)}
               onDrag={(factor: number, isUniform: boolean) => handleScaleDrag('z', factor, isUniform)}
               onDragEnd={handleDragEnd}

--- a/src/components/gizmo/move/GizmoMove.tsx
+++ b/src/components/gizmo/move/GizmoMove.tsx
@@ -78,7 +78,17 @@ export function GizmoMove({
   const axisDeltaRef = useRef(new THREE.Vector3());
   const scratchAxisDirRef = useRef(new THREE.Vector3());
   const scratchAxisToRayRef = useRef(new THREE.Vector3());
+  const scratchCameraOffsetRef = useRef(new THREE.Vector3());
   const { camera, gl } = useThree();
+
+  // World-space axis direction. Falls back to hardcoded world axis when
+  // worldAxisDir prop is not provided (existing behavior with no rotation).
+  const axisDirection = useMemo(() => {
+    if (worldAxisDir) return worldAxisDir.clone();
+    if (axis === 'x') return new THREE.Vector3(1, 0, 0);
+    if (axis === 'y') return new THREE.Vector3(0, 1, 0);
+    return new THREE.Vector3(0, 0, 1);
+  }, [axis, worldAxisDir]);
 
   const pickMeshRef = useRef<THREE.Group>(null);
   const pickIdRef = useRef<number | null>(null);
@@ -112,9 +122,17 @@ export function GizmoMove({
   const headRadius = Math.max(0.03, GIZMO_SIZES.arrowHeadRadius * moveHandleThicknessScale);
   const headLength = Math.max(0.08, GIZMO_SIZES.arrowHeadLength * moveHandleLengthScale);
 
-  const shouldFlipX = axis === 'x' && !disableArrowFlip && (camera.position.x - gizmoPosition.x > 0);
-  const shouldFlipY = axis === 'y' && !disableArrowFlip && (camera.position.y - gizmoPosition.y > 0);
-  const shouldFlipZ = axis === 'z' && !disableArrowFlip && (camera.position.z - gizmoPosition.z > 0);
+  // An arrow sits on whichever side of the model the camera is on, so it never
+  // hides behind the mesh. Which side that is has to be asked of the direction the
+  // arrow really points: in the model's own frame, comparing world components
+  // would answer for an axis this arrow does not follow.
+  const pointsTowardCamera = axisDirection.dot(
+    scratchCameraOffsetRef.current.subVectors(camera.position, gizmoPosition),
+  ) > 0;
+
+  const shouldFlipX = axis === 'x' && !disableArrowFlip && pointsTowardCamera;
+  const shouldFlipY = axis === 'y' && !disableArrowFlip && pointsTowardCamera;
+  const shouldFlipZ = axis === 'z' && !disableArrowFlip && pointsTowardCamera;
 
   const positiveAxisRotation: [number, number, number] =
     axis === 'x' ? [0, 0, -Math.PI / 2]
@@ -208,15 +226,6 @@ export function GizmoMove({
     e.stopPropagation();
     onPointerLeave();
   };
-
-  // World-space axis direction. Falls back to hardcoded world axis when
-  // worldAxisDir prop is not provided (existing behavior with no rotation).
-  const axisDirection = useMemo(() => {
-    if (worldAxisDir) return worldAxisDir.clone();
-    if (axis === 'x') return new THREE.Vector3(1, 0, 0);
-    if (axis === 'y') return new THREE.Vector3(0, 1, 0);
-    return new THREE.Vector3(0, 0, 1);
-  }, [axis, worldAxisDir]);
 
   useEffect(() => {
     if (!isDragging) return;

--- a/src/components/gizmo/rotate/GizmoRotation.tsx
+++ b/src/components/gizmo/rotate/GizmoRotation.tsx
@@ -344,6 +344,17 @@ export function GizmoRotation({
   const getCameraAlignedAngle = useCallback(() => {
     const cameraDir = new THREE.Vector3().subVectors(camera.position, gizmoPosition).normalize();
 
+    // Where the camera is IN THE RING'S OWN FRAME. The per-axis formulas below say
+    // the same thing for a world-aligned gizmo, but only this reading survives a
+    // gizmo whose frame is the model's own (local space), where the ring's plane
+    // has nothing to do with the world axes.
+    const ringGroup = ringGroupRef.current;
+    if (ringGroup) {
+      const ringBasis = new THREE.Matrix4().extractRotation(ringGroup.matrixWorld).invert();
+      const cameraDirInRing = cameraDir.clone().applyMatrix4(ringBasis);
+      return Math.atan2(cameraDirInRing.y, cameraDirInRing.x);
+    }
+
     if (axis === 'x') {
       return Math.atan2(cameraDir.z, cameraDir.y) + Math.PI / 2;
     }

--- a/src/components/gizmo/scale/GizmoScale.tsx
+++ b/src/components/gizmo/scale/GizmoScale.tsx
@@ -20,6 +20,12 @@ interface GizmoScaleProps {
   interactionsEnabled?: boolean;
   isUniform?: boolean;
   gizmoPosition: THREE.Vector3;
+  /**
+   * World-space direction for this axis. When the gizmo parent group is rotated,
+   * the hardcoded local-axis direction no longer matches the visual handle.
+   * Falls back to world X/Y/Z when not provided.
+   */
+  worldAxisDir?: THREE.Vector3;
   onDragStart: (isUniform: boolean) => boolean | void;
   onDrag: (factor: number, isUniform: boolean) => void;
   onDragEnd: () => void;
@@ -41,6 +47,7 @@ export function GizmoScale({
   interactionsEnabled = true,
   isUniform: isUniformProp = true,
   gizmoPosition,
+  worldAxisDir,
   onDragStart,
   onDrag,
   onDragEnd,
@@ -51,6 +58,7 @@ export function GizmoScale({
   const [isUniformScale, setIsUniformScale] = useState(false);
   const startDistance = useRef<number>(0);
   const startDirectionRef = useRef(new THREE.Vector2(1, 0));
+  const scratchCameraOffsetRef = useRef(new THREE.Vector3());
   const { camera, gl } = useThree();
 
   // GPU Picking registration
@@ -88,18 +96,30 @@ export function GizmoScale({
   // Get colors for this axis
   const axisColors = axis === 'x' ? GIZMO_COLORS.xAxis : axis === 'y' ? GIZMO_COLORS.yAxis : GIZMO_COLORS.zAxis;
 
-  const shouldFlipX = axis === 'x' && (camera.position.x - gizmoPosition.x > 0);
-  const shouldFlipY = axis === 'y' && (camera.position.y - gizmoPosition.y > 0);
-  const shouldFlipZ = axis === 'z' && (camera.position.z - gizmoPosition.z > 0);
+  // The handle sits on whichever side of the model the camera is on, the same rule
+  // the move arrow follows so the two never end up on opposite sides. Which side
+  // that is has to be asked of the direction the axis really points: in the model's
+  // own frame, comparing world components would answer for a different axis.
+  const axisDirection = useMemo(() => {
+    if (worldAxisDir) return worldAxisDir.clone();
+    if (axis === 'x') return new THREE.Vector3(1, 0, 0);
+    if (axis === 'y') return new THREE.Vector3(0, 1, 0);
+    return new THREE.Vector3(0, 0, 1);
+  }, [axis, worldAxisDir]);
+
+  const pointsTowardCamera = axisDirection.dot(
+    scratchCameraOffsetRef.current.subVectors(camera.position, gizmoPosition),
+  ) > 0;
 
   // Position for each axis (at end of line) with camera-relative flipping
   const length = GIZMO_SIZES.scaleLineLength;
+  const offset = pointsTowardCamera ? length : -length;
   const position: [number, number, number] =
     axis === 'x'
-      ? [shouldFlipX ? length : -length, 0, 0]
+      ? [offset, 0, 0]
       : axis === 'y'
-      ? [0, shouldFlipY ? length : -length, 0]
-      : [0, 0, shouldFlipZ ? length : -length];
+      ? [0, offset, 0]
+      : [0, 0, offset];
 
   // Rotate hexagon to face perpendicular to axis
   const rotation: [number, number, number] =

--- a/src/components/organisms/panels/PreparePanelStack.tsx
+++ b/src/components/organisms/panels/PreparePanelStack.tsx
@@ -48,6 +48,8 @@ export type PreparePanelStackProps = {
   scheduleCommitPendingTransformHistory: (frameDelay?: number) => void;
   uniformScaling: boolean;
   setUniformScaling: (value: boolean) => void;
+  localTransformSpace: boolean;
+  setLocalTransformSpace: (value: boolean) => void;
 
   isApplyingHolePunch: boolean;
   interiorView: boolean;
@@ -89,6 +91,8 @@ export function PreparePanelStack({
   scheduleCommitPendingTransformHistory,
   uniformScaling,
   setUniformScaling,
+  localTransformSpace,
+  setLocalTransformSpace,
   isApplyingHolePunch,
   interiorView,
   hasCavityGeometry,
@@ -261,6 +265,8 @@ export function PreparePanelStack({
           onResetScale={transformMgr.transformHook.resetScale}
           uniformScaling={uniformScaling}
           onUniformScalingChange={setUniformScaling}
+          localSpace={localTransformSpace}
+          onLocalSpaceChange={setLocalTransformSpace}
           modelBBox={scene.geom.bbox}
           autoLift={transformMgr.autoLift}
           onAutoLiftChange={handleAutoLiftChange}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -6106,9 +6106,6 @@ export function SceneCanvas({
                     (isMultiGizmoSelection ? (multiGizmoCenter?.z ?? activeModelTransform?.position.z) : activeModelTransform?.position.z) ?? 0,
                   ]}
                   rotation={gizmoFrameRotation}
-                  // A flipped arrow is decided from the world axes, so in the model's
-                  // frame it would point down an axis that is not the one it drags.
-                  disableArrowFlip={gizmoUsesLocalFrame}
                   enableMove
                   enableRotate={!isMultiGizmoSelection}
                   enableScale

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -339,6 +339,7 @@ export function SceneCanvas({
   transformMode,
   transform,
   uniformScaling = true,
+  localTransformSpace = false,
   autoLift = false,
   liftDistance = 5,
   autoSnapEnabled = true,
@@ -461,6 +462,8 @@ export function SceneCanvas({
   transformMode?: TransformMode;
   transform?: ModelTransform;
   uniformScaling?: boolean;
+  /** Drive the transform gizmo in the model's own frame instead of the world axes. */
+  localTransformSpace?: boolean;
   autoLift?: boolean;
   liftDistance?: number;
   autoSnapEnabled?: boolean;
@@ -3184,6 +3187,42 @@ export function SceneCanvas({
     if (transform && activeModelId === activeModel.id) return transform;
     return activeModel.transform;
   }, [activeModel, transform, activeModelId]);
+
+  // Local space puts the gizmo in the model's own frame: its arrows point along the
+  // model's axes and its rings turn about them. A multi-selection has no single
+  // frame to borrow, so it stays on the world axes.
+  const gizmoUsesLocalFrame = localTransformSpace && !isMultiGizmoSelection;
+
+  const gizmoFrameQuaternion = React.useMemo(() => (
+    gizmoUsesLocalFrame && activeModelTransform
+      ? quaternionFromGlobalEuler(activeModelTransform.rotation)
+      : new THREE.Quaternion()
+  ), [activeModelTransform, gizmoUsesLocalFrame]);
+
+  const gizmoFrameRotation = React.useMemo<[number, number, number]>(() => {
+    // The gizmo group takes an XYZ-ordered Euler, so the model's global-axis
+    // rotation has to travel through a quaternion to arrive unchanged.
+    const frame = new THREE.Euler().setFromQuaternion(gizmoFrameQuaternion, 'XYZ');
+    return [frame.x, frame.y, frame.z];
+  }, [gizmoFrameQuaternion]);
+
+  /**
+   * Where a gizmo handle's axis points in world coordinates. Handles with no axis
+   * of their own (the centre nub) get a zero vector, which reads as horizontal.
+   */
+  const gizmoAxisWorldDirection = React.useCallback((axis?: 'x' | 'y' | 'z') => new THREE.Vector3(
+    axis === 'x' ? 1 : 0,
+    axis === 'y' ? 1 : 0,
+    axis === 'z' ? 1 : 0,
+  ).applyQuaternion(gizmoFrameQuaternion), [gizmoFrameQuaternion]);
+
+  /**
+   * The frame a rotation drag turns about, frozen at the grab. In local space that
+   * is the model's orientation when the drag started — and since a rotation about
+   * an axis leaves that same axis where it was, holding it for the whole gesture is
+   * exact, not an approximation. Identity in world space.
+   */
+  const gizmoRotationFrameRef = React.useRef(new THREE.Quaternion());
 
   const multiGizmoCenter = React.useMemo(() => {
     if (!isMultiGizmoSelection || selectedTransformableModelIds.length === 0) return null;
@@ -6066,7 +6105,10 @@ export function SceneCanvas({
                     (isMultiGizmoSelection ? (multiGizmoCenter?.y ?? activeModelTransform?.position.y) : activeModelTransform?.position.y) ?? 0,
                     (isMultiGizmoSelection ? (multiGizmoCenter?.z ?? activeModelTransform?.position.z) : activeModelTransform?.position.z) ?? 0,
                   ]}
-                  rotation={[0, 0, 0]}
+                  rotation={gizmoFrameRotation}
+                  // A flipped arrow is decided from the world axes, so in the model's
+                  // frame it would point down an axis that is not the one it drags.
+                  disableArrowFlip={gizmoUsesLocalFrame}
                   enableMove
                   enableRotate={!isMultiGizmoSelection}
                   enableScale
@@ -6119,7 +6161,13 @@ export function SceneCanvas({
                       setActiveGizmoDragDescriptor({ operation: 'move', axis });
                     if (activeModelId && activeModel) {
                       const sourceTransform = transform ?? activeModel.transform;
-                      dragMoveLockZEnabledRef.current = axis !== 'z';
+                      // Dragging an in-plane arrow pins the height, so a sideways drag
+                      // can't drift off the plate. In the model's own frame those arrows
+                      // tilt out of the plate's plane, so ask the axis this drag actually
+                      // follows: pin the height only while it really is horizontal.
+                      dragMoveLockZEnabledRef.current = Math.abs(
+                        gizmoAxisWorldDirection(axis).z,
+                      ) < 1e-6;
                       dragMoveLockedZRef.current = sourceTransform.position.z;
                       const idsForCage = isMultiGizmoSelection
                         ? selectedTransformableModelIds
@@ -6255,6 +6303,9 @@ export function SceneCanvas({
                           : axis === 'y'
                             ? new THREE.Vector3(0, 1, 0)
                             : new THREE.Vector3(0, 0, 1);
+                      // In local space the ring's axis is the model's, so carry it into
+                      // world coordinates before turning about it.
+                      rotationAxis.applyQuaternion(gizmoRotationFrameRef.current);
                       const quaternion = new THREE.Quaternion().setFromAxisAngle(rotationAxis, -angle);
                       activeGroupRef.current.quaternion.premultiply(quaternion);
                       applySupportGroupDelta();
@@ -6276,6 +6327,7 @@ export function SceneCanvas({
                   onRotateStart={(axis) => {
                     stopActiveModelDropAnimation();
                     captureGizmoDragBeforeMatrix();
+                    gizmoRotationFrameRef.current.copy(gizmoFrameQuaternion);
                     const shouldProceed = onTransformStart?.('rotate', { axis });
                     if (shouldProceed === false) return false;
                     setActiveGizmoDragDescriptor({ operation: 'rotate', axis });

--- a/src/hotkeys/hotkeyConfig.ts
+++ b/src/hotkeys/hotkeyConfig.ts
@@ -85,6 +85,11 @@ export const DEFAULT_KEYBINDINGS: HotkeyConfig = {
             key: 'm',
             description: 'Switch canvas tool to Modify'
         },
+        TOOL_MODIFY_LOCAL: {
+            key: 'm',
+            modifier: 'shift',
+            description: 'Switch canvas tool to Modify with the gizmo in the model\'s own axes'
+        },
         TOOL_SMOOTH: {
             key: 's',
             description: 'Switch canvas tool to Smooth'

--- a/src/hotkeys/usePrepareTransformHotkeys.ts
+++ b/src/hotkeys/usePrepareTransformHotkeys.ts
@@ -8,6 +8,7 @@ type UsePrepareTransformHotkeysParams = {
   hasModels: boolean;
   transformMode: TransformMode;
   setTransformMode: (mode: TransformMode) => void;
+  setLocalTransformSpace: (value: boolean) => void;
   onArrangeAll: () => void;
 };
 
@@ -16,6 +17,7 @@ export function usePrepareTransformHotkeys({
   hasModels,
   transformMode,
   setTransformMode,
+  setLocalTransformSpace,
   onArrangeAll,
 }: UsePrepareTransformHotkeysParams) {
   useEffect(() => {
@@ -24,6 +26,7 @@ export function usePrepareTransformHotkeys({
 
     let wasSelectActive = false;
     let wasModifyActive = false;
+    let wasModifyLocalActive = false;
     let wasSmoothActive = false;
     let wasArrangeActive = false;
     let wasDuplicateActive = false;
@@ -32,6 +35,7 @@ export function usePrepareTransformHotkeys({
     const unsubscribe = hotkeyStore.subscribe(() => {
       const isSelectActive = isActionActiveSync('CANVAS', 'TOOL_SELECT');
       const isModifyActive = isActionActiveSync('CANVAS', 'TOOL_MODIFY');
+      const isModifyLocalActive = isActionActiveSync('CANVAS', 'TOOL_MODIFY_LOCAL');
       const isSmoothActive = isActionActiveSync('CANVAS', 'TOOL_SMOOTH');
       const isArrangeActive = isActionActiveSync('CANVAS', 'TOOL_ARRANGE');
       const isDuplicateActive = isActionActiveSync('CANVAS', 'TOOL_DUPLICATE');
@@ -40,6 +44,11 @@ export function usePrepareTransformHotkeys({
       if (isSelectActive && !wasSelectActive) {
         setTransformMode('select');
       } else if (isModifyActive && !wasModifyActive) {
+        // Modify on the build plate's axes; the shifted twin below takes the model's.
+        setLocalTransformSpace(false);
+        setTransformMode('transform');
+      } else if (isModifyLocalActive && !wasModifyLocalActive) {
+        setLocalTransformSpace(true);
         setTransformMode('transform');
       } else if (isSmoothActive && !wasSmoothActive) {
         setTransformMode('smoothing');
@@ -57,6 +66,7 @@ export function usePrepareTransformHotkeys({
 
       wasSelectActive = isSelectActive;
       wasModifyActive = isModifyActive;
+      wasModifyLocalActive = isModifyLocalActive;
       wasSmoothActive = isSmoothActive;
       wasArrangeActive = isArrangeActive;
       wasDuplicateActive = isDuplicateActive;
@@ -64,5 +74,5 @@ export function usePrepareTransformHotkeys({
     });
 
     return unsubscribe;
-  }, [appMode, hasModels, transformMode, setTransformMode, onArrangeAll]);
+  }, [appMode, hasModels, transformMode, setTransformMode, setLocalTransformSpace, onArrangeAll]);
 }


### PR DESCRIPTION
The transform gizmo can now take the active model's orientation as its
frame, so a leaning model spins about its own axis instead of the plate's.
Toggle it with the Local button on the Move and Rotate cards, or enter
Modify with Shift+M (plain M keeps the world axes).

Closes #504.