### PR TITLE
Use alias for AppHandle instead of the object itself (fix v0.1.13).

### DIFF
--- a/src-tauri/src/mesh_minima.rs
+++ b/src-tauri/src/mesh_minima.rs
@@ -615,7 +615,7 @@ pub struct CombinedIslandScanResult {
 /// minima scan **concurrently**. Surface-snapping projections are also parallelized.
 #[tauri::command]
 pub async fn scan_islands_from_path(
-    app: tauri::AppHandle,
+    app: crate::DragonFruitAppHandle,
     file_path: String,
     matrix: [f32; 16],
     center: [f32; 3],


### PR DESCRIPTION
This only got through because we don't build for Linux in CI.  ¯\_(ツ)_/¯