### PR TITLE
Enhance debugging with stall detection and logging

### DIFF
--- a/docs/dev/performance-debugging.md
+++ b/docs/dev/performance-debugging.md
@@ -9,7 +9,7 @@ you point at your own machine when you need a call stack.
 ### Main-thread stall detector
 
 `src/utils/debug/mainThreadHeartbeat.ts` is the UI's equivalent of a database
-slow query log. A timer that should fire every 250 ms measures how late it
+slow query log. A timer that should fire every 100 ms measures how late it
 actually woke up. The main thread is single-threaded, so a timer that is 12
 seconds late means the thread was held for 12 seconds and the window was frozen
 for exactly that long.
@@ -19,6 +19,12 @@ Reports land in `dragonfruit.log` at `WARN`:
 ```
 [stall] Main thread blocked for 12340 ms (threshold 500 ms) — pointer: canvas (12358 ms ago), hotkey: s (4.2 s ago)
 ```
+
+Because a stall is only noticed once a tick is late by the full threshold, a
+block starting just after a tick gets one tick for free: with a 100 ms tick and
+a 500 ms threshold, blocks up to 600 ms can go unreported, and a reported figure
+understates the real block by up to 100 ms. It is a floor, not an exact
+duration.
 
 The threshold defaults to 500 ms and is read once at startup from the
 `df.debug.stallThresholdMs` key in `localStorage`. Values below one tick are

--- a/docs/dev/performance-debugging.md
+++ b/docs/dev/performance-debugging.md
@@ -132,6 +132,46 @@ selector that applies without restarting, a live log viewer, and buttons to
 reveal or open the log file. Ask the user to set the level to `debug`, reproduce
 the problem, and send `dragonfruit.log`.
 
+## Measuring without lying to yourself
+
+Every one of these cost a wasted test cycle before it was understood.
+
+**`console.log` from the webview never reaches `dragonfruit.log`.** `attachConsole`
+mirrors Rust records *into* the webview console; nothing travels the other way.
+Measurements meant for a log file must go through `@tauri-apps/plugin-log`.
+
+**`Physical footprint (peak)` is reset** when WebKit relieves memory pressure, so
+reading it with `vmmap` after the fact reports a peak lower than the real one —
+in one case 7.2 GB against an actual 14.0 GB. Sample continuously during the
+run instead, and note that `vmmap` on a multi-gigabyte process takes long enough
+that a "once per second" loop really samples every two.
+
+**A late timer is not a blocked thread.** WebKit aligns and throttles timers when
+the window loses focus. One session logged 959 stalls that a `sample` showed to
+be an idle process. Corroborate with the animation frame clock, which is not
+aligned, and treat gaps beyond a minute as the machine sleeping.
+
+**Yielding with a timer stops working in the background**, throttled to about
+1 Hz, which turns eighty yields per pass into eighty seconds. A message channel is a macrotask
+that is not a timer and is not throttled, which is what the shared yield helper
+in the island scan uses.
+
+**Yielding is cheap; telling React is not.** A progress report is a state update
+that re-renders a tree with the 3D scene in it. Reporting on every yield added
+roughly twenty seconds to a forty-second scan. Yield as often as the work needs;
+report at a human rate.
+
+**Two detectors will find each other.** `RendererCrashDiagnostics` patches
+`console.warn` and `console.error` to collect breadcrumbs, and `attachConsole`
+feeds it every Rust log record. Anything logged from a hot path arrives there
+too. Check what already exists before adding an instrument.
+
+**The observer is a suspect.** In one session the Web Inspector killed the
+process, editing the worktree restarted the app under a running test, the stall
+detector invented hundreds of freezes, and the progress reporting doubled the
+runtime. When a measurement surprises you, question the instrument before the
+code.
+
 ## External profilers
 
 ### macOS: `sample` and flame graphs

