### PR TITLE
Close every modal dialog with Escape

### DIFF
--- a/docs/dev/hotkeys.md
+++ b/docs/dev/hotkeys.md
@@ -21,7 +21,16 @@ for working with it.
    less-specific binding that is a strict subset of a held one — e.g. `GLOBAL.REDO`
    (Ctrl+Shift+Z) suppresses `GLOBAL.UNDO` (Ctrl+Z) while Shift is held. When reading
    both, check the more specific one first.
-7. **The delete hotkey goes through the delete registry**: `useDeleteHotkey` calls
+7. **Escape in a modal goes through `useEscapeToClose`**: dialogs do not wire
+   their own `app-hotkey-keydown` listener. `useEscapeToClose(open, onClose)`
+   (`src/hotkeys/useEscapeToClose.ts`) registers the dialog while it is open;
+   only the most recently registered one reacts, and it consumes the press, so
+   a nested dialog closes before its parent and one press never closes two.
+   Pass no handler for a dialog that must not be dismissed by Escape (a
+   blocking progress overlay, a decision the user has to make): it then
+   swallows the key instead of letting it through to the scene. Dialogs built
+   on `StructuredDialogModal` get this for free.
+8. **The delete hotkey goes through the delete registry**: `useDeleteHotkey` calls
    `triggerDelete()` (`src/features/delete/deleteRegistry.ts`), not a direct handler —
    see `registration-seams.md`.
 

--- a/docs/internal/backlog.md
+++ b/docs/internal/backlog.md
@@ -277,16 +277,6 @@
 - Context: branch fix/history-undo-seam; `docs/dev/history-and-undo-redo.md`
   documents the façade this would enforce.
 
-### [fix] Esc does not close every modal — M · low risk
-- Where: src/components/modals/ and src/hotkeys/ (HotkeyRegistryManager already
-  special-cases Escape: see the comment about "Escape closing the Settings modal").
-- What: Escape closes some modals and not others. Spotted on the history debugger
-  (Cmd+Shift+C on macOS), which stays open. Audit them all and give them one
-  default behaviour instead of wiring it modal by modal.
-- Why: it is the universal convention, and today it depends on whether someone
-  remembered. The decision to make is where the default lives: in a base modal
-  component, or in the hotkey registry.
-
 ### [fix] Show continuous Euler angles in the Transform panel — M · medium risk
 - Where: the gizmo drag applies rotation as quaternion deltas
   (src/components/scene/SceneCanvas/SceneCanvas.tsx, onRotate:

--- a/docs/reference/hotkeys.md
+++ b/docs/reference/hotkeys.md
@@ -19,3 +19,9 @@ React hook. Reactive to modifier changes. Excludes overlapping modifiers.
 
 ### `isKeyPressedSync(key: string): boolean`
 Non-reactive getter. Direct Set lookup. Use in high-frequency requestAnimationFrame loops.
+
+### `useEscapeToClose(open: boolean, onClose?: () => void): void`
+React hook. Registers a dialog as the Escape target while `open`. Only the
+most recently registered dialog reacts, and it consumes the press. Omit
+`onClose` to swallow Escape (non-dismissible dialog). Non-React callers use
+`registerEscapeHandler(handler)`, which returns its unregister function.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -233,6 +233,7 @@ import { useCameraProjectionHotkey } from '@/hotkeys/useCameraProjectionHotkey';
 import { useInteriorViewHotkey } from '@/hotkeys/useInteriorViewHotkey';
 import { usePrepareTransformHotkeys } from '@/hotkeys/usePrepareTransformHotkeys';
 import { useHotkeyConfig } from '@/hotkeys/HotkeyContext';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { matchesConfiguredHotkeyDown, matchesConfiguredHotkeyUp } from '@/hotkeys/hotkeyConfig';
 import {
   clearHistory,
@@ -7102,6 +7103,12 @@ export default function Home() {
     sourcePath: scene.activeModel?.sourcePath,
     activeTab: scene.mode,
   });
+
+  // Blocking progress overlays are modal: while one is up it owns Escape, so
+  // the key never reaches whatever is behind it.
+  useEscapeToClose(islandsPoc.scanning && !autoSupportDrivingScan, undefined);
+  useEscapeToClose(autoSupportBusy, undefined);
+  useEscapeToClose(isExporting, undefined);
 
   // 5. Supports
   const supports = useSupportInteractionManager({ mode: scene.mode });

--- a/src/components/layout/FirstRunOnboarding.tsx
+++ b/src/components/layout/FirstRunOnboarding.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useLingui } from '@lingui/react';
 import { msg } from '@lingui/core/macro';
 import { Check, ChevronLeft, Moon, Sun } from 'lucide-react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import {
   applyThemeCustomColors,
   applyThemePreference,
