### PR TITLE
VOXL 2.2: chunk out modifier snapshots + incremental autosave

### DIFF
--- a/docs/dev/voxl-format-spec.md
+++ b/docs/dev/voxl-format-spec.md
@@ -8,9 +8,10 @@ VOXL is DragonFruit’s native scene container. This page captures the core cont
 | ---------- | -------------------------------------------------------- | ---------------------------- |
 | V1         | UTF-8 JSON (direct document or compressed JSON envelope) | Legacy read support required |
 | V2.0       | Binary chunk container                                   | Historical                   |
-| V2.1       | Binary chunk container                                   | Current read/write target    |
+| V2.1       | Binary chunk container                                   | Superseded by V2.2           |
+| V2.2       | Binary chunk container                                   | Current read/write target    |
 
-Readers must support V1 and V2.x. Writers should emit V2.1 semantics.
+Readers must support V1 and V2.x. Writers should emit V2.2 semantics.
 
 ## Core conventions
 
@@ -71,7 +72,7 @@ V2 layout:
 Header requirements:
 
 - `magic = VOXL`
-- `version = 2` (container-major; V2.0 and V2.1 both use this)
+- `version = 2` (container-major; V2.0, V2.1, and V2.2 all use this — semantic revisions do not bump the header. Identical-geometry dedup bumps it to `3`; the two are orthogonal.)
 - little-endian integer fields
 
 Compression codes:
@@ -93,6 +94,9 @@ Chunk types:
 | `MESH` | raw mesh bytes      |
 | `SUPP` | supports JSON       |
 | `EXTD` | extensions JSON     |
+| `HSRC` | hollowing source-mesh positions — V2.2   |
+| `CAVT` | hollowing cavity-mesh positions — V2.2   |
+| `PSRC` | hole-punch source-mesh positions — V2.2  |
 
 Unknown chunk types may be ignored.
 
@@ -116,6 +120,53 @@ Behavioral requirement:
 - Implementations must **not** fall back to re-hollowing the already-baked mesh when the snapshot is missing.
 
 This is required so hollowing and hole-punch workflows remain re-editable after VOXL round-trips.
+
+### V2.2 semantic revision (current)
+
+V2.2 is a semantic revision of the V2 binary container; like V2.1 it does **not** change the
+binary header major version (`version` stays `2`, or `3` when identical-geometry dedup also
+fired — the two are orthogonal).
+
+V2.2 moves the large modifier position snapshots **out of the `MODL` JSON and into raw-binary
+chunks**, indexed by model index like `MESH`:
+
+| Modifier field (in-memory / V2.1 JSON) | V2.2 chunk | Dedup pointer (MODL JSON)          |
+| -------------------------------------- | ---------- | --------------------------------- |
+| `hollowing.sourcePositionsBase64`      | `HSRC`     | `hollowing.sourceChunkIndex`      |
+| `hollowing.cavityPositionsBase64`      | `CAVT`     | `hollowing.cavityChunkIndex`      |
+| `holePunchSourcePositionsBase64`       | `PSRC`     | `holePunchSourceChunkIndex`       |
+
+Rationale: these snapshots are non-indexed `Float32` triangle-soup meshes (often larger than
+the model's own geometry). Concatenated as base64 inside one `MODL` JSON string, several such
+models exceed V8's ~512 MiB single-string ceiling, so `JSON.stringify(models)` (and, on read,
+`JSON.parse`) throws `RangeError: Invalid string length`. Chunking the raw bytes removes the
+ceiling on both sides and drops the 4/3 base64 inflation.
+
+Requirements:
+
+- Writers store the **raw `Float32` bytes** in `HSRC`/`CAVT`/`PSRC` (not base64), `zlib`
+  compressed, at the owning model's index.
+- The `*PositionCount` fields (`sourcePositionCount`, `cavityPositionCount`,
+  `holePunchSourcePositionCount`) and `enabled` / `bakedIntoGeometry` flags **remain in the
+  `MODL` JSON**; the matching `*Base64` fields are omitted.
+- These chunks are **content-deduplicated within each type**, mirroring `MESH` dedup:
+  identical snapshots across models share one chunk. The first occurrence owns it (chunk
+  `index` = owner model index); later identical ones write no chunk and instead carry a
+  `*ChunkIndex` pointer (see table) in the MODL JSON naming the owner. Dedup is keyed by the
+  blob's own content, **independent of `MESH` dedup** — a MESH-duplicate model may still own
+  its own `HSRC`/`CAVT`/`PSRC` chunk, and two models sharing `MESH` geometry may still hold
+  distinct modifier snapshots. Deduping these chunks does not bump the header (unlike MESH
+  dedup, which bumps to `3`): they are invisible to older readers.
+
+Detection (no version number is written for the semantic revision): a `MODL` entry whose
+`meshModifiers` carries a non-zero `*PositionCount` with the matching `*Base64` **absent**
+means the data lives in the corresponding `HSRC`/`CAVT`/`PSRC` chunk, read at
+`index = *ChunkIndex ?? modelIndex` (owner defaults to its own model index; a duplicate's
+`*ChunkIndex` names the owner).
+
+Backward compatibility (accepted tradeoff): because the header does not bump and unknown chunk
+types may be ignored, older V2/V3 readers still open a V2.2 file — baked geometry loads from
+`MESH`, and they silently drop only the hollow/hole re-editability snapshots.
 
 ## Supports and extensions
 

--- a/docs/dev/voxl-format-spec.md
+++ b/docs/dev/voxl-format-spec.md
@@ -165,7 +165,7 @@ means the data lives in the corresponding `HSRC`/`CAVT`/`PSRC` chunk, read at
 `*ChunkIndex` names the owner).
 
 Backward compatibility (accepted tradeoff): because the header does not bump and unknown chunk
-types may be ignored, older V2/V3 readers still open a V2.2 file — baked geometry loads from
+types may be ignored, older V2/V2.1 readers still open a V2.2 file — baked geometry loads from
 `MESH`, and they silently drop only the hollow/hole re-editability snapshots.
 
 ## Supports and extensions

--- a/docs/dev/voxl-format-spec.md
+++ b/docs/dev/voxl-format-spec.md
@@ -72,7 +72,7 @@ V2 layout:
 Header requirements:
 
 - `magic = VOXL`