--- a/docs/dev/performance-debugging.md
+++ b/docs/dev/performance-debugging.md
@@ -1,0 +1,167 @@
+# Performance Debugging
+
+How to find out where DragonFruit's time goes. Two halves: scaffolding that
+ships inside the app and reports from users' machines, and external profilers
+you point at your own machine when you need a call stack.
+
+## In-app scaffolding
+
+### Main-thread stall detector
+
+`src/utils/debug/mainThreadHeartbeat.ts` is the UI's equivalent of a database
+slow query log. A timer that should fire every 250 ms measures how late it
+actually woke up. The main thread is single-threaded, so a timer that is 12
+seconds late means the thread was held for 12 seconds and the window was frozen
+for exactly that long.
+
+Reports land in `dragonfruit.log` at `WARN`:
+
+```
+[stall] Main thread blocked for 12340 ms (threshold 500 ms) — pointer: canvas (12358 ms ago), hotkey: s (4.2 s ago)
+```
+
+The threshold defaults to 500 ms and is read once at startup from the
+`df.debug.stallThresholdMs` key in `localStorage`. Values below one tick are
+ignored — the detector would be reporting its own scheduling jitter. Pick the
+threshold the way you would pick `long_query_time`: low enough to catch what a
+user notices, high enough that a legitimately heavy frame does not fill the log.
+
+Ticks are skipped while the window is hidden and across any visibility change.
+An occluded or minimised window has its timers throttled by the OS, which from
+inside the page is indistinguishable from a freeze.
+
+**What it cannot tell you** is which function was responsible. While the thread
+is blocked no JavaScript runs, so there is nothing to sample from — this is a
+property of the platform, not a gap in the implementation. What the report gives
+you is the gesture that preceded the freeze, which is the part users can never
+describe and the part you need to reproduce it. Take it to `sample` from there.
+
+### Activity context
+
+`src/utils/debug/heartbeatContext.ts` records what the user was doing, so a
+stall report is more than a number. It listens to two signals the app already
+emits — `app-hotkey-keydown` and `pointerdown` — and wires nothing at any call
+site.
+
+To have a slow subsystem name itself, call `noteActivity` immediately before the
+expensive work:
+
+```ts
+import { noteActivity } from '@/utils/debug/heartbeatContext';
+
+noteActivity('island-scan:contour-markers');
+```
+
+The label is truncated to 80 characters and becomes the `activity:` field of the
+next stall report. Use a stable, greppable name; do not interpolate user data
+into it. Only the most recent call is kept, so put it at the start of a phase
+rather than inside a loop.
+
+The same rule applies to the element description recorded on `pointerdown`: only
+`data-testid`, `aria-label` and `title` are read, never text content, which would
+carry users' model and file names into a log they are about to email you.
+
+### Startup header
+
+Written once per run, in two halves, each on the side that has the information.
+Rust logs what the process knows, from `log_startup_header()` in `main.rs`:
+
+```
+[header] DragonFruit 0.1.13 (debug=false) os=macos arch=aarch64 cores=12 log_level=INFO
+```
+
+The webview logs what only it can see, from `src/utils/debug/startupHeader.ts`:
+GPU string, viewport, screen size and device pixel ratio.
+
+Without a header every report floats in a vacuum: a 12-second freeze means
+nothing until you know whether it happened on an M4 Max or a 2017 iMac.
+
+!!! warning "Nothing may be logged before `setup()`"
+    `tauri-plugin-log` attaches the `log` facade during its own plugin setup.
+    Any `log::info!` emitted earlier in `main()` is silently dropped — it does
+    not reach the file, or stdout, or anywhere. This is why the header is
+    emitted from inside `setup()`.
+
+### Asking a user for a report
+
+The plumbing already exists and needs no new UI: Settings has a log level
+selector that applies without restarting, a live log viewer, and buttons to
+reveal or open the log file. Ask the user to set the level to `debug`, reproduce
+the problem, and send `dragonfruit.log`.
+
+## External profilers
+
+### macOS: `sample` and flame graphs
+
+The heavy lifting happens in the WebKit content process, not in the app process.
+Find it and sample it:
+
+```bash
+ps -Ao pid,ppid,%cpu,command | grep 'WebKit.WebContent' | grep -v grep
+```
+
+```bash
+sample <pid> 60 -file /tmp/df-$(date +%H%M%S).txt
+```
+
+`-file` truncates the path it is given, so vary the name if you want to keep
+successive captures. For a flame graph:
+
+```bash
+~/FlameGraph/stackcollapse-sample.awk /tmp/df-*.txt | ~/FlameGraph/flamegraph.pl > /tmp/df.svg
+```
+
+Note that `sample` aggregates: you get totals, not a timeline. Take one capture
+per phase if you need the sequence.
+
+!!! warning "JIT frames are not symbolicated"
+    Application JavaScript appears as `???  (in <unknown binary>)`. Neither
+    `sample` nor Instruments can symbolicate JavaScriptCore's JIT output. These
+    tools tell you *where in WebKit* you are — event dispatch, GC, compositing —
+    not which of your functions is responsible. For that, use the Web Inspector
+    profiler, or profile the plain web build in Chrome.
+
+### Reading a WebKit sample
+
+Some stacks that come up repeatedly and what they mean:
+
+| Stack | Meaning |
+|---|---|
+| `mouseEvent` → `dispatchMouseEvent` → `performMicrotaskCheckpoint` | Work in a promise continuation after a click — typically a React state flush, not the handler itself |
+| `timerFired` → `WindowEventLoop` → `Worker::dispatchEvent` | The main thread processing worker messages. Work is *off* the worker but still blocking the UI |
+| `updateRendering` → `WebGLRenderingContextBase::prepareForDisplay` → `waitForSyncReply` | Blocked on synchronous IPC to the GPU process. Fixed per-frame cost of WKWebView; a scene rendering when nothing moves pays it for nothing |
+| `operationMapHash` + `JSRopeString::resolveRope` + `IsoInlinedHeapCellType<JSRopeString>::finishSweep` | `Map`/`Set` keyed by concatenated strings. The GC cost of the temporary keys is often as large as the lookups |
+
+That last row is worth internalising. Building keys with template literals is
+idiomatic and looks harmless, but in a hot loop it allocates a rope string per
+lookup, and the sweep shows up as a third of total time. Numeric keys cost
+nothing to hash and allocate nothing.
+
+### Web Inspector and Chrome
+
+For JavaScript with real function names, bracket the operation from the console
+rather than recording everything:
+
+```javascript
+console.profile('place-support'); /* do the thing */ console.profileEnd('place-support');
+```
+
+This works in both Safari's Web Inspector, attached to the real WKWebView, and
+in Chrome against `npm run dev`. Chrome has the better flame chart and exports a
+`.cpuprofile` that `npx speedscope` opens, but it will not reproduce anything
+WKWebView-specific.
+
+## Known gaps
+
+**A hung Rust command is invisible to the stall detector.** `invoke` is
+asynchronous: it posts a message and returns a promise. If a command never
+returns, the promise never settles, the main thread stays free, and the
+heartbeat says nothing — the UI is responsive and the feature is simply dead.
+Nothing currently watches for invokes that never come back.
+
+**Large payloads returned from Rust can stall the main thread**, on the return
+path rather than the call. Deserialising a large result happens on the webview's
+main thread and is charged to whatever happens to be running.
+
+**Only instrumented phases are named.** Everything else shows up as a stall with
+whatever `pointerdown` happened to be last.

--- a/docs/dev/performance-debugging.md
+++ b/docs/dev/performance-debugging.md
@@ -67,6 +67,43 @@ The same rule applies to the element description recorded on `pointerdown`: only
 `data-testid`, `aria-label` and `title` are read, never text content, which would
 carry users' model and file names into a log they are about to email you.
 
