### PR TITLE
fix: record model grouping actions in undo history

### DIFF
--- a/src/features/scene/__tests__/modelGroupingHistory.test.ts
+++ b/src/features/scene/__tests__/modelGroupingHistory.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  applyModelGrouping,
+  applyModelUngrouping,
+  applyModelGroupUngrouping,
+  type GroupableModel,
+} from '@/features/scene/modelGroupingHistory';
+
+const models: GroupableModel[] = [
+  { id: 'model-a', name: 'Alpha' },
+  { id: 'model-b', name: 'Beta' },
+  { id: 'model-c', name: 'Gamma', groupId: 'group-existing', groupName: 'Existing' },
+];
+
+test('applyModelGrouping reports a changed transition for undo history', () => {
+  const result = applyModelGrouping({
+    models,
+    modelIds: ['model-a', 'model-b'],
+    groupId: 'group-new',
+    activeModelId: null,
+    selectedModelIds: ['model-a'],
+  });
+
+  assert.equal(result.changed, true);
+  assert.equal(result.activeModelId, 'model-a');
+  assert.deepEqual(result.selectedModelIds, ['model-a', 'model-b']);
+  assert.equal(result.description, 'Group 2 Models');
+  assert.equal(result.models.find((model) => model.id === 'model-a')?.groupId, 'group-new');
+  assert.equal(result.models.find((model) => model.id === 'model-b')?.groupName, 'Alpha');
+});
+
+test('applyModelUngrouping reports a changed transition for undo history', () => {
+  const result = applyModelUngrouping({
+    models,
+    modelIds: ['model-c'],
+    activeModelId: 'model-c',
+    selectedModelIds: ['model-c'],
+  });
+
+  assert.equal(result.changed, true);
+  assert.equal(result.description, 'Ungroup Model Gamma');
+  assert.equal(result.models.find((model) => model.id === 'model-c')?.groupId, undefined);
+  assert.equal(result.models.find((model) => model.id === 'model-c')?.groupName, undefined);
+});
+
+test('applyModelGroupUngrouping reports a changed transition for undo history', () => {
+  const result = applyModelGroupUngrouping({
+    models,
+    groupId: 'group-existing',
+    activeModelId: 'model-c',
+    selectedModelIds: ['model-c'],
+  });
+
+  assert.equal(result.changed, true);
+  assert.equal(result.description, 'Ungroup Existing');
+  assert.equal(result.models.find((model) => model.id === 'model-c')?.groupId, undefined);
+});