-- `version = 2` (container-major; V2.0, V2.1, and V2.2 all use this — semantic revisions do not bump the header. Identical-geometry dedup bumps it to `3`; the two are orthogonal.)
+- `version = 2` (container-major; V2.0, V2.1, and V2.2 all use this — semantic revisions do not bump the header.)
 - little-endian integer fields
 
 Compression codes:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -822,6 +822,11 @@ export default function Home() {
   const [activePluginImportWarning, setActivePluginImportWarning] = React.useState<{ title: string; body: string; storageKey: string } | null>(null);
   const [activeSceneFilePath, setActiveSceneFilePath] = React.useState<string | null>(null);
   const [loadedSceneSaveSource, setLoadedSceneSaveSource] = React.useState<{ name: string; path: string | null } | null>(null);
+  // Save-format tracking: whether the current scene is the chunked VOXL 2.2
+  // layout. Autosave preserves a loaded old file's inline format but never
+  // downgrades a 2.2 file; manual saves always write 2.2 and latch this true.
+  // Defaults true (newest) for fresh scenes.
+  const [sceneFormatChunked, setSceneFormatChunked] = React.useState(true);
   const [showSceneSaveChoiceModal, setShowSceneSaveChoiceModal] = React.useState(false);
   const [sceneSaveChoiceFileName, setSceneSaveChoiceFileName] = React.useState<string | null>(null);
   const [sceneSaveChoicePath, setSceneSaveChoicePath] = React.useState<string | null>(null);
@@ -886,6 +891,11 @@ export default function Home() {
     // state (set on every successful save and on every scene open), so the
     // sidecar follows the project.
     preferredSavePath: activeSceneFilePath,
+    sceneFormatChunked,
+    // Inline autosave hit the string ceiling and escalated to 2.2 — latch the
+    // scene there so later ticks skip the failing inline attempt and never
+    // downgrade the now-2.2 file.
+    onSceneFormatUpgraded: React.useCallback(() => setSceneFormatChunked(true), []),
   });
 
   /**
@@ -1430,6 +1440,7 @@ export default function Home() {
     markSceneSaveBaseline,
     setActiveSceneFilePath,
     setLoadedSceneSaveSource,
+    setSceneFormatChunked,
     sceneImportAutosaveSuppressMs,
     deps: importExportDepsRef,
   });
@@ -4239,6 +4250,10 @@ export default function Home() {
         exportSuccessToastFadeTimeoutRef.current = null;
       }, 3800);
 
+      // Manual save always writes the newest (2.2) layout, so the scene is now
+      // 2.2 on disk — latch it so autosave keeps it there instead of trying to
+      // preserve a stale inline format and downgrading it.
+      setSceneFormatChunked(true);
       markSceneSaveBaseline();
       void clearAutosave();
     }
@@ -4487,6 +4502,7 @@ export default function Home() {
     preferredOverwriteScenePathRef.current = null;
     setActiveSceneFilePath(null);
     setLoadedSceneSaveSource(null);
+    setSceneFormatChunked(true);
     setShowCloseUnsavedChangesModal(false);
     setCloseUnsavedChangesBusy('none');
     if (sceneSaveChoiceResolveRef.current) {

--- a/src/features/export/logic/ExportManager.ts
+++ b/src/features/export/logic/ExportManager.ts
@@ -4,7 +4,7 @@ import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import type { ModelMeshModifiers } from '@/features/mesh-modifiers/types';
 import { resolveModelMeshModifiers } from '@/features/mesh-modifiers/meshModifierStore';
 import { KNOWN_SOURCE_EXTENSION_STRIP_RE } from '@/features/plugins/pluginFileTypeExtensions';
-import { buildSupportExportFromStores, serializeVoxlDocumentV2, serializeVoxlDocumentV2Streaming, VoxlSizeLimitError, VoxlUnchangedError, type PrecompressedChunk, type VoxlChunkCache } from '@/features/scene/voxl';
+import { buildSupportExportFromStores, serializeVoxlDocumentV2, serializeVoxlDocumentV2Streaming, VoxlSizeLimitError, VoxlUnchangedError, type PrecompressedChunk, type VoxlChunkCache, type VoxlChunkReportEntry } from '@/features/scene/voxl';
 import { type BakedChunk, meshChunkStore } from '@/features/scene/voxl/meshChunkStore';
 import { buildScopedSupportExportDocument, buildScopedSupportGeometryGroup } from '@/features/export/logic/supportExportReconstruction';
 import { allocateMeshStagePath, exportMeshFile, pickSavePathWithNativeDialog, writeChunkedToNativePath, writeFileAtomicToNativePath, writeFileAtomicStreamedToNativePath } from '@/features/slicing/tauri/nativeSlicerBridge';
@@ -1210,6 +1210,42 @@ export class ExportManager {
     return this.downloadFile(stlBytes, options.filename, 'stl', 'application/octet-stream', null, false);
   }
 
+  /**
+   * Emit the per-autosave "which chunks changed" line (info level → Tauri log
+   * file). Called only when a chunkCache is in play, i.e. autosave. A skipped
+   * write means the whole document matched disk; otherwise we list the chunks
+   * that moved and note the ones reused untouched.
+   */
+  private static logVoxlChunkReport(report: VoxlChunkReportEntry[], skipped: boolean): void {
+    if (report.length === 0) return;
+
+    const label = (c: VoxlChunkReportEntry): string => `${c.type}[${c.index}]`;
+    const changed = report.filter((c) => c.changed);
+    const unchanged = report.filter((c) => !c.changed);
+
+    if (skipped) {
+      console.info(
+        `[SceneAutosave] VOXL unchanged — write skipped; all ${report.length} chunk(s) identical to disk.`,
+      );
+      return;
+    }
+
+    const changedList = changed
+      .map((c) => `${label(c)} ${c.isNew ? 'new' : 'changed'} (${c.source}, ${(c.compressedSize / 1024).toFixed(1)} KB)`)
+      .join(', ');
+    const reusedList = unchanged
+      .map((c) => `${label(c)} (${c.source})`)
+      .join(', ');
+
+    console.info(
+      `[SceneAutosave] VOXL chunk delta — ${changed.length} changed, ${unchanged.length} unchanged.`,
+      {
+        changed: changedList || '(none)',
+        unchanged: reusedList || '(none)',
+      },
+    );
+  }
+
   private static async exportVoxl(
     sceneContext: ExportSceneContext | undefined,
     options: ExportOptions,
@@ -1467,6 +1503,9 @@ export class ExportManager {
             serializeOptions,
           );
           streamFingerprint = streamResult.fingerprint;
+          // Only autosave supplies a chunkCache; that is exactly when the report
+          // is populated and the "which chunks changed" log is wanted.
+          if (chunkCache) this.logVoxlChunkReport(streamResult.chunkReport, streamResult.skipped);
           // Fingerprint matched the file already on disk: nothing was emitted.
           // Throw so the atomic writer discards its (empty) temp and leaves the
           // correct file untouched; caught just below as success.

--- a/src/features/export/logic/ExportManager.ts
+++ b/src/features/export/logic/ExportManager.ts
@@ -4,7 +4,7 @@ import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import type { ModelMeshModifiers } from '@/features/mesh-modifiers/types';
 import { resolveModelMeshModifiers } from '@/features/mesh-modifiers/meshModifierStore';
 import { KNOWN_SOURCE_EXTENSION_STRIP_RE } from '@/features/plugins/pluginFileTypeExtensions';
-import { buildSupportExportFromStores, serializeVoxlDocumentV2, serializeVoxlDocumentV2Streaming, VoxlSizeLimitError, type PrecompressedChunk } from '@/features/scene/voxl';
+import { buildSupportExportFromStores, serializeVoxlDocumentV2, serializeVoxlDocumentV2Streaming, VoxlSizeLimitError, VoxlUnchangedError, type PrecompressedChunk, type VoxlChunkCache } from '@/features/scene/voxl';
 import { type BakedChunk, meshChunkStore } from '@/features/scene/voxl/meshChunkStore';
 import { buildScopedSupportExportDocument, buildScopedSupportGeometryGroup } from '@/features/export/logic/supportExportReconstruction';
 import { allocateMeshStagePath, exportMeshFile, pickSavePathWithNativeDialog, writeChunkedToNativePath, writeFileAtomicToNativePath, writeFileAtomicStreamedToNativePath } from '@/features/slicing/tauri/nativeSlicerBridge';
@@ -48,6 +48,42 @@ export interface ExportSceneSaveTarget {
    * that is already 2.2 — that would downgrade it.
    */
   chunkModifierSnapshots?: boolean;
+  /**
+   * Cross-tick chunk cache (autosave incremental writes, Phase 1). When present,
+   * unchanged modifier/SUPP chunks reuse their compressed bytes and the write is
+   * skipped when the document fingerprint matches `previousFingerprint`. Manual
+   * saves omit it (they always write fresh).
+   */
+  chunkCache?: VoxlChunkCache;
+  /** Fingerprint of the last committed autosave to this path; enables the write-skip. */
+  previousFingerprint?: string;
+  /**
+   * Reports the fingerprint of the file now on disk (whether freshly written or
+   * confirmed-unchanged), or `undefined` when it could not be determined (browser
+   * fallback) so the caller invalidates its stored value rather than skipping on
+   * a stale one.
+   */
+  onFingerprint?: (fingerprint: string | undefined) => void;
+}
+
+/**
+ * Assigns each distinct store-snapshot object a stable token so the SUPP chunk
+ * can be content-keyed by identity. The support/kickstand stores replace their
+ * snapshot immutably on every mutation, so an unchanged snapshot keeps the same
+ * reference → same token → cache hit; any edit yields a new reference → new
+ * token → miss. Keyed weakly so retired snapshots are collected.
+ */
+const snapshotTokens = new WeakMap<object, string>();
+let snapshotTokenCounter = 0;
+function snapshotToken(obj: unknown): string {
+  if (obj === null || typeof obj !== 'object') return '0';
+  let token = snapshotTokens.get(obj);
+  if (token === undefined) {
+    snapshotTokenCounter += 1;
+    token = `s${snapshotTokenCounter}`;
+    snapshotTokens.set(obj, token);
+  }
+  return token;
 }
 
 export class ExportManager {
@@ -978,7 +1014,12 @@ export class ExportManager {
 
     // VOXL path: serialization can be expensive, so destination is pre-picked above.
     if (options.format === 'voxl') {
-      return this.exportVoxl(sceneContext, options, prePickedNativePath, useNativeWrite, saveTarget?.chunkModifierSnapshots ?? true);
+      return this.exportVoxl(sceneContext, options, prePickedNativePath, useNativeWrite, {
+        chunkModifierSnapshots: saveTarget?.chunkModifierSnapshots ?? true,
+        chunkCache: saveTarget?.chunkCache,
+        previousFingerprint: saveTarget?.previousFingerprint,
+        onFingerprint: saveTarget?.onFingerprint,
+      });
     }
 
     // Collect live scene objects for serialization — no cloning, no InstancedMesh expansion.
@@ -1174,8 +1215,19 @@ export class ExportManager {
     options: ExportOptions,
     prePickedNativePath: string | null,
     useNativeWrite: boolean,
-    chunkModifierSnapshots = true,
+    voxlOptions: {
+      chunkModifierSnapshots?: boolean;
+      chunkCache?: VoxlChunkCache;
+      previousFingerprint?: string;
+      onFingerprint?: (fingerprint: string | undefined) => void;
+    } = {},
   ): Promise<string | null> {
+    const {
+      chunkModifierSnapshots = true,
+      chunkCache,
+      previousFingerprint,
+      onFingerprint,
+    } = voxlOptions;
     // Yield before the (synchronous) support snapshot so the render loop stays
     // alive on scenes with many support nodes.
     await this.yieldToBrowserFrame();
@@ -1220,6 +1272,8 @@ export class ExportManager {
     const sha256Map = new Map<number, string>();
     const precompressedMap = new Map<number, PrecompressedChunk>();
     const precompressedOriginalMap = new Map<number, PrecompressedChunk>();
+    // ORIG content digests, for the document fingerprint (autosave write-skip).
+    const sha256OriginalMap = new Map<number, string>();
     const staleModelIds = new Set<string>();
 
     const models = options.includeModel
@@ -1279,6 +1333,7 @@ export class ExportManager {
                 compression: origChunk.compression,
                 uncompressedSize: origChunk.uncompressedSize,
               });
+              sha256OriginalMap.set(index, origChunk.sha256);
             }
 
             exportedModels.push({
@@ -1368,6 +1423,19 @@ export class ExportManager {
       },
       extensions: voxlExtensions,
     };
+    // The SUPP chunk's bytes are a pure function of the two store snapshots plus
+    // the include/scope flags. Key on the snapshot identities so an unchanged
+    // support forest (every non-support edit) reuses the cached compressed SUPP
+    // chunk and skips its `JSON.stringify`. Only derived when a cache is in play.
+    const supportsCacheKey = chunkCache
+      ? [
+          snapshotToken(supportSnapshot),
+          snapshotToken(kickstandSnapshot),
+          options.includeSupports ? 'S1' : 'S0',
+          hasScopedModelFilter ? [...scopedModelIds].sort().join(',') : '*',
+        ].join('|')
+      : undefined;
+
     // `chunkModifierSnapshots` selects the VOXL 2.2 layout (chunked, the default
     // and the manual-save path) or the pre-2.2 inline layout (autosave preserving
     // an old file's format). Autosave owns the escalate-on-failure decision so it
@@ -1377,6 +1445,10 @@ export class ExportManager {
       precompressedOriginal: precompressedOriginalMap,
       embedOriginalMesh: options.embedOriginalMesh ?? true,
       chunkModifierSnapshots,
+      chunkCache,
+      sha256Original: sha256OriginalMap,
+      supportsCacheKey,
+      previousFingerprint,
     };
 
     // Native path: stream straight into the atomic writer's temp file, so the
@@ -1385,21 +1457,37 @@ export class ExportManager {
     // one that runs unattended and the one that most needed the buffer gone.
     if (useNativeWrite && prePickedNativePath && this.requiresAtomicCommit('voxl')) {
       try {
+        let streamFingerprint = '';
         await writeFileAtomicStreamedToNativePath(prePickedNativePath, async (emit) => {
-          await serializeVoxlDocumentV2Streaming(
+          const streamResult = await serializeVoxlDocumentV2Streaming(
             documentInput,
             meshBytesMap,
             sha256Map,
             emit,
             serializeOptions,
           );
+          streamFingerprint = streamResult.fingerprint;
+          // Fingerprint matched the file already on disk: nothing was emitted.
+          // Throw so the atomic writer discards its (empty) temp and leaves the
+          // correct file untouched; caught just below as success.
+          if (streamResult.skipped) throw new VoxlUnchangedError(streamResult.fingerprint);
         });
+        onFingerprint?.(streamFingerprint || undefined);
         return prePickedNativePath;
       } catch (error) {
+        if (error instanceof VoxlUnchangedError) {
+          onFingerprint?.(error.fingerprint);
+          return prePickedNativePath;
+        }
         if (error instanceof VoxlSizeLimitError) throw error;
         console.warn('[ExportManager] Streamed VOXL write failed, retrying buffered.', error);
       }
     }
+
+    // Buffered fallback (browser download, or after a streamed failure). It does
+    // not surface a fingerprint, so invalidate any stored one — the caller must
+    // not skip a future write against a fingerprint we did not confirm on disk.
+    onFingerprint?.(undefined);
 
     // serializeVoxlDocumentV2 is async — compression runs off the main thread.
     const binary = await serializeVoxlDocumentV2(

--- a/src/features/export/logic/ExportManager.ts
+++ b/src/features/export/logic/ExportManager.ts
@@ -40,6 +40,14 @@ export interface ExportSceneContext {
 
 export interface ExportSceneSaveTarget {
   nativePath?: string | null;
+  /**
+   * VOXL 2.2 modifier-snapshot chunking. Omitted/`true` writes the newest
+   * (chunked 2.2) layout — the manual-save default. Autosave passes `false` to
+   * preserve a pre-2.2 file's inline layout, and escalates to `true` itself if
+   * that write throws (see `useSceneAutosave`). Never write `false` for a file
+   * that is already 2.2 — that would downgrade it.
+   */
+  chunkModifierSnapshots?: boolean;
 }
 
 export class ExportManager {
@@ -970,7 +978,7 @@ export class ExportManager {
 
     // VOXL path: serialization can be expensive, so destination is pre-picked above.
     if (options.format === 'voxl') {
-      return this.exportVoxl(sceneContext, options, prePickedNativePath, useNativeWrite);
+      return this.exportVoxl(sceneContext, options, prePickedNativePath, useNativeWrite, saveTarget?.chunkModifierSnapshots ?? true);
     }
 
     // Collect live scene objects for serialization — no cloning, no InstancedMesh expansion.
@@ -1166,6 +1174,7 @@ export class ExportManager {
     options: ExportOptions,
     prePickedNativePath: string | null,
     useNativeWrite: boolean,
+    chunkModifierSnapshots = true,
   ): Promise<string | null> {
     // Yield before the (synchronous) support snapshot so the render loop stays
     // alive on scenes with many support nodes.
@@ -1359,10 +1368,15 @@ export class ExportManager {
       },
       extensions: voxlExtensions,
     };
+    // `chunkModifierSnapshots` selects the VOXL 2.2 layout (chunked, the default
+    // and the manual-save path) or the pre-2.2 inline layout (autosave preserving
+    // an old file's format). Autosave owns the escalate-on-failure decision so it
+    // can also latch the scene to 2.2 — see `useSceneAutosave`.
     const serializeOptions = {
       precompressed: precompressedMap,
       precompressedOriginal: precompressedOriginalMap,
       embedOriginalMesh: options.embedOriginalMesh ?? true,
+      chunkModifierSnapshots,
     };
 
     // Native path: stream straight into the atomic writer's temp file, so the

--- a/src/features/export/logic/ExportManager.ts
+++ b/src/features/export/logic/ExportManager.ts
@@ -8,6 +8,7 @@ import { buildSupportExportFromStores, serializeVoxlDocumentV2, serializeVoxlDoc
 import { type BakedChunk, meshChunkStore } from '@/features/scene/voxl/meshChunkStore';
 import { buildScopedSupportExportDocument, buildScopedSupportGeometryGroup } from '@/features/export/logic/supportExportReconstruction';
 import { allocateMeshStagePath, exportMeshFile, pickSavePathWithNativeDialog, writeChunkedToNativePath, writeFileAtomicToNativePath, writeFileAtomicStreamedToNativePath } from '@/features/slicing/tauri/nativeSlicerBridge';
+import { info as logInfo } from '@tauri-apps/plugin-log';
 import { getKickstandSnapshot } from '@/supports/SupportTypes/Kickstand/kickstandStore';
 import { getSnapshot } from '@/supports/state';
 import { getRaftSettings, getRaftSettingsForModel } from '@/supports/Rafts/Crenelated/RaftState';
@@ -1211,39 +1212,39 @@ export class ExportManager {
   }
 
   /**
-   * Emit the per-autosave "which chunks changed" line (info level → Tauri log
-   * file). Called only when a chunkCache is in play, i.e. autosave. A skipped
-   * write means the whole document matched disk; otherwise we list the chunks
-   * that moved and note the ones reused untouched.
+   * Emit the per-autosave "which chunks changed" line to the platform log file
+   * via the Tauri log plugin's `info` (plain `console.*` never reaches the file —
+   * `attachConsole` only mirrors Rust records INTO the devtools console). Called
+   * only when a chunkCache is in play, i.e. autosave. A skipped write means the
+   * whole document matched disk; otherwise we list the chunks that moved and note
+   * the ones reused untouched. `info` takes a single string, so the whole report
+   * is folded into `message`; fire-and-forget (a reject outside Tauri is ignored).
    */
   private static logVoxlChunkReport(report: VoxlChunkReportEntry[], skipped: boolean): void {
     if (report.length === 0) return;
+
+    if (skipped) {
+      void logInfo(
+        `[SceneAutosave] VOXL unchanged — write skipped; all ${report.length} chunk(s) identical to disk.`,
+      ).catch(() => {});
+      return;
+    }
 
     const label = (c: VoxlChunkReportEntry): string => `${c.type}[${c.index}]`;
     const changed = report.filter((c) => c.changed);
     const unchanged = report.filter((c) => !c.changed);
 
-    if (skipped) {
-      console.info(
-        `[SceneAutosave] VOXL unchanged — write skipped; all ${report.length} chunk(s) identical to disk.`,
-      );
-      return;
-    }
-
     const changedList = changed
       .map((c) => `${label(c)} ${c.isNew ? 'new' : 'changed'} (${c.source}, ${(c.compressedSize / 1024).toFixed(1)} KB)`)
-      .join(', ');
+      .join(', ') || '(none)';
     const reusedList = unchanged
       .map((c) => `${label(c)} (${c.source})`)
-      .join(', ');
+      .join(', ') || '(none)';
 
-    console.info(
-      `[SceneAutosave] VOXL chunk delta — ${changed.length} changed, ${unchanged.length} unchanged.`,
-      {
-        changed: changedList || '(none)',
-        unchanged: reusedList || '(none)',
-      },
-    );
+    void logInfo(
+      `[SceneAutosave] VOXL chunk delta — ${changed.length} changed, ${unchanged.length} unchanged`
+      + ` | changed: ${changedList} | unchanged: ${reusedList}`,
+    ).catch(() => {});
   }
 
   private static async exportVoxl(

--- a/src/features/import-export/useImportExportManager.ts
+++ b/src/features/import-export/useImportExportManager.ts
@@ -57,6 +57,10 @@ export type UseImportExportManagerOptions = {
   markSceneSaveBaseline: () => void;
   setActiveSceneFilePath: React.Dispatch<React.SetStateAction<string | null>>;
   setLoadedSceneSaveSource: React.Dispatch<React.SetStateAction<{ name: string; path: string | null } | null>>;
+  /** Seeds the scene's save-format on load: a loaded 2.2 file autosaves as 2.2
+   *  (never downgraded); anything else preserves its inline format. Non-voxl and
+   *  fresh scenes are the newest (chunked) format. */
+  setSceneFormatChunked: React.Dispatch<React.SetStateAction<boolean>>;
   sceneImportAutosaveSuppressMs: number;
   /** Late / cross-domain deps (see ImportExportManagerDeps). */
   deps: React.MutableRefObject<ImportExportManagerDeps>;
@@ -72,6 +76,7 @@ export function useImportExportManager({
   markSceneSaveBaseline,
   setActiveSceneFilePath,
   setLoadedSceneSaveSource,
+  setSceneFormatChunked,
   sceneImportAutosaveSuppressMs,
   deps,
 }: UseImportExportManagerOptions) {
@@ -161,9 +166,13 @@ export function useImportExportManager({
           name: importedSingleFile.name,
           path: normalizedScenePath,
         });
+        // Preserve the loaded .voxl's format on autosave; a 2.2 file stays 2.2.
+        setSceneFormatChunked(scene.lastLoadedVoxlFormatChunkedRef.current);
         markSceneSaveBaseline();
       } else {
         setLoadedSceneSaveSource(null);
+        // Non-voxl scene import → newest format.
+        setSceneFormatChunked(true);
       }
 
       suppressSceneAutosave(sceneImportAutosaveSuppressMs);
@@ -362,9 +371,12 @@ export function useImportExportManager({
           name: entry.name,
           path: normalizeActiveVoxlScenePath(sourcePath),
         });
+        // Preserve the reopened .voxl's format on autosave; a 2.2 file stays 2.2.
+        setSceneFormatChunked(scene.lastLoadedVoxlFormatChunkedRef.current);
         markSceneSaveBaseline();
       } else {
         setLoadedSceneSaveSource(null);
+        setSceneFormatChunked(true);
       }
     }
     return reopened;

--- a/src/features/mesh-modifiers/types.ts
+++ b/src/features/mesh-modifiers/types.ts
@@ -7,10 +7,19 @@ export type ModelHollowingModifier = {
   bakedIntoGeometry?: boolean;
   sourcePositionsBase64?: string;
   sourcePositionCount?: number;
+  /**
+   * VOXL 2.2 dedup pointer: the HSRC chunk index this model's source-position
+   * snapshot lives in, present only on models that SHARE another model's chunk
+   * (identical-snapshot dedup). Absent ⇒ the owner's own model index. Set by
+   * the codec on read/write; not persisted in-memory outside serialization.
+   */
+  sourceChunkIndex?: number;
   /** Base64-encoded Float32Array of cavity interior mesh positions. */
   cavityPositionsBase64?: string;
   /** Number of vertices in the cavity mesh (count × 3 = float count). */
   cavityPositionCount?: number;
+  /** VOXL 2.2 dedup pointer for the CAVT chunk (see `sourceChunkIndex`). */
+  cavityChunkIndex?: number;
   blockedVoxelIndices?: number[];
   /** Scene rotation (unit quaternion [x, y, z, w]) captured when
    *  blockedVoxelIndices were committed. Blocker indices address the
@@ -44,4 +53,6 @@ export type ModelMeshModifiers = {
   holePunchesBakedIntoGeometry?: boolean;
   holePunchSourcePositionsBase64?: string;
   holePunchSourcePositionCount?: number;
+  /** VOXL 2.2 dedup pointer for the PSRC chunk (see `ModelHollowingModifier.sourceChunkIndex`). */
+  holePunchSourceChunkIndex?: number;
 };

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -1149,6 +1149,11 @@ export function useSceneCollectionManager() {
   const modelsRef = useRef<LoadedModel[]>([]);
   const activeModelIdRef = useRef<string | null>(null);
   const selectedModelIdsRef = useRef<string[]>([]);
+  // Whether the most recently loaded .voxl was the chunked 2.2 layout. Read by
+  // the import/export manager right after a load to seed the scene's save-format
+  // so autosave preserves an old file's format without ever downgrading a 2.2
+  // one. Defaults to true (newest) for non-voxl / fresh scenes.
+  const lastLoadedVoxlFormatChunkedRef = useRef<boolean>(true);
   modelsRef.current = models;
   activeModelIdRef.current = activeModelId;
   selectedModelIdsRef.current = selectedModelIds;
@@ -4861,6 +4866,9 @@ export function useSceneCollectionManager() {
         resolvedMeshBytes = r.meshBytes;
         resolvedOriginalMeshBytes = r.originalMeshBytes;
         originalMeshChunks = r.originalMeshChunks;
+        // sourceVersion is 2.2 only when the file actually carries modifier
+        // chunks; anything lower is treated as inline for format preservation.
+        lastLoadedVoxlFormatChunkedRef.current = r.sourceVersion >= 2.2;
       } else {
         document = parseVoxlDocument(await file.text());
         resolvedMeshBytes = new Map();
@@ -5705,6 +5713,7 @@ export function useSceneCollectionManager() {
     setActiveModelId,
     selectedModelIds,
     setSelectedModelIds,
+    lastLoadedVoxlFormatChunkedRef,
     selectModel,
     clearModelSelection,
     activeModel,

--- a/src/features/scene/voxl/__tests__/voxlChunkCache.test.ts
+++ b/src/features/scene/voxl/__tests__/voxlChunkCache.test.ts
@@ -149,6 +149,41 @@ test('write-skip: a matching previousFingerprint emits nothing and reports skipp
   });
 });
 
+test('the chunk report flags a transform edit as MODL-changed, snapshots unchanged', async () => {
+  await withFrozenClock(async () => {
+    const cache = new VoxlChunkCache();
+    const base = testModel('m0', { meshModifiers: hollowMods(SOURCE, CAVITY, HOLE) });
+
+    // First tick: every chunk is new.
+    const first = await streamSerialize(testInput([base]), { chunkCache: cache });
+    assert.ok(first.chunkReport.length > 0, 'a cache-enabled serialize must report chunks');
+    assert.ok(first.chunkReport.every((c) => c.isNew && c.changed), 'first tick ⇒ all chunks new');
+
+    // Second tick: only the transform moved. MODL carries the transform JSON so
+    // it changes; the HSRC/CAVT/PSRC snapshot chunks are byte-identical (local
+    // frame) and must report unchanged + reused from cache.
+    const moved = testModel('m0', {
+      meshModifiers: hollowMods(SOURCE, CAVITY, HOLE),
+      transform: {
+        position: { x: 7, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+      },
+    });
+    const second = await streamSerialize(testInput([moved]), { chunkCache: cache });
+
+    const byKey = (t: string) => second.chunkReport.find((c) => c.type === t);
+    assert.equal(byKey('MODL')?.changed, true, 'a moved model must mark MODL changed');
+    assert.equal(byKey('MODL')?.isNew, false, 'MODL existed last tick, so not new');
+    for (const t of ['HSRC', 'CAVT', 'PSRC']) {
+      const row = byKey(t);
+      assert.ok(row, `expected a ${t} chunk in the report`);
+      assert.equal(row?.changed, false, `${t} snapshot must be unchanged on a transform edit`);
+      assert.equal(row?.source, 'cache', `${t} must be reused from the chunk cache`);
+    }
+  });
+});
+
 test('write-skip does not fire when the content changed', async () => {
   await withFrozenClock(async () => {
     const cache = new VoxlChunkCache();

--- a/src/features/scene/voxl/__tests__/voxlChunkCache.test.ts
+++ b/src/features/scene/voxl/__tests__/voxlChunkCache.test.ts
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  serializeVoxlDocumentV2,
+  serializeVoxlDocumentV2Streaming,
+} from '../codec-v2';
+import { VoxlChunkCache } from '../voxlChunkCache';
+import { testInput, testModel, withFrozenClock } from './voxlTestSupport';
+import { bytesToBase64 } from '@/utils/base64';
+import type { ModelMeshModifiers } from '@/features/mesh-modifiers/types';
+
+const floats = (seed: number, verts: number): string => {
+  const arr = new Float32Array(verts * 3);
+  for (let i = 0; i < arr.length; i += 1) arr[i] = seed + i * 0.5;
+  return bytesToBase64(new Uint8Array(arr.buffer));
+};
+
+const SOURCE = floats(1, 512);
+const CAVITY = floats(2, 512);
+const HOLE = floats(3, 512);
+
+const hollowMods = (source: string, cavity: string, hole: string): ModelMeshModifiers => ({
+  hollowing: {
+    enabled: true,
+    bakedIntoGeometry: true,
+    mode: 'cavity',
+    voxelSizeMm: 0.5,
+    shellThicknessMm: 2,
+    openFace: 'z_max',
+    sourcePositionsBase64: source,
+    sourcePositionCount: 512,
+    cavityPositionsBase64: cavity,
+    cavityPositionCount: 512,
+  },
+  holePunchesBakedIntoGeometry: true,
+  holePunchSourcePositionsBase64: hole,
+  holePunchSourcePositionCount: 512,
+});
+
+async function streamSerialize(
+  input: ReturnType<typeof testInput>,
+  options?: Parameters<typeof serializeVoxlDocumentV2Streaming>[4],
+) {
+  const parts: Uint8Array[] = [];
+  const res = await serializeVoxlDocumentV2Streaming(
+    input,
+    new Map(),
+    undefined,
+    (b) => { parts.push(b); },
+    options,
+  );
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const bytes = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) { bytes.set(p, off); off += p.length; }
+  return { bytes, ...res };
+}
+
+test('a chunk cache leaves output byte-identical to the no-cache path', async () => {
+  await withFrozenClock(async () => {
+    const model = testModel('m0', { meshModifiers: hollowMods(SOURCE, CAVITY, HOLE) });
+
+    const plain = await serializeVoxlDocumentV2(testInput([model]), new Map());
+    const cache = new VoxlChunkCache();
+    const cached = await serializeVoxlDocumentV2(testInput([model]), new Map(), undefined, { chunkCache: cache });
+
+    assert.deepEqual([...cached], [...plain], 'cache must not change the emitted bytes');
+    assert.ok(cache.size > 0, 'the modifier/SUPP chunks should have populated the cache');
+  });
+});
+
+test('a warm cache reproduces identical bytes on the next tick (cache hit path)', async () => {
+  await withFrozenClock(async () => {
+    const model = testModel('m0', { meshModifiers: hollowMods(SOURCE, CAVITY, HOLE) });
+    const cache = new VoxlChunkCache();
+
+    const first = await serializeVoxlDocumentV2(testInput([model]), new Map(), undefined, { chunkCache: cache });
+    // Second serialize reuses the cache — the modifier chunks take the hit path.
+    const second = await serializeVoxlDocumentV2(testInput([model]), new Map(), undefined, { chunkCache: cache });
+
+    assert.deepEqual([...second], [...first], 'a cache hit must emit the same bytes as a miss');
+  });
+});
+
+test('the fingerprint is stable for identical input and changes when content changes', async () => {
+  await withFrozenClock(async () => {
+    const model = testModel('m0', { meshModifiers: hollowMods(SOURCE, CAVITY, HOLE) });
+    const cache = new VoxlChunkCache();
+
+    const a = await streamSerialize(testInput([model]), { chunkCache: cache });
+    const b = await streamSerialize(testInput([model]), { chunkCache: cache });
+    assert.notEqual(a.fingerprint, '', 'a cache-enabled serialize must produce a fingerprint');
+    assert.equal(a.fingerprint, b.fingerprint, 'identical input ⇒ identical fingerprint');
+
+    // A transform edit changes MODL but not the modifier snapshots.
+    const moved = testModel('m0', {
+      meshModifiers: hollowMods(SOURCE, CAVITY, HOLE),
+      transform: {
+        position: { x: 5, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+      },
+    });
+    const c = await streamSerialize(testInput([moved]), { chunkCache: cache });
+    assert.notEqual(c.fingerprint, a.fingerprint, 'a moved model must change the fingerprint');
+  });
+});
+
+test('a transform edit reuses the modifier snapshot chunks unchanged', async () => {
+  await withFrozenClock(async () => {
+    const cache = new VoxlChunkCache();
+    const base = testModel('m0', { meshModifiers: hollowMods(SOURCE, CAVITY, HOLE) });
+    await streamSerialize(testInput([base]), { chunkCache: cache });
+    const sizeAfterFirst = cache.size;
+
+    // Same modifier snapshots (same base64 refs), only the transform differs.
+    const moved = testModel('m0', {
+      meshModifiers: hollowMods(SOURCE, CAVITY, HOLE),
+      transform: {
+        position: { x: 9, y: 1, z: 2 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+      },
+    });
+    const movedOut = await streamSerialize(testInput([moved]), { chunkCache: cache });
+
+    // The cache did not grow — the modifier chunks were reused, not re-added.
+    assert.equal(cache.size, sizeAfterFirst, 'unchanged snapshots must not add cache entries');
+    assert.equal(movedOut.skipped, false);
+  });
+});
+
+test('write-skip: a matching previousFingerprint emits nothing and reports skipped', async () => {
+  await withFrozenClock(async () => {
+    const model = testModel('m0', { meshModifiers: hollowMods(SOURCE, CAVITY, HOLE) });
+    const cache = new VoxlChunkCache();
+
+    const first = await streamSerialize(testInput([model]), { chunkCache: cache });
+    assert.equal(first.skipped, false);
+    assert.ok(first.bytes.length > 0);
+
+    const again = await streamSerialize(testInput([model]), {
+      chunkCache: cache,
+      previousFingerprint: first.fingerprint,
+    });
+    assert.equal(again.skipped, true, 'identical fingerprint must skip the write');
+    assert.equal(again.bytes.length, 0, 'a skipped write must emit no bytes');
+  });
+});
+
+test('write-skip does not fire when the content changed', async () => {
+  await withFrozenClock(async () => {
+    const cache = new VoxlChunkCache();
+    const first = await streamSerialize(
+      testInput([testModel('m0', { meshModifiers: hollowMods(SOURCE, CAVITY, HOLE) })]),
+      { chunkCache: cache },
+    );
+
+    const changed = await streamSerialize(
+      testInput([testModel('m0', { meshModifiers: hollowMods(floats(9, 512), CAVITY, HOLE) })]),
+      { chunkCache: cache, previousFingerprint: first.fingerprint },
+    );
+    assert.equal(changed.skipped, false, 'changed content must not be skipped');
+    assert.ok(changed.bytes.length > 0);
+  });
+});

--- a/src/features/scene/voxl/__tests__/voxlModifierChunks.test.ts
+++ b/src/features/scene/voxl/__tests__/voxlModifierChunks.test.ts
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  serializeVoxlDocumentV2,
+  serializeVoxlDocumentV2Streaming,
+  parseVoxlBinaryV2,
+  VOXL_V2,
+  VOXL_V2_SEMANTIC_REVISION,
+  VOXL_V2_INLINE_REVISION,
+} from '../codec-v2';
+import { countVoxlChunks, readVoxlVersion, testInput, testModel, withFrozenClock } from './voxlTestSupport';
+import { bytesToBase64 } from '@/utils/base64';
+import type { ModelMeshModifiers } from '@/features/mesh-modifiers/types';
+
+// Distinctive Float32-sized blobs. Content identity (not SHA) keys the dedup, so
+// any stable byte pattern that base64-encodes deterministically works.
+const floats = (seed: number, verts: number): string => {
+  const arr = new Float32Array(verts * 3);
+  for (let i = 0; i < arr.length; i += 1) arr[i] = seed + i * 0.5;
+  return bytesToBase64(new Uint8Array(arr.buffer));
+};
+
+const SOURCE = floats(1, 64);
+const CAVITY = floats(2, 32);
+const HOLE = floats(3, 48);
+
+const hollowMods = (source: string, cavity: string): ModelMeshModifiers => ({
+  hollowing: {
+    enabled: true,
+    bakedIntoGeometry: true,
+    mode: 'cavity',
+    voxelSizeMm: 0.5,
+    shellThicknessMm: 2,
+    openFace: 'z_max',
+    sourcePositionsBase64: source,
+    sourcePositionCount: 64,
+    cavityPositionsBase64: cavity,
+    cavityPositionCount: 32,
+  },
+  holePunchesBakedIntoGeometry: true,
+  holePunchSourcePositionsBase64: HOLE,
+  holePunchSourcePositionCount: 48,
+});
+
+test('modifier snapshots move into HSRC/CAVT/PSRC chunks and round-trip byte-for-byte', async () => {
+  const model = testModel('m0', { meshModifiers: hollowMods(SOURCE, CAVITY) });
+  const bin = await serializeVoxlDocumentV2(testInput([model]), new Map());
+
+  // The blobs are no longer inside MODL: header stays V2 (no MESH dedup fired),
+  // and one chunk of each modifier type is present.
+  assert.equal(readVoxlVersion(bin), VOXL_V2, 'a modifier-only file must stay V2');
+  assert.equal(countVoxlChunks(bin, 'HSRC'), 1);
+  assert.equal(countVoxlChunks(bin, 'CAVT'), 1);
+  assert.equal(countVoxlChunks(bin, 'PSRC'), 1);
+
+  const { document } = parseVoxlBinaryV2(bin);
+  const mm = document.models[0].meshModifiers!;
+  assert.equal(mm.hollowing!.sourcePositionsBase64, SOURCE, 'source snapshot round-trips exactly');
+  assert.equal(mm.hollowing!.cavityPositionsBase64, CAVITY, 'cavity snapshot round-trips exactly');
+  assert.equal(mm.holePunchSourcePositionsBase64, HOLE, 'hole-punch snapshot round-trips exactly');
+  // Pointers are an on-disk detail; the re-attached in-memory shape has none.
+  assert.equal(mm.hollowing!.sourceChunkIndex, undefined);
+  assert.equal(mm.hollowing!.cavityChunkIndex, undefined);
+  assert.equal(mm.holePunchSourceChunkIndex, undefined);
+});
+
+test('identical snapshots across models collapse to one chunk per type, and both re-attach', async () => {
+  const a = testModel('a', { meshModifiers: hollowMods(SOURCE, CAVITY) });
+  const b = testModel('b', { meshModifiers: hollowMods(SOURCE, CAVITY) });
+  const bin = await serializeVoxlDocumentV2(testInput([a, b]), new Map());
+
+  assert.equal(countVoxlChunks(bin, 'HSRC'), 1, '2 identical source snapshots → 1 HSRC chunk');
+  assert.equal(countVoxlChunks(bin, 'CAVT'), 1);
+  assert.equal(countVoxlChunks(bin, 'PSRC'), 1);
+  // Modifier-blob dedup is invisible to old readers → no header bump.
+  assert.equal(readVoxlVersion(bin), VOXL_V2, 'modifier dedup must not bump the header');
+
+  const { document } = parseVoxlBinaryV2(bin);
+  for (const m of document.models) {
+    assert.equal(m.meshModifiers!.hollowing!.sourcePositionsBase64, SOURCE);
+    assert.equal(m.meshModifiers!.hollowing!.cavityPositionsBase64, CAVITY);
+    assert.equal(m.meshModifiers!.holePunchSourcePositionsBase64, HOLE);
+  }
+});
+
+test('distinct snapshots keep distinct chunks and map to the right owner', async () => {
+  const otherSource = floats(9, 64);
+  const a = testModel('a', { meshModifiers: hollowMods(SOURCE, CAVITY) });
+  const b = testModel('b', { meshModifiers: hollowMods(otherSource, CAVITY) });
+  const bin = await serializeVoxlDocumentV2(testInput([a, b]), new Map());
+
+  assert.equal(countVoxlChunks(bin, 'HSRC'), 2, 'differing source snapshots must not share a chunk');
+  assert.equal(countVoxlChunks(bin, 'CAVT'), 1, 'shared cavity snapshot still dedups');
+
+  const { document } = parseVoxlBinaryV2(bin);
+  assert.equal(document.models[0].meshModifiers!.hollowing!.sourcePositionsBase64, SOURCE);
+  assert.equal(document.models[1].meshModifiers!.hollowing!.sourcePositionsBase64, otherSource);
+});
+
+test('chunkModifierSnapshots:false keeps snapshots inline (2.1 layout) and still round-trips', async () => {
+  const model = testModel('m0', { meshModifiers: hollowMods(SOURCE, CAVITY) });
+  const bin = await serializeVoxlDocumentV2(testInput([model]), new Map(), undefined, {
+    chunkModifierSnapshots: false,
+  });
+
+  // Format-preserving write: no modifier chunks, base64 stays in MODL.
+  assert.equal(countVoxlChunks(bin, 'HSRC'), 0);
+  assert.equal(countVoxlChunks(bin, 'CAVT'), 0);
+  assert.equal(countVoxlChunks(bin, 'PSRC'), 0);
+
+  const { document } = parseVoxlBinaryV2(bin);
+  const mm = document.models[0].meshModifiers!;
+  assert.equal(mm.hollowing!.sourcePositionsBase64, SOURCE);
+  assert.equal(mm.hollowing!.cavityPositionsBase64, CAVITY);
+  assert.equal(mm.holePunchSourcePositionsBase64, HOLE);
+});
+
+test('the chunking flag is byte-neutral for scenes without modifier snapshots', async () => {
+  await withFrozenClock(async () => {
+    const plain = testModel('m0');
+    const chunked = await serializeVoxlDocumentV2(testInput([plain]), new Map(), undefined, {
+      chunkModifierSnapshots: true,
+    });
+    const inline = await serializeVoxlDocumentV2(testInput([plain]), new Map(), undefined, {
+      chunkModifierSnapshots: false,
+    });
+    assert.deepEqual([...inline], [...chunked], 'no-snapshot scenes must serialize identically either way');
+  });
+});
+
+test('sourceVersion distinguishes chunked (2.2) from inline (2.1) — the no-downgrade signal', async () => {
+  const model = testModel('m0', { meshModifiers: hollowMods(SOURCE, CAVITY) });
+
+  const chunked = await serializeVoxlDocumentV2(testInput([model]), new Map(), undefined, {
+    chunkModifierSnapshots: true,
+  });
+  assert.equal(parseVoxlBinaryV2(chunked).sourceVersion, VOXL_V2_SEMANTIC_REVISION, 'chunked file reads as 2.2');
+
+  const inline = await serializeVoxlDocumentV2(testInput([model]), new Map(), undefined, {
+    chunkModifierSnapshots: false,
+  });
+  assert.equal(parseVoxlBinaryV2(inline).sourceVersion, VOXL_V2_INLINE_REVISION, 'inline file reads as 2.1');
+});
+
+test('buffered and streaming writers stay byte-identical with modifier chunks', async () => {
+  const model = testModel('m0', { meshModifiers: hollowMods(SOURCE, CAVITY) });
+
+  await withFrozenClock(async () => {
+    const buffered = await serializeVoxlDocumentV2(testInput([model]), new Map());
+
+    const parts: Uint8Array[] = [];
+    await serializeVoxlDocumentV2Streaming(testInput([model]), new Map(), undefined, (b) => {
+      parts.push(b);
+    });
+    const total = parts.reduce((n, p) => n + p.length, 0);
+    const streamed = new Uint8Array(total);
+    let off = 0;
+    for (const p of parts) {
+      streamed.set(p, off);
+      off += p.length;
+    }
+
+    assert.deepEqual([...streamed], [...buffered], 'both writers must emit identical bytes');
+  });
+});

--- a/src/features/scene/voxl/codec-v2.ts
+++ b/src/features/scene/voxl/codec-v2.ts
@@ -41,6 +41,8 @@ import {
 import type { DragonfruitImportFormat } from '@/supports/types';
 import type { ModelMeshModifiers } from '@/features/mesh-modifiers/types';
 import { base64ToBytes, bytesToBase64 } from '@/utils/base64';
+import { sha256Hex } from './meshChunkStore';
+import type { VoxlChunkCache, CachedChunkPayload } from './voxlChunkCache';
 
 type ZlibCompressionLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
@@ -285,6 +287,44 @@ export interface VoxlSerializeOptions {
    * without modifier snapshots serialize identically either way.
    */
   chunkModifierSnapshots?: boolean;
+  /**
+   * Cross-tick compressed-chunk cache (autosave Phase 1). When present, the
+   * modifier-snapshot and SUPP chunks reuse their already-compressed bytes and
+   * content digest whenever their content is unchanged (see `voxlChunkCache`),
+   * and the prepared document carries a `fingerprint` for the caller's
+   * write-skip. Absent ⇒ no caching, no fingerprint, byte-identical to before.
+   */
+  chunkCache?: VoxlChunkCache;
+  /** Model index → hex SHA-256 of the ORIG (original-mesh) payload, for the fingerprint. */
+  sha256Original?: Map<number, string>;
+  /**
+   * Small, stable identity for the SUPP chunk's content — derived by the caller
+   * from the support-store snapshot references. Equal keys across ticks ⇒
+   * identical support bytes ⇒ the codec reuses the cached SUPP chunk and skips
+   * the `JSON.stringify` + zlib entirely.
+   */
+  supportsCacheKey?: string;
+  /**
+   * The fingerprint of the last committed write to this destination. When it
+   * equals the freshly-prepared fingerprint the streaming writer emits NOTHING
+   * and reports `skipped: true`, so the caller can abort the atomic commit and
+   * leave the already-correct file in place. Requires `chunkCache` (no cache ⇒
+   * no fingerprint ⇒ never skips).
+   */
+  previousFingerprint?: string;
+}
+
+/**
+ * Thrown by the export path to abort an atomic streamed write when the document
+ * fingerprint matches the last committed one. The atomic writer discards its
+ * temp on any thrown error, so the original file is left untouched; `exportVoxl`
+ * catches this and reports success. It must never escape the export layer.
+ */
+export class VoxlUnchangedError extends Error {
+  constructor(public readonly fingerprint: string) {
+    super('VOXL document unchanged since last write; skipping.');
+    this.name = 'VoxlUnchangedError';
+  }
 }
 
 interface ResolvedChunk {
@@ -293,6 +333,8 @@ interface ResolvedChunk {
   compression: number;
   data: Uint8Array;
   uncompressedSize: number;
+  /** SHA-256 hex of the raw content; populated only when a `chunkCache` is in use. */
+  digest?: string;
 }
 
 interface PreparedDocument {
@@ -300,6 +342,12 @@ interface PreparedDocument {
   directory: ChunkDirEntry[];
   totalSize: number;
   version: number;
+  /**
+   * Content fingerprint of the whole document (ordered per-chunk digests).
+   * Empty string when no `chunkCache` was supplied. Two prepares with equal,
+   * non-empty fingerprints would emit byte-identical files.
+   */
+  fingerprint: string;
 }
 
 /**
@@ -383,7 +431,11 @@ async function prepareVoxlDocumentV2(
   // Independent of MESH dedup — a MESH-duplicate model may still own its own
   // HSRC/CAVT/PSRC, and vice-versa — and invisible to old readers, so it does
   // NOT bump the header version (only MESH dedup does).
-  interface ModifierChunk { type: string; index: number; raw: Uint8Array; }
+  // Decode of the (potentially ~512 MiB) base64 is DEFERRED to `b64` so a cache
+  // hit in the resolve step below can reuse the compressed bytes without ever
+  // decoding. `cacheKey` is a small, stable per-model handle; the base64 string
+  // itself is the cache's `===` signal.
+  interface ModifierChunk { type: string; index: number; b64: string; cacheKey: string; }
   const modifierChunks: ModifierChunk[] = [];
   const strippedModifiersByModel = new Map<number, ModelMeshModifiers>();
   const hollowSourceOwner = new Map<string, number>();
@@ -396,6 +448,7 @@ async function prepareVoxlDocumentV2(
   for (let i = 0; chunkModifierSnapshots && i < input.models.length; i += 1) {
     const mm = input.models[i].meshModifiers;
     if (!mm) continue;
+    const modelId = input.models[i].id ?? String(i);
 
     let nextHollowing = mm.hollowing;
     if (mm.hollowing) {
@@ -408,7 +461,7 @@ async function prepareVoxlDocumentV2(
         const owner = hollowSourceOwner.get(h.sourcePositionsBase64);
         if (owner === undefined) {
           hollowSourceOwner.set(h.sourcePositionsBase64, i);
-          modifierChunks.push({ type: CHUNK_HSRC, index: i, raw: base64ToBytes(h.sourcePositionsBase64) });
+          modifierChunks.push({ type: CHUNK_HSRC, index: i, b64: h.sourcePositionsBase64, cacheKey: `${modelId}:hsrc` });
         } else {
           sourceChunkIndex = owner;
         }
@@ -418,7 +471,7 @@ async function prepareVoxlDocumentV2(
         const owner = hollowCavityOwner.get(h.cavityPositionsBase64);
         if (owner === undefined) {
           hollowCavityOwner.set(h.cavityPositionsBase64, i);
-          modifierChunks.push({ type: CHUNK_CAVT, index: i, raw: base64ToBytes(h.cavityPositionsBase64) });
+          modifierChunks.push({ type: CHUNK_CAVT, index: i, b64: h.cavityPositionsBase64, cacheKey: `${modelId}:cavt` });
         } else {
           cavityChunkIndex = owner;
         }
@@ -441,7 +494,7 @@ async function prepareVoxlDocumentV2(
       const owner = holeSourceOwner.get(mm.holePunchSourcePositionsBase64);
       if (owner === undefined) {
         holeSourceOwner.set(mm.holePunchSourcePositionsBase64, i);
-        modifierChunks.push({ type: CHUNK_PSRC, index: i, raw: base64ToBytes(mm.holePunchSourcePositionsBase64) });
+        modifierChunks.push({ type: CHUNK_PSRC, index: i, b64: mm.holePunchSourcePositionsBase64, cacheKey: `${modelId}:psrc` });
       } else {
         holePunchSourceChunkIndex = owner;
       }
@@ -517,8 +570,16 @@ async function prepareVoxlDocumentV2(
     type: string;
     index: number;
     raw?: Uint8Array;
+    /** Deferred raw builder — invoked only on a cache MISS, so a hit skips the
+     *  base64 decode / `JSON.stringify` that produces the bytes. */
+    rawThunk?: () => Uint8Array;
     pre?: PrecompressedChunk;
     compress: boolean;
+    /** Small stable cache key; paired with `cacheSignal` compared by `===`. */
+    cacheKey?: string;
+    cacheSignal?: string;
+    /** Known content digest (mesh/orig sha) — lets the fingerprint skip re-hashing big blobs. */
+    digestHint?: string;
   };
   const pending: PendingChunk[] = [];
 
@@ -531,36 +592,55 @@ async function prepareVoxlDocumentV2(
   for (const modelIndex of [...dedupedChunkIndices].sort((a, b) => a - b)) {
     const pre = precompressed?.get(modelIndex);
     if (pre) {
-      pending.push({ type: CHUNK_MESH, index: modelIndex, pre, compress: true });
+      pending.push({ type: CHUNK_MESH, index: modelIndex, pre, compress: true, digestHint: sha256Map?.get(modelIndex) });
     } else {
       const raw = meshBytes.get(modelIndex);
       if (raw) {
-        pending.push({ type: CHUNK_MESH, index: modelIndex, raw, compress: true });
+        pending.push({ type: CHUNK_MESH, index: modelIndex, raw, compress: true, digestHint: sha256Map?.get(modelIndex) });
       }
     }
   }
 
   // Additive ORIG chunks for full-res original mesh embedding
   if (embedOriginalMesh) {
+    const sha256Original = options?.sha256Original;
     for (const modelIndex of [...dedupedChunkIndices].sort((a, b) => a - b)) {
       const preOrig = precompressedOriginal?.get(modelIndex);
       const rawOrig = originalMeshBytes?.get(modelIndex);
       if (preOrig) {
-        pending.push({ type: CHUNK_ORIG, index: modelIndex, pre: preOrig, compress: true });
+        pending.push({ type: CHUNK_ORIG, index: modelIndex, pre: preOrig, compress: true, digestHint: sha256Original?.get(modelIndex) });
       } else if (rawOrig) {
-        pending.push({ type: CHUNK_ORIG, index: modelIndex, raw: rawOrig, compress: true });
+        pending.push({ type: CHUNK_ORIG, index: modelIndex, raw: rawOrig, compress: true, digestHint: sha256Original?.get(modelIndex) });
       }
     }
   }
 
   // V2.2 modifier-snapshot chunks (owners only; duplicates were pointer-linked
   // above). Insertion order is deterministic (models ascending, HSRC/CAVT/PSRC
-  // per model), so both writers stay byte-identical.
+  // per model), so both writers stay byte-identical. The base64 decode is
+  // deferred via `rawThunk` so a cache hit (the common transform-edit case)
+  // reuses the compressed bytes without decoding the up-to-512-MiB string.
   for (const chunk of modifierChunks) {
-    pending.push({ type: chunk.type, index: chunk.index, raw: chunk.raw, compress: true });
+    pending.push({
+      type: chunk.type,
+      index: chunk.index,
+      rawThunk: () => base64ToBytes(chunk.b64),
+      compress: true,
+      cacheKey: chunk.cacheKey,
+      cacheSignal: chunk.b64,
+    });
   }
 
-  pending.push({ type: CHUNK_SUPP, index: 0, raw: textEncoder.encode(JSON.stringify(input.supports)), compress: true });
+  // SUPP: `JSON.stringify` of the (potentially huge) support forest is deferred
+  // so a cache hit — a model transform never touches support state — skips it.
+  const supportsCacheKey = options?.supportsCacheKey;
+  pending.push({
+    type: CHUNK_SUPP,
+    index: 0,
+    rawThunk: () => textEncoder.encode(JSON.stringify(input.supports)),
+    compress: true,
+    ...(supportsCacheKey !== undefined ? { cacheKey: 'supp', cacheSignal: supportsCacheKey } : {}),
+  });
 
   if (input.extensions && Object.keys(input.extensions).length > 0) {
     pending.push({ type: CHUNK_EXTD, index: 0, raw: textEncoder.encode(JSON.stringify(input.extensions)), compress: false });
@@ -568,44 +648,72 @@ async function prepareVoxlDocumentV2(
 
   // ── Compress (async – does not block the main thread) ─────────────────
   //
-  // A chunk that arrives pre-compressed skips this entirely. That is the whole
-  // sub-phase-C win: for an unchanged scene, every MESH chunk takes this branch
-  // and the per-tick zlib cost collapses to the KB-scale JSON chunks.
+  // A chunk that arrives pre-compressed, or that hits the cross-tick chunk
+  // cache, skips zlib entirely. That is the sub-phase-C + Phase-1 win: for an
+  // unchanged scene, MESH takes the `pre` branch and modifier/SUPP take the
+  // cache branch, collapsing the per-tick cost to the KB-scale JSON chunks.
+  //
+  // `digest` (SHA-256 of the raw content) is computed only when a `chunkCache`
+  // is supplied — it feeds the document fingerprint the caller uses to skip an
+  // unchanged write. Big chunks reuse a `digestHint` (mesh/orig sha) or a cached
+  // digest, so no large blob is re-hashed per tick.
+  const cache = options?.chunkCache;
+  const wantFingerprint = cache !== undefined;
 
   const resolved: ResolvedChunk[] = await Promise.all(pending.map(async (chunk): Promise<ResolvedChunk> => {
+    if (cache && chunk.cacheKey !== undefined && chunk.cacheSignal !== undefined) {
+      const hit = cache.get(chunk.cacheKey, chunk.cacheSignal);
+      if (hit) {
+        return {
+          type: chunk.type,
+          index: chunk.index,
+          compression: hit.compression,
+          data: hit.data,
+          uncompressedSize: hit.uncompressedSize,
+          digest: hit.digest,
+        };
+      }
+    }
+
     if (chunk.pre) {
+      const digest = wantFingerprint ? (chunk.digestHint ?? await sha256Hex(chunk.pre.data)) : undefined;
       return {
         type: chunk.type,
         index: chunk.index,
         compression: chunk.pre.compression,
         data: chunk.pre.data,
         uncompressedSize: chunk.pre.uncompressedSize,
+        digest,
       };
     }
 
-    const raw = chunk.raw!;
+    const raw = chunk.raw ?? chunk.rawThunk!();
+    let result: ResolvedChunk;
     if (chunk.compress && raw.length > 64) {
       if (chunk.type === CHUNK_MESH) voxlCodecStats.meshChunkCompressions += 1;
       else voxlCodecStats.jsonChunkCompressions += 1;
 
       const compressed = await compressAsync(raw, 6);
-      if (compressed.length < raw.length) {
-        return {
-          type: chunk.type,
-          index: chunk.index,
-          compression: COMPRESSION_ZLIB,
-          data: compressed,
-          uncompressedSize: raw.length,
-        };
+      result = compressed.length < raw.length
+        ? { type: chunk.type, index: chunk.index, compression: COMPRESSION_ZLIB, data: compressed, uncompressedSize: raw.length }
+        : { type: chunk.type, index: chunk.index, compression: COMPRESSION_NONE, data: raw, uncompressedSize: raw.length };
+    } else {
+      result = { type: chunk.type, index: chunk.index, compression: COMPRESSION_NONE, data: raw, uncompressedSize: raw.length };
+    }
+
+    if (wantFingerprint) {
+      const digest = chunk.digestHint ?? await sha256Hex(raw);
+      result.digest = digest;
+      if (cache && chunk.cacheKey !== undefined && chunk.cacheSignal !== undefined) {
+        cache.set(chunk.cacheKey, chunk.cacheSignal, {
+          compression: result.compression,
+          data: result.data,
+          uncompressedSize: result.uncompressedSize,
+          digest,
+        });
       }
     }
-    return {
-      type: chunk.type,
-      index: chunk.index,
-      compression: COMPRESSION_NONE,
-      data: raw,
-      uncompressedSize: raw.length,
-    };
+    return result;
   }));
 
   // ── Calculate layout ──────────────────────────────────────────────────
@@ -636,14 +744,30 @@ async function prepareVoxlDocumentV2(
   // typed, user-readable error instead of wrapping its offsets silently.
   assertVoxlSizeLimits(directory, totalSize, { modelNames: input.models.map((m) => m.name) });
 
+  // Version bumps to 3 only when dedup removed chunks, so old readers reject
+  // deduped files cleanly rather than losing the shared-chunk models;
+  // non-deduped scenes stay V2 and remain readable by older builds.
+  const version = dedupRemovedChunks ? VOXL_V3 : VOXL_V2;
+
+  // Document fingerprint (only when a chunk cache is in use): an ordered digest
+  // of every chunk's identity. Equal, non-empty fingerprints across two prepares
+  // guarantee byte-identical output — the signal the caller uses to skip writing
+  // an unchanged file. Built from cached/hinted digests, so no big blob is
+  // re-hashed here; only the small descriptor string is hashed per tick.
+  let fingerprint = '';
+  if (wantFingerprint) {
+    const descriptor = resolved
+      .map((c) => `${c.type}:${c.index}:${c.compression}:${c.uncompressedSize}:${c.digest ?? ''}`)
+      .join('\n');
+    fingerprint = await sha256Hex(textEncoder.encode(`v${version}\n${descriptor}`));
+  }
+
   return {
     resolved,
     directory,
     totalSize,
-    // Version bumps to 3 only when dedup removed chunks, so old readers reject
-    // deduped files cleanly rather than losing the shared-chunk models;
-    // non-deduped scenes stay V2 and remain readable by older builds.
-    version: dedupRemovedChunks ? VOXL_V3 : VOXL_V2,
+    version,
+    fingerprint,
   };
 }
 
@@ -735,15 +859,26 @@ export async function serializeVoxlDocumentV2Streaming(
   sha256Map: Map<number, string> | undefined,
   sink: (bytes: Uint8Array) => void | Promise<void>,
   options?: VoxlSerializeOptions,
-): Promise<{ totalSize: number; version: number }> {
+): Promise<{ totalSize: number; version: number; fingerprint: string; skipped: boolean }> {
   const prepared = await prepareVoxlDocumentV2(input, meshBytes, sha256Map, options);
+
+  // Write-skip: identical, non-empty fingerprint ⇒ the bytes would match the
+  // file already on disk. Emit nothing and let the caller abort the commit.
+  const previousFingerprint = options?.previousFingerprint;
+  if (
+    previousFingerprint !== undefined &&
+    prepared.fingerprint !== '' &&
+    prepared.fingerprint === previousFingerprint
+  ) {
+    return { totalSize: 0, version: prepared.version, fingerprint: prepared.fingerprint, skipped: true };
+  }
 
   await sink(buildVoxlPreamble(prepared));
   for (const chunk of prepared.resolved) {
     await sink(chunk.data);
   }
 
-  return { totalSize: prepared.totalSize, version: prepared.version };
+  return { totalSize: prepared.totalSize, version: prepared.version, fingerprint: prepared.fingerprint, skipped: false };
 }
 
 // ─── V2 Binary Reader ─────────────────────────────────────────────────────────

--- a/src/features/scene/voxl/codec-v2.ts
+++ b/src/features/scene/voxl/codec-v2.ts
@@ -15,7 +15,7 @@
  *   12..15 reserved  uint32 LE (0)
  *
  * Chunk directory entry (20 bytes each):
- *   0..3   type        4 ASCII chars (META, SCNE, MODL, MESH, SUPP, EXTD)
+ *   0..3   type        4 ASCII chars (META, SCNE, MODL, MESH, SUPP, EXTD, HSRC, CAVT, PSRC)
  *   4..5   index       uint16 LE (multi-instance ordinal, e.g. MESH per model)
  *   6..7   compression uint16 LE (0 = none, 1 = zlib)
  *   8..11  offset      uint32 LE (byte offset from file start)
@@ -39,6 +39,8 @@ import {
   type PrecompressedChunk,
 } from './types';
 import type { DragonfruitImportFormat } from '@/supports/types';
+import type { ModelMeshModifiers } from '@/features/mesh-modifiers/types';
+import { base64ToBytes, bytesToBase64 } from '@/utils/base64';
 
 type ZlibCompressionLevel = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
@@ -54,7 +56,14 @@ const compressAsync = (data: Uint8Array, level: ZlibCompressionLevel): Promise<U
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 export const VOXL_V2 = 2;
-export const VOXL_V2_SEMANTIC_REVISION = 2.1;
+export const VOXL_V2_SEMANTIC_REVISION = 2.2;
+/**
+ * Semantic revision reported for a binary V2 file that has NO modifier-snapshot
+ * chunks — either a genuinely pre-2.2 ("2.1") file with inline base64, or a
+ * 2.2-capable write of a scene that had no snapshots to chunk (byte-identical).
+ * Save-time format preservation treats such files as "inline".
+ */
+export const VOXL_V2_INLINE_REVISION = 2.1;
 /**
  * Container version written when identical-geometry MESH chunk dedup removed
  * at least one chunk (duplicate models share one chunk via meshRef.chunkIndex).
@@ -81,6 +90,13 @@ const CHUNK_MESH = 'MESH';
 export const CHUNK_ORIG = 'ORIG';
 const CHUNK_SUPP = 'SUPP';
 const CHUNK_EXTD = 'EXTD';
+// VOXL 2.2 modifier-snapshot chunks: the large Float32 position snapshots that
+// hollowing / hole-punch bakes into meshModifiers, moved OUT of the MODL JSON
+// (where they were base64 strings that summed past V8's ~512 MiB single-string
+// ceiling) and into raw-bytes chunks indexed by owning model, like MESH.
+const CHUNK_HSRC = 'HSRC'; // hollowing.sourcePositions (raw Float32 bytes)
+const CHUNK_CAVT = 'CAVT'; // hollowing.cavityPositions (raw Float32 bytes)
+const CHUNK_PSRC = 'PSRC'; // holePunchSourcePositions  (raw Float32 bytes)
 
 // ─── Internal Types ───────────────────────────────────────────────────────────
 
@@ -260,6 +276,15 @@ export interface VoxlSerializeOptions {
   /** Model index → raw uncompressed ORIG payload. */
   originalMeshBytes?: Map<number, Uint8Array>;
   embedOriginalMesh?: boolean;
+  /**
+   * VOXL 2.2 modifier-snapshot chunking. `true` (default) moves the large
+   * hollow/hole position snapshots out of MODL into HSRC/CAVT/PSRC chunks.
+   * `false` keeps them inline as base64 (the pre-2.2 = "2.1" layout), used by
+   * autosave to preserve the loaded file's format; the caller escalates to
+   * `true` if the inline write throws (e.g. the MODL string ceiling). Scenes
+   * without modifier snapshots serialize identically either way.
+   */
+  chunkModifierSnapshots?: boolean;
 }
 
 interface ResolvedChunk {
@@ -293,6 +318,7 @@ async function prepareVoxlDocumentV2(
   const precompressedOriginal = options?.precompressedOriginal;
   const originalMeshBytes = options?.originalMeshBytes;
   const embedOriginalMesh = options?.embedOriginalMesh ?? true;
+  const chunkModifierSnapshots = options?.chunkModifierSnapshots ?? true;
   const nowIso = new Date().toISOString();
 
   // ── Build chunk payloads ──────────────────────────────────────────────
@@ -345,6 +371,93 @@ async function prepareVoxlDocumentV2(
   }
   const dedupRemovedChunks = chunkCandidateCount > dedupedChunkIndices.length;
 
+  // ── Modifier-snapshot chunks (V2.2): HSRC / CAVT / PSRC ────────────────
+  // The hollowing/hole-punch bake stores three full-mesh position snapshots as
+  // base64 inside meshModifiers. Summed across models these blow past V8's
+  // ~512 MiB single-string ceiling when JSON.stringify(models) concatenates
+  // them, throwing RangeError. Move each into a raw-bytes chunk indexed by
+  // owning model, and content-dedup PER TYPE keyed by the base64 string itself:
+  // identical snapshots across models share one chunk (first occurrence owns
+  // it; duplicates carry a *ChunkIndex pointer in the stripped MODL entry).
+  //
+  // Independent of MESH dedup — a MESH-duplicate model may still own its own
+  // HSRC/CAVT/PSRC, and vice-versa — and invisible to old readers, so it does
+  // NOT bump the header version (only MESH dedup does).
+  interface ModifierChunk { type: string; index: number; raw: Uint8Array; }
+  const modifierChunks: ModifierChunk[] = [];
+  const strippedModifiersByModel = new Map<number, ModelMeshModifiers>();
+  const hollowSourceOwner = new Map<string, number>();
+  const hollowCavityOwner = new Map<string, number>();
+  const holeSourceOwner = new Map<string, number>();
+
+  // Skipped entirely when chunkModifierSnapshots is false: the base64 blobs stay
+  // inline in the MODL entries (pre-2.2 "2.1" layout) and no HSRC/CAVT/PSRC
+  // chunk is emitted. Autosave uses this to preserve an old file's format.
+  for (let i = 0; chunkModifierSnapshots && i < input.models.length; i += 1) {
+    const mm = input.models[i].meshModifiers;
+    if (!mm) continue;
+
+    let nextHollowing = mm.hollowing;
+    if (mm.hollowing) {
+      const h = mm.hollowing;
+      let sourceChunkIndex: number | undefined;
+      let cavityChunkIndex: number | undefined;
+      let hollowChanged = false;
+
+      if (h.sourcePositionsBase64) {
+        const owner = hollowSourceOwner.get(h.sourcePositionsBase64);
+        if (owner === undefined) {
+          hollowSourceOwner.set(h.sourcePositionsBase64, i);
+          modifierChunks.push({ type: CHUNK_HSRC, index: i, raw: base64ToBytes(h.sourcePositionsBase64) });
+        } else {
+          sourceChunkIndex = owner;
+        }
+        hollowChanged = true;
+      }
+      if (h.cavityPositionsBase64) {
+        const owner = hollowCavityOwner.get(h.cavityPositionsBase64);
+        if (owner === undefined) {
+          hollowCavityOwner.set(h.cavityPositionsBase64, i);
+          modifierChunks.push({ type: CHUNK_CAVT, index: i, raw: base64ToBytes(h.cavityPositionsBase64) });
+        } else {
+          cavityChunkIndex = owner;
+        }
+        hollowChanged = true;
+      }
+      if (hollowChanged) {
+        nextHollowing = { ...h };
+        delete nextHollowing.sourcePositionsBase64;
+        delete nextHollowing.cavityPositionsBase64;
+        // Owners default to their own index (no pointer) so single-owner files
+        // stay byte-identical to the non-dedup case.
+        if (sourceChunkIndex !== undefined) nextHollowing.sourceChunkIndex = sourceChunkIndex;
+        if (cavityChunkIndex !== undefined) nextHollowing.cavityChunkIndex = cavityChunkIndex;
+      }
+    }
+
+    let holePunchSourceChunkIndex: number | undefined;
+    let holeSourceStripped = false;
+    if (mm.holePunchSourcePositionsBase64) {
+      const owner = holeSourceOwner.get(mm.holePunchSourcePositionsBase64);
+      if (owner === undefined) {
+        holeSourceOwner.set(mm.holePunchSourcePositionsBase64, i);
+        modifierChunks.push({ type: CHUNK_PSRC, index: i, raw: base64ToBytes(mm.holePunchSourcePositionsBase64) });
+      } else {
+        holePunchSourceChunkIndex = owner;
+      }
+      holeSourceStripped = true;
+    }
+
+    if (nextHollowing !== mm.hollowing || holeSourceStripped) {
+      const stripped: ModelMeshModifiers = { ...mm, hollowing: nextHollowing };
+      if (holeSourceStripped) {
+        delete stripped.holePunchSourcePositionsBase64;
+        if (holePunchSourceChunkIndex !== undefined) stripped.holePunchSourceChunkIndex = holePunchSourceChunkIndex;
+      }
+      strippedModifiersByModel.set(i, stripped);
+    }
+  }
+
   const models: VoxlModelEntry[] = input.models.map((m, i) => {
     const hasChunk = hasChunkFor(i);
     const ownerIndex = chunkOwnerByModelIndex.get(i);
@@ -391,7 +504,7 @@ async function prepareVoxlDocumentV2(
         rotation: { x: m.transform.rotation.x, y: m.transform.rotation.y, z: m.transform.rotation.z },
         scale: { x: m.transform.scale.x, y: m.transform.scale.y, z: m.transform.scale.z },
       },
-      meshModifiers: m.meshModifiers,
+      meshModifiers: strippedModifiersByModel.get(i) ?? m.meshModifiers,
       mesh: meshRef,
       isSupportGeometry: m.isSupportGeometry,
       linkGroupId: m.linkGroupId,
@@ -438,6 +551,13 @@ async function prepareVoxlDocumentV2(
         pending.push({ type: CHUNK_ORIG, index: modelIndex, raw: rawOrig, compress: true });
       }
     }
+  }
+
+  // V2.2 modifier-snapshot chunks (owners only; duplicates were pointer-linked
+  // above). Insertion order is deterministic (models ascending, HSRC/CAVT/PSRC
+  // per model), so both writers stay byte-identical.
+  for (const chunk of modifierChunks) {
+    pending.push({ type: chunk.type, index: chunk.index, raw: chunk.raw, compress: true });
   }
 
   pending.push({ type: CHUNK_SUPP, index: 0, raw: textEncoder.encode(JSON.stringify(input.supports)), compress: true });
@@ -812,8 +932,61 @@ export function parseVoxlBinaryV2(data: Uint8Array): ParsedVoxlResult {
     }
   }
 
-  const lazyOriginalMeshBytesMap = originalMeshChunksMap.size > 0 
-    ? new LazyOriginalMeshBytesMap(originalMeshChunksMap) 
+  // ── Re-attach V2.2 modifier-snapshot chunks (HSRC/CAVT/PSRC) ──────────
+  // The writer moved these Float32 position snapshots out of the MODL JSON into
+  // raw-bytes chunks (§ CHUNK_HSRC). A snapshot lives in a chunk when its
+  // *PositionCount is non-zero but the matching *Base64 is absent. Resolve the
+  // owning chunk at `*ChunkIndex ?? modelIndex` (dedup pointer; owners default
+  // to their own index) and re-encode as base64 so downstream consumers see the
+  // exact V2.1 in-memory shape. Older V2 files simply have the base64 already
+  // present and skip every branch here.
+  const modifierChunkCache = new Map<string, Uint8Array>();
+  const readModifierChunk = (type: string, index: number): Uint8Array | undefined => {
+    const key = `${type}:${index}`;
+    const cached = modifierChunkCache.get(key);
+    if (cached) return cached;
+    const entry = entries.find((e) => e.type === type && e.index === index);
+    if (!entry) return undefined;
+    const bytes = readChunk(entry);
+    modifierChunkCache.set(key, bytes);
+    return bytes;
+  };
+
+  for (let i = 0; i < models.length; i += 1) {
+    const mm = models[i].meshModifiers;
+    if (!mm) continue;
+
+    const h = mm.hollowing;
+    if (h) {
+      if (h.sourcePositionCount && !h.sourcePositionsBase64) {
+        const bytes = readModifierChunk(CHUNK_HSRC, h.sourceChunkIndex ?? i);
+        if (bytes) h.sourcePositionsBase64 = bytesToBase64(bytes);
+      }
+      delete h.sourceChunkIndex;
+      if (h.cavityPositionCount && !h.cavityPositionsBase64) {
+        const bytes = readModifierChunk(CHUNK_CAVT, h.cavityChunkIndex ?? i);
+        if (bytes) h.cavityPositionsBase64 = bytesToBase64(bytes);
+      }
+      delete h.cavityChunkIndex;
+    }
+    if (mm.holePunchSourcePositionCount && !mm.holePunchSourcePositionsBase64) {
+      const bytes = readModifierChunk(CHUNK_PSRC, mm.holePunchSourceChunkIndex ?? i);
+      if (bytes) mm.holePunchSourcePositionsBase64 = bytesToBase64(bytes);
+    }
+    delete mm.holePunchSourceChunkIndex;
+  }
+
+  // A file is 2.2 iff it actually carries modifier-snapshot chunks; otherwise it
+  // is the inline ("2.1") layout — including 2.2-capable writes of scenes that
+  // simply had no snapshots to chunk (byte-identical either way). Save-time
+  // format preservation keys off this: a 2.2 file must never be autosaved back
+  // to inline.
+  const hasModifierChunks = entries.some(
+    (e) => e.type === CHUNK_HSRC || e.type === CHUNK_CAVT || e.type === CHUNK_PSRC,
+  );
+
+  const lazyOriginalMeshBytesMap = originalMeshChunksMap.size > 0
+    ? new LazyOriginalMeshBytesMap(originalMeshChunksMap)
     : undefined;
 
   return {
@@ -829,7 +1002,7 @@ export function parseVoxlBinaryV2(data: Uint8Array): ParsedVoxlResult {
     meshBytes: meshBytesMap,
     ...(lazyOriginalMeshBytesMap ? { originalMeshBytes: lazyOriginalMeshBytesMap } : {}),
     ...(originalMeshChunksMap.size > 0 ? { originalMeshChunks: originalMeshChunksMap } : {}),
-    sourceVersion: VOXL_V2_SEMANTIC_REVISION,
+    sourceVersion: hasModifierChunks ? VOXL_V2_SEMANTIC_REVISION : VOXL_V2_INLINE_REVISION,
   };
 }
 

--- a/src/features/scene/voxl/codec-v2.ts
+++ b/src/features/scene/voxl/codec-v2.ts
@@ -327,6 +327,13 @@ export class VoxlUnchangedError extends Error {
   }
 }
 
+/** How a chunk's bytes were obtained this tick — the "did we do work" axis, as
+ *  opposed to `changed` (the "did content move" axis) in the report below. */
+export type VoxlChunkSource =
+  | 'cache' // reused already-compressed bytes from the cross-tick chunk cache
+  | 'precompressed' // reused the mesh store's precompressed bytes (no zlib here)
+  | 'built'; // decoded/stringified + (maybe) compressed this tick
+
 interface ResolvedChunk {
   type: string;
   index: number;
@@ -335,6 +342,24 @@ interface ResolvedChunk {
   uncompressedSize: number;
   /** SHA-256 hex of the raw content; populated only when a `chunkCache` is in use. */
   digest?: string;
+  /** How the bytes were produced; populated only when a `chunkCache` is in use. */
+  source?: VoxlChunkSource;
+}
+
+/**
+ * One row of the per-tick change report (built only when a `chunkCache` is in
+ * use — i.e. autosave). `changed` is a true content-digest comparison against
+ * the previous prepared document; `source` says whether real work ran to make
+ * the bytes. Surfaced so autosave can log which chunks moved and which didn't.
+ */
+export interface VoxlChunkReportEntry {
+  type: string;
+  index: number;
+  changed: boolean;
+  isNew: boolean;
+  source: VoxlChunkSource;
+  compressedSize: number;
+  uncompressedSize: number;
 }
 
 interface PreparedDocument {
@@ -348,6 +373,11 @@ interface PreparedDocument {
    * non-empty fingerprints would emit byte-identical files.
    */
   fingerprint: string;
+  /**
+   * Per-chunk change report vs. the last prepared document. Empty unless a
+   * `chunkCache` was supplied (autosave); the caller logs it.
+   */
+  chunkReport: VoxlChunkReportEntry[];
 }
 
 /**
@@ -671,6 +701,7 @@ async function prepareVoxlDocumentV2(
           data: hit.data,
           uncompressedSize: hit.uncompressedSize,
           digest: hit.digest,
+          source: 'cache',
         };
       }
     }
@@ -684,6 +715,7 @@ async function prepareVoxlDocumentV2(
         data: chunk.pre.data,
         uncompressedSize: chunk.pre.uncompressedSize,
         digest,
+        source: 'precompressed',
       };
     }
 
@@ -695,10 +727,10 @@ async function prepareVoxlDocumentV2(
 
       const compressed = await compressAsync(raw, 6);
       result = compressed.length < raw.length
-        ? { type: chunk.type, index: chunk.index, compression: COMPRESSION_ZLIB, data: compressed, uncompressedSize: raw.length }
-        : { type: chunk.type, index: chunk.index, compression: COMPRESSION_NONE, data: raw, uncompressedSize: raw.length };
+        ? { type: chunk.type, index: chunk.index, compression: COMPRESSION_ZLIB, data: compressed, uncompressedSize: raw.length, source: 'built' }
+        : { type: chunk.type, index: chunk.index, compression: COMPRESSION_NONE, data: raw, uncompressedSize: raw.length, source: 'built' };
     } else {
-      result = { type: chunk.type, index: chunk.index, compression: COMPRESSION_NONE, data: raw, uncompressedSize: raw.length };
+      result = { type: chunk.type, index: chunk.index, compression: COMPRESSION_NONE, data: raw, uncompressedSize: raw.length, source: 'built' };
     }
 
     if (wantFingerprint) {
@@ -755,11 +787,31 @@ async function prepareVoxlDocumentV2(
   // an unchanged file. Built from cached/hinted digests, so no big blob is
   // re-hashed here; only the small descriptor string is hashed per tick.
   let fingerprint = '';
+  let chunkReport: VoxlChunkReportEntry[] = [];
   if (wantFingerprint) {
     const descriptor = resolved
       .map((c) => `${c.type}:${c.index}:${c.compression}:${c.uncompressedSize}:${c.digest ?? ''}`)
       .join('\n');
     fingerprint = await sha256Hex(textEncoder.encode(`v${version}\n${descriptor}`));
+
+    // Per-chunk change report (autosave logging). Diff each chunk's content
+    // digest against the last prepared document; `source` records whether work
+    // ran. `cache!` is safe here — `wantFingerprint === (cache !== undefined)`.
+    const status = cache!.diffAndRecordDocument(
+      resolved.map((c) => ({ type: c.type, index: c.index, digest: c.digest ?? '' })),
+    );
+    chunkReport = resolved.map((c, i) => {
+      const change = status.get(`${c.type}:${c.index}`) ?? 'changed';
+      return {
+        type: c.type,
+        index: c.index,
+        changed: change !== 'unchanged',
+        isNew: change === 'new',
+        source: c.source ?? 'built',
+        compressedSize: directory[i].compressedSize,
+        uncompressedSize: c.uncompressedSize,
+      };
+    });
   }
 
   return {
@@ -768,6 +820,7 @@ async function prepareVoxlDocumentV2(
     totalSize,
     version,
     fingerprint,
+    chunkReport,
   };
 }
 
@@ -859,7 +912,13 @@ export async function serializeVoxlDocumentV2Streaming(
   sha256Map: Map<number, string> | undefined,
   sink: (bytes: Uint8Array) => void | Promise<void>,
   options?: VoxlSerializeOptions,
-): Promise<{ totalSize: number; version: number; fingerprint: string; skipped: boolean }> {
+): Promise<{
+  totalSize: number;
+  version: number;
+  fingerprint: string;
+  skipped: boolean;
+  chunkReport: VoxlChunkReportEntry[];
+}> {
   const prepared = await prepareVoxlDocumentV2(input, meshBytes, sha256Map, options);
 
   // Write-skip: identical, non-empty fingerprint ⇒ the bytes would match the
@@ -870,7 +929,13 @@ export async function serializeVoxlDocumentV2Streaming(
     prepared.fingerprint !== '' &&
     prepared.fingerprint === previousFingerprint
   ) {
-    return { totalSize: 0, version: prepared.version, fingerprint: prepared.fingerprint, skipped: true };
+    return {
+      totalSize: 0,
+      version: prepared.version,
+      fingerprint: prepared.fingerprint,
+      skipped: true,
+      chunkReport: prepared.chunkReport,
+    };
   }
 
   await sink(buildVoxlPreamble(prepared));
@@ -878,7 +943,13 @@ export async function serializeVoxlDocumentV2Streaming(
     await sink(chunk.data);
   }
 
-  return { totalSize: prepared.totalSize, version: prepared.version, fingerprint: prepared.fingerprint, skipped: false };
+  return {
+    totalSize: prepared.totalSize,
+    version: prepared.version,
+    fingerprint: prepared.fingerprint,
+    skipped: false,
+    chunkReport: prepared.chunkReport,
+  };
 }
 
 // ─── V2 Binary Reader ─────────────────────────────────────────────────────────

--- a/src/features/scene/voxl/index.ts
+++ b/src/features/scene/voxl/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './codec';
 export * from './codec-v2';
 export * from './meshChunkStore';
+export * from './voxlChunkCache';

--- a/src/features/scene/voxl/voxlChunkCache.ts
+++ b/src/features/scene/voxl/voxlChunkCache.ts
@@ -41,12 +41,45 @@ interface CacheEntry {
  * `VoxlSerializeOptions.chunkCache`. Manual/one-off saves pass none, so they
  * behave exactly as before.
  */
+/** Per-chunk change status vs. the previously-prepared document. */
+export type VoxlChunkChange = 'new' | 'changed' | 'unchanged';
+
 export class VoxlChunkCache {
   private readonly entries = new Map<string, CacheEntry>();
   private readonly maxEntries: number;
 
+  /**
+   * The previous prepared document's per-chunk content digests, keyed by
+   * `${type}:${index}`. Powers the per-autosave "which chunks changed" log —
+   * a true digest comparison, so a MODL that was rebuilt but is byte-identical
+   * still reads as `unchanged`, and META (its timestamp moves every tick) reads
+   * as `changed`.
+   */
+  private prevDocDigests = new Map<string, string>();
+
   constructor(maxEntries = 256) {
     this.maxEntries = Math.max(1, maxEntries);
+  }
+
+  /**
+   * Diff this document's chunk digests against the last one this cache saw, then
+   * record the new set as the baseline for next tick. Returns a status per chunk
+   * keyed by `${type}:${index}`. A chunk unseen last tick is `new`; a chunk whose
+   * digest moved is `changed`; an identical digest is `unchanged`.
+   */
+  diffAndRecordDocument(
+    chunks: ReadonlyArray<{ type: string; index: number; digest: string }>,
+  ): Map<string, VoxlChunkChange> {
+    const status = new Map<string, VoxlChunkChange>();
+    const next = new Map<string, string>();
+    for (const chunk of chunks) {
+      const key = `${chunk.type}:${chunk.index}`;
+      const prev = this.prevDocDigests.get(key);
+      status.set(key, prev === undefined ? 'new' : prev === chunk.digest ? 'unchanged' : 'changed');
+      next.set(key, chunk.digest);
+    }
+    this.prevDocDigests = next;
+    return status;
   }
 
   /**
@@ -77,6 +110,7 @@ export class VoxlChunkCache {
 
   clear(): void {
     this.entries.clear();
+    this.prevDocDigests.clear();
   }
 
   get size(): number {

--- a/src/features/scene/voxl/voxlChunkCache.ts
+++ b/src/features/scene/voxl/voxlChunkCache.ts
@@ -1,0 +1,85 @@
+/**
+ * Cross-tick compressed-chunk cache for VOXL autosave (per-chunk hashing, Phase 1).
+ *
+ * Autosave re-serializes the whole scene every tick. Geometry (MESH/ORIG) is
+ * already content-addressed by `meshChunkStore`, but the modifier-snapshot and
+ * support chunks were decoded + zlib'd from scratch every time. This cache lets
+ * the codec reuse a chunk's already-compressed bytes (and its content digest)
+ * across ticks when the chunk's content is unchanged.
+ *
+ * Design note — why we do NOT key by the payload itself:
+ *   The modifier snapshots are base64 strings up to ~512 MiB. A `Map` keyed by
+ *   that string would hash the whole string on every lookup, which is exactly
+ *   the per-tick cost we are trying to remove. Instead the key is a SMALL,
+ *   stable handle (`${modelId}:hsrc`, `supp`, …) and the large payload is kept
+ *   as a `signal` compared with `===`. String `===` is content equality but V8
+ *   fast-paths it on pointer identity, and the base64 reference is preserved
+ *   across object spreads while the snapshot is unchanged — so the hot path is
+ *   an O(1) pointer compare and a genuine content change is still caught
+ *   (different string ⇒ `===` false ⇒ recompute). No false "unchanged".
+ */
+
+export interface CachedChunkPayload {
+  /** Container compression tag (0 = none, 1 = zlib) of `data`. */
+  compression: number;
+  /** The emitted (already-compressed, or stored-raw) chunk bytes. */
+  data: Uint8Array;
+  /** Uncompressed byte length — the directory's rawSize field. */
+  uncompressedSize: number;
+  /** SHA-256 hex of the RAW (uncompressed) content, for the document fingerprint. */
+  digest: string;
+}
+
+interface CacheEntry {
+  signal: string;
+  payload: CachedChunkPayload;
+}
+
+/**
+ * A bounded, caller-owned cache. One instance lives for the lifetime of a loaded
+ * scene (owned by the autosave hook) and is passed into the serializer via
+ * `VoxlSerializeOptions.chunkCache`. Manual/one-off saves pass none, so they
+ * behave exactly as before.
+ */
+export class VoxlChunkCache {
+  private readonly entries = new Map<string, CacheEntry>();
+  private readonly maxEntries: number;
+
+  constructor(maxEntries = 256) {
+    this.maxEntries = Math.max(1, maxEntries);
+  }
+
+  /**
+   * Returns the cached payload for `key` only when its stored `signal` is `===`
+   * the one supplied — i.e. the content is provably unchanged. Any mismatch (or
+   * a miss) returns undefined so the caller recomputes.
+   */
+  get(key: string, signal: string): CachedChunkPayload | undefined {
+    const entry = this.entries.get(key);
+    if (entry !== undefined && entry.signal === signal) {
+      // Refresh recency (Map preserves insertion order → re-insert = move to end).
+      this.entries.delete(key);
+      this.entries.set(key, entry);
+      return entry.payload;
+    }
+    return undefined;
+  }
+
+  set(key: string, signal: string, payload: CachedChunkPayload): void {
+    this.entries.delete(key);
+    this.entries.set(key, { signal, payload });
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}

--- a/src/hooks/__tests__/autosaveFailureHonesty.test.ts
+++ b/src/hooks/__tests__/autosaveFailureHonesty.test.ts
@@ -86,10 +86,30 @@ describe('autosave contention policy (D4)', () => {
     modelCount: 3,
     navigationBusy: false,
     forced: false,
+    // Dirty by default: one edit since the last committed write.
+    revision: 1,
+    lastPersistedRevision: 0,
   };
 
   test('a quiet desktop scene with models runs', () => {
     assert.deepEqual(decideAutosaveGate(base), { action: 'run' });
+  });
+
+  test('a scene unchanged since the last committed write is skipped', () => {
+    const decision = decideAutosaveGate({ ...base, revision: 4, lastPersistedRevision: 4 });
+    assert.equal(decision.action, 'skip');
+    assert.equal(decision.reason, 'unchanged');
+    assert.equal(decision.retainDirty, false);
+  });
+
+  test('a forced flush writes even when the revision is unchanged', () => {
+    const decision = decideAutosaveGate({
+      ...base,
+      revision: 4,
+      lastPersistedRevision: 4,
+      forced: true,
+    });
+    assert.equal(decision.action, 'run');
   });
 
   test('a suppressed window DEFERS and keeps the scene dirty', () => {

--- a/src/hooks/useSceneAutosave.ts
+++ b/src/hooks/useSceneAutosave.ts
@@ -320,6 +320,19 @@ export type UseSceneAutosaveOptions = {
   debounceMs?: number;
   capMs?: number;
   preferredSavePath?: string | null;
+  /**
+   * Whether the current scene's on-disk format is the chunked VOXL 2.2 layout.
+   * Autosave preserves the inline (pre-2.2) layout only when this is `false`; a
+   * scene that is already 2.2 is never written back to inline (no downgrade).
+   * Defaults to `true` (newest) so an unknown/new scene autosaves as 2.2.
+   */
+  sceneFormatChunked?: boolean;
+  /**
+   * Fired when autosave had to escalate an inline write to the 2.2 chunked
+   * layout (the inline write threw). The owner latches the scene to chunked so
+   * later ticks stop re-attempting — and never downgrade — the now-2.2 file.
+   */
+  onSceneFormatUpgraded?: () => void;
 };
 
 export type UseSceneAutosaveResult = {
@@ -346,6 +359,8 @@ export function useSceneAutosave({
   debounceMs = AUTOSAVE_DEBOUNCE_MS,
   capMs = AUTOSAVE_CAP_MS,
   preferredSavePath = null,
+  sceneFormatChunked = true,
+  onSceneFormatUpgraded,
 }: UseSceneAutosaveOptions): UseSceneAutosaveResult {
   const [isAutosaving, setIsAutosaving] = React.useState(false);
   const [lastAutosaveAt, setLastAutosaveAt] = React.useState<string | null>(null);
@@ -367,6 +382,10 @@ export function useSceneAutosave({
   capMsRef.current = capMs;
   const preferredSavePathRef = React.useRef(preferredSavePath);
   preferredSavePathRef.current = preferredSavePath;
+  const sceneFormatChunkedRef = React.useRef(sceneFormatChunked);
+  sceneFormatChunkedRef.current = sceneFormatChunked;
+  const onSceneFormatUpgradedRef = React.useRef(onSceneFormatUpgraded);
+  onSceneFormatUpgradedRef.current = onSceneFormatUpgraded;
 
   const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const capRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -454,25 +473,44 @@ export function useSceneAutosave({
         const paths = await getAutosavePaths(preferredSavePathRef.current);
         const { voxlPath } = paths;
 
-        await ExportManager.exportScene(
-          null,
-          null,
-          {
-            filename: 'autosave',
-            format: 'voxl',
-            binary: true,
-            separateFiles: false,
-            includeRaft: false,
-            includeSupports: true,
-            includeModel: true,
-          },
-          {
-            models: currentModels,
-            activeModelId: activeModelIdRef.current,
-            selectedModelIds: selectedModelIdsRef.current,
-          },
-          { nativePath: voxlPath },
-        );
+        // Format preservation: keep a pre-2.2 file inline, but never downgrade a
+        // file that is already 2.2. If the inline write throws (typically the
+        // MODL string ceiling on snapshots too large to inline), escalate to the
+        // chunked 2.2 layout and latch the scene there so later ticks stop
+        // re-attempting inline.
+        const runExport = (chunkModifierSnapshots: boolean): Promise<string | null> =>
+          ExportManager.exportScene(
+            null,
+            null,
+            {
+              filename: 'autosave',
+              format: 'voxl',
+              binary: true,
+              separateFiles: false,
+              includeRaft: false,
+              includeSupports: true,
+              includeModel: true,
+            },
+            {
+              models: currentModels,
+              activeModelId: activeModelIdRef.current,
+              selectedModelIds: selectedModelIdsRef.current,
+            },
+            { nativePath: voxlPath, chunkModifierSnapshots },
+          );
+
+        if (sceneFormatChunkedRef.current) {
+          await runExport(true);
+        } else {
+          try {
+            await runExport(false);
+          } catch (error) {
+            console.warn('[autosave] Inline VOXL write failed; upgrading scene to the 2.2 chunked layout.', error);
+            onSceneFormatUpgradedRef.current?.();
+            sceneFormatChunkedRef.current = true;
+            await runExport(true);
+          }
+        }
 
         // Ordering is load-bearing and must stay this way: payload first, then
         // manifest. `exportScene` above commits the VOXL through the atomic

--- a/src/hooks/useSceneAutosave.ts
+++ b/src/hooks/useSceneAutosave.ts
@@ -3,6 +3,7 @@
 import React from 'react';
 import { subscribeHistory } from '@/history/historyStore';
 import { ExportManager } from '@/features/export/logic/ExportManager';
+import { VoxlChunkCache } from '@/features/scene/voxl';
 import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 
 // ---------------------------------------------------------------------------
@@ -197,12 +198,22 @@ export type AutosaveGateInput = {
   navigationBusy: boolean;
   /** An explicit flush: quit, or a hand-off from the save path. */
   forced: boolean;
+  /**
+   * Monotonic scene-content revision at the moment this tick started, and the
+   * revision the last SUCCESSFUL persist committed. Equal ⇒ nothing has changed
+   * since the file on disk was written, so the whole tick is skipped before any
+   * build/stringify/hash/I/O. `revision` bumps on every autosave trigger
+   * (history push, model add/remove); `lastPersistedRevision` advances only on a
+   * committed write, so a failed save is never mistaken for a clean scene.
+   */
+  revision: number;
+  lastPersistedRevision: number;
 };
 
 export type AutosaveGateDecision =
   | { action: 'run' }
   | { action: 'defer'; reason: 'navigation' | 'suppressed'; retainDirty: true }
-  | { action: 'skip'; reason: 'disabled' | 'not-desktop' | 'empty-scene'; retainDirty: boolean };
+  | { action: 'skip'; reason: 'disabled' | 'not-desktop' | 'empty-scene' | 'unchanged'; retainDirty: boolean };
 
 /**
  * Decides whether a tick runs now, later, or not at all.
@@ -233,6 +244,13 @@ export function decideAutosaveGate(input: AutosaveGateInput): AutosaveGateDecisi
     }
     if (input.navigationBusy) {
       return { action: 'defer', reason: 'navigation', retainDirty: true };
+    }
+    // Nothing changed since the last committed write — skip the entire tick.
+    // retainDirty:false because there is genuinely nothing outstanding; a real
+    // edit bumps `revision` and re-arms a tick. Forced flushes bypass this so
+    // the quit/hand-off path always reaches disk.
+    if (input.revision === input.lastPersistedRevision) {
+      return { action: 'skip', reason: 'unchanged', retainDirty: false };
     }
   }
 
@@ -397,6 +415,22 @@ export function useSceneAutosave({
   const autosavePromiseRef = React.useRef<Promise<void> | null>(null);
   const dirtyRef = React.useRef(false);
 
+  // Monotonic scene-content revision: bumped by `scheduleSave` on every autosave
+  // trigger, and snapshotted into `lastPersistedRevisionRef` only when a write
+  // commits. The gate skips a tick whose revision already matches the last
+  // committed one, so an idle/duplicate tick does no build/stringify/hash/I/O.
+  // Starts at 0 == lastPersisted so a freshly loaded scene (disk already current)
+  // does not autosave until the first real edit.
+  const revisionRef = React.useRef(0);
+  const lastPersistedRevisionRef = React.useRef(0);
+
+  // Incremental-write state (Phase 1). The chunk cache persists across ticks so
+  // unchanged modifier/SUPP chunks reuse their compressed bytes; the last-write
+  // fingerprint (scoped to its path) drives the "content unchanged → skip the
+  // disk write" decision inside `ExportManager.exportVoxl`.
+  const chunkCacheRef = React.useRef<VoxlChunkCache | null>(null);
+  const lastWriteFingerprintRef = React.useRef<{ path: string; fingerprint: string } | null>(null);
+
   const clearDeferredAutosave = React.useCallback(() => {
     if (deferredAutosaveRef.current === null) return;
     clearTimeout(deferredAutosaveRef.current);
@@ -436,6 +470,12 @@ export function useSceneAutosave({
     const run = async () => {
       const currentModels = modelsRef.current;
 
+      // Snapshot the revision BEFORE the gate/write: edits that land while this
+      // tick is in flight bump `revisionRef` past this value, so committing this
+      // one only advances `lastPersistedRevision` to what it actually wrote,
+      // leaving the scene correctly dirty for a follow-up tick.
+      const revisionAtStart = revisionRef.current;
+
       // One explicit policy decision instead of five early returns, so
       // "does the dirtiness survive this?" is answerable by reading it (D4).
       const decision = decideAutosaveGate({
@@ -446,6 +486,8 @@ export function useSceneAutosave({
         modelCount: currentModels.length,
         navigationBusy: shouldDeferAutosaveForNavigation(),
         forced: options?.force === true,
+        revision: revisionAtStart,
+        lastPersistedRevision: lastPersistedRevisionRef.current,
       });
 
       if (decision.action !== 'run') {
@@ -478,6 +520,16 @@ export function useSceneAutosave({
         // MODL string ceiling on snapshots too large to inline), escalate to the
         // chunked 2.2 layout and latch the scene there so later ticks stop
         // re-attempting inline.
+        // Incremental-write cache (Phase 1): reuse compressed chunks across
+        // ticks and skip the disk write entirely when the document fingerprint
+        // matches what is already on `voxlPath`. The fingerprint is trusted only
+        // for the SAME path — a Save As moves `voxlPath`, so a stale fingerprint
+        // must not authorize a skip.
+        if (chunkCacheRef.current === null) chunkCacheRef.current = new VoxlChunkCache();
+        const priorWrite = lastWriteFingerprintRef.current;
+        const previousFingerprint =
+          priorWrite !== null && priorWrite.path === voxlPath ? priorWrite.fingerprint : undefined;
+
         const runExport = (chunkModifierSnapshots: boolean): Promise<string | null> =>
           ExportManager.exportScene(
             null,
@@ -496,7 +548,17 @@ export function useSceneAutosave({
               activeModelId: activeModelIdRef.current,
               selectedModelIds: selectedModelIdsRef.current,
             },
-            { nativePath: voxlPath, chunkModifierSnapshots },
+            {
+              nativePath: voxlPath,
+              chunkModifierSnapshots,
+              chunkCache: chunkCacheRef.current ?? undefined,
+              previousFingerprint,
+              onFingerprint: (fingerprint) => {
+                lastWriteFingerprintRef.current = fingerprint
+                  ? { path: voxlPath, fingerprint }
+                  : null;
+              },
+            },
           );
 
         if (sceneFormatChunkedRef.current) {
@@ -528,6 +590,11 @@ export function useSceneAutosave({
           projectPath: paths.projectPath,
           fallbackReason: paths.fallbackReason,
         });
+        // Commit succeeded: the file on disk now reflects `revisionAtStart`.
+        // Advance the persisted marker so the gate skips ticks until the next
+        // real edit. Set to the snapshot, NOT the current revision — edits that
+        // arrived mid-write are not in this file and must remain outstanding.
+        lastPersistedRevisionRef.current = revisionAtStart;
         failureTrackerRef.current.recordSuccess(savedAt);
         setLastAutosaveAt(savedAt);
         setLastAutosaveError(null);
@@ -590,6 +657,9 @@ export function useSceneAutosave({
     // waited for the next unrelated history push to be persisted. Recording it
     // here costs nothing and means the window closing is enough to fire a tick.
     dirtyRef.current = true;
+    // Every trigger advances the content revision; the gate compares this to the
+    // revision of the last committed write to skip idle/duplicate ticks.
+    revisionRef.current += 1;
     if (!enabledRef.current) return;
 
     // Reset the debounce window


### PR DESCRIPTION
## Why

Two related problems on large scenes with mesh modifiers (hollowing / hole-punch):

1. **Saves could fail outright.** Modifier position snapshots are non-indexed `Float32` triangle-soup meshes — often larger than a model's own geometry — and V2.1 stored them as base64 *inside* the `MODL` JSON string. Concatenate a few and `JSON.stringify(models)` (and `JSON.parse` on read) blows past V8's ~512 MiB single-string ceiling and throws `RangeError: Invalid string length`. The scene simply couldn't be written.

2. **Autosave re-did all the work every tick.** Each autosave re-serialized, re-encoded, and re-`zlib`'d the entire scene from scratch — including snapshot chunks that hadn't changed — and always hit the disk, even when nothing had changed since the last committed write.

## What changed

### VOXL 2.2 format — `HSRC` / `CAVT` / `PSRC` chunks

Modifier snapshots move **out of `MODL` JSON and into raw-binary chunks**, indexed by model like `MESH`:

| Modifier field (V2.1 JSON)          | V2.2 chunk | Dedup pointer (MODL JSON)    |
| ----------------------------------- | ---------- | --------------------------- |
| `hollowing.sourcePositionsBase64`   | `HSRC`     | `hollowing.sourceChunkIndex` |
| `hollowing.cavityPositionsBase64`   | `CAVT`     | `hollowing.cavityChunkIndex` |
| `holePunchSourcePositionsBase64`    | `PSRC`     | `holePunchSourceChunkIndex`  |

- Writers store **raw `Float32` bytes**, `zlib`-compressed, at the owning model's index — removing the string ceiling on both read and write and dropping the 4/3 base64 inflation.
- `*PositionCount` and `enabled` / `bakedIntoGeometry` flags stay in `MODL` JSON; the `*Base64` fields are omitted.
- Chunks are **content-deduplicated per type**, independent of `MESH` dedup: identical snapshots across models share one chunk (first occurrence owns it; duplicates carry a `*ChunkIndex` pointer). Two models sharing `MESH` geometry can still hold distinct snapshots, and vice versa.
- **No header bump.** `version` stays `2`; the semantic revision is detected structurally — a `MODL` with a non-zero `*PositionCount` but its `*Base64` absent means the data lives in the chunk at `index = *ChunkIndex ?? modelIndex`.
- **Backward compatible (accepted tradeoff):** because the header doesn't bump and unknown chunk types are ignored, older V2/V2.1 readers still open a V2.2 file — baked geometry loads from `MESH`; they silently drop only the hollow/hole-punch re-editability snapshots.

Full spec in [docs/dev/voxl-format-spec.md](https://github.com/Open-Resin-Alliance/DragonFruit/blob/sin/voxl2.2-pr/docs/dev/voxl-format-spec.md).

### Incremental autosave

- **Cross-tick chunk cache** ([voxlChunkCache.ts](src/features/scene/voxl/voxlChunkCache.ts)): unchanged modifier/SUPP chunks reuse their already-compressed bytes and content digest across ticks. Keyed by a *small* stable handle (`${modelId}:hsrc`, `supp`, …) with the large payload compared by reference (`===`, pointer-fast-pathed) — so the hot path is an O(1) pointer compare, never a re-hash of a ~512 MiB string, while a genuine content change still recomputes.
- **Skip unchanged ticks:** a monotonic `revision` (bumped on every autosave trigger) vs. `lastPersistedRevision` (advanced only on a committed write) lets the gate skip the entire tick — no build/stringify/hash/I/O — when nothing has changed since the file on disk was written. A failed save doesn't advance the persisted revision, so it's never mistaken for a clean scene. Forced flushes (quit / hand-off) bypass the skip.
- **Write-skip:** a matching `previousFingerprint` in `ExportManager.exportVoxl` emits nothing and reports skipped when content is byte-identical.
- **No downgrade:** a scene already in 2.2 is never written back to inline. If an inline write throws, autosave escalates to chunked and latches the scene to 2.2 (`onSceneFormatUpgraded`) so later ticks don't retry or downgrade.

## Tests

New coverage in `voxl/__tests__/` and `hooks/__tests__/`:

- Chunk cache is **byte-identical to the no-cache path**, and a warm cache reproduces identical bytes on the next tick.
- Modifier snapshots **round-trip byte-for-byte** through `HSRC`/`CAVT`/`PSRC`; identical snapshots collapse to one chunk and re-attach to every owner; distinct snapshots map to the right owner.
- `chunkModifierSnapshots:false` keeps the 2.1 inline layout and still round-trips; the flag is byte-neutral for scenes without snapshots.
- Buffered and streaming writers stay byte-identical with modifier chunks.
- Autosave gate: an unchanged scene is skipped; a forced flush writes even when the revision is unchanged.