+### The 16 GB ceiling, and the watchdog
+
+WebKit gives each content process a hard memory limit — 16 GB on macOS — and
+kills it when it cannot shrink below it. This is not system memory pressure and
+not jetsam: WebKit does it to itself, and it logs the whole thing through the
+app process:
+
+```
+Current memory footprint: 27351 MB
+Process is above the memory kill threshold. Trying to shrink down.
+New memory footprint: 16630 MB
+Unable to shrink memory footprint of process (16630 MB) below the kill thresold (16384 MB). Killed
+```
+
+The app process survives, so the window stays open and grey with nothing to
+explain it. To confirm this is what happened:
+
+```bash
+log show --last 10m --predicate 'eventMessage CONTAINS[c] "memory kill threshold"' --style compact
+```
+
+WebKit dumps its own counters as it dies — `javascript_gc_object_count` is
+usually the one that names the culprit; a scan that kept one object per contact
+voxel showed 99,593,201 live objects there. `vmmap -summary <pid>` on a running
+process gives the same picture earlier: look at *WebKit Malloc* and at
+*Physical footprint (peak)*, which remembers the spike long after the heap has
+settled.
+
+`webview_watchdog.rs` and `webviewHeartbeat.ts` handle the aftermath. The
+webview pings the native side every five seconds; ninety seconds of silence
+means the process is presumed dead and the user is offered a reload.
+
+Recovery is deliberately **not** automatic. Silence from a blocked main thread
+and silence from a dead process look identical from the native side, and
+reloading a merely busy webview would throw away the user's scene. A webview
+that catches up and pings again re-arms the watchdog and nothing happens.
+
 ### Startup header
 
 Written once per run, in two halves, each on the side that has the information.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
           - page.tsx Refactor Handoff: dev/page-tsx-refactor-handoff.md
           - Contributing: dev/contributing.md
           - Backlog and Known Gotchas: dev/backlog.md
+          - Performance Debugging: dev/performance-debugging.md
       - Feature Frameworks:
           - Experiments Framework: dev/experiments-framework.md
           - Plugin Framework: dev/plugins-framework.md

--- a/scripts/docs-accuracy-allowlist.json
+++ b/scripts/docs-accuracy-allowlist.json
@@ -1,5 +1,5 @@
 {
-      "_comment": "Deliberate exceptions for scripts/check-docs-accuracy.mjs. Every entry needs a reason \u2014 an unexplained entry is how a checker stops catching things.",
+      "_comment": "Deliberate exceptions for scripts/check-docs-accuracy.mjs. Every entry needs a reason — an unexplained entry is how a checker stops catching things.",
       "symbols": [
             "registerX",
             "subscribeX",
@@ -21,7 +21,15 @@
             "useHistoryControls",
             "packageManager",
             "island_replay",
-            "pushToast"
+            "pushToast",
+            "javascript_gc_object_count",
+            "dispatchMouseEvent",
+            "performMicrotaskCheckpoint",
+            "timerFired",
+            "WindowEventLoop",
+            "updateRendering",
+            "waitForSyncReply",
+            "operationMapHash"
       ],
       "paths": [
             "src/features/plugins/generatedBuiltinComplexPlugins.ts",
@@ -39,5 +47,6 @@
             "aspirational": "page-tsx-refactor-handoff.md is a refactor plan; its symbols name extractions not yet made. packageManager is a package.json key npm has not adopted here.",
             "generated at build time": "the paths are produced by scripts/generate-plugin-registry.mjs and are gitignored (**/generated*), so they are absent from a clean checkout.",
             "proposed, not built": "island_replay is the name ADR-0025 proposes for a capability not yet folded in; pushToast is named in notifications.md precisely to state that no such API exists."
-      }
+      },
+      "_comment_webkit_symbols": "The eight WebKit/JavaScriptCore internals above (javascript_gc_object_count through operationMapHash) are cited by docs/dev/performance-debugging.md as they appear in `sample` output and WebKit's own logs. They belong to the platform, not to this codebase, and will never be found here."
 }

--- a/scripts/docs-accuracy-allowlist.json
+++ b/scripts/docs-accuracy-allowlist.json
@@ -29,7 +29,8 @@
             "WindowEventLoop",
             "updateRendering",
             "waitForSyncReply",
-            "operationMapHash"
+            "operationMapHash",
+            "MessageChannel"
       ],
       "paths": [
             "src/features/plugins/generatedBuiltinComplexPlugins.ts",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3904,6 +3904,30 @@ fn resolve_log_level_pref_path() -> std::path::PathBuf {
     }
 }
 