--- a/src/features/scene/modelGroupingHistory.ts
+++ b/src/features/scene/modelGroupingHistory.ts
@@ -1,0 +1,144 @@
+export type GroupableModel = {
+  id: string;
+  name: string;
+  groupId?: string;
+  groupName?: string;
+};
+
+type GroupingTransition<T extends GroupableModel> = {
+  models: T[];
+  activeModelId: string | null;
+  selectedModelIds: string[];
+  changed: boolean;
+  groupId?: string;
+  description?: string;
+};
+
+export function applyModelGrouping<T extends GroupableModel>({
+  models,
+  modelIds,
+  groupId,
+  groupName,
+  activeModelId,
+  selectedModelIds,
+}: {
+  models: T[];
+  modelIds: string[];
+  groupId: string;
+  groupName?: string;
+  activeModelId: string | null;
+  selectedModelIds: string[];
+}): GroupingTransition<T> {
+  const ids = Array.from(new Set(modelIds));
+  if (ids.length === 0) {
+    return { models, activeModelId, selectedModelIds, changed: false };
+  }
+
+  const selected = models.filter((model) => ids.includes(model.id));
+  if (selected.length === 0) {
+    return { models, activeModelId, selectedModelIds, changed: false };
+  }
+
+  const commonGroupId = selected.every((model) => model.groupId && model.groupId === selected[0].groupId)
+    ? (selected[0].groupId ?? null)
+    : null;
+
+  const resolvedGroupId = commonGroupId ?? groupId;
+  const rawName = groupName?.trim();
+  const resolvedGroupName = rawName && rawName.length > 0
+    ? rawName
+    : (selected.find((model) => model.groupName?.trim())?.groupName ?? selected[0].name);
+
+  let changed = false;
+  const nextModels = models.map((model) => {
+    if (!ids.includes(model.id)) return model;
+    if (model.groupId === resolvedGroupId && model.groupName === resolvedGroupName) return model;
+    changed = true;
+    return {
+      ...model,
+      groupId: resolvedGroupId,
+      groupName: resolvedGroupName,
+    };
+  });
+
+  if (!changed) {
+    return { models, activeModelId, selectedModelIds, changed: false, groupId: resolvedGroupId };
+  }
+
+  return {
+    models: nextModels,
+    activeModelId: activeModelId ?? ids[0] ?? null,
+    selectedModelIds: Array.from(new Set([...selectedModelIds, ...ids])),
+    changed: true,
+    groupId: resolvedGroupId,
+    description: selected.length === 1 ? `Group Model ${selected[0].name}` : `Group ${selected.length} Models`,
+  };
+}
+
+export function applyModelUngrouping<T extends GroupableModel>({
+  models,
+  modelIds,
+  activeModelId,
+  selectedModelIds,
+}: {
+  models: T[];
+  modelIds: string[];
+  activeModelId: string | null;
+  selectedModelIds: string[];
+}): GroupingTransition<T> {
+  const ids = new Set(modelIds);
+  if (ids.size === 0) {
+    return { models, activeModelId, selectedModelIds, changed: false };
+  }
+
+  const affected = models.filter((model) => ids.has(model.id) && model.groupId);
+  if (affected.length === 0) {
+    return { models, activeModelId, selectedModelIds, changed: false };
+  }
+
+  const nextModels = models.map((model) => (
+    ids.has(model.id) && model.groupId
+      ? { ...model, groupId: undefined, groupName: undefined }
+      : model
+  ));
+
+  return {
+    models: nextModels,
+    activeModelId,
+    selectedModelIds,
+    changed: true,
+    description: affected.length === 1 ? `Ungroup Model ${affected[0].name}` : `Ungroup ${affected.length} Models`,
+  };
+}
+
+export function applyModelGroupUngrouping<T extends GroupableModel>({
+  models,
+  groupId,
+  activeModelId,
+  selectedModelIds,
+}: {
+  models: T[];
+  groupId: string;
+  activeModelId: string | null;
+  selectedModelIds: string[];
+}): GroupingTransition<T> {
+  const affected = models.filter((model) => model.groupId === groupId);
+  if (affected.length === 0) {
+    return { models, activeModelId, selectedModelIds, changed: false };
+  }
+
+  const nextModels = models.map((model) => (
+    model.groupId === groupId
+      ? { ...model, groupId: undefined, groupName: undefined }
+      : model
+  ));
+  const groupName = affected.find((model) => model.groupName?.trim())?.groupName?.trim();
+
+  return {
+    models: nextModels,
+    activeModelId,
+    selectedModelIds,
+    changed: true,
+    description: groupName ? `Ungroup ${groupName}` : `Ungroup ${affected.length} Models`,
+  };
+}

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -42,6 +42,11 @@ import {
   storeModelMeshModifiers,
 } from '@/features/mesh-modifiers/meshModifierStore';
 import { splitClassifiedSupportGeometry } from '@/features/scene/splitClassifiedSupports';
