### PR TITLE
Fix release updater, add logs and proper errors

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1397,6 +1397,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "time",
  "tokio",
  "tokio-util",
  "tungstenite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,8 @@ tauri-plugin-single-instance = { version = "2", optional = true }
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 url = "2"
+# Only to hand the updater's OffsetDateTime to the frontend as RFC 3339.
+time = { version = "0.3", features = ["formatting"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 log = "0.4"

--- a/src-tauri/src/updater_channel.rs
+++ b/src-tauri/src/updater_channel.rs
@@ -174,8 +174,14 @@ pub async fn perform_update(
     };
 
     let Some(update) = update else {
+        warn!("[updater] perform_update called with no cached update");
         return Err("No cached update. Call check_updates first.".into());
     };
+
+    info!(
+        "[updater] perform_update starting: version={} url={}",
+        update.version, update.download_url
+    );
 
     // Emit a Started progress event.
     let _ = on_chunk.send(PerformUpdateProgress {
@@ -184,18 +190,25 @@ pub async fn perform_update(
         phase: "downloading".into(),
     });
 
+    // The plugin reports the length of each chunk, not the running total.
+    let downloaded = std::sync::atomic::AtomicU64::new(0);
+
     // The plugin's Update::download_and_install handles the whole flow:
     // download → verify signature → launch installer → exit app.
     update
         .download_and_install(
             |chunk_len, total_len| {
+                let total = downloaded
+                    .fetch_add(chunk_len as u64, std::sync::atomic::Ordering::Relaxed)
+                    + chunk_len as u64;
                 let _ = on_chunk.send(PerformUpdateProgress {
-                    downloaded_bytes: chunk_len as u64,
+                    downloaded_bytes: total,
                     total_bytes: total_len,
                     phase: "downloading".into(),
                 });
             },
             || {
+                info!("[updater] download complete — installing");
                 let _ = on_chunk.send(PerformUpdateProgress {
                     downloaded_bytes: 0,
                     total_bytes: None,
@@ -204,8 +217,12 @@ pub async fn perform_update(
             },
         )
         .await
-        .map_err(|e| format!("Update failed: {e}"))?;
+        .map_err(|e| {
+            warn!("[updater] download_and_install failed: {e}");
+            format!("Update failed: {e}")
+        })?;
 
+    info!("[updater] update installed successfully");
     Ok("Update installed successfully".into())
 }
 

--- a/src-tauri/src/updater_channel.rs
+++ b/src-tauri/src/updater_channel.rs
@@ -126,7 +126,11 @@ pub async fn check_updates(
             let version = update.version.clone();
             let current_version = update.current_version.clone();
             let body = update.body.clone();
-            let date = update.date.map(|d| d.to_string());
+            // RFC 3339, not Display: `time` renders as "2026-07-06 4:55:17.703
+            // +00:00:00", which `new Date()` on the frontend cannot parse.
+            let date = update
+                .date
+                .and_then(|d| d.format(&time::format_description::well_known::Rfc3339).ok());
             let download_url = Some(update.download_url.to_string());
 
             info!("[updater] Update available: current={current_version} → new={version} url={}", download_url.as_deref().unwrap_or("?"));

--- a/src/features/updater/GlobalUpdateIndicator.tsx
+++ b/src/features/updater/GlobalUpdateIndicator.tsx
@@ -157,8 +157,11 @@ export function GlobalUpdateIndicator() {
 
   // Format the release date in the app's own locale, not the browser's — the
   // language switcher must move the whole dialog, dates included.
-  const releaseDate = info?.date
-    ? new Date(info.date).toLocaleDateString(i18n.locale, { year: 'numeric', month: 'long', day: 'numeric' })
+  // An unparseable date yields "Invalid Date" from toLocaleDateString, so drop
+  // the subtitle entirely rather than showing that to the user.
+  const parsedDate = info?.date ? new Date(info.date) : null;
+  const releaseDate = parsedDate && !Number.isNaN(parsedDate.getTime())
+    ? parsedDate.toLocaleDateString(i18n.locale, { year: 'numeric', month: 'long', day: 'numeric' })
     : null;
   const subtitle = releaseDate ? _(msg`Released ${releaseDate}`) : undefined;
   const version = info?.version ?? '?';

--- a/src/features/updater/GlobalUpdateIndicator.tsx
+++ b/src/features/updater/GlobalUpdateIndicator.tsx
@@ -18,7 +18,7 @@ type IndicatorState =
   | { status: 'checking' }
   | { status: 'available'; info: UpdateInfo }
   | { status: 'downloading'; pct: number }
-  | { status: 'error' };
+  | { status: 'error'; message: string };
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -115,18 +115,20 @@ export function GlobalUpdateIndicator() {
     if (state.status !== 'available') return;
     setState({ status: 'downloading', pct: 0 });
 
-    const success = await downloadAndInstall((progress: DownloadProgress) => {
-      const pct =
-        progress.contentLength > 0
-          ? Math.round((progress.downloaded / progress.contentLength) * 100)
-          : 0;
-      setState({ status: 'downloading', pct });
-    });
-
-    if (!success) {
-      setState({ status: 'error' });
+    try {
+      await downloadAndInstall((progress: DownloadProgress) => {
+        const pct =
+          progress.contentLength > 0
+            ? Math.round((progress.downloaded / progress.contentLength) * 100)
+            : 0;
+        setState({ status: 'downloading', pct });
+      });
+      // On success the app relaunches.
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Unknown error installing the update.';
+      setState({ status: 'error', message });
     }
-    // On success the app relaunches.
   }, [state.status]);
 
   const handleDismiss = useCallback(() => {
@@ -153,6 +155,7 @@ export function GlobalUpdateIndicator() {
   const info = state.status === 'available' ? state.info : null;
   const isDownloading = state.status === 'downloading';
   const isError = state.status === 'error';
+  const errorMessage = state.status === 'error' ? state.message : null;
   const pct = state.status === 'downloading' ? state.pct : 0;
 
   // Format the release date in the app's own locale, not the browser's — the
@@ -242,7 +245,10 @@ export function GlobalUpdateIndicator() {
             color: 'var(--danger)',
           }}
         >
-          <Trans>The update download or install failed. Please check your connection and try again.</Trans>
+          <Trans>The update download or install failed.</Trans>
+          {errorMessage && (
+            <div className="mt-1 font-mono text-[10px] opacity-80 break-all">{errorMessage}</div>
+          )}
         </div>
       )}
 

--- a/src/features/updater/updateBridge.ts
+++ b/src/features/updater/updateBridge.ts
@@ -5,7 +5,7 @@
  * Browser-mode calls return null gracefully.
  */
 
-import { invoke } from '@tauri-apps/api/core';
+import { Channel, invoke } from '@tauri-apps/api/core';
 import { relaunch } from '@tauri-apps/plugin-process';
 
 // ---------------------------------------------------------------------------
@@ -112,18 +112,46 @@ export async function fetchUpdateInfo(
 // Download + install (via Rust — uses cached Update)
 // ---------------------------------------------------------------------------
 
+/** Progress payload pushed by the Rust `perform_update` channel. */
+type PerformUpdateProgress = {
+  downloadedBytes: number;
+  totalBytes: number | null;
+  phase: string;
+};
+
 /**
  * Download and install the previously cached update.
  * The Rust side handles signature verification, installer launch, and exit.
+ *
+ * Throws with the real backend message on failure — the caller shows it.
  */
 export async function downloadAndInstall(
-  _onProgress?: (progress: DownloadProgress) => void,
-): Promise<boolean> {
+  onProgress?: (progress: DownloadProgress) => void,
+): Promise<void> {
+  if (!isTauriAvailable()) {
+    throw new Error('Updates are only available in the desktop app.');
+  }
+
+  // `perform_update` takes a Channel. Invoking without it fails argument
+  // deserialization before the command body runs at all, so the channel is
+  // what makes the call reach Rust — not just what reports progress.
+  const onChunk = new Channel<PerformUpdateProgress>();
+  onChunk.onmessage = ({ downloadedBytes, totalBytes, phase }) => {
+    console.log(`[updater] ${phase}: ${downloadedBytes}/${totalBytes ?? '?'} bytes`);
+    onProgress?.({ contentLength: totalBytes ?? 0, downloaded: downloadedBytes });
+  };
+
   try {
-    await invoke('perform_update');
+    await invoke('perform_update', { onChunk });
+  } catch (err) {
+    console.error('[updater] perform_update failed:', err);
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+
+  try {
     await relaunch();
-    return true;
-  } catch {
-    return false;
+  } catch (err) {
+    console.error('[updater] relaunch after install failed:', err);
+    throw err instanceof Error ? err : new Error(String(err));
   }
 }

--- a/src/features/updater/useUpdateChecker.ts
+++ b/src/features/updater/useUpdateChecker.ts
@@ -84,18 +84,18 @@ export function useUpdateChecker() {
   const handleDownloadAndInstall = useCallback(async () => {
     setState({ status: 'downloading', progress: { contentLength: 0, downloaded: 0 } });
 
-    const success = await downloadAndInstall((progress: DownloadProgress) => {
-      setState({ status: 'downloading', progress });
-    });
-
-    if (success) {
+    try {
+      await downloadAndInstall((progress: DownloadProgress) => {
+        setState({ status: 'downloading', progress });
+      });
       // The app should relaunch — if we get here, show installed state.
       setState({ status: 'installed' });
-    } else {
-      setState({
-        status: 'error',
-        message: 'Download or install failed. Please try again.',
-      });
+    } catch (err) {
+      // Show what actually broke. A generic "check your connection" hides
+      // failures that have nothing to do with the network.
+      const message =
+        err instanceof Error ? err.message : 'Unknown error installing the update.';
+      setState({ status: 'error', message });
     }
   }, []);
 


### PR DESCRIPTION
The updater never worked. *facepalm*

`perform_update()` in Rust requests a progress channel:

`pub async fn perform_update(on_chunk: tauri::ipc::Channel<PerformUpdateProgress>)`

And our frontend calls it with no arguments, in `updateBridge.ts:122`:

`await invoke('perform_update');`

There's also a `try/catch` with a `return false` that hid the error, and a message using the wrong date format.