+/// Fixed header written once per run, as the first thing in the log file.
+///
+/// Every performance report needs an anchor: a 12-second freeze means nothing
+/// until you know the version, the platform and how many cores it had. The
+/// webview logs its own half (GPU, viewport) from `startupHeader.ts`.
+///
+/// Must run inside `setup()` — the log plugin attaches the `log` facade during
+/// plugin setup, so records emitted before that are dropped on the floor.
+fn log_startup_header() {
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+
+    log::info!(
+        "[header] DragonFruit {} (debug={}) os={} arch={} cores={} log_level={}",
+        env!("CARGO_PKG_VERSION"),
+        cfg!(debug_assertions),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        cores,
+        log::max_level(),
+    );
+}
+
 fn read_log_level_pref() -> log::LevelFilter {
     let content = std::fs::read_to_string(resolve_log_level_pref_path()).unwrap_or_default();
     match content.trim() {
@@ -4075,11 +4099,10 @@ fn main() {
         }
     }
 
-    log::info!(
-        "DragonFruit {} starting (debug={})",
-        env!("CARGO_PKG_VERSION"),
-        cfg!(debug_assertions)
-    );
+    // NOTE: nothing may be logged before this point. `tauri-plugin-log` attaches
+    // the `log` facade during its plugin setup, so any record emitted earlier is
+    // silently dropped. The startup header lives in `log_startup_header()`,
+    // called from `setup()`, for exactly this reason.
 
     let _log_level = read_log_level_pref();
     // Log plugin disabled on CEF — it pulls tauri/wry transitively, causing
@@ -4120,6 +4143,8 @@ fn main() {
     let builder = builder.plugin(log_plugin);
     let builder = builder.setup(|app| {
         let app_handle = app.handle().clone();
+
+        log_startup_header();
 
         app.manage(window_state::WindowStateTracker::default());
         app.manage(experiments::ExperimentsState::default());

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -59,6 +59,7 @@ fn default_dither_device_gamma() -> f64 {
 
 mod experiments;
 mod plugin_registry;
+mod webview_watchdog;
 mod window_state;
 
 use rayon::{ThreadPool, ThreadPoolBuilder};
@@ -4147,6 +4148,8 @@ fn main() {
         log_startup_header();
 
         app.manage(window_state::WindowStateTracker::default());
+        app.manage(webview_watchdog::WebviewLiveness::default());
+        webview_watchdog::spawn(app_handle.clone());
         app.manage(experiments::ExperimentsState::default());
 
         // Defer main window creation to an async task so the splashscreen's
@@ -4241,6 +4244,7 @@ fn main() {
 
     builder
         .invoke_handler(tauri::generate_handler![
+            webview_watchdog::webview_heartbeat,
             stage_mesh_binary_start,
             allocate_mesh_stage_path,
             append_mesh_stage_chunk,

--- a/src-tauri/src/webview_watchdog.rs
+++ b/src-tauri/src/webview_watchdog.rs
@@ -25,6 +25,11 @@ const GRACE_PERIOD: Duration = Duration::from_secs(90);
 /// How often the watchdog looks at the clock.
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
 
+/// A poll that arrives this much later than scheduled means the machine slept
+/// or the app was suspended, not that anything died. Everything stopped in that
+/// window — including the webview — so the silence proves nothing.
+const SUSPENSION_SLACK: Duration = Duration::from_secs(20);
+
 #[derive(Default)]
 pub struct WebviewLiveness {
     /// Milliseconds since the epoch of the last ping; 0 before the first one.
@@ -72,8 +77,28 @@ pub async fn webview_heartbeat(
 /// Starts the watchdog. Safe to call once, from `setup()`.
 pub fn spawn(app: crate::DragonFruitAppHandle) {
     tauri::async_runtime::spawn(async move {
+        let mut last_poll_ms = now_ms();
         loop {
             tokio::time::sleep(POLL_INTERVAL).await;
+
+            // The watchdog's own clock is the sleep detector: this task is
+            // suspended alongside everything else, so a poll that took far
+            // longer than it asked for means the machine was not running. Start
+            // the grace period again rather than alarming on a gap nobody was
+            // awake for.
+            let polled_at = now_ms();
+            let poll_gap_ms = polled_at.saturating_sub(last_poll_ms);
+            last_poll_ms = polled_at;
+            if poll_gap_ms > (POLL_INTERVAL + SUSPENSION_SLACK).as_millis() as u64 {
+                if let Some(state) = app.try_state::<WebviewLiveness>() {
+                    log::info!(
+                        "[webview-watchdog] Woke after {} s of suspension; restarting the grace period.",
+                        poll_gap_ms / 1000
+                    );
+                    state.record_ping();
+                }
+                continue;
+            }
 
             use tauri::Manager;
             let Some(state) = app.try_state::<WebviewLiveness>() else {

--- a/src-tauri/src/webview_watchdog.rs
+++ b/src-tauri/src/webview_watchdog.rs
@@ -1,0 +1,141 @@
+//! Detects a dead web content process and offers to bring the window back.
+//!
+//! WebKit gives each content process a hard memory ceiling — 16 GB on macOS —
+//! and kills it on the spot when it cannot shrink below it. The app process
+//! survives, so the window stays open, empty and grey, with no error anywhere
+//! the user can see. That is what a "DragonFruit just froze" report looks like
+//! from the outside.
+//!
+//! The webview pings this module while it is alive. Silence means one of two
+//! things — the process is gone, or the main thread is busy in a long
+//! synchronous pass — and from here the two are indistinguishable. So the
+//! grace period is deliberately long, and recovery is never automatic: a
+//! reload would discard the user's scene, which is the wrong trade to make on
+//! a guess. We ask instead, and a busy webview that catches up cancels the
+//! whole thing by simply pinging again.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Silence after which the webview is presumed dead. Well above any plausible
+/// main-thread stall — the island scan's synchronous passes used to hold the
+/// thread for tens of seconds before they learned to yield.
+const GRACE_PERIOD: Duration = Duration::from_secs(90);
+
+/// How often the watchdog looks at the clock.
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+#[derive(Default)]
+pub struct WebviewLiveness {
+    /// Milliseconds since the epoch of the last ping; 0 before the first one.
+    last_seen_ms: AtomicU64,
+    /// Set once the user has been asked, so a dead webview prompts only once.
+    prompted: AtomicBool,
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+impl WebviewLiveness {
+    fn record_ping(&self) {
+        self.last_seen_ms.store(now_ms(), Ordering::Relaxed);
+        // A webview that speaks again was only busy, not dead. Re-arm so a
+        // later death still prompts.
+        self.prompted.store(false, Ordering::Relaxed);
+    }
+
+    /// Milliseconds of silence, or None before the first ping has ever arrived
+    /// (startup, or a build with the frontend half missing — neither is a
+    /// crash, and neither should raise a dialog).
+    fn silence_ms(&self) -> Option<u64> {
+        let last = self.last_seen_ms.load(Ordering::Relaxed);
+        if last == 0 {
+            return None;
+        }
+        Some(now_ms().saturating_sub(last))
+    }
+}
+
+/// Called by the webview on a timer. Cheap by design: one atomic store.
+#[tauri::command]
+pub async fn webview_heartbeat(
+    state: tauri::State<'_, WebviewLiveness>,
+) -> Result<(), String> {
+    state.record_ping();
+    Ok(())
+}
+
+/// Starts the watchdog. Safe to call once, from `setup()`.
+pub fn spawn(app: crate::DragonFruitAppHandle) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            tokio::time::sleep(POLL_INTERVAL).await;
+
+            use tauri::Manager;
+            let Some(state) = app.try_state::<WebviewLiveness>() else {
+                continue;
+            };
+            let Some(silence_ms) = state.silence_ms() else {
+                continue;
+            };
+            if silence_ms < GRACE_PERIOD.as_millis() as u64 {
+                continue;
+            }
+            // compare_exchange so a slow dialog cannot stack a second one.
+            if state
+                .prompted
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_err()
+            {
+                continue;
+            }
+
+            log::error!(
+                "[webview-watchdog] No heartbeat for {} s — the web content process is presumed dead. Offering a reload.",
+                silence_ms / 1000
+            );
+            offer_reload(app.clone());
+        }
+    });
+}
+
+/// Asks, on the main thread, and reloads only if the user agrees.
+fn offer_reload(app: crate::DragonFruitAppHandle) {
+    let dialog_app = app.clone();
+    let result = app.run_on_main_thread(move || {
+        use tauri::Manager;
+
+        let choice = rfd::MessageDialog::new()
+            .set_level(rfd::MessageLevel::Error)
+            .set_title("DragonFruit stopped responding")
+            .set_description(
+                "The display process ran out of memory and was shut down by the system. \
+                 Reloading restores the window, but unsaved changes to the scene are lost.\n\n\
+                 Reload now?",
+            )
+            .set_buttons(rfd::MessageButtons::YesNo)
+            .show();
+
+        if choice != rfd::MessageDialogResult::Yes {
+            log::info!("[webview-watchdog] Reload declined.");
+            return;
+        }
+
+        let Some(window) = dialog_app.get_webview_window("main") else {
+            log::error!("[webview-watchdog] No 'main' window to reload.");
+            return;
+        };
+        match window.eval("window.location.reload()") {
+            Ok(()) => log::info!("[webview-watchdog] Reload requested."),
+            Err(error) => log::error!("[webview-watchdog] Reload failed: {error}"),
+        }
+    });
+
+    if let Err(error) = result {
+        log::error!("[webview-watchdog] Could not reach the main thread: {error}");
+    }
+}

--- a/src-tauri/src/webview_watchdog.rs
+++ b/src-tauri/src/webview_watchdog.rs
@@ -113,8 +113,8 @@ fn offer_reload(app: crate::DragonFruitAppHandle) {
             .set_level(rfd::MessageLevel::Error)
             .set_title("DragonFruit stopped responding")
             .set_description(
-                "The display process ran out of memory and was shut down by the system. \
-                 Reloading restores the window, but unsaved changes to the scene are lost.\n\n\
+                "The window's display process stopped and had to be shut down. \
+                 Reloading brings the window back, but unsaved changes to the scene are lost.\n\n\
                  Reload now?",
             )
             .set_buttons(rfd::MessageButtons::YesNo)
@@ -129,9 +129,20 @@ fn offer_reload(app: crate::DragonFruitAppHandle) {
             log::error!("[webview-watchdog] No 'main' window to reload.");
             return;
         };
-        match window.eval("window.location.reload()") {
-            Ok(()) => log::info!("[webview-watchdog] Reload requested."),
-            Err(error) => log::error!("[webview-watchdog] Reload failed: {error}"),
+        // Navigate, never eval. With the content process gone there is no
+        // JavaScript context left to run `location.reload()` in — the call
+        // returns Ok and does nothing, which is exactly the false success this
+        // used to report. Navigation is native and spawns a fresh process.
+        let url = match window.url() {
+            Ok(url) => url,
+            Err(error) => {
+                log::error!("[webview-watchdog] Could not read the window URL: {error}");
+                return;
+            }
+        };
+        match window.navigate(url.clone()) {
+            Ok(()) => log::info!("[webview-watchdog] Reloaded via navigation to {url}."),
+            Err(error) => log::error!("[webview-watchdog] Navigation failed: {error}"),
         }
     });
 

--- a/src/components/AppLogger.tsx
+++ b/src/components/AppLogger.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { startMainThreadHeartbeat } from "@/utils/debug/mainThreadHeartbeat";
 import { logStartupHeader } from "@/utils/debug/startupHeader";
+import { startWebviewHeartbeat } from "@/utils/debug/webviewHeartbeat";
 
 /**
  * Attaches the native Tauri log plugin to the browser console so that all
@@ -23,11 +24,13 @@ export function AppLogger() {
       "__TAURI_INTERNALS__" in window;
 
     const stopHeartbeat = startMainThreadHeartbeat();
+    const stopWebviewHeartbeat = startWebviewHeartbeat();
 
     if (!isTauri) {
       logStartupHeader((message) => console.info(message));
       return () => {
         stopHeartbeat();
+        stopWebviewHeartbeat();
       };
     }
 
@@ -51,6 +54,7 @@ export function AppLogger() {
     return () => {
       detach?.();
       stopHeartbeat();
+      stopWebviewHeartbeat();
     };
   }, []);
 

--- a/src/components/AppLogger.tsx
+++ b/src/components/AppLogger.tsx
@@ -1,13 +1,20 @@
 "use client";
 
 import { useEffect } from "react";
+import { startMainThreadHeartbeat } from "@/utils/debug/mainThreadHeartbeat";
+import { logStartupHeader } from "@/utils/debug/startupHeader";
 
 /**
  * Attaches the native Tauri log plugin to the browser console so that all
  * console.log / warn / error calls made anywhere in the frontend are written
  * to the platform log file (e.g. %APPDATA%\org.openresinalliance.dragonfruit\logs\dragonfruit.log).
  *
- * This is a no-op when running outside of a Tauri context (e.g. browser dev).
+ * Also starts the main-thread stall detector and writes the webview half of the
+ * startup header. Both are cheap enough to run unconditionally: the detector is
+ * one timer at 4 Hz that logs only when something is already wrong.
+ *
+ * The console attachment is a no-op outside of a Tauri context (e.g. browser
+ * dev); the stall detector still runs there and reports to the console.
  */
 export function AppLogger() {
   useEffect(() => {
@@ -15,7 +22,14 @@ export function AppLogger() {
       typeof window !== "undefined" &&
       "__TAURI_INTERNALS__" in window;
 
-    if (!isTauri) return;
+    const stopHeartbeat = startMainThreadHeartbeat();
+
+    if (!isTauri) {
+      logStartupHeader((message) => console.info(message));
+      return () => {
+        stopHeartbeat();
+      };
+    }
 
     let detach: (() => void) | undefined;
 
@@ -24,6 +38,9 @@ export function AppLogger() {
         attachConsole().then((detachFn) => {
           detach = detachFn;
           info("Frontend logger attached");
+          logStartupHeader((message) => {
+            void info(message);
+          });
         });
       })
       .catch((err) => {
@@ -33,6 +50,7 @@ export function AppLogger() {
 
     return () => {
       detach?.();
+      stopHeartbeat();
     };
   }, []);
 

--- a/src/utils/debug/heartbeatContext.ts
+++ b/src/utils/debug/heartbeatContext.ts
@@ -1,0 +1,96 @@
+/**
+ * "What were we doing?" — the context a stall report is worthless without.
+ *
+ * Deliberately minimal: two passive listeners on signals the app already emits,
+ * and no wiring at any call site. A stall says the UI froze; this says what the
+ * user had just done, which is what turns a report into a reproduction.
+ *
+ * {@link noteActivity} exists so slow subsystems can name themselves without
+ * this module having to know about them.
+ */
+
+const MAX_LABEL_LENGTH = 80;
+
+interface ContextEntry {
+    label: string;
+    atMs: number;
+}
+
+let lastHotkey: ContextEntry | null = null;
+let lastPointerTarget: ContextEntry | null = null;
+let lastActivity: ContextEntry | null = null;
+
+function truncate(value: string): string {
+    const trimmed = value.trim().replace(/\s+/g, ' ');
+    return trimmed.length > MAX_LABEL_LENGTH
+        ? `${trimmed.slice(0, MAX_LABEL_LENGTH - 1)}…`
+        : trimmed;
+}
+
+/**
+ * Best-effort human label for a clicked element. Reads only attributes the app
+ * already sets for testing and accessibility — never text content, which can
+ * carry a user's model or file names into the log.
+ */
+function describeTarget(target: EventTarget | null): string {
+    if (!(target instanceof Element)) return 'unknown';
+
+    const labelled = target.closest('[data-testid], [aria-label], [title], button, canvas');
+    if (!labelled) return target.tagName.toLowerCase();
+
+    const attribute = labelled.getAttribute('data-testid')
+        ?? labelled.getAttribute('aria-label')
+        ?? labelled.getAttribute('title');
+
+    return attribute
+        ? `${labelled.tagName.toLowerCase()}[${truncate(attribute)}]`
+        : labelled.tagName.toLowerCase();
+}
+
+/**
+ * Records a named activity as the most recent thing the app was doing.
+ * Call it right before something known to be expensive.
+ */
+export function noteActivity(label: string): void {
+    lastActivity = { label: truncate(label), atMs: performance.now() };
+}
+
+/** Installs the listeners. Returns a detach function. */
+export function attachHeartbeatContext(): () => void {
+    if (typeof window === 'undefined') return () => { };
+
+    const handleHotkey = (event: Event) => {
+        const key = (event as CustomEvent<{ key?: string }>).detail?.key;
+        if (!key) return;
+        lastHotkey = { label: truncate(key), atMs: performance.now() };
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+        lastPointerTarget = { label: describeTarget(event.target), atMs: performance.now() };
+    };
+
+    window.addEventListener('app-hotkey-keydown', handleHotkey as EventListener);
+    window.addEventListener('pointerdown', handlePointerDown, { capture: true, passive: true });
+
+    return () => {
+        window.removeEventListener('app-hotkey-keydown', handleHotkey as EventListener);
+        window.removeEventListener('pointerdown', handlePointerDown, { capture: true });
+    };
+}
+
+function formatEntry(name: string, entry: ContextEntry | null, nowMs: number): string | null {
+    if (!entry) return null;
+    return `${name}: ${entry.label} (${Math.round(nowMs - entry.atMs)} ms ago)`;
+}
+
+/** One-line summary of the most recent user activity, for the stall report. */
+export function describeHeartbeatContext(): string {
+    const nowMs = performance.now();
+    const parts = [
+        formatEntry('activity', lastActivity, nowMs),
+        formatEntry('pointer', lastPointerTarget, nowMs),
+        formatEntry('hotkey', lastHotkey, nowMs),
+    ].filter((part): part is string => part !== null);
+
+    return parts.length > 0 ? parts.join(', ') : 'no recorded activity';
+}

--- a/src/utils/debug/mainThreadHeartbeat.ts
+++ b/src/utils/debug/mainThreadHeartbeat.ts
@@ -6,6 +6,13 @@
  * something held the thread for 12 seconds and the UI was frozen for exactly
  * that long.
  *
+ * A late timer alone is not evidence: WebKit aligns and throttles timers when
+ * the window loses focus, which reads from in here exactly like a blocked
+ * thread and produced hundreds of phantom reports before this was corrected. So
+ * a report needs two witnesses — the timer arrived late AND the animation frame
+ * clock also stopped. Frames are not subject to that alignment, so if they kept
+ * coming the thread was never blocked.
+ *
  * What it CANNOT do is say which function was responsible — while the thread is
  * blocked no JavaScript runs, so there is nothing to sample from. What it does
  * give is the gesture that preceded the freeze, which is the part users can
@@ -32,6 +39,12 @@ const TICK_MS = 100;
 const DEFAULT_STALL_THRESHOLD_MS = 500;
 
 const THRESHOLD_STORAGE_KEY = 'df.debug.stallThresholdMs';
+
+/**
+ * Gaps beyond this are the machine sleeping or the app being suspended, not a
+ * stall. Nothing was running to be blocked, and no real freeze lasts minutes.
+ */
+const SUSPENSION_MS = 60_000;
 
 function readThresholdMs(): number {
     try {
@@ -75,6 +88,15 @@ export function startMainThreadHeartbeat(): () => void {
 
     let expectedAt = performance.now() + TICK_MS;
 
+    // Second witness: frames keep arriving unless the thread is genuinely stuck.
+    let lastFrameAt = performance.now();
+    let frameHandle = 0;
+    const onFrame = () => {
+        lastFrameAt = performance.now();
+        frameHandle = window.requestAnimationFrame(onFrame);
+    };
+    frameHandle = window.requestAnimationFrame(onFrame);
+
     // A hidden or minimised window has its timers throttled by the OS, which
     // looks identical to a stall from in here. Skip the tick that spans a
     // visibility change, and every tick while hidden.
@@ -95,14 +117,22 @@ export function startMainThreadHeartbeat(): () => void {
 
         if (latenessMs < thresholdMs) return;
 
+        // The frame clock is the arbiter, and it also measures the block better:
+        // it counts from the last frame actually painted, not from when a timer
+        // was scheduled.
+        const frameGapMs = now - lastFrameAt;
+        if (frameGapMs < thresholdMs) return;
+        if (frameGapMs > SUSPENSION_MS) return;
+
         // Round: sub-millisecond precision on a multi-second freeze is noise.
         warn(
-            `[stall] Main thread blocked for ${Math.round(latenessMs)} ms `
+            `[stall] Main thread blocked for ${Math.round(frameGapMs)} ms `
             + `(threshold ${thresholdMs} ms) — ${describeHeartbeatContext()}`,
         );
     }, TICK_MS);
 
     return () => {
+        window.cancelAnimationFrame(frameHandle);
         window.clearInterval(intervalId);
         document.removeEventListener('visibilitychange', handleVisibilityChange);
         detachContext();

--- a/src/utils/debug/mainThreadHeartbeat.ts
+++ b/src/utils/debug/mainThreadHeartbeat.ts
@@ -17,9 +17,14 @@
 
 import { attachHeartbeatContext, describeHeartbeatContext } from './heartbeatContext';
 
-/** How often the heartbeat wakes up. Well below the threshold so a stall is
- *  attributed to a narrow window rather than a whole tick. */
-const TICK_MS = 250;
+/** How often the heartbeat wakes up.
+ *
+ *  This is the measurement granularity, and it cuts twice: a stall is only
+ *  noticed once a tick is `threshold` ms late, so a block starting right after
+ *  a tick gets one free tick before the clock starts, and the reported duration
+ *  understates the real block by up to one tick. Keeping it well below the
+ *  threshold bounds both errors. A no-op timer at 10 Hz costs nothing. */
+const TICK_MS = 100;
 
 /** Default lateness before a tick is considered a stall. Analogous to MySQL's
  *  `long_query_time`: low enough to catch what a user notices, high enough that

--- a/src/utils/debug/mainThreadHeartbeat.ts
+++ b/src/utils/debug/mainThreadHeartbeat.ts
@@ -1,0 +1,105 @@
+/**
+ * Main-thread stall detector — the "slow query log" of the UI.
+ *
+ * A timer that should fire every {@link TICK_MS} measures how late it actually
+ * woke up. The main thread is single-threaded: if the timer is 12 seconds late,
+ * something held the thread for 12 seconds and the UI was frozen for exactly
+ * that long.
+ *
+ * What it CANNOT do is say which function was responsible — while the thread is
+ * blocked no JavaScript runs, so there is nothing to sample from. What it does
+ * give is the gesture that preceded the freeze, which is the part users can
+ * never describe and the part needed to reproduce it. Take the report to
+ * `sample <pid>` from there.
+ *
+ * Reports land in dragonfruit.log at WARN, so a user only has to send the log.
+ */
+
+import { attachHeartbeatContext, describeHeartbeatContext } from './heartbeatContext';
+
+/** How often the heartbeat wakes up. Well below the threshold so a stall is
+ *  attributed to a narrow window rather than a whole tick. */
+const TICK_MS = 250;
+
+/** Default lateness before a tick is considered a stall. Analogous to MySQL's
+ *  `long_query_time`: low enough to catch what a user notices, high enough that
+ *  a legitimately heavy frame does not fill the log with noise. */
+const DEFAULT_STALL_THRESHOLD_MS = 500;
+
+const THRESHOLD_STORAGE_KEY = 'df.debug.stallThresholdMs';
+
+function readThresholdMs(): number {
+    try {
+        const raw = window.localStorage.getItem(THRESHOLD_STORAGE_KEY);
+        if (!raw) return DEFAULT_STALL_THRESHOLD_MS;
+        const parsed = Number.parseInt(raw, 10);
+        // Below one tick the detector would report its own scheduling jitter.
+        if (!Number.isFinite(parsed) || parsed < TICK_MS) return DEFAULT_STALL_THRESHOLD_MS;
+        return parsed;
+    } catch {
+        return DEFAULT_STALL_THRESHOLD_MS;
+    }
+}
+
+type LogFn = (message: string) => void;
+
+async function resolveWarn(): Promise<LogFn> {
+    const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+    if (!isTauri) return (message) => console.warn(message);
+
+    try {
+        const { warn } = await import('@tauri-apps/plugin-log');
+        return (message) => {
+            void warn(message);
+        };
+    } catch {
+        return (message) => console.warn(message);
+    }
+}
+
+/**
+ * Starts the detector. Returns a stop function; calling it twice is safe.
+ * A second call while already running is a no-op.
+ */
+export function startMainThreadHeartbeat(): () => void {
+    if (typeof window === 'undefined') return () => { };
+
+    const thresholdMs = readThresholdMs();
+    let warn: LogFn = (message) => console.warn(message);
+    void resolveWarn().then((fn) => { warn = fn; });
+
+    let expectedAt = performance.now() + TICK_MS;
+
+    // A hidden or minimised window has its timers throttled by the OS, which
+    // looks identical to a stall from in here. Skip the tick that spans a
+    // visibility change, and every tick while hidden.
+    let skipNextTick = false;
+    const handleVisibilityChange = () => { skipNextTick = true; };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    const detachContext = attachHeartbeatContext();
+
+    const intervalId = window.setInterval(() => {
+        const now = performance.now();
+        const latenessMs = now - expectedAt;
+        expectedAt = now + TICK_MS;
+
+        const skip = skipNextTick || document.hidden;
+        skipNextTick = false;
+        if (skip) return;
+
+        if (latenessMs < thresholdMs) return;
+
+        // Round: sub-millisecond precision on a multi-second freeze is noise.
+        warn(
+            `[stall] Main thread blocked for ${Math.round(latenessMs)} ms `
+            + `(threshold ${thresholdMs} ms) — ${describeHeartbeatContext()}`,
+        );
+    }, TICK_MS);
+
+    return () => {
+        window.clearInterval(intervalId);
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+        detachContext();
+    };
+}

--- a/src/utils/debug/startupHeader.ts
+++ b/src/utils/debug/startupHeader.ts
@@ -1,0 +1,53 @@
+/**
+ * Fixed header written once per run, from the webview side.
+ *
+ * Without it every performance report floats in a vacuum: a 12-second freeze
+ * means nothing until you know whether it happened on an M4 Max or a 2017 iMac.
+ * The Rust side logs what the process knows (version, OS, CPU count); this logs
+ * what only the webview can see.
+ *
+ * Nothing here is user data — no paths, no model names.
+ */
+
+type LogFn = (message: string) => void;
+
+/**
+ * Queries the GPU string. WebKit may mask this for fingerprinting reasons, in
+ * which case the generic renderer name is still worth having.
+ */
+function describeGpu(): string {
+    let canvas: HTMLCanvasElement | null = null;
+    try {
+        canvas = document.createElement('canvas');
+        const gl = canvas.getContext('webgl2') ?? canvas.getContext('webgl');
+        if (!gl) return 'no WebGL context';
+
+        const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+        const renderer = debugInfo
+            ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)
+            : gl.getParameter(gl.RENDERER);
+
+        // Release the context immediately — a lingering one costs a GPU process
+        // slot for the whole session.
+        gl.getExtension('WEBGL_lose_context')?.loseContext();
+
+        return typeof renderer === 'string' && renderer.length > 0 ? renderer : 'unknown';
+    } catch {
+        return 'unavailable';
+    } finally {
+        canvas?.remove();
+    }
+}
+
+/** Writes the webview half of the startup header. */
+export function logStartupHeader(info: LogFn): void {
+    if (typeof window === 'undefined') return;
+
+    const { width, height } = window.screen;
+    info(
+        `[header] gpu=${describeGpu()} `
+        + `viewport=${window.innerWidth}x${window.innerHeight} `
+        + `screen=${width}x${height}@${window.devicePixelRatio}x `
+        + `cores=${navigator.hardwareConcurrency ?? 'unknown'}`,
+    );
+}

--- a/src/utils/debug/webviewHeartbeat.ts
+++ b/src/utils/debug/webviewHeartbeat.ts
@@ -1,0 +1,44 @@
+/**
+ * Tells the native side that this webview is still alive.
+ *
+ * The counterpart of `webview_watchdog.rs`. When WebKit kills the content
+ * process for exceeding its memory ceiling, the window stays open and empty
+ * with nothing to tell the user what happened — these pings stopping is the
+ * only signal the app process gets.
+ *
+ * The ping deliberately rides on a plain timer: if the main thread is blocked
+ * it does not fire, which is exactly the condition worth noticing. The native
+ * side waits far longer than any plausible stall before concluding anything,
+ * and asks before reloading.
+ */
+
+/** Comfortably below the native grace period, so a missed tick is harmless. */
+const PING_INTERVAL_MS = 5_000;
+
+export function startWebviewHeartbeat(): () => void {
+    if (typeof window === 'undefined') return () => { };
+    if (!('__TAURI_INTERNALS__' in window)) return () => { };
+
+    let stopped = false;
+    let intervalId: number | undefined;
+
+    void import('@tauri-apps/api/core')
+        .then(({ invoke }) => {
+            if (stopped) return;
+
+            const ping = () => {
+                // A rejected ping is not worth reporting: it means the native
+                // side is gone, in which case nothing here matters either.
+                void invoke('webview_heartbeat').catch(() => { });
+            };
+
+            ping();
+            intervalId = window.setInterval(ping, PING_INTERVAL_MS);
+        })
+        .catch(() => { /* not a Tauri context after all */ });
+
+    return () => {
+        stopped = true;
+        if (intervalId !== undefined) window.clearInterval(intervalId);
+    };
+}


### PR DESCRIPTION
This patch adds a watchdog to record stalls and the last user action in the application log, and catches the case of the WebKit view being killed due to OOM or other circumstances, and offers the user to restart the application.