+import {
+  applyModelGrouping,
+  applyModelGroupUngrouping,
+  applyModelUngrouping,
+} from '@/features/scene/modelGroupingHistory';
 
 type PersistedMeshAppearance = {
   v: 1;
@@ -3146,65 +3151,67 @@ export function useSceneCollectionManager() {
   }, []);
 
   const groupModels = useCallback((modelIds: string[], groupName?: string) => {
-    const ids = Array.from(new Set(modelIds));
-    if (ids.length === 0) return null;
-
-    let resolvedGroupId: string | null = null;
-    let resolvedGroupName: string | null = null;
-
-    setModels((prev) => {
-      const selected = prev.filter((model) => ids.includes(model.id));
-      if (selected.length === 0) return prev;
-
-      const commonGroupId = selected.every((model) => model.groupId && model.groupId === selected[0].groupId)
-        ? (selected[0].groupId ?? null)
-        : null;
-
-      resolvedGroupId = commonGroupId ?? `group-${uuidv4()}`;
-      const rawName = groupName?.trim();
-      resolvedGroupName = rawName && rawName.length > 0
-        ? rawName
-        : (selected.find((model) => model.groupName?.trim())?.groupName ?? selected[0].name);
-
-      return prev.map((model) => {
-        if (!ids.includes(model.id)) return model;
-        return {
-          ...model,
-          groupId: resolvedGroupId ?? undefined,
-          groupName: resolvedGroupName ?? undefined,
-        };
-      });
+    const currentModels = modelsRef.current;
+    const currentActiveModelId = activeModelIdRef.current;
+    const currentSelectedModelIds = selectedModelIdsRef.current;
+    const before = captureSceneSnapshot(currentModels, currentActiveModelId, currentSelectedModelIds);
+    const transition = applyModelGrouping({
+      models: currentModels,
+      modelIds,
+      groupId: `group-${uuidv4()}`,
+      groupName,
+      activeModelId: currentActiveModelId,
+      selectedModelIds: currentSelectedModelIds,
     });
 
-    if (resolvedGroupId) {
-      setSelectedModelIds((prev) => {
-        const next = Array.from(new Set([...prev, ...ids]));
-        return next;
-      });
-      setActiveModelId((prev) => prev ?? ids[0] ?? null);
-    }
+    if (!transition.changed) return transition.groupId ?? null;
 
-    return resolvedGroupId;
-  }, []);
+    setModels(transition.models);
+    setActiveModelId(transition.activeModelId);
+    setSelectedModelIds(transition.selectedModelIds);
+
+    const after = captureSceneSnapshot(transition.models, transition.activeModelId, transition.selectedModelIds);
+    pushSceneSnapshotHistory(before, after, transition.description);
+    return transition.groupId ?? null;
+  }, [pushSceneSnapshotHistory]);
 
   const ungroupModels = useCallback((modelIds: string[]) => {
-    const ids = new Set(modelIds);
-    if (ids.size === 0) return;
+    const currentModels = modelsRef.current;
+    const currentActiveModelId = activeModelIdRef.current;
+    const currentSelectedModelIds = selectedModelIdsRef.current;
+    const before = captureSceneSnapshot(currentModels, currentActiveModelId, currentSelectedModelIds);
+    const transition = applyModelUngrouping({
+      models: currentModels,
+      modelIds,
+      activeModelId: currentActiveModelId,
+      selectedModelIds: currentSelectedModelIds,
+    });
 
-    setModels((prev) => prev.map((model) => (
-      ids.has(model.id)
-        ? { ...model, groupId: undefined, groupName: undefined }
-        : model
-    )));
-  }, []);
+    if (!transition.changed) return;
+
+    setModels(transition.models);
+    const after = captureSceneSnapshot(transition.models, transition.activeModelId, transition.selectedModelIds);
+    pushSceneSnapshotHistory(before, after, transition.description);
+  }, [pushSceneSnapshotHistory]);
 
   const ungroupGroup = useCallback((groupId: string) => {
-    setModels((prev) => prev.map((model) => (
-      model.groupId === groupId
-        ? { ...model, groupId: undefined, groupName: undefined }
-        : model
-    )));
-  }, []);
+    const currentModels = modelsRef.current;
+    const currentActiveModelId = activeModelIdRef.current;
+    const currentSelectedModelIds = selectedModelIdsRef.current;
+    const before = captureSceneSnapshot(currentModels, currentActiveModelId, currentSelectedModelIds);
+    const transition = applyModelGroupUngrouping({
+      models: currentModels,
+      groupId,
+      activeModelId: currentActiveModelId,
+      selectedModelIds: currentSelectedModelIds,
+    });
+
+    if (!transition.changed) return;
+
+    setModels(transition.models);
+    const after = captureSceneSnapshot(transition.models, transition.activeModelId, transition.selectedModelIds);
+    pushSceneSnapshotHistory(before, after, transition.description);
+  }, [pushSceneSnapshotHistory]);
 
   /** Splits a multi-body 3MF model into independent models using the
    *  pre-processed `splitBodies` geometries. Instant — no reprocessing. */


### PR DESCRIPTION
## Summary
- record before/after scene snapshots for model grouping, selected-model ungrouping, and whole-group ungrouping
- extract the grouping transitions into a small testable helper while preserving the existing state and selection behavior
- add regression coverage for each grouping transition

Fixes #528.

## Verification
- `node --import tsx --test src/features/scene/__tests__/modelGroupingHistory.test.ts`
- `npx tsc --noEmit`
- `npx eslint src/features/scene/modelGroupingHistory.ts src/features/scene/__tests__/modelGroupingHistory.test.ts`
- `npm run check:generated-plugin-registry`
- `npm run check:plugin-allowlist`
- `npm run guard:plugin-boundaries`

`npm test` retains two existing failures in the field-deterministic and potential-field support solver tests; the same two failures reproduce on clean upstream. The new focused regression test passes.
