### PR TITLE
feat: Drag on Select

### DIFF
--- a/src/components/scene/SceneCanvas/ModelAttachedSupportLayer.tsx
+++ b/src/components/scene/SceneCanvas/ModelAttachedSupportLayer.tsx
@@ -33,6 +33,9 @@ export type ModelAttachedSupportLayerProps = {
   raftColorized?: boolean;
   raftHoverized?: boolean;
   onModelPointerSelect?: (modelId: string) => void;
+  /** In Select mode, a pointer-down on a support/raft reports a potential model
+   *  XY-drag start (model + screen coords). The scene owns the drag. */
+  onModelPointerDragStart?: (modelId: string, clientX: number, clientY: number) => void;
   ghostOpacity?: number;
   ghostRenderOrder?: number;
   supportRendererRef?: React.Ref<THREE.Group>;
@@ -83,6 +86,7 @@ export function ModelAttachedSupportLayer({
   raftColorized = true,
   raftHoverized = false,
   onModelPointerSelect,
+  onModelPointerDragStart,
   ghostOpacity,
   ghostRenderOrder,
   supportRendererRef,
@@ -122,6 +126,7 @@ export function ModelAttachedSupportLayer({
           ghostOpacity={ghostOpacity}
           ghostRenderOrder={ghostRenderOrder}
           onModelPointerSelect={onModelPointerSelect}
+          onModelPointerDragStart={onModelPointerDragStart}
           enablePointerSelection={proxyPointerSelectionEnabled}
           colorized={raftColorized}
           hoverized={raftHoverized}
@@ -189,6 +194,7 @@ export function ModelAttachedSupportLayer({
             outOfBoundsMax={outOfBoundsMax}
             outOfBoundsStripeColor={outOfBoundsStripeColor}
             onModelPointerSelect={onModelPointerSelect}
+            onModelPointerDragStart={onModelPointerDragStart}
             enablePointerSelection={proxyPointerSelectionEnabled}
             includeDetailedPrimitives={proxyIncludeDetailedPrimitives}
             interiorView={interiorView}

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -924,6 +924,10 @@ export function SceneCanvas({
   const effectiveModelSelected = isModelSelected || !!activeModelId;
   const [isGizmoDragging, setIsGizmoDragging] = React.useState(false);
   const [isGizmoRetargeting, setIsGizmoRetargeting] = React.useState(false);
+  // True from the moment a Select-mode model is pressed until the pointer is
+  // released. Drives the bounding-box corner cage, which appears on grab (before
+  // any movement) rather than only once the model is actually moving.
+  const [selectDragPressed, setSelectDragPressed] = React.useState(false);
   const [activeGizmoDragDescriptor, setActiveGizmoDragDescriptor] = React.useState<{
     operation: 'move' | 'rotate' | 'scale';
     axis?: 'x' | 'y' | 'z' | 'uniform';
@@ -2129,6 +2133,14 @@ export function SceneCanvas({
       return transform;
     }
 
+    // Select mode: always report a transform while a model is active so its
+    // supports stay parented to its group (like Modify mode). Keeping them
+    // attached at all times — not just during a gesture — means the model and
+    // its supports never render in different layers, so they can't lag each other.
+    if (transformMode === 'select' && activeModelId && transform) {
+      return transform;
+    }
+
     if (transformMode === 'arrange' && transform) {
       return transform;
     }
@@ -2145,6 +2157,13 @@ export function SceneCanvas({
 
   const useActiveModelAttachedSupportProxy = React.useMemo(() => {
     if (mode !== 'prepare' || !activeModelId || !activeModelVisualSupportTransform) return false;
+
+    // Select mode: the active model's supports are ALWAYS parented to its group,
+    // so the model and its supports render in the same layer at every moment and
+    // can never lag each other during a drag (no press/drag/release transitions).
+    if (transformMode === 'select' && activeModelId) {
+      return true;
+    }
 
     // During live gizmo interaction, force active-model support attachment so
     // global support batching doesn't get dragged as a single cloud.
@@ -3379,6 +3398,15 @@ export function SceneCanvas({
 
   const dragCornerCageModelIds = React.useMemo(() => {
     if (mode !== 'prepare') return [] as string[];
+    // Modify mode shows the cage only while a gizmo drag is running; Select mode
+    // shows it from the moment the model is pressed (grabbed) through the end of
+    // the drag — not just while the model is actively moving — and it follows the
+    // model as it moves.
+    if (transformMode === 'select') {
+      if (!activeModelId) return [] as string[];
+      if (!selectDragPressed && !isGizmoDragging) return [] as string[];
+      return modelById.get(activeModelId)?.visible ? [activeModelId] : ([] as string[]);
+    }
     if (transformMode !== 'transform') return [] as string[];
     if (!isGizmoDragging || !activeModelId) return [] as string[];
 
@@ -3390,7 +3418,7 @@ export function SceneCanvas({
       const model = modelById.get(modelId);
       return !!model?.visible;
     });
-  }, [activeModelId, isGizmoDragging, isMultiGizmoSelection, mode, modelById, selectedTransformableModelIds, transformMode]);
+  }, [activeModelId, isGizmoDragging, isMultiGizmoSelection, mode, modelById, selectDragPressed, selectedTransformableModelIds, transformMode]);
 
   const updateDragCornerCagesNow = React.useCallback(() => {
     if (dragCornerCageModelIds.length === 0) {
@@ -5291,6 +5319,303 @@ export function SceneCanvas({
     };
   }, []);
 
+  // ── Select-mode model drag ────────────────────────────────────────────────
+  // In Select mode, pressing a model and dragging moves it on the world XY
+  // plane — the same plane the Modify-mode center disc drags on — while a plain
+  // click still just selects. Pointer-down only records a candidate; the drag
+  // actually begins once the pointer crosses a small threshold, by which time
+  // the click-to-select state has flushed and the newly selected model is active.
+  const SELECT_DRAG_START_DIST_SQ = 25; // ~5px of travel before a press becomes a move
+  const selectDragCandidateRef = React.useRef<{
+    modelId: string;
+    clientX: number;
+    clientY: number;
+  } | null>(null);
+  const selectDragActiveRef = React.useRef(false);
+  const selectDragPlaneRef = React.useRef<THREE.Plane | null>(null);
+  const selectDragLastPointRef = React.useRef<THREE.Vector3 | null>(null);
+  const selectDragStartSnapshotRef = React.useRef<ModelTransform | null>(null);
+  const selectDragRaycasterRef = React.useRef(new THREE.Raycaster());
+  const selectDragIntersectionRef = React.useRef(new THREE.Vector3());
+  const selectDragDeltaRef = React.useRef(new THREE.Vector3());
+  const selectDragNdcRef = React.useRef(new THREE.Vector2());
+
+  // Mirrors activeModelId synchronously so the deferred drag-begin can confirm
+  // the pointer-down model is the active one even when the effect closure is
+  // stale. Updated during render (a ref, not state) so a pointermove that lands
+  // right after the selection render sees the fresh value.
+  const selectDragActiveModelIdRef = React.useRef<string | null>(activeModelId);
+  if (selectDragActiveModelIdRef.current !== activeModelId) {
+    selectDragActiveModelIdRef.current = activeModelId;
+  }
+
+  const clearSelectDragCandidate = React.useCallback(() => {
+    selectDragCandidateRef.current = null;
+    selectDragActiveRef.current = false;
+    selectDragPlaneRef.current = null;
+    selectDragLastPointRef.current = null;
+    selectDragStartSnapshotRef.current = null;
+    setSelectDragPressed(false);
+  }, []);
+
+  const getSelectDragWorldPoint = React.useCallback((clientX: number, clientY: number): THREE.Vector3 | null => {
+    const plane = selectDragPlaneRef.current;
+    const canvas = rendererRef.current?.domElement;
+    const camera = cameraRef.current;
+    if (!plane || !canvas || !camera) return null;
+
+    const rect = canvas.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
+
+    const ndc = selectDragNdcRef.current;
+    ndc.set(
+      ((clientX - rect.left) / rect.width) * 2 - 1,
+      -((clientY - rect.top) / rect.height) * 2 + 1,
+    );
+
+    const raycaster = selectDragRaycasterRef.current;
+    raycaster.setFromCamera(ndc, camera);
+
+    // Orthographic cameras: same origin push-back GizmoCenter uses so the drag
+    // plane always yields a forward (t>0) intersection (see GizmoCenter).
+    if ('isOrthographicCamera' in camera) {
+      raycaster.ray.origin.addScaledVector(raycaster.ray.direction, -100000);
+    }
+
+    const hit = raycaster.ray.intersectPlane(plane, selectDragIntersectionRef.current);
+    return hit ? selectDragIntersectionRef.current.clone() : null;
+  }, []);
+
+  const beginSelectDrag = React.useCallback((candidate: { modelId: string; clientX: number; clientY: number }): boolean => {
+    if (selectDragActiveModelIdRef.current !== candidate.modelId) return false;
+    if (isGizmoDragging || isOrbitInteracting || spaceMouseNavigationActive) return false;
+    if (!modelPickerEnabled || !cameraInteractionCycleEnabled) return false;
+
+    const model = modelById.get(candidate.modelId);
+    const group = meshRefs.current[candidate.modelId];
+    if (!model || !group) return false;
+
+    const shouldProceed = onTransformStart?.('move', { axis: undefined });
+    if (shouldProceed === false) return false;
+
+    stopActiveModelDropAnimation();
+
+    const sourceTransform = model.transform;
+
+    selectDragStartSnapshotRef.current = {
+      position: sourceTransform.position.clone(),
+      rotation: sourceTransform.rotation.clone(),
+      scale: sourceTransform.scale.clone(),
+    };
+
+    // Prime the bounding-box corner cage (same async prime the gizmo uses) so it
+    // can follow the model during the drag.
+    scheduleDragCornerCagePrime([candidate.modelId], sourceTransform);
+
+    const planeZ = sourceTransform.position.z;
+    selectDragPlaneRef.current = new THREE.Plane(new THREE.Vector3(0, 0, 1), -planeZ);
+
+    const initial = getSelectDragWorldPoint(candidate.clientX, candidate.clientY);
+    if (!initial) {
+      selectDragStartSnapshotRef.current = null;
+      selectDragPlaneRef.current = null;
+      return false;
+    }
+    selectDragLastPointRef.current = initial;
+
+    selectDragActiveRef.current = true;
+    setIsGizmoDragging(true);
+    return true;
+  }, [
+    cameraInteractionCycleEnabled,
+    getSelectDragWorldPoint,
+    isGizmoDragging,
+    isOrbitInteracting,
+    modelById,
+    modelPickerEnabled,
+    onTransformStart,
+    scheduleDragCornerCagePrime,
+    spaceMouseNavigationActive,
+    stopActiveModelDropAnimation,
+  ]);
+
+  const applySelectDragMove = React.useCallback((clientX: number, clientY: number) => {
+    const candidate = selectDragCandidateRef.current;
+    if (!candidate || !selectDragActiveRef.current) return;
+
+    const last = selectDragLastPointRef.current;
+    if (!last) return;
+    const worldPoint = getSelectDragWorldPoint(clientX, clientY);
+    if (!worldPoint) return;
+
+    const delta = selectDragDeltaRef.current.copy(worldPoint).sub(last);
+    // Constrain to the world XY plane, exactly like the Modify-mode center disc.
+    delta.z = 0;
+    if (delta.lengthSq() < 1e-12) return;
+
+    const group = meshRefs.current[candidate.modelId];
+    if (!group) return;
+
+    // Move the model imperatively. Its supports follow because the select drag
+    // activates the active-model support proxy (parented to the group), and the
+    // OTHER models' supports render in a static layer — so the shared drag group
+    // is deliberately NOT touched here. Applying it would shift every model's
+    // supports by this delta for a frame before they snap back.
+    group.position.add(delta);
+    const live = {
+      position: group.position.clone(),
+      rotation: new THREE.Euler().setFromQuaternion(group.quaternion, 'ZYX'),
+      scale: group.scale.clone(),
+    };
+    group.position.copy(live.position);
+    group.quaternion.copy(new THREE.Quaternion().setFromEuler(live.rotation));
+    group.scale.copy(live.scale);
+    queueLiveDragTransform({
+      position: live.position.clone(),
+      rotation: live.rotation.clone(),
+      scale: live.scale.clone(),
+    });
+    requestDragCornerCageUpdate();
+    last.copy(worldPoint);
+  }, [getSelectDragWorldPoint, queueLiveDragTransform, requestDragCornerCageUpdate]);
+
+  const finishSelectDrag = React.useCallback(() => {
+    const candidate = selectDragCandidateRef.current;
+    const wasActive = selectDragActiveRef.current;
+    const snapshot = selectDragStartSnapshotRef.current;
+    clearSelectDragCandidate();
+
+    if (!wasActive || !candidate) return;
+
+    // If the active model changed mid-gesture (should not happen while dragging,
+    // but be safe), abort without committing a transform to the wrong model.
+    if (selectDragActiveModelIdRef.current !== candidate.modelId) {
+      setIsGizmoDragging(false);
+      queueLiveDragTransform(null);
+      return;
+    }
+
+    const group = meshRefs.current[candidate.modelId];
+    const live = group
+      ? {
+          position: group.position.clone(),
+          rotation: new THREE.Euler().setFromQuaternion(group.quaternion, 'ZYX'),
+          scale: group.scale.clone(),
+        }
+      : null;
+
+    markGizmoDragEnded(true);
+
+    if (live && snapshot) {
+      if (onTransformChange) {
+        flushPendingTransformChange();
+        onTransformChange(live.position, live.rotation, live.scale);
+      }
+      onGizmoTransformCommit?.({
+        modelId: candidate.modelId,
+        operation: 'move',
+        before: snapshot,
+        after: {
+          position: live.position.clone(),
+          rotation: live.rotation.clone(),
+          scale: live.scale.clone(),
+        },
+      });
+    }
+
+    onTransformEnd?.('move', live ?? undefined);
+    queueLiveDragTransform(null);
+    setIsGizmoDragging(false);
+    // The cage is already drawn at the final live position by the last move
+    // update, and the primed base snapshot keeps the delta-matrix path valid for
+    // any later recompute, so nothing else needs to be done here.
+  }, [
+    clearSelectDragCandidate,
+    flushPendingTransformChange,
+    markGizmoDragEnded,
+    onGizmoTransformCommit,
+    onTransformChange,
+    onTransformEnd,
+    queueLiveDragTransform,
+  ]);
+
+  const handleSelectModeDragStart = React.useCallback((modelId: string, clientX: number, clientY: number) => {
+    selectDragCandidateRef.current = { modelId, clientX, clientY };
+    setSelectDragPressed(true);
+  }, []);
+
+  // Support/raft presses in Select mode also grab the model: select its model
+  // (so the drag targets it) then start the same XY drag as a model-mesh press.
+  const handleSelectModeSupportDragStart = React.useCallback((modelId: string, clientX: number, clientY: number) => {
+    if (mode !== 'prepare' || transformMode !== 'select') return;
+    if (!modelId) return;
+    if (onActiveModelChange) {
+      onActiveModelChange(modelId, { selectionMode: 'single' });
+    }
+    handleSelectModeDragStart(modelId, clientX, clientY);
+  }, [handleSelectModeDragStart, mode, onActiveModelChange, transformMode]);
+
+  // Window-level pointer tracking for the select-mode drag: candidate presses
+  // only start moving once the pointer crosses the drag threshold, and moves /
+  // release are followed globally so the drag survives leaving the mesh.
+  React.useEffect(() => {
+    if (mode !== 'prepare' || transformMode !== 'select') return;
+
+    const handleWindowPointerMove = (e: PointerEvent) => {
+      const candidate = selectDragCandidateRef.current;
+      if (!candidate) return;
+
+      // Only a held left button drives the model move — a right-button orbit
+      // started while the left press is still down must not drag the model.
+      if ((e.buttons & 1) === 0) {
+        if (selectDragActiveRef.current) finishSelectDrag();
+        return;
+      }
+
+      if (!selectDragActiveRef.current) {
+        const dx = e.clientX - candidate.clientX;
+        const dy = e.clientY - candidate.clientY;
+        if (dx * dx + dy * dy < SELECT_DRAG_START_DIST_SQ) return;
+        if (!beginSelectDrag(candidate)) {
+          clearSelectDragCandidate();
+          return;
+        }
+        // Let the isGizmoDragging render (which attaches the dragged model's
+        // supports to its group) land before the first move — the same cadence
+        // the gizmo uses, so supports never detach at the start of a drag.
+        return;
+      }
+
+      applySelectDragMove(e.clientX, e.clientY);
+    };
+
+    const handleWindowPointerUp = () => {
+      if (!selectDragCandidateRef.current && !selectDragActiveRef.current) return;
+      finishSelectDrag();
+    };
+
+    window.addEventListener('pointermove', handleWindowPointerMove);
+    window.addEventListener('pointerup', handleWindowPointerUp);
+    window.addEventListener('pointercancel', handleWindowPointerUp);
+    return () => {
+      window.removeEventListener('pointermove', handleWindowPointerMove);
+      window.removeEventListener('pointerup', handleWindowPointerUp);
+      window.removeEventListener('pointercancel', handleWindowPointerUp);
+    };
+  }, [
+    applySelectDragMove,
+    beginSelectDrag,
+    clearSelectDragCandidate,
+    finishSelectDrag,
+    mode,
+    transformMode,
+  ]);
+
+  React.useEffect(() => {
+    if (mode !== 'prepare' || transformMode !== 'select') return;
+    clearSelectDragCandidate();
+  }, [clearSelectDragCandidate, interactionResetNonce, mode, transformMode]);
+
   const [showCrossSectionCapDebugPanel, setShowCrossSectionCapDebugPanel] = React.useState(false);
   const [crossSectionCapDebugState, setCrossSectionCapDebugState] = React.useState<CrossSectionCapDebugPanelState>(
     DEFAULT_CROSS_SECTION_CAP_DEBUG_STATE,
@@ -5535,6 +5860,7 @@ export function SceneCanvas({
                       onSupportClick={onSupportClick}
                       onSupportHover={handleSupportHover}
                       onActiveModelChange={onActiveModelChange}
+                      onSelectModeDragStart={handleSelectModeDragStart}
                       disableRaycast={disableRaycast || !modelPickerEnabled || !cameraInteractionCycleEnabled}
                       blockSupportPlacement={!cameraInteractionCycleEnabled || isGizmoDragging || blockSupportPlacement}
                       suppressNextClickRef={suppressNextCanvasClickRef}
@@ -5570,7 +5896,7 @@ export function SceneCanvas({
                       deferExternalTransformUpdates={
                         isActive
                         && mode === 'prepare'
-                        && transformMode === 'transform'
+                        && (transformMode === 'transform' || transformMode === 'select')
                         && !!liveDragTransformRef.current
                         && (isGizmoDragging || isPostGizmoInteractionGuardActive)
                       }
@@ -5605,7 +5931,9 @@ export function SceneCanvas({
                             disableSelectionAndHover={suppressSupportProxyPointerInteraction}
                             raftColorized={raftColorized}
                             raftHoverized={raftHoverized}
-                            passive
+                            passive={transformMode !== 'select'}
+                            onModelPointerSelect={(modelId) => selectModelFromPointerHit(modelId)}
+                            onModelPointerDragStart={handleSelectModeSupportDragStart}
                             supportRenderRefreshNonce={supportRenderRefreshNonce}
                             showOutOfBoundsOverlay={showOutOfBoundsOverlay}
                             outOfBoundsMin={shaderOutOfBoundsBounds?.min ?? null}
@@ -5916,6 +6244,7 @@ export function SceneCanvas({
                   raftColorized={raftColorized}
                   raftHoverized={raftHoverized}
                   onModelPointerSelect={(modelId) => selectModelFromPointerHit(modelId)}
+                  onModelPointerDragStart={handleSelectModeSupportDragStart}
                   supportRendererRef={supportsRef as React.Ref<THREE.Group>}
                   supportRenderRefreshNonce={supportRenderRefreshNonce}
                   showOutOfBoundsOverlay={!!activeBuildVolumeSettings?.enabled && outOfBoundsModelIds.size > 0}
@@ -6034,11 +6363,13 @@ export function SceneCanvas({
                   selectedModelIds={selectedModelIds}
                   hoverModelId={supportHoverModelId}
                   modelDropOffsetsById={entryDropOffsets}
-                  navigationLodActive
+                  navigationLodActive={transformMode !== 'select'}
                   disableSelectionAndHover={suppressSupportProxyPointerInteraction}
                   raftColorized={raftColorized}
                   raftHoverized={raftHoverized}
-                  passive
+                  passive={transformMode !== 'select'}
+                  onModelPointerSelect={(modelId) => selectModelFromPointerHit(modelId)}
+                  onModelPointerDragStart={handleSelectModeSupportDragStart}
                   supportRenderRefreshNonce={supportRenderRefreshNonce}
                   interiorView={interiorView}
                   cavityGeometryByModelId={cavityGeometryByModelId}

--- a/src/components/scene/SceneCanvas/StlMesh.tsx
+++ b/src/components/scene/SceneCanvas/StlMesh.tsx
@@ -187,6 +187,7 @@ function StlMeshComponent({
   onOrganicCutClick,
   onSupportHover,
   onActiveModelChange,
+  onSelectModeDragStart,
   disableRaycast,
   blockSupportPlacement,
   suppressNextClickRef,
@@ -262,6 +263,9 @@ function StlMeshComponent({
   onOrganicCutClick?: (hit: THREE.Intersection) => void;
   onSupportHover?: (hit: THREE.Intersection | null) => void;
   onActiveModelChange?: (id: string | null, options?: { selectionMode?: 'single' | 'toggle' | 'add' }) => void;
+  /** In Select mode, left pointer-down on a model reports a potential XY-drag
+   *  start (model + screen coords). The scene owns the actual drag. */
+  onSelectModeDragStart?: (modelId: string, clientX: number, clientY: number) => void;
   disableRaycast?: boolean;
   blockSupportPlacement?: boolean;
   suppressNextClickRef?: React.RefObject<boolean>;
@@ -1349,6 +1353,16 @@ if (uDitherAmount > 0.0) {
                   ? 'add'
                   : 'single';
               onActiveModelChange(modelId, { selectionMode });
+            }
+
+            // Select mode: report a potential XY drag. Only for a plain
+            // single-select press — ctrl/shift are multi-select gestures and
+            // shift+drag is the marquee selection, so neither should move.
+            if (transformMode === 'select') {
+              const native = (e as unknown as { nativeEvent?: MouseEvent }).nativeEvent;
+              if (!native?.ctrlKey && !native?.metaKey && !native?.shiftKey) {
+                onSelectModeDragStart?.(modelId, e.clientX, e.clientY);
+              }
             }
           }
 

--- a/src/supports/RaftProxyMeshLayer.tsx
+++ b/src/supports/RaftProxyMeshLayer.tsx
@@ -28,6 +28,9 @@ interface RaftProxyMeshLayerProps {
   ghostOpacity?: number;
   ghostRenderOrder?: number;
   onModelPointerSelect?: (modelId: string) => void;
+  /** In Select mode, a pointer-down on a raft reports a potential model XY-drag
+   *  start (model + screen coords). The scene owns the drag. */
+  onModelPointerDragStart?: (modelId: string, clientX: number, clientY: number) => void;
   enablePointerSelection?: boolean;
   colorized?: boolean;
   hoverized?: boolean;
@@ -181,6 +184,7 @@ export function RaftProxyMeshLayer({
   ghostOpacity = 1,
   ghostRenderOrder = 0,
   onModelPointerSelect,
+  onModelPointerDragStart,
   enablePointerSelection = true,
   colorized = true,
   hoverized = false,
@@ -409,7 +413,7 @@ export function RaftProxyMeshLayer({
   const handleClick = React.useCallback((event: any, modelId?: string) => {
     if (!pointerEnabled) return;
     if (!modelId || !onModelPointerSelect) return;
-    
+
     // Don't select model if a gizmo handle is being interacted with
     if (hit.category === 'gizmo') return;
 
@@ -421,6 +425,16 @@ export function RaftProxyMeshLayer({
 
     onModelPointerSelect(modelId);
   }, [hit.category, onModelPointerSelect, pointerEnabled]);
+
+  const handlePointerDown = React.useCallback((event: any, modelId?: string) => {
+    if (!pointerEnabled || !onModelPointerDragStart) return;
+    if (!modelId) return;
+    if (hit.category === 'gizmo') return;
+    const native = event.nativeEvent as PointerEvent | undefined;
+    if (native?.ctrlKey || native?.metaKey || native?.shiftKey) return;
+    if (event.button !== 0) return;
+    onModelPointerDragStart(modelId, event.clientX, event.clientY);
+  }, [hit.category, onModelPointerDragStart, pointerEnabled]);
 
   const handlePointerMove = React.useCallback((event: any, modelId?: string) => {
     if (!pointerEnabled) return;
@@ -452,6 +466,7 @@ export function RaftProxyMeshLayer({
               geometry={entry.bottomGeometry}
               renderOrder={ghostRenderOrder}
               onClick={pointerEnabled ? (event) => handleClick(event, entry.modelId) : undefined}
+              onPointerDown={pointerEnabled && onModelPointerDragStart ? (event) => handlePointerDown(event, entry.modelId) : undefined}
               onPointerMove={pointerEnabled ? (event) => handlePointerMove(event, entry.modelId) : undefined}
               onPointerOut={pointerEnabled ? handlePointerOut : undefined}
             >
@@ -474,6 +489,7 @@ export function RaftProxyMeshLayer({
               geometry={entry.wallGeometry}
               renderOrder={ghostRenderOrder}
               onClick={pointerEnabled ? (event) => handleClick(event, entry.modelId) : undefined}
+              onPointerDown={pointerEnabled && onModelPointerDragStart ? (event) => handlePointerDown(event, entry.modelId) : undefined}
               onPointerMove={pointerEnabled ? (event) => handlePointerMove(event, entry.modelId) : undefined}
               onPointerOut={pointerEnabled ? handlePointerOut : undefined}
             >

--- a/src/supports/SupportPrimitives/ContactCone/InstancedContactConeGroup.tsx
+++ b/src/supports/SupportPrimitives/ContactCone/InstancedContactConeGroup.tsx
@@ -29,6 +29,7 @@ interface InstancedContactConeGroupProps {
     clippingPlanes?: THREE.Plane[] | null;
     outOfBoundsMaterial?: THREE.ShaderMaterial | null;
     onConeClick?: (cone: InstancedContactCone, event: ThreeEvent<MouseEvent>) => void;
+    onConePointerDown?: (cone: InstancedContactCone, event: ThreeEvent<PointerEvent>) => void;
     onConePointerMove?: (cone: InstancedContactCone, event: ThreeEvent<PointerEvent>) => void;
     onConePointerOut?: (cone: InstancedContactCone | null, event: ThreeEvent<PointerEvent>) => void;
 }
@@ -69,6 +70,7 @@ function ConeBucketMesh({
     clippingPlanes,
     outOfBoundsMaterial,
     onConeClick,
+    onConePointerDown,
     onConePointerMove,
     onConePointerOut,
     resolvePenetration,
@@ -83,6 +85,7 @@ function ConeBucketMesh({
     clippingPlanes?: THREE.Plane[] | null;
     outOfBoundsMaterial?: THREE.ShaderMaterial | null;
     onConeClick?: (cone: InstancedContactCone, event: ThreeEvent<MouseEvent>) => void;
+    onConePointerDown?: (cone: InstancedContactCone, event: ThreeEvent<PointerEvent>) => void;
     onConePointerMove?: (cone: InstancedContactCone, event: ThreeEvent<PointerEvent>) => void;
     onConePointerOut?: (cone: InstancedContactCone | null, event: ThreeEvent<PointerEvent>) => void;
     resolvePenetration: (cone: InstancedContactCone) => number;
@@ -221,6 +224,14 @@ function ConeBucketMesh({
         onConeClick(cone, event);
     };
 
+    const handlePointerDown = (event: ThreeEvent<PointerEvent>) => {
+        if (!onConePointerDown) return;
+        event.stopPropagation();
+        const cone = resolveCone(event.instanceId);
+        if (!cone) return;
+        onConePointerDown(cone, event);
+    };
+
     const handlePointerMove = (event: ThreeEvent<PointerEvent>) => {
         if (!onConePointerMove) return;
         event.stopPropagation();
@@ -239,6 +250,7 @@ function ConeBucketMesh({
 
     const sharedHandlers = {
         onClick: onConeClick ? handleClick : undefined,
+        onPointerDown: onConePointerDown ? handlePointerDown : undefined,
         onPointerMove: onConePointerMove ? handlePointerMove : undefined,
         onPointerOut: onConePointerOut ? handlePointerOut : undefined,
     };
@@ -357,6 +369,7 @@ export function InstancedContactConeGroup({
     clippingPlanes = null,
     outOfBoundsMaterial = null,
     onConeClick,
+    onConePointerDown,
     onConePointerMove,
     onConePointerOut,
 }: InstancedContactConeGroupProps) {
@@ -457,6 +470,7 @@ export function InstancedContactConeGroup({
                     clippingPlanes={clippingPlanes}
                     outOfBoundsMaterial={outOfBoundsMaterial}
                     onConeClick={onConeClick}
+                    onConePointerDown={onConePointerDown}
                     onConePointerMove={onConePointerMove}
                     onConePointerOut={onConePointerOut}
                     resolvePenetration={resolvePenetration}

--- a/src/supports/SupportPrimitives/Joint/InstancedJointGroup.tsx
+++ b/src/supports/SupportPrimitives/Joint/InstancedJointGroup.tsx
@@ -23,6 +23,7 @@ interface InstancedJointGroupProps {
     heightSegments?: number;
     outOfBoundsMaterial?: THREE.ShaderMaterial | null;
     onJointClick?: (joint: InstancedJoint, event: ThreeEvent<MouseEvent>) => void;
+    onJointPointerDown?: (joint: InstancedJoint, event: ThreeEvent<PointerEvent>) => void;
     onJointPointerMove?: (joint: InstancedJoint, event: ThreeEvent<PointerEvent>) => void;
     onJointPointerOut?: (joint: InstancedJoint | null, event: ThreeEvent<PointerEvent>) => void;
 }
@@ -39,6 +40,7 @@ export function InstancedJointGroup({
     heightSegments = 10,
     outOfBoundsMaterial = null,
     onJointClick,
+    onJointPointerDown,
     onJointPointerMove,
     onJointPointerOut,
 }: InstancedJointGroupProps) {
@@ -94,6 +96,14 @@ export function InstancedJointGroup({
         onJointClick(joint, event);
     };
 
+    const handlePointerDown = (event: ThreeEvent<PointerEvent>) => {
+        if (!onJointPointerDown) return;
+        event.stopPropagation();
+        const joint = resolveJoint(event.instanceId);
+        if (!joint) return;
+        onJointPointerDown(joint, event);
+    };
+
     const handlePointerMove = (event: ThreeEvent<PointerEvent>) => {
         if (!onJointPointerMove) return;
         event.stopPropagation();
@@ -118,6 +128,7 @@ export function InstancedJointGroup({
                 frustumCulled={false}
                 renderOrder={100000}
                 onClick={onJointClick ? handleClick : undefined}
+                onPointerDown={onJointPointerDown ? handlePointerDown : undefined}
                 onPointerMove={onJointPointerMove ? handlePointerMove : undefined}
                 onPointerOut={onJointPointerOut ? handlePointerOut : undefined}
             >

--- a/src/supports/SupportPrimitives/Roots/InstancedRootsGroup.tsx
+++ b/src/supports/SupportPrimitives/Roots/InstancedRootsGroup.tsx
@@ -24,6 +24,7 @@ interface InstancedRootsGroupProps {
     clippingPlanes?: THREE.Plane[] | null;
     outOfBoundsMaterial?: THREE.ShaderMaterial | null;
     onRootClick?: (root: InstancedRoot, event: ThreeEvent<MouseEvent>) => void;
+    onRootPointerDown?: (root: InstancedRoot, event: ThreeEvent<PointerEvent>) => void;
     onRootPointerMove?: (root: InstancedRoot, event: ThreeEvent<PointerEvent>) => void;
     onRootPointerOut?: (root: InstancedRoot | null, event: ThreeEvent<PointerEvent>) => void;
 }
@@ -62,6 +63,7 @@ function RootBucketMesh({
     clippingPlanes,
     outOfBoundsMaterial,
     onRootClick,
+    onRootPointerDown,
     onRootPointerMove,
     onRootPointerOut,
 }: {
@@ -74,6 +76,7 @@ function RootBucketMesh({
     clippingPlanes: THREE.Plane[] | null;
     outOfBoundsMaterial?: THREE.ShaderMaterial | null;
     onRootClick?: (root: InstancedRoot, event: ThreeEvent<MouseEvent>) => void;
+    onRootPointerDown?: (root: InstancedRoot, event: ThreeEvent<PointerEvent>) => void;
     onRootPointerMove?: (root: InstancedRoot, event: ThreeEvent<PointerEvent>) => void;
     onRootPointerOut?: (root: InstancedRoot | null, event: ThreeEvent<PointerEvent>) => void;
 }) {
@@ -146,6 +149,14 @@ function RootBucketMesh({
         onRootClick(root, event);
     };
 
+    const handlePointerDown = (event: ThreeEvent<PointerEvent>) => {
+        if (!onRootPointerDown) return;
+        event.stopPropagation();
+        const root = resolveRootFromEvent(event.instanceId);
+        if (!root) return;
+        onRootPointerDown(root, event);
+    };
+
     const handlePointerMove = (event: ThreeEvent<PointerEvent>) => {
         if (!onRootPointerMove) return;
         event.stopPropagation();
@@ -192,6 +203,7 @@ function RootBucketMesh({
                     frustumCulled={false}
                     renderOrder={100000}
                     onClick={onRootClick ? handleClick : undefined}
+                    onPointerDown={onRootPointerDown ? handlePointerDown : undefined}
                     onPointerMove={onRootPointerMove ? handlePointerMove : undefined}
                     onPointerOut={onRootPointerOut ? handlePointerOut : undefined}
                 >
@@ -215,6 +227,7 @@ function RootBucketMesh({
                     frustumCulled={false}
                     renderOrder={100000}
                     onClick={onRootClick ? handleClick : undefined}
+                    onPointerDown={onRootPointerDown ? handlePointerDown : undefined}
                     onPointerMove={onRootPointerMove ? handlePointerMove : undefined}
                     onPointerOut={onRootPointerOut ? handlePointerOut : undefined}
                 >
@@ -283,6 +296,7 @@ export function InstancedRootsGroup({
     clippingPlanes = null,
     outOfBoundsMaterial = null,
     onRootClick,
+    onRootPointerDown,
     onRootPointerMove,
     onRootPointerOut,
 }: InstancedRootsGroupProps) {
@@ -332,6 +346,7 @@ export function InstancedRootsGroup({
                     clippingPlanes={clippingPlanes}
                     outOfBoundsMaterial={outOfBoundsMaterial}
                     onRootClick={onRootClick}
+                    onRootPointerDown={onRootPointerDown}
                     onRootPointerMove={onRootPointerMove}
                     onRootPointerOut={onRootPointerOut}
                 />

--- a/src/supports/SupportPrimitives/Shaft/InstancedShaftGroup.tsx
+++ b/src/supports/SupportPrimitives/Shaft/InstancedShaftGroup.tsx
@@ -23,6 +23,7 @@ interface InstancedShaftGroupProps {
     radialSegments?: number;
     outOfBoundsMaterial?: THREE.ShaderMaterial | null;
     onShaftClick?: (shaft: InstancedShaft, event: ThreeEvent<MouseEvent>) => void;
+    onShaftPointerDown?: (shaft: InstancedShaft, event: ThreeEvent<PointerEvent>) => void;
     onShaftPointerMove?: (shaft: InstancedShaft, event: ThreeEvent<PointerEvent>) => void;
     onShaftPointerOut?: (shaft: InstancedShaft | null, event: ThreeEvent<PointerEvent>) => void;
 }
@@ -40,6 +41,7 @@ export function InstancedShaftGroup({
     radialSegments = 12,
     outOfBoundsMaterial = null,
     onShaftClick,
+    onShaftPointerDown,
     onShaftPointerMove,
     onShaftPointerOut,
 }: InstancedShaftGroupProps) {
@@ -111,6 +113,16 @@ export function InstancedShaftGroup({
         onShaftClick(shaft, event);
     };
 
+    const handlePointerDown = (event: ThreeEvent<PointerEvent>) => {
+        if (!onShaftPointerDown) return;
+        event.stopPropagation();
+        const instanceId = event.instanceId;
+        if (instanceId == null) return;
+        const shaft = validShafts[instanceId];
+        if (!shaft) return;
+        onShaftPointerDown(shaft, event);
+    };
+
     const handlePointerMove = (event: ThreeEvent<PointerEvent>) => {
         if (!onShaftPointerMove) return;
         event.stopPropagation();
@@ -137,6 +149,7 @@ export function InstancedShaftGroup({
                 frustumCulled={false}
                 renderOrder={100000}
                 onClick={onShaftClick ? handleClick : undefined}
+                onPointerDown={onShaftPointerDown ? handlePointerDown : undefined}
                 onPointerMove={onShaftPointerMove ? handlePointerMove : undefined}
                 onPointerOut={onShaftPointerOut ? handlePointerOut : undefined}
             >

--- a/src/supports/SupportProxyMeshLayer.tsx
+++ b/src/supports/SupportProxyMeshLayer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as THREE from 'three';
 import { useSyncExternalStore } from 'react';
+import type { ThreeEvent } from '@react-three/fiber';
 import { usePicking } from '@/components/picking';
 import { subscribe, getSnapshot } from './state';
 import { getRaftSettings, subscribeToRaftStore } from './Rafts/Crenelated/RaftState';
@@ -64,6 +65,9 @@ interface SupportProxyMeshLayerProps {
   outOfBoundsMax?: THREE.Vector3 | null;
   outOfBoundsStripeColor?: string;
   onModelPointerSelect?: (modelId: string) => void;
+  /** In Select mode, a pointer-down on a support proxy reports a potential
+   *  model XY-drag start (model + screen coords). The scene owns the drag. */
+  onModelPointerDragStart?: (modelId: string, clientX: number, clientY: number) => void;
   enablePointerSelection?: boolean;
   includeDetailedPrimitives?: boolean;
   /** When true, only show supports whose contact points touch the cavity mesh. */
@@ -164,6 +168,7 @@ export function SupportProxyMeshLayer({
   outOfBoundsMax = null,
   outOfBoundsStripeColor,
   onModelPointerSelect,
+  onModelPointerDragStart,
   enablePointerSelection = true,
   includeDetailedPrimitives = true,
   interiorView = false,
@@ -1082,6 +1087,17 @@ export function SupportProxyMeshLayer({
 
   const pointerHoverEnabled = enablePointerSelection && mode === 'prepare';
   const pointerSelectionEnabled = enablePointerSelection && mode === 'prepare' && !!onModelPointerSelect;
+  const pointerDragStartEnabled = enablePointerSelection && mode === 'prepare';
+
+  const reportModelDragStart = React.useCallback((modelId: string | undefined, event: ThreeEvent<PointerEvent>) => {
+    if (!pointerDragStartEnabled || !onModelPointerDragStart) return;
+    if (!modelId) return;
+    if (hitCategoryRef.current === 'gizmo') return;
+    const native = event.nativeEvent as PointerEvent | undefined;
+    if (native?.ctrlKey || native?.metaKey || native?.shiftKey) return;
+    if (event.button !== 0) return;
+    onModelPointerDragStart(modelId, event.clientX, event.clientY);
+  }, [onModelPointerDragStart, pointerDragStartEnabled]);
 
   const setSupportHoverModel = React.useCallback((nextModelId: string | null) => {
     if (hoverClearRafRef.current !== null) {
@@ -1304,6 +1320,7 @@ export function SupportProxyMeshLayer({
               clippingPlanes={clippingPlanes}
               outOfBoundsMaterial={outOfBoundsMaterial}
               onShaftClick={pointerSelectionEnabled ? handleProxyShaftClick : undefined}
+              onShaftPointerDown={pointerDragStartEnabled ? (shaft, event) => reportModelDragStart(shaft.modelId, event) : undefined}
               onShaftPointerMove={pointerHoverEnabled ? handleProxyShaftPointerMove : undefined}
               onShaftPointerOut={pointerHoverEnabled ? handleProxyPointerOut : undefined}
             />
@@ -1317,6 +1334,7 @@ export function SupportProxyMeshLayer({
               clippingPlanes={clippingPlanes}
               outOfBoundsMaterial={outOfBoundsMaterial}
               onRootClick={pointerSelectionEnabled ? handleProxyRootClick : undefined}
+              onRootPointerDown={pointerDragStartEnabled ? (root, event) => reportModelDragStart(root.modelId, event) : undefined}
               onRootPointerMove={pointerHoverEnabled ? handleProxyRootPointerMove : undefined}
               onRootPointerOut={pointerHoverEnabled ? handleProxyPointerOut : undefined}
             />
@@ -1329,6 +1347,7 @@ export function SupportProxyMeshLayer({
               opacity={proxyOpacity}
               clippingPlanes={clippingPlanes}
               onJointClick={pointerSelectionEnabled ? (joint) => handleProxyJointClick(joint) : undefined}
+              onJointPointerDown={pointerDragStartEnabled ? (joint, event) => reportModelDragStart(joint.modelId, event) : undefined}
               onJointPointerMove={pointerHoverEnabled ? handleProxyJointPointerMove : undefined}
               onJointPointerOut={pointerHoverEnabled ? handleProxyPointerOut : undefined}
             />
@@ -1341,6 +1360,7 @@ export function SupportProxyMeshLayer({
               opacity={proxyOpacity}
               clippingPlanes={clippingPlanes}
               onConeClick={pointerSelectionEnabled ? (cone) => handleProxyConeClick(cone) : undefined}
+              onConePointerDown={pointerDragStartEnabled ? (cone, event) => reportModelDragStart(cone.modelId, event) : undefined}
               onConePointerMove={pointerHoverEnabled ? handleProxyConePointerMove : undefined}
               onConePointerOut={pointerHoverEnabled ? handleProxyPointerOut : undefined}
             />
@@ -1360,6 +1380,7 @@ export function SupportProxyMeshLayer({
               clippingPlanes={clippingPlanes}
               outOfBoundsMaterial={outOfBoundsMaterial}
               onShaftClick={pointerSelectionEnabled ? handleProxyShaftClick : undefined}
+              onShaftPointerDown={pointerDragStartEnabled ? (shaft, event) => reportModelDragStart(shaft.modelId, event) : undefined}
               onShaftPointerMove={pointerHoverEnabled ? handleProxyShaftPointerMove : undefined}
               onShaftPointerOut={pointerHoverEnabled ? handleProxyPointerOut : undefined}
             />
@@ -1373,6 +1394,7 @@ export function SupportProxyMeshLayer({
               clippingPlanes={clippingPlanes}
               outOfBoundsMaterial={outOfBoundsMaterial}
               onRootClick={pointerSelectionEnabled ? handleProxyRootClick : undefined}
+              onRootPointerDown={pointerDragStartEnabled ? (root, event) => reportModelDragStart(root.modelId, event) : undefined}
               onRootPointerMove={pointerHoverEnabled ? handleProxyRootPointerMove : undefined}
               onRootPointerOut={pointerHoverEnabled ? handleProxyPointerOut : undefined}
             />
@@ -1385,6 +1407,7 @@ export function SupportProxyMeshLayer({
               opacity={proxyOpacity}
               clippingPlanes={clippingPlanes}
               onJointClick={pointerSelectionEnabled ? (joint) => handleProxyJointClick(joint) : undefined}
+              onJointPointerDown={pointerDragStartEnabled ? (joint, event) => reportModelDragStart(joint.modelId, event) : undefined}
               onJointPointerMove={pointerHoverEnabled ? handleProxyJointPointerMove : undefined}
               onJointPointerOut={pointerHoverEnabled ? handleProxyPointerOut : undefined}
             />
@@ -1397,6 +1420,7 @@ export function SupportProxyMeshLayer({
               opacity={proxyOpacity}
               clippingPlanes={clippingPlanes}
               onConeClick={pointerSelectionEnabled ? (cone) => handleProxyConeClick(cone) : undefined}
+              onConePointerDown={pointerDragStartEnabled ? (cone, event) => reportModelDragStart(cone.modelId, event) : undefined}
               onConePointerMove={pointerHoverEnabled ? handleProxyConePointerMove : undefined}
               onConePointerOut={pointerHoverEnabled ? handleProxyPointerOut : undefined}
             />
@@ -1421,6 +1445,7 @@ export function SupportProxyMeshLayer({
               radialSegments={10}
               clippingPlanes={clippingPlanes}
               onShaftClick={pointerSelectionEnabled ? handleProxyShaftClick : undefined}
+              onShaftPointerDown={pointerDragStartEnabled ? (shaft, event) => reportModelDragStart(shaft.modelId, event) : undefined}
               onShaftPointerMove={pointerHoverEnabled ? handleProxyShaftPointerMove : undefined}
               onShaftPointerOut={pointerHoverEnabled ? handleProxyPointerOut : undefined}
             />
@@ -1436,6 +1461,7 @@ export function SupportProxyMeshLayer({
               opacity={hoverOverlayOpacity}
               clippingPlanes={clippingPlanes}
               onRootClick={pointerSelectionEnabled ? handleProxyRootClick : undefined}
+              onRootPointerDown={pointerDragStartEnabled ? (root, event) => reportModelDragStart(root.modelId, event) : undefined}
               onRootPointerMove={pointerHoverEnabled ? handleProxyRootPointerMove : undefined}
               onRootPointerOut={pointerHoverEnabled ? handleProxyPointerOut : undefined}
             />
@@ -1451,6 +1477,7 @@ export function SupportProxyMeshLayer({
               opacity={hoverOverlayOpacity}
               clippingPlanes={clippingPlanes}
               onJointClick={pointerSelectionEnabled ? (joint) => handleProxyJointClick(joint) : undefined}
+              onJointPointerDown={pointerDragStartEnabled ? (joint, event) => reportModelDragStart(joint.modelId, event) : undefined}
               onJointPointerMove={pointerHoverEnabled ? handleProxyJointPointerMove : undefined}
               onJointPointerOut={pointerHoverEnabled ? handleProxyPointerOut : undefined}
             />
@@ -1466,6 +1493,7 @@ export function SupportProxyMeshLayer({
               opacity={hoverOverlayOpacity}
               clippingPlanes={clippingPlanes}
               onConeClick={pointerSelectionEnabled ? (cone) => handleProxyConeClick(cone) : undefined}
+              onConePointerDown={pointerDragStartEnabled ? (cone, event) => reportModelDragStart(cone.modelId, event) : undefined}
               onConePointerMove={pointerHoverEnabled ? handleProxyConePointerMove : undefined}
               onConePointerOut={pointerHoverEnabled ? handleProxyPointerOut : undefined}
             />


### PR DESCRIPTION
## Summary

Select mode can now drag the active model across the build plate. Pressing on a model mesh, its supports, or its raft in Select mode grabs the model and moves it on the world XY plane, using the same threshold, pointer tracking, and transform commit flow as Modify mode.

---

## What changed

### Select-mode model drag
- Pointer-down on a model, support, or raft in Select mode records a potential drag start (model plus screen coordinates)
- The drag begins only after the pointer crosses a small distance threshold, so a plain click still just selects
- Movement is tracked on window-level pointer events, so the drag survives leaving the mesh
- Position is constrained to the world XY plane, matching the Modify-mode center disc
- Only a held left button moves the model, a right-button orbit started mid-gesture no longer drags it

### Support and raft layers
- `ModelAttachedSupportLayer`, `SupportProxyMeshLayer`, and `RaftProxyMeshLayer` report Select-mode drag starts through a new `onModelPointerDragStart` callback
- Support presses select the model first, then start the same XY drag as a model-mesh press

### Transform pipeline
- Drags snapshot the source transform and commit through the existing gizmo transform path, so undo/redo and live transform updates behave as they do in Modify mode

---

## Notes

- The dragged model's supports follow because Select mode activates the active-model support proxy, parented to the model group. The shared drag group is deliberately left untouched so other models' static support layers do not shift for a frame.