@@ -38,6 +39,9 @@ function applyBuiltInThemePreference(preference: ThemePreference): void {
 }
 
 export function FirstRunOnboarding({ onExit }: FirstRunOnboardingProps) {
+  // The wizard is finished by its own controls, not dismissed: swallow Escape.
+  useEscapeToClose(true, undefined);
+
   const { _ } = useLingui();
   const [step, setStep] = React.useState<WizardStep>('welcome');
   const [direction, setDirection] = React.useState<'forward' | 'backward'>('forward');

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { useLingui } from '@lingui/react';
 import { msg } from '@lingui/core/macro';
 import { ViewTypeDropdown } from '@/components/controls/ViewTypeDropdown';
@@ -176,6 +177,7 @@ export function TopBar({
   const [profileModalOpenNetworkSettingsToken, setProfileModalOpenNetworkSettingsToken] = useState(0);
   const [profileModalOpenMaterialAntiAliasingToken, setProfileModalOpenMaterialAntiAliasingToken] = useState(0);
   const [showProfileChangeWarning, setShowProfileChangeWarning] = useState(false);
+  useEscapeToClose(showProfileChangeWarning, () => setShowProfileChangeWarning(false));
   const [isDesktopWindow, setIsDesktopWindow] = useState(false);
   const [isDesktopWindowMaximized, setIsDesktopWindowMaximized] = useState(false);
   const [isLightTheme, setIsLightTheme] = useState(() => {

--- a/src/components/modals/DestructiveTransformModal.tsx
+++ b/src/components/modals/DestructiveTransformModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { AlertTriangle, X } from 'lucide-react';
 
 type DestructiveTransformModalProps = {
@@ -20,18 +21,7 @@ export function DestructiveTransformModal({
   onCancel,
   onConfirm,
 }: DestructiveTransformModalProps) {
-  React.useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (event: CustomEvent) => {
-      if (event.detail.key === 'Escape') {
-        onCancel();
-      }
-    };
-
-    window.addEventListener('app-hotkey-keydown', handleKeyDown as EventListener);
-    return () => window.removeEventListener('app-hotkey-keydown', handleKeyDown as EventListener);
-  }, [isOpen, onCancel]);
+  useEscapeToClose(isOpen, onCancel);
 
   if (!isOpen) return null;
 

--- a/src/components/modals/DiagnosticsModal.tsx
+++ b/src/components/modals/DiagnosticsModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { X } from 'lucide-react';
 import { SelectDropdown } from '@/components/ui/SelectDropdown';
 import { getSnapshot as getSupportSnapshot } from '@/supports/state';
@@ -332,15 +333,8 @@ export function DiagnosticsModal({
 
     rafId = requestAnimationFrame(tick);
 
-    const onKeyDown = (event: CustomEvent) => {
-      if (event.detail.key === 'Escape') onClose();
-    };
-
-    window.addEventListener('app-hotkey-keydown', onKeyDown as EventListener);
-
     return () => {
       cancelAnimationFrame(rafId);
-      window.removeEventListener('app-hotkey-keydown', onKeyDown as EventListener);
     };
   }, [isOpen, onClose]);
 

--- a/src/components/modals/HistoryDebugModal.tsx
+++ b/src/components/modals/HistoryDebugModal.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { X } from 'lucide-react';
 import type { HistoryDebugEvent } from '@/history/types';
 import { formatHistoryLabel } from '@/history/formatHistoryLabel';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 
 type HistoryDebugModalProps = {
   isOpen: boolean;
@@ -42,6 +43,8 @@ export function HistoryDebugModal({
   onClearUndoRedoStacks,
   onClearAll,
 }: HistoryDebugModalProps) {
+  useEscapeToClose(isOpen, onClose);
+
   const historyDebugEventsNewestFirst = React.useMemo(
     () => [...historyDebugEvents].reverse(),
     [historyDebugEvents],

--- a/src/components/modals/IslandHierarchyModal.tsx
+++ b/src/components/modals/IslandHierarchyModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import type { Island } from '@/volumeAnalysis/IslandScan/types';
 import { X, ChevronDown, ChevronRight } from 'lucide-react';
 
@@ -18,16 +19,7 @@ type TreeNode = {
 };
 
 export function IslandHierarchyModal({ islands, isOpen, onClose, layerHeightMm, zOffsetMm }: IslandHierarchyModalProps) {
-  React.useEffect(() => {
-    if (!isOpen) return;
-
-    const onKeyDown = (event: CustomEvent) => {
-      if (event.detail.key === 'Escape') onClose();
-    };
-
-    window.addEventListener('app-hotkey-keydown', onKeyDown as EventListener);
-    return () => window.removeEventListener('app-hotkey-keydown', onKeyDown as EventListener);
-  }, [isOpen, onClose]);
+  useEscapeToClose(isOpen, onClose);
 
   if (!isOpen) return null;
 

--- a/src/components/modals/ModelSupportsModal.tsx
+++ b/src/components/modals/ModelSupportsModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { ChevronDown, ChevronRight, X } from 'lucide-react';
 import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import { getSnapshot as getSupportSnapshot, subscribe as subscribeSupportState } from '@/supports/state';
@@ -45,16 +46,7 @@ export function ModelSupportsModal({ isOpen, onClose, model }: ModelSupportsModa
   const kickstandSnapshot = React.useSyncExternalStore(subscribeToKickstandStore, getKickstandSnapshot, getKickstandSnapshot);
   const [collapsedGroups, setCollapsedGroups] = React.useState<Record<string, boolean>>({});
 
-  React.useEffect(() => {
-    if (!isOpen) return;
-
-    const onKeyDown = (event: CustomEvent) => {
-      if (event.detail.key === 'Escape') onClose();
-    };
-
-    window.addEventListener('app-hotkey-keydown', onKeyDown as EventListener);
-    return () => window.removeEventListener('app-hotkey-keydown', onKeyDown as EventListener);
-  }, [isOpen, onClose]);
+  useEscapeToClose(isOpen, onClose);
 
   const groups = React.useMemo<ModelSupportGroups>(() => {
     const modelId = model?.id;

--- a/src/components/modals/SliceCompletedModal.tsx
+++ b/src/components/modals/SliceCompletedModal.tsx
@@ -23,19 +23,6 @@ export function SliceCompletedModal({
   const [openDirectoryError, setOpenDirectoryError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (event: CustomEvent) => {
-      if (event.detail.key === 'Escape') {
-        onClose();
-      }
-    };
-
-    window.addEventListener('app-hotkey-keydown', handleKeyDown as EventListener);
-    return () => window.removeEventListener('app-hotkey-keydown', handleKeyDown as EventListener);
-  }, [isOpen, onClose]);
-
-  React.useEffect(() => {
     if (!isOpen) {
       setOpenDirectoryError(null);
     }

--- a/src/components/modals/UvToolsLaunchingModal.tsx
+++ b/src/components/modals/UvToolsLaunchingModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { createPortal } from 'react-dom';
 import { ExternalLink, Loader2 } from 'lucide-react';
 
@@ -22,20 +23,8 @@ export function UvToolsLaunchingModal({
   filePath,
   onLaunchComplete,
 }: UvToolsLaunchingModalProps) {
-  // Trap focus inside the modal while open (prevent accidental Escape)
-  React.useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (event: CustomEvent) => {
-      if (event.detail.key === 'Escape') {
-        event.stopImmediatePropagation();
-      }
-    };
-
-    // Use capture phase to intercept Escape before anything else
-    window.addEventListener('app-hotkey-keydown', handleKeyDown as EventListener, { capture: true });
-    return () => window.removeEventListener('app-hotkey-keydown', handleKeyDown as EventListener, { capture: true });
-  }, [isOpen]);
+  // Registering without a close handler swallows Escape instead of dismissing.
+  useEscapeToClose(isOpen, undefined);
 
   if (!isOpen || typeof document === 'undefined') return null;
 

--- a/src/components/modals/ZipFilePickerModal.tsx
+++ b/src/components/modals/ZipFilePickerModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { ArchiveRestore, FileArchive, X } from 'lucide-react';
 import { getFileExtensionLower } from '@/utils/zipImport';
 import { SCENE_FILE_EXTENSIONS } from '@/features/plugins/pluginFileTypeExtensions';
@@ -137,13 +138,7 @@ export function ZipFilePickerModal({
     setSelectedIndices(defaultSelectedIndices);
   }, [defaultSelectedIndices]);
 
-  React.useEffect(() => {
-    const handleKeyDown = (e: CustomEvent) => {
-      if (e.detail.key === 'Escape') onCancel();
-    };
-    window.addEventListener('app-hotkey-keydown', handleKeyDown as EventListener);
-    return () => window.removeEventListener('app-hotkey-keydown', handleKeyDown as EventListener);
-  }, [onCancel]);
+  useEscapeToClose(true, onCancel);
 
   const toggleFile = (index: number) => {
     setSelectedIndices((prev) => {

--- a/src/components/organisms/modals/MeshRepairModals.tsx
+++ b/src/components/organisms/modals/MeshRepairModals.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, Loader2, Wrench, X } from 'lucide-react';
 import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { MeshRepairConfirmModal } from '@/components/scene/MeshRepairConfirmModal';
 import { MeshRepairReportModal } from '@/components/scene/MeshRepairReportModal';
 import { useSceneCollectionManager } from '@/features/scene/useSceneCollectionManager';
@@ -24,6 +25,12 @@ export function MeshRepairModals({
   setShowDamagedModelDialog,
   showDamagedModelDialog,
 }: MeshRepairModalsProps) {
+  // Escape mirrors the backdrop click: it cannot leave mid-repair.
+  useEscapeToClose(
+    manualRepairModelId !== null,
+    isManualRepairing ? undefined : () => setManualRepairModelId(null),
+  );
+
   return (
     <>
       <StructuredDialogModal

--- a/src/components/organisms/modals/ModifierModals.tsx
+++ b/src/components/organisms/modals/ModifierModals.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle } from 'lucide-react';
 import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { DestructiveTransformModal } from '@/components/modals/DestructiveTransformModal';
 import { type HollowingPanelState } from '@/features/hollowing';
 
@@ -47,6 +48,9 @@ export function ModifierModals({
   showUnappliedHolePunchModal,
   unappliedHolePunchResolveRef,
 }: ModifierModalsProps) {
+  // A blocking progress overlay: swallow Escape rather than let it through.
+  useEscapeToClose(showModifierApplyBlockingOverlay, undefined);
+
   return (
     <>
       <StructuredDialogModal

--- a/src/components/organisms/modals/PrintingModals.tsx
+++ b/src/components/organisms/modals/PrintingModals.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { msg } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
 import { AlertTriangle, CheckCircle2, ChevronDown, Download, LayoutGrid, Maximize2, Minimize2, Play, Printer, RefreshCw, Trash2, X } from 'lucide-react';
@@ -368,6 +369,39 @@ export function PrintingModals({
   uvToolsLaunchingPath,
 }: PrintingModalsProps) {
   const { _ } = useLingui();
+
+  const cancelPreSlicePrintConfirm = React.useCallback(() => {
+    setPreSlicePrintConfirmOpen(false);
+    if (preSlicePrintConfirmResolverRef.current) {
+      preSlicePrintConfirmResolverRef.current(false);
+      preSlicePrintConfirmResolverRef.current = null;
+    }
+  }, [preSlicePrintConfirmResolverRef, setPreSlicePrintConfirmOpen]);
+
+  const cancelPrintingTargetPicker = React.useCallback(() => {
+    setPrintingTargetPickerOpen(false);
+    if (isPreSliceTargetPicker && preSliceTargetPickerResolverRef.current) {
+      preSliceTargetPickerResolverRef.current(null);
+      preSliceTargetPickerResolverRef.current = null;
+    }
+    setPrintingTargetPickerMode('post-slice');
+  }, [isPreSliceTargetPicker, preSliceTargetPickerResolverRef, setPrintingTargetPickerMode, setPrintingTargetPickerOpen]);
+
+  // Escape closes the top-most of these dialogs; the upload dialog only while
+  // its Close button is available, and never while a send is in flight.
+  useEscapeToClose(Boolean(printingMonitorPendingConfirmation), () => setPrintingMonitorPendingConfirmation(null));
+  useEscapeToClose(preSlicePrintConfirmOpen, cancelPreSlicePrintConfirm);
+  useEscapeToClose(printingTargetPickerOpen, printingSendBusy ? undefined : cancelPrintingTargetPicker);
+  useEscapeToClose(
+    printingUploadDialogOpen,
+    (printingUploadDialogStage === 'failed' || printingUploadDialogStage === 'started' || printingUploadDialogStage === 'ready')
+      && !printingSendBusy
+      && !printingPrintNowBusy
+      ? () => setPrintingUploadDialogOpen(false)
+      : undefined,
+  );
+  useEscapeToClose(printingMonitorModalOpen, () => setPrintingMonitorModalOpen(false));
+
   return (
     <>
       <SliceCompletedModal
@@ -577,11 +611,7 @@ export function PrintingModals({
           className="fixed inset-0 z-[220] flex items-center justify-center bg-black/55 backdrop-blur-sm px-3"
           onMouseDown={(event) => {
             if (event.target === event.currentTarget) {
-              setPreSlicePrintConfirmOpen(false);
-              if (preSlicePrintConfirmResolverRef.current) {
-                preSlicePrintConfirmResolverRef.current(false);
-                preSlicePrintConfirmResolverRef.current = null;
-              }
+              cancelPreSlicePrintConfirm();
             }
           }}
         >
@@ -913,14 +943,7 @@ export function PrintingModals({
                 <button
                   type="button"
                   className="ui-button ui-button-secondary !h-9 px-3 text-xs"
-                  onClick={() => {
-                    setPrintingTargetPickerOpen(false);
-                    if (isPreSliceTargetPicker && preSliceTargetPickerResolverRef.current) {
-                      preSliceTargetPickerResolverRef.current(null);
-                      preSliceTargetPickerResolverRef.current = null;
-                    }
-                    setPrintingTargetPickerMode('post-slice');
-                  }}
+                  onClick={cancelPrintingTargetPicker}
                   disabled={printingSendBusy}
                 >
                   Cancel

--- a/src/components/organisms/modals/SceneFileModals.tsx
+++ b/src/components/organisms/modals/SceneFileModals.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AlertTriangle, CheckCircle2, LayoutGrid, Trash2, X } from 'lucide-react';
 import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { ModelSupportsModal } from '@/components/modals/ModelSupportsModal';
 import { SceneAutosaveRecoveryModal } from '@/components/scene/SceneAutosaveRecoveryModal';
 import { ZipFilePickerModal } from '@/components/modals/ZipFilePickerModal';
@@ -76,6 +77,13 @@ export function SceneFileModals({
   zipPickerResolveRef,
   zipPickerState,
 }: SceneFileModalsProps) {
+  // Escape mirrors each dialog's backdrop click; the arrange overlay is a
+  // blocking progress state, so it swallows the key instead.
+  useEscapeToClose(Boolean(scene.sceneImportPlacementPrompt), () => scene.resolveSceneImportPlacementPrompt('load_as_is'));
+  useEscapeToClose(showPluginImportWarningModal, handleCancelPluginImportWarning);
+  useEscapeToClose(showSceneSaveChoiceModal, () => resolveSceneSaveChoice('cancel'));
+  useEscapeToClose(showArrangeBlockingOverlay, undefined);
+
   return (
     <>
       <StructuredDialogModal

--- a/src/components/printers/PrinterVariantPickerModal.tsx
+++ b/src/components/printers/PrinterVariantPickerModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { useLingui } from '@lingui/react';
 import { msg } from '@lingui/core/macro';
 import type { MessageDescriptor } from '@lingui/core';
@@ -165,14 +166,7 @@ export function PrinterVariantPickerModal({
   // show the connection progress instead of the scanning bar.
   const scanAbortRef = React.useRef(false);
 
-  React.useEffect(() => {
-    const handleHotkey = (event: CustomEvent) => {
-      if (event.detail.key !== 'Escape') return;
-      onClose();
-    };
-    window.addEventListener('app-hotkey-keydown', handleHotkey as EventListener);
-    return () => window.removeEventListener('app-hotkey-keydown', handleHotkey as EventListener);
-  }, [onClose]);
+  useEscapeToClose(true, onClose);
 
   const runScan = React.useCallback(async () => {
     if (!networkAdapter) return;

--- a/src/components/scene/MeshRepairConfirmModal.tsx
+++ b/src/components/scene/MeshRepairConfirmModal.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Wrench, X, AlertTriangle } from 'lucide-react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import type { MeshRepairConfirmPrompt } from '@/features/scene/useSceneCollectionManager';
 
 type Props = {
@@ -23,6 +24,8 @@ function StatRow({ label, value }: { label: string; value: string | number }) {
 }
 
 export function MeshRepairConfirmModal({ prompt, onRepair, onLoadAsIs, onCancelImport }: Props) {
+  useEscapeToClose(true, onCancelImport);
+
   const { fileName, analysis } = prompt;
 
   return (

--- a/src/components/scene/MeshRepairReportModal.tsx
+++ b/src/components/scene/MeshRepairReportModal.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { CheckCircle2, AlertTriangle, XCircle, X, Wrench, ClipboardCopy, ChevronDown, ChevronRight } from 'lucide-react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import type { MeshRepairReportEntry } from '@/features/scene/useSceneCollectionManager';
 import type { MeshAnalysisJson } from '@/utils/meshRepair';
 
@@ -55,6 +56,8 @@ function summarizeRepairWins(report: MeshRepairReportEntry['report']): string[] 
 }
 
 export function MeshRepairReportModal({ reports, presentation = 'default', onDismiss }: Props) {
+  useEscapeToClose(reports.length > 0, onDismiss);
+
   const [expandedId, setExpandedId] = React.useState<string | null>(
     reports.length === 1 ? reports[0].id : null,
   );

--- a/src/components/scene/SceneAutosaveRecoveryModal.tsx
+++ b/src/components/scene/SceneAutosaveRecoveryModal.tsx
@@ -5,6 +5,7 @@ import { useLingui } from '@lingui/react';
 import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import { AlertTriangle, ArchiveRestore, Trash2, X } from 'lucide-react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 
 type Props = {
   savedAt: string;
@@ -17,6 +18,9 @@ type Props = {
 };
 
 export function SceneAutosaveRecoveryModal({ savedAt, voxlPath, origin, onRestore, onDiscard }: Props) {
+  // Restore or discard is a deliberate choice: swallow Escape, never guess one.
+  useEscapeToClose(true, undefined);
+
   const { _, i18n } = useLingui();
   const [busy, setBusy] = React.useState<'none' | 'restore' | 'discard'>('none');
 

--- a/src/components/settings/BackupsSettingsTab.tsx
+++ b/src/components/settings/BackupsSettingsTab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { ArchiveRestore, CheckCircle2, CircleHelp, Eye, Github, Loader2, RefreshCcw, ShieldCheck, ShieldX, Trash2, UploadCloud, X } from 'lucide-react';
 import { getProfileStoreSnapshot } from '@/features/profiles/profileStore';
 import { NumberInput } from '@/components/ui/NumberInput';
@@ -414,6 +415,8 @@ export function BackupsSettingsTab() {
   const [selectedStorageKey, setSelectedStorageKey] = React.useState<string | null>(null);
   const [selectedProfilesPrinterId, setSelectedProfilesPrinterId] = React.useState<string | null>(null);
   const [showOAuthSetupModal, setShowOAuthSetupModal] = React.useState(false);
+  useEscapeToClose(showSnapshotModal, () => setShowSnapshotModal(false));
+  useEscapeToClose(showOAuthSetupModal, () => setShowOAuthSetupModal(false));
   const [oauthCookieSecretDraft, setOauthCookieSecretDraft] = React.useState<string>(() => {
     if (typeof window === 'undefined') return '';
     return window.localStorage.getItem('dragonfruit-backups:oauth-cookie-secret-draft') ?? '';

--- a/src/components/settings/ExperimentsSettingsTab.tsx
+++ b/src/components/settings/ExperimentsSettingsTab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { createPortal } from 'react-dom';
 import { AlertTriangle, FlaskConical, X } from 'lucide-react';
 import {
@@ -29,6 +30,8 @@ type ExperimentsDisclaimerProps = {
  * entry animation transform (which would otherwise offset a fixed overlay).
  */
 function ExperimentsDisclaimer({ onAcknowledge, onExit }: ExperimentsDisclaimerProps) {
+  useEscapeToClose(true, onExit);
+
   return (
     <div
       className="fixed inset-0 z-[220] flex items-center justify-center bg-black/55 backdrop-blur-sm px-3"

--- a/src/components/settings/LocalBackupsSettingsTab.tsx
+++ b/src/components/settings/LocalBackupsSettingsTab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { AlertTriangle, ArchiveRestore, CheckCircle2, Eye, FolderOpen, HardDrive, Loader2, RefreshCcw, Trash2, UploadCloud, X } from 'lucide-react';
 import { getProfileStoreSnapshot } from '@/features/profiles/profileStore';
 import { NumberInput } from '@/components/ui/NumberInput';
@@ -338,7 +339,9 @@ export function LocalBackupsSettingsTab() {
   const [selectedHistoryId, setSelectedHistoryId] = React.useState<string | null>(null);
   const [selectedHistoryDocument, setSelectedHistoryDocument] = React.useState<SelectedHistoryDocument | null>(null);
   const [showSnapshotModal, setShowSnapshotModal] = React.useState(false);
+  useEscapeToClose(showSnapshotModal, () => setShowSnapshotModal(false));
   const [confirmRestoreId, setConfirmRestoreId] = React.useState<string | null>(null);
+  useEscapeToClose(confirmRestoreId !== null, () => setConfirmRestoreId(null));
   const [confirmDeleteId, setConfirmDeleteId] = React.useState<string | null>(null);
   const [snapshotModalTab, setSnapshotModalTab] = React.useState<SnapshotModalTab>('overview');
   const [selectedStorageKey, setSelectedStorageKey] = React.useState<string | null>(null);

--- a/src/components/settings/PluginStudioModal.tsx
+++ b/src/components/settings/PluginStudioModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { AlertTriangle, Archive, Check, ChevronDown, ChevronLeft, ChevronRight, Copy, FileText, FlaskConical, GitBranch, Layers, Maximize2, Minimize2, Plus, Printer, Search, Square, Trash2, X } from 'lucide-react';
 import JSZip from 'jszip';
 import hljs from 'highlight.js';
@@ -3473,24 +3474,8 @@ export function PluginStudioModal({ isOpen, onClose }: PluginStudioModalProps) {
     onClose();
   }, [onClose]);
 
-  React.useEffect(() => {
-    if (!isOpen) return;
-
-    const onKeyDown = (event: CustomEvent) => {
-      if (event.detail.key !== 'Escape') return;
-      event.preventDefault();
-      event.stopPropagation();
-      event.stopImmediatePropagation?.();
-      if (showExitConfirm) {
-        setShowExitConfirm(false);
-        return;
-      }
-      setShowExitConfirm(true);
-    };
-
-    window.addEventListener('app-hotkey-keydown', onKeyDown as EventListener, true);
-    return () => window.removeEventListener('app-hotkey-keydown', onKeyDown as EventListener, true);
-  }, [isOpen, showExitConfirm]);
+  // Escape asks to leave the studio, and asks again to dismiss that prompt.
+  useEscapeToClose(isOpen, () => setShowExitConfirm((prev) => !prev));
 
   React.useEffect(() => {
     if (!isOpen) return;

--- a/src/components/settings/ProfileSettingsModal.tsx
+++ b/src/components/settings/ProfileSettingsModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { AlertTriangle, Box, Check, ChevronLeft, ChevronRight, Copy, Download, Edit3, FlaskConical, Frown, ImagePlus, LayoutGrid, Loader2, Lock, Plus, Printer, RefreshCw, Search, Trash2, Unlock, Upload, Wifi, WifiOff, X } from 'lucide-react';
 import FleetManagement from '@/components/settings/FleetManagement';
 import { NumberInput } from '@/components/ui/NumberInput';
@@ -1730,10 +1731,10 @@ export function ProfileSettingsModal({
     selectedMaterialId,
   ]);
 
-  React.useEffect(() => {
-    if (!isOpen) return;
-
-    const handleTopMostDialogEscape = (): boolean => {
+  // Escape unwinds this modal's own nested dialogs one at a time before it
+  // closes the modal itself; nested dialogs of their own take precedence.
+  useEscapeToClose(isOpen, () => {
+    const closedNestedDialog = ((): boolean => {
       if (deleteConfirmTarget) {
         setDeleteConfirmTarget(null);
         return true;
@@ -1803,40 +1804,11 @@ export function ProfileSettingsModal({
       }
 
       return false;
-    };
+    })();
 
-    const onKeyDown = (event: CustomEvent) => {
-      if (event.detail.key !== 'Escape') return;
-
-      if (handleTopMostDialogEscape()) {
-        event.preventDefault?.();
-        event.stopPropagation?.();
-        return;
-      }
-
-      onClose();
-    };
-
-    window.addEventListener('app-hotkey-keydown', onKeyDown as EventListener);
-    return () => window.removeEventListener('app-hotkey-keydown', onKeyDown as EventListener);
-  }, [
-    deleteConfirmTarget,
-    isCreateMaterialOpen,
-    isEditFleetUnitModalOpen,
-    isEditingPrinter,
-    isMaterialEditorOpen,
-    isNetworkSettingsOpen,
-    isOpen,
-    isRemoteMaterialEditDialogOpen,
-    isSavingRemoteMaterialEdit,
-    onClose,
-    showMaterialPresetPicker,
-    showOfficialLockDialog,
-    showOfficialMaterialLockDialog,
-    showPresetPicker,
-    showPrinterUpdateDiffModal,
-    variantChooserPreset,
-  ]);
+    if (closedNestedDialog) return;
+    onClose();
+  });
 
   React.useEffect(() => {
     if (!selectedPrinter) {

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -50,6 +50,7 @@ import {
   type SavedCustomThemeProfile,
 } from '@/components/settings/themeCustomizations';
 import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { Tooltip } from '@/components/ui/Tooltip';
 import {
   DEFAULT_SPACEMOUSE_SETTINGS,
@@ -1103,44 +1104,28 @@ export function SettingsModal({
     };
   }, []);
 
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const onKeyDown = (e: CustomEvent) => {
-      if (e.detail.key !== 'Escape') return;
-      if (showThemeDeleteConfirm) {
-        handleCancelThemeDeleteConfirm();
-        return;
-      }
-      if (showThemeRenameDialog) {
-        handleCancelThemeRenameDialog();
-        return;
-      }
-      if (showThemeSaveConfirm) {
-        handleCancelThemeSaveConfirm();
-        return;
-      }
-      if (showRestoreDefaultsConfirm) {
-        handleCancelRestoreDefaults();
-        return;
-      }
-      handleCancel();
-    };
-
-    window.addEventListener('app-hotkey-keydown', onKeyDown as EventListener);
-    return () => window.removeEventListener('app-hotkey-keydown', onKeyDown as EventListener);
-  }, [
-    isOpen,
-    handleCancel,
-    handleCancelRestoreDefaults,
-    handleCancelThemeDeleteConfirm,
-    handleCancelThemeRenameDialog,
-    handleCancelThemeSaveConfirm,
-    showRestoreDefaultsConfirm,
-    showThemeDeleteConfirm,
-    showThemeRenameDialog,
-    showThemeSaveConfirm,
-  ]);
+  // Nested dialogs rendered through StructuredDialogModal register their own
+  // Escape handler and take precedence; the cascade here covers the inline
+  // restore-defaults confirmation, which does not.
+  useEscapeToClose(isOpen, () => {
+    if (showThemeDeleteConfirm) {
+      handleCancelThemeDeleteConfirm();
+      return;
+    }
+    if (showThemeRenameDialog) {
+      handleCancelThemeRenameDialog();
+      return;
+    }
+    if (showThemeSaveConfirm) {
+      handleCancelThemeSaveConfirm();
+      return;
+    }
+    if (showRestoreDefaultsConfirm) {
+      handleCancelRestoreDefaults();
+      return;
+    }
+    handleCancel();
+  });
 
   const handleSpaceMouseChange = React.useCallback((partial: Partial<SpaceMouseSettings>) => {
     setDraftSpaceMouseSettings((prev) => normalizeSpaceMouseSettings({ ...prev, ...partial }));

--- a/src/components/ui/SelectDropdown.tsx
+++ b/src/components/ui/SelectDropdown.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { ChevronDown } from 'lucide-react';
 import { createPortal } from 'react-dom';
 
@@ -121,20 +122,16 @@ export function SelectDropdown<T extends string | number = string>({
       setIsOpen(false);
     };
 
-    const onEscape = (event: CustomEvent) => {
-      if (event.detail.key === 'Escape') {
-        setIsOpen(false);
-      }
-    };
-
     window.addEventListener('pointerdown', onPointerDown);
-    window.addEventListener('app-hotkey-keydown', onEscape as EventListener);
 
     return () => {
       window.removeEventListener('pointerdown', onPointerDown);
-      window.removeEventListener('app-hotkey-keydown', onEscape as EventListener);
     };
   }, [isOpen]);
+
+  // An open menu takes Escape ahead of the dialog it sits in, so the first
+  // press closes the menu and not the whole modal.
+  useEscapeToClose(isOpen, () => setIsOpen(false));
 
   const updateMenuPosition = React.useCallback((measureMenu: boolean) => {
     const trigger = containerRef.current;

--- a/src/components/ui/StructuredDialogModal.tsx
+++ b/src/components/ui/StructuredDialogModal.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 
 type DialogIconTone = 'warning' | 'danger' | 'accent' | 'neutral';
 
@@ -68,6 +69,11 @@ export function StructuredDialogModal({
   children,
   actions,
 }: StructuredDialogModalProps) {
+  // Escape closes the dialog by default; a dialog whose close button is
+  // disabled (or that has no close affordance) swallows the key instead.
+  const escapeClose = closeDisabled ? undefined : (onClose ?? onBackdropClick);
+  useEscapeToClose(open, escapeClose);
+
   if (!open) return null;
 
   const handleBackdropMouseDown: React.MouseEventHandler<HTMLDivElement> = (event) => {

--- a/src/features/slicing/components/LutCurveEditor.tsx
+++ b/src/features/slicing/components/LutCurveEditor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { AlertTriangle, Check, Download, Edit3, Pencil, Plus, Trash2, Upload, X, RotateCcw, TrendingUp } from 'lucide-react';
 import { SelectDropdown } from '@/components/ui/SelectDropdown';
 import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
@@ -842,6 +843,8 @@ export function LutCurveEditorModal({
   const handleCancelDiscardClose = useCallback(() => {
     setShowDiscardConfirm(false);
   }, []);
+
+  useEscapeToClose(isOpen, requestClose);
 
   const handleConfirmDelete = useCallback(() => {
     if (!editingCurve || !onDelete) return;

--- a/src/features/slicing/components/SliceMetricsDebugModal.tsx
+++ b/src/features/slicing/components/SliceMetricsDebugModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Activity, Cpu, Layers3, Timer, X } from 'lucide-react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import type { SliceExportResult } from '@/features/slicing/sliceExportOrchestrator';
 
 type SliceMetricsDebugModalProps = {
@@ -66,6 +67,8 @@ export function SliceMetricsDebugModal({
   outputName,
   outputSizeLabel,
 }: SliceMetricsDebugModalProps) {
+  useEscapeToClose(isOpen, onClose);
+
   const [copyState, setCopyState] = React.useState<'idle' | 'copied' | 'error'>('idle');
 
   const copyPayload = React.useMemo(() => {

--- a/src/features/slicing/components/SlicingPanel.tsx
+++ b/src/features/slicing/components/SlicingPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { createPortal } from 'react-dom';
 import { AlertTriangle, ChevronDown, CircleHelp, Cpu, Download, Edit3, ExternalLink, Layers3, Loader2, Play, Printer, Timer, X } from 'lucide-react';
 import { MouseTooltip } from '@/components/ui/MouseTooltip';
@@ -851,6 +852,12 @@ export function SlicingPanel({
   const [sessionAaOverrideDraft, setSessionAaOverrideDraft] = useState<MaterialDraft | null>(null);
   const [editingSessionAaOverrideDraft, setEditingSessionAaOverrideDraft] = useState<MaterialDraft | null>(null);
   const [isSessionAaOverrideOpen, setIsSessionAaOverrideOpen] = useState(false);
+
+  // Escape closes both anti-aliasing editors; the slicing progress modal is
+  // blocking, so it swallows the key instead of letting it through.
+  useEscapeToClose(isMaterialAaEditorOpen, () => setIsMaterialAaEditorOpen(false));
+  useEscapeToClose(isSessionAaOverrideOpen, () => setIsSessionAaOverrideOpen(false));
+  useEscapeToClose(showSlicingModal, undefined);
   const [zBlendResinType, setZBlendResinType] = useState<'opaque' | 'clear' | 'custom'>(resolveInitialZBlendResinType);
   const [savedCurves, setSavedCurves] = useState<SavedCurve[]>(() => resolveInitialSavedCurves());
   const [selectedCurveId, setSelectedCurveId] = useState<string>(() => resolveInitialSelectedCurveId(resolveInitialSavedCurves()));

--- a/src/hotkeys/__tests__/useEscapeToClose.test.ts
+++ b/src/hotkeys/__tests__/useEscapeToClose.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { registerEscapeHandler } from '../useEscapeToClose';
+
+// The registry attaches its capture-phase listener to `window` on the first
+// registration, so a minimal stand-in has to exist by then.
+type FakeHotkeyEvent = { type: string; detail: { key: string }; stopImmediatePropagation: () => void };
+type FakeListener = (event: FakeHotkeyEvent) => void;
+
+const listeners = new Map<string, Set<FakeListener>>();
+if (typeof globalThis.window === 'undefined') {
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: {
+            addEventListener(type: string, callback: FakeListener) {
+                if (!listeners.has(type)) listeners.set(type, new Set());
+                listeners.get(type)!.add(callback);
+            },
+            removeEventListener(type: string, callback: FakeListener) {
+                listeners.get(type)?.delete(callback);
+            },
+        },
+    });
+}
+
+function pressKey(key: string) {
+    let stopped = false;
+    const event: FakeHotkeyEvent = {
+        type: 'app-hotkey-keydown',
+        detail: { key },
+        stopImmediatePropagation: () => { stopped = true; },
+    };
+    for (const callback of Array.from(listeners.get('app-hotkey-keydown') ?? [])) {
+        callback(event);
+        if (stopped) break;
+    }
+    return stopped;
+}
+
+test('Escape closes the top-most registered dialog only', () => {
+    const closed: string[] = [];
+    const unregisterParent = registerEscapeHandler(() => closed.push('parent'));
+    const unregisterChild = registerEscapeHandler(() => closed.push('child'));
+
+    pressKey('Escape');
+    assert.deepEqual(closed, ['child'], 'only the last registration reacts');
+
+    unregisterChild();
+    pressKey('Escape');
+    assert.deepEqual(closed, ['child', 'parent'], 'the parent takes over once the child unregisters');
+
+    unregisterParent();
+});
+
+test('Other keys are ignored', () => {
+    let closeCount = 0;
+    const unregister = registerEscapeHandler(() => { closeCount += 1; });
+
+    pressKey('Enter');
+    assert.equal(closeCount, 0);
+
+    unregister();
+});
+
+test('A registration without a handler swallows Escape', () => {
+    const closed: string[] = [];
+    const unregisterDialog = registerEscapeHandler(() => closed.push('dialog'));
+    const unregisterBlocking = registerEscapeHandler(undefined);
+
+    const stopped = pressKey('Escape');
+    assert.equal(stopped, true, 'the press is consumed');
+    assert.deepEqual(closed, [], 'nothing behind the blocking modal closes');
+
+    unregisterBlocking();
+    unregisterDialog();
+});
+
+test('Escape is left alone once every dialog is closed', () => {
+    const unregister = registerEscapeHandler(() => {});
+    unregister();
+
+    assert.equal(pressKey('Escape'), false, 'no listener consumes the press');
+});

--- a/src/hotkeys/useEscapeToClose.ts
+++ b/src/hotkeys/useEscapeToClose.ts
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * The default dismissal behaviour for modals: Escape closes the top-most open
+ * one. Dialogs register while they are open instead of each wiring its own
+ * `app-hotkey-keydown` listener, so a nested dialog closes before its parent
+ * and a single press never closes two of them.
+ *
+ * A registration without a handler swallows Escape instead of closing — that is
+ * how a deliberately non-dismissible modal keeps the key from reaching whatever
+ * is behind it.
+ */
+type EscapeHandler = (() => void) | undefined;
+
+type EscapeEntry = { handler: EscapeHandler };
+
+const openDialogs: EscapeEntry[] = [];
+let listening = false;
+
+function handleHotkeyKeydown(event: Event) {
+    if ((event as CustomEvent).detail?.key !== 'Escape') return;
+
+    const top = openDialogs[openDialogs.length - 1];
+    if (!top) return;
+
+    // The top-most dialog consumes the press so nothing behind it — another
+    // dialog, a canvas tool — acts on the same Escape.
+    event.stopImmediatePropagation?.();
+    top.handler?.();
+}
+
+function startListening() {
+    if (listening || typeof window === 'undefined') return;
+    window.addEventListener('app-hotkey-keydown', handleHotkeyKeydown, true);
+    listening = true;
+}
+
+function stopListening() {
+    if (!listening || typeof window === 'undefined') return;
+    window.removeEventListener('app-hotkey-keydown', handleHotkeyKeydown, true);
+    listening = false;
+}
+
+/**
+ * Registers an open dialog as the current Escape target. Returns the
+ * unregister function; call it when the dialog closes or unmounts.
+ */
+export function registerEscapeHandler(handler: EscapeHandler): () => void {
+    const entry: EscapeEntry = { handler };
+    openDialogs.push(entry);
+    startListening();
+
+    return () => {
+        const index = openDialogs.lastIndexOf(entry);
+        if (index !== -1) openDialogs.splice(index, 1);
+        if (openDialogs.length === 0) stopListening();
+    };
+}
+
+/**
+ * React binding for {@link registerEscapeHandler}. Pass the dialog's open flag
+ * and its close callback; omit the callback for a modal that must not be
+ * dismissed by Escape.
+ */
+export function useEscapeToClose(open: boolean, onClose?: () => void) {
+    const onCloseRef = useRef<EscapeHandler>(onClose);
+
+    useEffect(() => {
+        onCloseRef.current = onClose;
+    });
+
+    useEffect(() => {
+        if (!open) return;
+        return registerEscapeHandler(onCloseRef.current ? () => onCloseRef.current?.() : undefined);
+    }, [open]);
+}


### PR DESCRIPTION
We have to build a React state for every modal that we create in order to close it with Esc.  This diff removes all the existing logic and unifies it under a single function, which is then used in every modal in the app.