### PR TITLE
Enhance performance and UI responsiveness for islands analysis

### DIFF
--- a/docs/adr/0039-island-scan-data-shapes.md
+++ b/docs/adr/0039-island-scan-data-shapes.md
@@ -1,0 +1,23 @@
+---
+issue: islands-memory
+kind: decision
+date: 2026-08-21
+---
+
+# ADR-0039: The island scan stores voxels in buffers, not in objects
+
+**Status**: accepted
+
+Context: a 5292-layer scan of a 3647×1814 grid put the WebKit content process at 27 GB and it was killed against WebKit's hard 16 GB ceiling, leaving the window grey with nothing to explain it. The process reported `javascript_gc_object_count: 99,593,201` as it died. Nothing was leaking — the memory came back between runs — the peak alone was fatal. Every structure involved was written the idiomatic way, and that is precisely what made it fatal: an object per voxel, a `Set` of boxed numbers per voxel, a typed array per row, a fresh coordinate object per lookup.
+
+Decision: in the island scan's hot structures, **a voxel is an offset into a buffer, never an object**. Four shapes follow from that, and each one is load-bearing:
+
+**Contact footprints are interleaved `Float32Array`s** behind accessor helpers, not `{ x, y }[]`. This alone took the live object count from 99.6 million to 11 million. Footprints are retained — they live in React state and in the scan cache — so their representation is the one that matters most.
+
+**Empty RLE rows are one shared array.** A layer is 1814 rows and a scan is 5292 layers, so the naive `new Int32Array(0)` per empty row allocated 9.6 million typed arrays holding half a megabyte between them. Sharing is sound because rows are never written in place: producers build a fresh row and assign it. Structured clone preserves identity within a message, so the sharing survives the trip from the worker. Live arrays dropped from 9,599,688 to 32,304.
+
+**The flood fill consumes its candidate set.** Deleting each voxel as it is reached makes the candidate set itself the unvisited set, instead of a second `Set` holding the same ten million boxed numbers. Claiming a neighbour becomes one hash lookup rather than three. The cost is a contract: `buildIslands` empties what it is given.
+
+**Grid coordinates are read, not unpacked.** `unpack` returns a fresh object, and the flood calls it once per voxel as it walks plus twice more per voxel afterwards — around thirty million throwaway objects to carry three numbers. Component accessors do the same arithmetic and allocate nothing; that change alone took the flood from 20 seconds to 14.
+
+Consequences: **the readable shape is the dangerous one here**, so these four will look like candidates for cleanup to anyone who has not measured. `{ x, y }` reads better than an accessor call, and a separate visited set reads better than mutating the input. Reverting any of them in good faith puts the peak back where it was. The boundary is drawn where the data stops being retained: the auto-support placement helpers still take point arrays, materialised for the duration of one placement run, because their results are discarded immediately and their algorithms are unit-tested against plain arrays. Peak footprint for a full scan went from 14 GB measured continuously — 27 GB at the crash — to 5.1 GB, and the scan from over a minute to about 45 seconds. Anything added to these paths should be measured against the phase and step timings the scan writes to the app log, rather than reasoned about from the source.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
           - Auto-Support Roads Not Taken: adr/0038-auto-support-placement-roads-not-taken.md
           - Stream CTB Layer Payloads to Disk: adr/0036-stream-ctb-layer-payloads-to-disk.md
           - Cut the Surface, Not a Volume: adr/0037-cut-the-surface-not-a-volume.md
+          - Island Scan Data Shapes: adr/0039-island-scan-data-shapes.md
           - Organic Cut Surface Redesign: dev/organic-cut-surface-redesign.md
       - Integration and Operations:
           - RTSP Relay: dev/rtsp-relay.md

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -672,32 +672,6 @@ input[type="number"].no-spinners {
   }
 }
 
-/**
- * Narrow bouncing dot for a bar that has no percentage yet.
- *
- * Unlike .ui-loading-indicator, which is a third of the track wide and travels
- * by multiples of its own width, this one is a few pixels and travels the
- * track. A wide sweeping block on a progress bar reads as the value itself
- * growing and then collapsing.
- */
-@keyframes uiLoadingDot {
-  0% {
-    left: -14px;
-  }
-  100% {
-    left: 100%;
-  }
-}
-
-.ui-loading-dot {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 14px;
-  border-radius: 9999px;
-  animation: uiLoadingDot 1.05s ease-in-out infinite alternate;
-}
-
 .ui-loading-track {
   position: relative;
   overflow: hidden;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -672,6 +672,32 @@ input[type="number"].no-spinners {
   }
 }
 
+/**
+ * Narrow bouncing dot for a bar that has no percentage yet.
+ *
+ * Unlike .ui-loading-indicator, which is a third of the track wide and travels
+ * by multiples of its own width, this one is a few pixels and travels the
+ * track. A wide sweeping block on a progress bar reads as the value itself
+ * growing and then collapsing.
+ */
+@keyframes uiLoadingDot {
+  0% {
+    left: -14px;
+  }
+  100% {
+    left: 100%;
+  }
+}
+
+.ui-loading-dot {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 14px;
+  border-radius: 9999px;
+  animation: uiLoadingDot 1.05s ease-in-out infinite alternate;
+}
+
 .ui-loading-track {
   position: relative;
   overflow: hidden;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10743,7 +10743,7 @@ export default function Home() {
               <p>Slicing and analysis in progress...</p>
               {islandsPoc.scanProgress && islandsPoc.scanProgress.total > 100 && (
                 <p>
-                  Layer {islandsPoc.scanProgress.done} of {islandsPoc.scanProgress.total}
+                  {islandsPoc.scanProgress.phase ?? 'Layer'} {islandsPoc.scanProgress.done} of {islandsPoc.scanProgress.total}
                 </p>
               )}
             </div>
@@ -10781,7 +10781,7 @@ export default function Home() {
             <div className="mt-1 space-y-0.5 text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
               <p>{islandsPoc.scanning ? 'Scanning islands & minima…' : 'Placing and bracing supports…'}</p>
               {islandsPoc.scanProgress && islandsPoc.scanProgress.total > 100 && (
-                <p>Layer {islandsPoc.scanProgress.done} of {islandsPoc.scanProgress.total}</p>
+                <p>{islandsPoc.scanProgress.phase ?? 'Layer'} {islandsPoc.scanProgress.done} of {islandsPoc.scanProgress.total}</p>
               )}
             </div>
             <div className="mt-2 text-[11px] font-medium tracking-wide" style={{ color: 'var(--accent)' }}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -68,6 +68,7 @@ import { SlicingPanel, type SliceIntent } from '@/features/slicing/components/Sl
 import { PrintingPanel } from '@/features/printing/components/PrintingPanel';
 import { usePrintingPreviewManager, type PrintingPreviewManagerDeps } from '@/features/printing/usePrintingPreviewManager';
 import { useEditorToasts } from '@/features/notifications/useEditorToasts';
+import { ScanProgressBar } from '@/components/scene/ScanProgressBar';
 import { SliceMetricsDebugModal } from '@/features/slicing/components/SliceMetricsDebugModal';
 import { MeshSmoothingSettingsPanel } from '@/features/mesh-smoothing/MeshSmoothingSettingsPanel';
 import { MeshSmoothingBrushCursor } from '@/features/mesh-smoothing/MeshSmoothingBrushCursor';
@@ -10741,11 +10742,6 @@ export default function Home() {
             </div>
             <div className="mt-1 space-y-0.5 text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
               <p>Slicing and analysis in progress...</p>
-              {islandsPoc.scanProgress && islandsPoc.scanProgress.total > 100 && (
-                <p>
-                  {islandsPoc.scanProgress.phase ?? 'Layer'} {islandsPoc.scanProgress.done} of {islandsPoc.scanProgress.total}
-                </p>
-              )}
             </div>
 
             <div className="mt-2 text-[11px] font-medium tracking-wide" style={{ color: 'var(--accent)' }}>
@@ -10755,15 +10751,7 @@ export default function Home() {
               Processing 1 model
             </div>
 
-            <div
-              className="ui-loading-track mt-3 h-2.5 w-full rounded-full"
-              style={{ background: 'color-mix(in srgb, var(--surface-2), black 20%)' }}
-            >
-              <div
-                className="ui-loading-indicator"
-                style={{ background: 'linear-gradient(90deg, var(--accent), #ff79c6)' }}
-              />
-            </div>
+            <ScanProgressBar progress={islandsPoc.scanProgress} />
           </div>
         </div>
       )}
@@ -10780,9 +10768,6 @@ export default function Home() {
             </div>
             <div className="mt-1 space-y-0.5 text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
               <p>{islandsPoc.scanning ? 'Scanning islands & minima…' : 'Placing and bracing supports…'}</p>
-              {islandsPoc.scanProgress && islandsPoc.scanProgress.total > 100 && (
-                <p>{islandsPoc.scanProgress.phase ?? 'Layer'} {islandsPoc.scanProgress.done} of {islandsPoc.scanProgress.total}</p>
-              )}
             </div>
             <div className="mt-2 text-[11px] font-medium tracking-wide" style={{ color: 'var(--accent)' }}>
               Elapsed: {islandsPoc.scanning ? islandsPoc.elapsedLabel : '…'}
@@ -10790,9 +10775,7 @@ export default function Home() {
             <div className="mt-1 text-[11px]" style={{ color: 'var(--text-muted)' }}>
               Processing 1 model
             </div>
-            <div className="ui-loading-track mt-3 h-2.5 w-full rounded-full" style={{ background: 'color-mix(in srgb, var(--surface-2), black 20%)' }}>
-              <div className="ui-loading-indicator" style={{ background: 'linear-gradient(90deg, var(--accent), #ff79c6)' }} />
-            </div>
+            <ScanProgressBar progress={islandsPoc.scanning ? islandsPoc.scanProgress : null} />
           </div>
         </div>
       )}

--- a/src/components/controls/IslandScanCard.tsx
+++ b/src/components/controls/IslandScanCard.tsx
@@ -227,7 +227,7 @@ export function IslandScanCard({
 
             {islands.scanProgress && (
                 <div className="text-[11px] px-1" style={{ color: 'var(--text-muted)' }}>
-                    {islands.scanProgress.done} / {islands.scanProgress.total} layers
+                    {islands.scanProgress.phase ? `${islands.scanProgress.phase}: ` : ''}{islands.scanProgress.done} / {islands.scanProgress.total} layers
                     {islands.scanData && islands.scanData.islands.length > 0 && (
                         <span className="ml-1" style={{ color: 'var(--text-strong)' }}>({islands.scanData.islands.length} islands)</span>
                     )}

--- a/src/components/controls/IslandsPanel.tsx
+++ b/src/components/controls/IslandsPanel.tsx
@@ -196,7 +196,7 @@ export function IslandsPanel({ islands, hasGeometry, bottomClearancePx = 88 }: I
               }}
             >
               {scanning
-                ? `Scanning… ${scanProgress?.done ?? 0}/${scanProgress?.total ?? 0}`
+                ? `${scanProgress?.phase ?? 'Scanning'}… ${scanProgress?.done ?? 0}/${scanProgress?.total ?? 0}`
                 : 'Scan Islands'}
             </button>
 

--- a/src/components/controls/IslandsPanel.tsx
+++ b/src/components/controls/IslandsPanel.tsx
@@ -66,7 +66,6 @@ export function IslandsPanel({ islands, hasGeometry, bottomClearancePx = 88 }: I
 
   const {
     scanning,
-    scanProgress,
     showVoxelOnly,
     setShowVoxelOnly,
     showMinimaOnly,
@@ -195,23 +194,9 @@ export function IslandsPanel({ islands, hasGeometry, bottomClearancePx = 88 }: I
                 color: 'var(--accent)',
               }}
             >
-              {scanning
-                ? `${scanProgress?.phase ?? 'Scanning'}… ${scanProgress?.done ?? 0}/${scanProgress?.total ?? 0}`
-                : 'Scan Islands'}
+              {scanning ? 'Scanning…' : 'Scan Islands'}
             </button>
 
-            {/* Progress bar */}
-            {scanning && scanProgress && (
-              <div className="h-1 rounded-full overflow-hidden" style={{ background: 'var(--surface-2)' }}>
-                <div
-                  className="h-full rounded-full transition-all duration-200"
-                  style={{
-                    width: `${Math.min(100, (scanProgress.done / Math.max(1, scanProgress.total)) * 100)}%`,
-                    background: 'var(--accent)',
-                  }}
-                />
-              </div>
-            )}
 
             {/* --- Post-scan content --- */}
             {hasData && !scanning && (

--- a/src/components/scene/ScanProgressBar.tsx
+++ b/src/components/scene/ScanProgressBar.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+export type ScanProgress = {
+  done: number;
+  total: number;
+  phase?: string;
+  phaseNumber?: number;
+  phaseCount?: number;
+};
+
+/**
+ * Determinate progress for the island scan, phase by phase.
+ *
+ * The scan is a sequence of passes and each one restarts at zero, so a single
+ * bar would appear to go backwards. It shows which pass is running out of how
+ * many — a count that travels with the report, because the two scan paths have
+ * a different number of phases — and fills for the current one.
+ *
+ * Falls back to an indeterminate stripe only while no progress has arrived yet.
+ */
+export function ScanProgressBar({ progress }: { progress: ScanProgress | null }) {
+  const total = progress?.total ?? 0;
+  const percent = total > 0
+    ? Math.min(100, Math.max(0, (progress!.done / total) * 100))
+    : null;
+
+  return (
+    <div className="mt-3 space-y-1">
+      <div className="flex items-baseline justify-between text-[11px]" style={{ color: 'var(--text-muted)' }}>
+        <span>
+          {progress?.phase ?? 'Starting'}
+          {progress?.phaseNumber && progress?.phaseCount
+            ? ` (${progress.phaseNumber}/${progress.phaseCount})`
+            : ''}
+        </span>
+        <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+          {percent === null ? '' : `${Math.round(percent)}%`}
+        </span>
+      </div>
+
+      <div
+        className="h-2.5 w-full overflow-hidden rounded-full"
+        style={{ background: 'color-mix(in srgb, var(--surface-2), black 20%)' }}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={percent === null ? undefined : Math.round(percent)}
+        aria-label={progress?.phase ?? 'Scan progress'}
+      >
+        {percent === null ? (
+          <div className="ui-loading-indicator" style={{ background: 'linear-gradient(90deg, var(--accent), #ff79c6)' }} />
+        ) : (
+          <div
+            className="h-full rounded-full transition-[width] duration-200"
+            style={{ width: `${percent}%`, background: 'linear-gradient(90deg, var(--accent), #ff79c6)' }}
+          />
+        )}
+      </div>
+
+      {total > 0 && (
+        <div className="text-[11px]" style={{ color: 'var(--text-muted)', fontVariantNumeric: 'tabular-nums' }}>
+          {progress!.done.toLocaleString()} / {total.toLocaleString()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/scene/ScanProgressBar.tsx
+++ b/src/components/scene/ScanProgressBar.tsx
@@ -16,13 +16,14 @@ export type ScanProgress = {
  * many — a count that travels with the report, because the two scan paths have
  * a different number of phases — and fills for the current one.
  *
- * Falls back to an indeterminate stripe only while no progress has arrived yet.
+ * Before the first report it simply sits at zero. An indeterminate animation
+ * here was worse than nothing: it reads as the value moving on its own.
  */
 export function ScanProgressBar({ progress }: { progress: ScanProgress | null }) {
   const total = progress?.total ?? 0;
   const percent = total > 0
     ? Math.min(100, Math.max(0, (progress!.done / total) * 100))
-    : null;
+    : 0;
 
   return (
     <div className="mt-3 space-y-1">
@@ -34,31 +35,23 @@ export function ScanProgressBar({ progress }: { progress: ScanProgress | null })
             : ''}
         </span>
         <span style={{ fontVariantNumeric: 'tabular-nums' }}>
-          {percent === null ? '' : `${Math.round(percent)}%`}
+          {total > 0 ? `${Math.round(percent)}%` : ''}
         </span>
       </div>
 
-      {/* ui-loading-track is what makes this the positioning context. The
-          indeterminate stripe is absolutely positioned, so without it the
-          stripe lays itself out against the modal and sweeps across the whole
-          screen as a giant ellipse. */}
       <div
-        className="ui-loading-track h-2.5 w-full rounded-full"
+        className="h-2.5 w-full overflow-hidden rounded-full"
         style={{ background: 'color-mix(in srgb, var(--surface-2), black 20%)' }}
         role="progressbar"
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-valuenow={percent === null ? undefined : Math.round(percent)}
+        aria-valuenow={total > 0 ? Math.round(percent) : undefined}
         aria-label={progress?.phase ?? 'Scan progress'}
       >
-        {percent === null ? (
-          <div className="ui-loading-dot" style={{ background: 'var(--accent)' }} />
-        ) : (
-          <div
-            className="h-full rounded-full transition-[width] duration-200"
-            style={{ width: `${percent}%`, background: 'linear-gradient(90deg, var(--accent), #ff79c6)' }}
-          />
-        )}
+        <div
+          className="h-full rounded-full transition-[width] duration-200"
+          style={{ width: `${percent}%`, background: 'linear-gradient(90deg, var(--accent), #ff79c6)' }}
+        />
       </div>
 
       {total > 0 && (

--- a/src/components/scene/ScanProgressBar.tsx
+++ b/src/components/scene/ScanProgressBar.tsx
@@ -38,8 +38,12 @@ export function ScanProgressBar({ progress }: { progress: ScanProgress | null })
         </span>
       </div>
 
+      {/* ui-loading-track is what makes this the positioning context. The
+          indeterminate stripe is absolutely positioned, so without it the
+          stripe lays itself out against the modal and sweeps across the whole
+          screen as a giant ellipse. */}
       <div
-        className="h-2.5 w-full overflow-hidden rounded-full"
+        className="ui-loading-track h-2.5 w-full rounded-full"
         style={{ background: 'color-mix(in srgb, var(--surface-2), black 20%)' }}
         role="progressbar"
         aria-valuemin={0}

--- a/src/components/scene/ScanProgressBar.tsx
+++ b/src/components/scene/ScanProgressBar.tsx
@@ -52,7 +52,7 @@ export function ScanProgressBar({ progress }: { progress: ScanProgress | null })
         aria-label={progress?.phase ?? 'Scan progress'}
       >
         {percent === null ? (
-          <div className="ui-loading-indicator" style={{ background: 'linear-gradient(90deg, var(--accent), #ff79c6)' }} />
+          <div className="ui-loading-dot" style={{ background: 'var(--accent)' }} />
         ) : (
           <div
             className="h-full rounded-full transition-[width] duration-200"

--- a/src/supports/__tests__/autoPlace.test.ts
+++ b/src/supports/__tests__/autoPlace.test.ts
@@ -1,3 +1,4 @@
+import { footprintFromPoints } from '@/volumeAnalysis/Islands/voxelFootprint';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import * as THREE from 'three';
@@ -125,7 +126,7 @@ test('runAutoPlace anchors a large flat region as a densified grid (planar → g
         contact: new THREE.Vector3(0, 0, 6.5),
         baseZ: 6.5,
         areaMm2: 400,
-        contactVoxels,
+        contactVoxels: footprintFromPoints(contactVoxels),
     };
 
     const result = runAutoPlace([facet], 'model-a', { debugSkipAutoBracing: true });
@@ -191,7 +192,7 @@ test('runAutoPlace places grid trunks on a rotated mesh via the region normal', 
         baseZ: 6.34,
         areaMm2: 400 * (Math.sqrt(3) / 2), // projected area ≈ 346
         surfaceNormal: normal,
-        contactVoxels,
+        contactVoxels: footprintFromPoints(contactVoxels),
     };
 
     const result = runAutoPlace([facet], 'model-a', { debugSkipAutoBracing: true });
@@ -227,7 +228,7 @@ test('runAutoPlace gap-fills under-covered regions (coverage convergence)', () =
         baseZ: 6.5,
         areaMm2: 400,
         surfaceNormal: { x: 0, y: 0, z: -1 },
-        contactVoxels,
+        contactVoxels: footprintFromPoints(contactVoxels),
     };
 
     const result = runAutoPlace([facet], 'model-a', {
@@ -266,7 +267,7 @@ test('runAutoPlace densifies small anchor regions below the grid threshold', () 
         contact: new THREE.Vector3(0, 0, 6.5),
         baseZ: 6.5,
         areaMm2: 16,
-        contactVoxels,
+        contactVoxels: footprintFromPoints(contactVoxels),
     };
 
     const result = runAutoPlace([foot], 'model-a', { debugSkipAutoBracing: true });
@@ -298,11 +299,11 @@ test('runAutoPlace fans sub-threshold overhang candidates instead of standalone 
                 contact: new THREE.Vector3(3, 0, 33),
                 baseZ: 33,
                 areaMm2: 16,
-                contactVoxels: [
+                contactVoxels: footprintFromPoints([
                     { x: 2.75, y: -0.25 }, { x: 3, y: -0.25 }, { x: 3.25, y: -0.25 },
                     { x: 2.75, y: 0 }, { x: 3, y: 0 }, { x: 3.25, y: 0 },
                     { x: 2.75, y: 0.25 }, { x: 3, y: 0.25 }, { x: 3.25, y: 0.25 },
-                ],
+                ]),
             },
         ],
         'model-a',
@@ -349,7 +350,7 @@ test('runAutoPlace falls back to a standalone trunk when no fan host exists', ()
                 contact: new THREE.Vector3(20, 0, 30),
                 baseZ: 30,
                 areaMm2: 16,
-                contactVoxels: [{ x: 19.75, y: 0 }, { x: 20, y: 0 }, { x: 20.25, y: 0 }],
+                contactVoxels: footprintFromPoints([{ x: 19.75, y: 0 }, { x: 20, y: 0 }, { x: 20.25, y: 0 }]),
             },
         ],
         'model-a',
@@ -387,7 +388,7 @@ test('runAutoPlace dispatches by shape: planar → grid, organic → Poisson', (
         contact: new THREE.Vector3(0, 0, 6.5),
         baseZ: 6.5,
         areaMm2: 400,
-        contactVoxels: planarVoxels,
+        contactVoxels: footprintFromPoints(planarVoxels),
     };
 
     // Curved region (z = 6.5 + x²/20) offset far away, higher cluster →
@@ -404,7 +405,7 @@ test('runAutoPlace dispatches by shape: planar → grid, organic → Poisson', (
         contact: new THREE.Vector3(40, 40, 25),
         baseZ: 25,
         areaMm2: 400,
-        contactVoxels: curvedVoxels,
+        contactVoxels: footprintFromPoints(curvedVoxels),
     };
 
     const result = runAutoPlace([planar, organic], 'model-a', { debugSkipAutoBracing: true });
@@ -444,7 +445,7 @@ test('runAutoPlace fans organic poisson points into island trunks instead of dup
                 contact: new THREE.Vector3(0, 0, 33),
                 baseZ: 33,
                 areaMm2: 400,
-                contactVoxels: curvedVoxels,
+                contactVoxels: footprintFromPoints(curvedVoxels),
             },
         ],
         'model-a',
@@ -500,7 +501,7 @@ test('runAutoPlace consolidates organic poisson trunks into island trunks placed
                 contact: new THREE.Vector3(0, 0, 25),
                 baseZ: 25,
                 areaMm2: 400,
-                contactVoxels: curvedVoxels,
+                contactVoxels: footprintFromPoints(curvedVoxels),
             },
             makeIsland('A', 2.5, 0, 30, 0.5),
         ],
@@ -596,17 +597,17 @@ test('runAutoPlace keeps low undersides a standalone anchor pillar forest', () =
             {
                 id: 'o0', source: 'overhang',
                 contact: new THREE.Vector3(0, 0, 6.5), baseZ: 6.5,
-                areaMm2: 64, contactVoxels,
+                areaMm2: 64, contactVoxels: footprintFromPoints(contactVoxels),
             },
             {
                 id: 'o15', source: 'overhang',
                 contact: new THREE.Vector3(3, 0, 8), baseZ: 8,
                 areaMm2: 16,
-                contactVoxels: [
+                contactVoxels: footprintFromPoints([
                     { x: 2.75, y: -0.25 }, { x: 3, y: -0.25 }, { x: 3.25, y: -0.25 },
                     { x: 2.75, y: 0 }, { x: 3, y: 0 }, { x: 3.25, y: 0 },
                     { x: 2.75, y: 0.25 }, { x: 3, y: 0.25 }, { x: 3.25, y: 0.25 },
-                ],
+                ]),
             },
         ],
         'model-a',

--- a/src/supports/__tests__/coverage.test.ts
+++ b/src/supports/__tests__/coverage.test.ts
@@ -1,3 +1,4 @@
+import { footprintFromPoints } from '@/volumeAnalysis/Islands/voxelFootprint';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import * as THREE from 'three';
@@ -30,7 +31,7 @@ function rectRegion(id: string, minX: number, maxX: number, minY: number, maxY: 
         baseZ: 10,
         areaMm2: (maxX - minX) * (maxY - minY),
         surfaceNormal: { x: 0, y: 0, z: -1 },
-        contactVoxels,
+        contactVoxels: footprintFromPoints(contactVoxels),
     };
 }
 

--- a/src/supports/__tests__/gridPlacement.test.ts
+++ b/src/supports/__tests__/gridPlacement.test.ts
@@ -1,3 +1,4 @@
+import { footprintFromPoints } from '@/volumeAnalysis/Islands/voxelFootprint';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import * as THREE from 'three';
@@ -31,7 +32,7 @@ function rectRegion(
         baseZ,
         areaMm2,
         overhangAngleDeg: angleDeg,
-        contactVoxels,
+        contactVoxels: footprintFromPoints(contactVoxels),
     };
 }
 
@@ -50,7 +51,7 @@ function ringRegion(id: string, areaMm2: number): DetectedIsland {
         contact: new THREE.Vector3(0, 0, 6.5),
         baseZ: 6.5,
         areaMm2,
-        contactVoxels,
+        contactVoxels: footprintFromPoints(contactVoxels),
     };
 }
 
@@ -154,7 +155,7 @@ test('uses the region surface Z at each grid point (sloped facet)', () => {
         contact: new THREE.Vector3(0, 0, 6.5),
         baseZ: 6.5,
         areaMm2: 400,
-        contactVoxels,
+        contactVoxels: footprintFromPoints(contactVoxels),
     };
 
     const settings = { ...createDefaultAutoSupportSettings(), areaPerSupportMm2: 8, gridAreaThresholdMm2: 25 };

--- a/src/supports/__tests__/poissonPlacement.test.ts
+++ b/src/supports/__tests__/poissonPlacement.test.ts
@@ -1,3 +1,4 @@
+import { footprintFromPoints, footprintToPoints } from '@/volumeAnalysis/Islands/voxelFootprint';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import * as THREE from 'three';
@@ -31,7 +32,7 @@ function rectRegion(
         baseZ,
         areaMm2,
         overhangAngleDeg: angleDeg,
-        contactVoxels,
+        contactVoxels: footprintFromPoints(contactVoxels),
     };
 }
 
@@ -50,7 +51,7 @@ function ringRegion(id: string, areaMm2: number): DetectedIsland {
         contact: new THREE.Vector3(0, 0, 6.5),
         baseZ: 6.5,
         areaMm2,
-        contactVoxels,
+        contactVoxels: footprintFromPoints(contactVoxels),
     };
 }
 
@@ -184,8 +185,8 @@ test('tighter anchor perimeter factor yields a denser ring', () => {
 // ---------------------------------------------------------------------------
 
 test('erodeFootprint insets by the contact radius and empties thin regions', () => {
-    const rect = rectRegion('o0', -2, 2, -2, 2, 16, 6.5, 0).contactVoxels ?? [];
-    const eroded = erodeFootprint(rect);
+    const rect = rectRegion('o0', -2, 2, -2, 2, 16, 6.5, 0).contactVoxels;
+    const eroded = erodeFootprint(rect ? footprintToPoints(rect) : []);
 
     assert.ok(eroded.length > 0, '4×4 mm foot survives erosion');
     const xs = eroded.map((v) => v.x);
@@ -194,9 +195,9 @@ test('erodeFootprint insets by the contact radius and empties thin regions', () 
     assert.ok(Math.min(...ys) >= -1.9 && Math.max(...ys) <= 1.9);
 
     // A 1-voxel-thin strip erodes to nothing → callers fall back to the raw boundary.
-    const strip: DetectedIsland['contactVoxels'] = [];
+    const strip: Array<{ x: number; y: number; z?: number }> = [];
     for (let x = -4; x <= 4; x += 0.25) strip.push({ x, y: 0, z: 6.5 });
-    assert.equal(erodeFootprint(strip ?? []).length, 0);
+    assert.equal(erodeFootprint(strip).length, 0);
 });
 
 test('perimeter ring is inset so the contact disc stays on the surface', () => {
@@ -235,7 +236,7 @@ test('flatness metric: curved region reads organic (above the threshold)', () =>
         contact: new THREE.Vector3(0, 0, 6.5),
         baseZ: 6.5,
         areaMm2: 400,
-        contactVoxels,
+        contactVoxels: footprintFromPoints(contactVoxels),
     };
 
     const metric = computeRegionFlatnessDeg(curved);

--- a/src/supports/autoSupport/autoPlace.ts
+++ b/src/supports/autoSupport/autoPlace.ts
@@ -1,3 +1,4 @@
+import { footprintX, footprintY } from '@/volumeAnalysis/Islands/voxelFootprint';
 import * as THREE from 'three';
 import type { CandidatePoint, AutoPlaceResult, AutoPlaceAnalytics, RejectReason, AutoSupportPlan, PlacementDiagnostics, FanLeafRefusal, ForestLedgerEntry, ForestReport, ForestTree } from './types';
 import type { SupportState, SupportOrigin } from '../types';
@@ -1881,7 +1882,7 @@ export function computeAutoSupportPlan(
         // grid read 1% covered — which sent the fanning pass after
         // already-supported surfaces (redundant "floating" leaves).
         let fraction: number;
-        if (island.contactVoxels && island.contactVoxels.length > 0) {
+        if (island.contactVoxels && island.contactVoxels.count > 0) {
             fraction = computeRegionCoverage(island, allTips, SUPPORT_COVERAGE_RADIUS_MM);
         } else {
             // No footprint (minima islands): centroid proximity fallback.
@@ -2091,15 +2092,17 @@ export function computeAutoSupportPlan(
 
         const area = bestIsland.areaMm2 ?? 0;
         const voxels = bestIsland.contactVoxels;
-        if (area < OVERHANG_AREA_THRESHOLD_MM2 || !voxels || voxels.length < 3) continue;
+        if (area < OVERHANG_AREA_THRESHOLD_MM2 || !voxels || voxels.count < 3) continue;
 
         // Compute bounding box of contact voxels.
         let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-        for (const v of voxels) {
-            if (v.x < minX) minX = v.x;
-            if (v.y < minY) minY = v.y;
-            if (v.x > maxX) maxX = v.x;
-            if (v.y > maxY) maxY = v.y;
+        for (let vi = 0; vi < voxels.count; vi++) {
+            const vx = footprintX(voxels, vi);
+            const vy = footprintY(voxels, vi);
+            if (vx < minX) minX = vx;
+            if (vy < minY) minY = vy;
+            if (vx > maxX) maxX = vx;
+            if (vy > maxY) maxY = vy;
         }
         const width = maxX - minX;
         const height = maxY - minY;
@@ -2117,9 +2120,9 @@ export function computeAutoSupportPlan(
                 // Check if this grid point is within the voxel footprint
                 // (simple containment: near any contact voxel).
                 let inFootprint = false;
-                for (const v of voxels) {
-                    const dx = gx - v.x;
-                    const dy = gy - v.y;
+                for (let vi = 0; vi < voxels.count; vi++) {
+                    const dx = gx - footprintX(voxels, vi);
+                    const dy = gy - footprintY(voxels, vi);
                     if (dx * dx + dy * dy <= OVERHANG_GRID_SPACING_MM * OVERHANG_GRID_SPACING_MM) {
                         inFootprint = true;
                         break;

--- a/src/supports/autoSupport/coverage.ts
+++ b/src/supports/autoSupport/coverage.ts
@@ -2,6 +2,7 @@ import type { DetectedIsland } from '../../volumeAnalysis/Islands/types';
 import type { CandidatePoint } from './types';
 import type { AutoSupportSettings } from './settings';
 import type { SupportState } from '../types';
+import { footprintX, footprintY, footprintZ } from '@/volumeAnalysis/Islands/voxelFootprint';
 
 /** A tip covers surface within this radius (mm) — mirrors ALREADY_SUPPORTED_RADIUS_MM. */
 export const TIP_COVERAGE_RADIUS_MM = 3.0;
@@ -37,16 +38,18 @@ export function computeRegionCoverage(
     radiusMm: number = TIP_COVERAGE_RADIUS_MM,
 ): number {
     const voxels = region.contactVoxels;
-    if (!voxels || voxels.length === 0) return 0;
+    if (!voxels || voxels.count === 0) return 0;
     if (tips.length === 0) return 0;
 
     const r2 = radiusMm * radiusMm;
     let covered = 0;
-    for (const v of voxels) {
+    for (let i = 0; i < voxels.count; i++) {
+        const vx = footprintX(voxels, i);
+        const vy = footprintY(voxels, i);
         let hit = false;
         for (const tip of tips) {
-            const dx = v.x - tip.x;
-            const dy = v.y - tip.y;
+            const dx = vx - tip.x;
+            const dy = vy - tip.y;
             if (dx * dx + dy * dy <= r2) {
                 hit = true;
                 break;
@@ -54,7 +57,7 @@ export function computeRegionCoverage(
         }
         if (hit) covered++;
     }
-    return covered / voxels.length;
+    return covered / voxels.count;
 }
 
 /**
@@ -69,7 +72,7 @@ export function findUncoveredClusters(
     minClusterMm2: number = MIN_GAP_CLUSTER_MM2,
 ): Array<{ x: number; y: number; z: number }> {
     const voxels = region.contactVoxels;
-    if (!voxels || voxels.length === 0) return [];
+    if (!voxels || voxels.count === 0) return [];
     if (tips.length === 0) {
         // No tips at all — a single cluster covering everything is not useful;
         // return [] so the caller's main grid handles the region instead.
@@ -90,7 +93,8 @@ export function findUncoveredClusters(
     const cellSize = Math.max(0.5, radiusMm / 2);
     const uncovered = new Map<string, Array<{ x: number; y: number; z?: number }>>();
     const cells: Array<{ x: number; y: number; z?: number }> = [];
-    for (const v of voxels) {
+    for (let i = 0; i < voxels.count; i++) {
+        const v = { x: footprintX(voxels, i), y: footprintY(voxels, i), z: footprintZ(voxels, i) ?? undefined };
         if (isCovered(v)) continue;
         const key = `${Math.floor(v.x / cellSize)},${Math.floor(v.y / cellSize)}`;
         let bucket = uncovered.get(key);
@@ -176,7 +180,7 @@ export function buildGapFillCandidates(
     const coverageTarget = (settings.coverageTargetPercent ?? 95) / 100;
     for (const region of overhangIslands) {
         if (region.source !== 'overhang') continue;
-        if (!region.contactVoxels || region.contactVoxels.length === 0) continue;
+        if (!region.contactVoxels || region.contactVoxels.count === 0) continue;
         if (computeRegionCoverage(region, tips) >= coverageTarget) continue;
 
         const clusters = findUncoveredClusters(region, tips);

--- a/src/supports/autoSupport/gridPlacement.ts
+++ b/src/supports/autoSupport/gridPlacement.ts
@@ -1,3 +1,4 @@
+import { footprintToPoints, footprintX, footprintY, footprintZ } from '@/volumeAnalysis/Islands/voxelFootprint';
 import type { DetectedIsland } from '../../volumeAnalysis/Islands/types';
 import type { CandidatePoint } from './types';
 import type { AutoSupportSettings } from './settings';
@@ -217,7 +218,7 @@ export function generateGridCandidates(
         let spacing = computeRegionSpacing(island, settings, anchorScale);
 
         const voxels = island.contactVoxels;
-        if (!voxels || voxels.length === 0) continue;
+        if (!voxels || voxels.count === 0) continue;
 
         // Footprint bbox + spatial hash for containment / nearest-voxel Z.
         let minX = Infinity;
@@ -226,7 +227,10 @@ export function generateGridCandidates(
         let maxY = -Infinity;
         const cellSize = Math.max(spacing, 1.0);
         const hash = new Map<string, Array<{ x: number; y: number; z?: number }>>();
-        for (const p of voxels) {
+        for (let vi = 0; vi < voxels.count; vi++) {
+            // The bucket keeps point objects, but only for the duration of this
+            // placement run — the footprint itself stays packed.
+            const p = { x: footprintX(voxels, vi), y: footprintY(voxels, vi), z: footprintZ(voxels, vi) ?? undefined };
             if (p.x < minX) minX = p.x;
             if (p.y < minY) minY = p.y;
             if (p.x > maxX) maxX = p.x;
@@ -336,8 +340,9 @@ export function generateGridCandidates(
         // `gridSpacing`, add a support on the ERODED boundary — the contact
         // disc stays fully on the surface.
         const spacingSq = gridSpacing * gridSpacing;
-        const eroded = erodeFootprint(voxels);
-        const boundary = buildBoundaryPoints(eroded.length > 0 ? eroded : voxels, spacing * stride, minZ);
+        const voxelPoints = footprintToPoints(voxels);
+        const eroded = erodeFootprint(voxelPoints);
+        const boundary = buildBoundaryPoints(eroded.length > 0 ? eroded : voxelPoints, spacing * stride, minZ);
         for (const b of boundary) {
             let covered = false;
             for (const p of lattice) {

--- a/src/supports/autoSupport/poissonPlacement.ts
+++ b/src/supports/autoSupport/poissonPlacement.ts
@@ -1,3 +1,5 @@
+import { footprintToPoints, footprintX, footprintY, footprintZ } from '@/volumeAnalysis/Islands/voxelFootprint';
+import { cellKey } from '@/volumeAnalysis/Islands/spatialHashGrid2D';
 import type { DetectedIsland } from '../../volumeAnalysis/Islands/types';
 import type { CandidatePoint } from './types';
 import type { AutoSupportSettings } from './settings';
@@ -32,26 +34,26 @@ const BRIDSON_CANDIDATES = 30;
  */
 export function computeRegionFlatnessDeg(region: DetectedIsland): number {
     const voxels = region.contactVoxels;
-    if (!voxels || voxels.length < 4) return 0;
+    if (!voxels || voxels.count < 4) return 0;
 
-    const indexByKey = new Map<string, number>();
-    voxels.forEach((v, i) => {
-        indexByKey.set(`${Math.round(v.x * 4)},${Math.round(v.y * 4)}`, i);
-    });
+    const indexByKey = new Map<number, number>();
+    for (let i = 0; i < voxels.count; i++) {
+        indexByKey.set(cellKey(Math.round(footprintX(voxels, i) * 4), Math.round(footprintY(voxels, i) * 4)), i);
+    }
 
     const angles: number[] = [];
-    for (let i = 0; i < voxels.length; i++) {
-        const v = voxels[i];
-        if (v.z == null) continue;
-        const kx = Math.round(v.x * 4);
-        const ky = Math.round(v.y * 4);
+    for (let i = 0; i < voxels.count; i++) {
+        const vz = footprintZ(voxels, i);
+        if (vz == null) continue;
+        const kx = Math.round(footprintX(voxels, i) * 4);
+        const ky = Math.round(footprintY(voxels, i) * 4);
         let dzMax = 0;
         for (const [dx, dy] of [[1, 0], [-1, 0], [0, 1], [0, -1]] as const) {
-            const ni = indexByKey.get(`${kx + dx},${ky + dy}`);
+            const ni = indexByKey.get(cellKey(kx + dx, ky + dy));
             if (ni === undefined) continue;
-            const nz = voxels[ni].z;
+            const nz = footprintZ(voxels, ni);
             if (nz == null) continue;
-            const dz = Math.abs(nz - v.z);
+            const dz = Math.abs(nz - vz);
             if (dz > dzMax) dzMax = dz;
         }
         if (dzMax > 0) angles.push((Math.atan2(dzMax, 0.25) * 180) / Math.PI);
@@ -141,7 +143,7 @@ export function generatePoissonCandidates(
         );
 
         const voxels = island.contactVoxels;
-        if (!voxels || voxels.length === 0) continue;
+        if (!voxels || voxels.count === 0) continue;
 
         // Footprint bbox + spatial hash for containment / nearest-voxel Z.
         let minX = Infinity;
@@ -150,7 +152,10 @@ export function generatePoissonCandidates(
         let maxY = -Infinity;
         const cellSize = Math.max(interiorSpacing, 1.0);
         const hash = new Map<string, Array<{ x: number; y: number; z?: number }>>();
-        for (const p of voxels) {
+        for (let vi = 0; vi < voxels.count; vi++) {
+            // The bucket keeps point objects, but only for the duration of this
+            // placement run — the footprint itself stays packed.
+            const p = { x: footprintX(voxels, vi), y: footprintY(voxels, vi), z: footprintZ(voxels, vi) ?? undefined };
             if (p.x < minX) minX = p.x;
             if (p.y < minY) minY = p.y;
             if (p.x > maxX) maxX = p.x;
@@ -226,8 +231,9 @@ export function generatePoissonCandidates(
         // 1. Perimeter ring — guaranteed retained (denser than the interior).
         //    Generated on the ERODED footprint so the contact disc sits fully
         //    on the surface, not half past the region edge (half in air).
-        const eroded = erodeFootprint(voxels);
-        for (const b of buildBoundaryPoints(eroded.length > 0 ? eroded : voxels, perimeterSpacing, minZ)) {
+        const voxelPoints = footprintToPoints(voxels);
+        const eroded = erodeFootprint(voxelPoints);
+        for (const b of buildBoundaryPoints(eroded.length > 0 ? eroded : voxelPoints, perimeterSpacing, minZ)) {
             insert({ x: b.x, y: b.y, z: b.z, kind: 'perimeter' });
         }
 

--- a/src/utils/yieldToEventLoop.ts
+++ b/src/utils/yieldToEventLoop.ts
@@ -38,3 +38,22 @@ export function yieldToEventLoop(): Promise<void> {
         channel!.port2.postMessage(null);
     });
 }
+
+/**
+ * Rate limiter for progress callbacks.
+ *
+ * Yielding is cheap; telling React about it is not. A progress report is a
+ * state update, and a state update re-renders a tree with a 3D scene in it, so
+ * reporting on every yield turned a 38-second scan into well over a minute.
+ * Chunks still yield as often as they like — the UI just hears about it at a
+ * human rate.
+ */
+export function createProgressThrottle(minIntervalMs = 250) {
+    let lastReportMs = 0;
+    return function report(emit: () => void, force = false): void {
+        const now = performance.now();
+        if (!force && now - lastReportMs < minIntervalMs) return;
+        lastReportMs = now;
+        emit();
+    };
+}

--- a/src/utils/yieldToEventLoop.ts
+++ b/src/utils/yieldToEventLoop.ts
@@ -1,0 +1,40 @@
+/**
+ * Hands the thread back to the event loop, without the background penalty.
+ *
+ * The obvious `setTimeout(resolve, 0)` is a timer, and WebKit throttles timers
+ * to roughly 1 Hz in a hidden or occluded window. A pass that yields eighty
+ * times then takes eighty seconds instead of a fraction of one, purely because
+ * the user switched to another app — which is exactly when they are most likely
+ * to leave a long scan running.
+ *
+ * A MessageChannel message is not a timer and is not throttled, while still
+ * being a macrotask: rendering and input get their turn between chunks, which
+ * is the entire point of yielding.
+ */
+
+let channel: MessageChannel | null = null;
+let pending: Array<() => void> = [];
+
+export function yieldToEventLoop(): Promise<void> {
+    if (typeof MessageChannel === 'undefined') {
+        // Non-browser contexts (tests, SSR): the timer is fine, nothing is hidden.
+        return new Promise((resolve) => { setTimeout(resolve, 0); });
+    }
+
+    if (!channel) {
+        channel = new MessageChannel();
+        channel.port1.onmessage = () => {
+            // Drain by swapping, so a resolver that yields again queues into a
+            // fresh batch rather than extending the one being drained.
+            const batch = pending;
+            pending = [];
+            for (const resolve of batch) resolve();
+        };
+        channel.port1.start();
+    }
+
+    return new Promise<void>((resolve) => {
+        pending.push(resolve);
+        channel!.port2.postMessage(null);
+    });
+}

--- a/src/volumeAnalysis/IslandScan/ScanOrchestrator.ts
+++ b/src/volumeAnalysis/IslandScan/ScanOrchestrator.ts
@@ -1,3 +1,4 @@
+import { yieldToEventLoop } from '@/utils/yieldToEventLoop';
 import * as THREE from 'three';
 import { IslandTracker } from './islandTracker';
 import { type RleMask, type RleLabels, rleDecode, rleEncodeLabels } from './rle';
@@ -53,18 +54,6 @@ export type ScanProgressCallback = (done: number, total: number, phase: string) 
 /** Layers processed between yields in the single-threaded passes. */
 const YIELD_INTERVAL_LAYERS = 64;
 
-/**
- * Hands the thread back so React can paint and input can be handled.
- *
- * The passes below are inherently sequential — island ids propagate from one
- * layer to the next — so they cannot be split across workers, and they run as a
- * microtask continuation of the last worker message, which puts them squarely
- * on the main thread. Without yielding, a tall model freezes the window for the
- * length of each pass with the progress bar stuck on the last painted value.
- */
-function yieldToEventLoop(): Promise<void> {
-  return new Promise((resolve) => { setTimeout(resolve, 0); });
-}
 
 export async function runIslandScan(
   geom: { geometry: THREE.BufferGeometry; bbox: THREE.Box3 },

--- a/src/volumeAnalysis/IslandScan/ScanOrchestrator.ts
+++ b/src/volumeAnalysis/IslandScan/ScanOrchestrator.ts
@@ -49,7 +49,21 @@ export type ScanParams = {
  * names the pass so the modal can say which of the four is running — the bar
  * restarts at zero for each.
  */
-export type ScanProgressCallback = (done: number, total: number, phase: string) => void;
+export type ScanProgressCallback = (
+  done: number,
+  total: number,
+  phase: string,
+  phaseNumber: number,
+  phaseCount: number,
+) => void;
+
+/** This path's phases, in order. See the note on ScanProgressCallback. */
+const SCAN_PHASES = ['Slicing', 'Tracking islands', 'Tracking territories', 'Compiling results'] as const;
+
+function orchestratorPhaseNumber(phase: string): number {
+  const index = SCAN_PHASES.indexOf(phase as typeof SCAN_PHASES[number]);
+  return index < 0 ? 1 : index + 1;
+}
 
 /** Layers processed between yields in the single-threaded passes. */
 const YIELD_INTERVAL_LAYERS = 64;
@@ -148,7 +162,7 @@ async function runScanInternal(
 
         workerResults[idx] = { islandMaskRle, solidMaskRle, islandCount, islandLabelsRle, components, territoryLabelsRle };
         done++;
-        reportProgress(() => onProgress?.(done, numLayers, 'Slicing'));
+        reportProgress(() => onProgress?.(done, numLayers, 'Slicing', orchestratorPhaseNumber('Slicing'), SCAN_PHASES.length));
         runNext();
       };
       w.addEventListener('message', onMessage);
@@ -177,7 +191,7 @@ async function runScanInternal(
   // Process layers sequentially to propagate island IDs
   for (let L = 0; L < numLayers; L++) {
     if (L % YIELD_INTERVAL_LAYERS === 0) {
-      reportProgress(() => onProgress?.(L, numLayers, 'Tracking islands'));
+      reportProgress(() => onProgress?.(L, numLayers, 'Tracking islands', orchestratorPhaseNumber('Tracking islands'), SCAN_PHASES.length));
       await yieldToEventLoop();
     }
     const workerResult = workerResults[L];
@@ -208,7 +222,7 @@ async function runScanInternal(
 
   for (let L = 0; L < numLayers; L++) {
     if (L % YIELD_INTERVAL_LAYERS === 0) {
-      reportProgress(() => onProgress?.(L, numLayers, 'Tracking territories'));
+      reportProgress(() => onProgress?.(L, numLayers, 'Tracking territories', orchestratorPhaseNumber('Tracking territories'), SCAN_PHASES.length));
       await yieldToEventLoop();
     }
     const workerResult = workerResults[L];
@@ -265,7 +279,7 @@ async function runScanInternal(
   // Optimized RLE iteration for firstHit/lastHit and baseLabels
   for (let L = 0; L < results.length; L++) {
     if (L % YIELD_INTERVAL_LAYERS === 0) {
-      reportProgress(() => onProgress?.(L, results.length, 'Compiling results'));
+      reportProgress(() => onProgress?.(L, results.length, 'Compiling results', orchestratorPhaseNumber('Compiling results'), SCAN_PHASES.length));
       await yieldToEventLoop();
     }
     const rleLabels = results[L].islandLabels;

--- a/src/volumeAnalysis/IslandScan/ScanOrchestrator.ts
+++ b/src/volumeAnalysis/IslandScan/ScanOrchestrator.ts
@@ -43,11 +43,34 @@ export type ScanParams = {
   useSurfaceContiguity?: boolean; // If true, favors surface connectivity (neighbors) over internal volume proximity
 };
 
+/**
+ * Progress reporting for the whole scan, not just the slicing phase. `phase`
+ * names the pass so the modal can say which of the four is running — the bar
+ * restarts at zero for each.
+ */
+export type ScanProgressCallback = (done: number, total: number, phase: string) => void;
+
+/** Layers processed between yields in the single-threaded passes. */
+const YIELD_INTERVAL_LAYERS = 64;
+
+/**
+ * Hands the thread back so React can paint and input can be handled.
+ *
+ * The passes below are inherently sequential — island ids propagate from one
+ * layer to the next — so they cannot be split across workers, and they run as a
+ * microtask continuation of the last worker message, which puts them squarely
+ * on the main thread. Without yielding, a tall model freezes the window for the
+ * length of each pass with the progress bar stuck on the last painted value.
+ */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => { setTimeout(resolve, 0); });
+}
+
 export async function runIslandScan(
   geom: { geometry: THREE.BufferGeometry; bbox: THREE.Box3 },
   layerHeightMm: number,
   params: ScanParams,
-  onProgress?: (done: number, total: number) => void,
+  onProgress?: ScanProgressCallback,
 ): Promise<ScanResults> {
   return runScanInternal(
     geom,
@@ -62,7 +85,7 @@ export async function runScanlineScan(
   geom: { geometry: THREE.BufferGeometry; bbox: THREE.Box3 },
   layerHeightMm: number,
   params: ScanParams,
-  onProgress?: (done: number, total: number) => void,
+  onProgress?: ScanProgressCallback,
 ): Promise<ScanResults> {
   return runScanInternal(
     geom,
@@ -78,7 +101,7 @@ async function runScanInternal(
   layerHeightMm: number,
   params: ScanParams,
   createWorker: () => Worker,
-  onProgress?: (done: number, total: number) => void,
+  onProgress?: ScanProgressCallback,
 ): Promise<ScanResults> {
   const bb = geom.bbox;
   const minX = bb.min.x, maxX = bb.max.x;
@@ -135,7 +158,7 @@ async function runScanInternal(
 
         workerResults[idx] = { islandMaskRle, solidMaskRle, islandCount, islandLabelsRle, components, territoryLabelsRle };
         done++;
-        onProgress?.(done, numLayers);
+        onProgress?.(done, numLayers, 'Slicing');
         runNext();
       };
       w.addEventListener('message', onMessage);
@@ -163,6 +186,10 @@ async function runScanInternal(
 
   // Process layers sequentially to propagate island IDs
   for (let L = 0; L < numLayers; L++) {
+    if (L % YIELD_INTERVAL_LAYERS === 0) {
+      onProgress?.(L, numLayers, 'Tracking islands');
+      await yieldToEventLoop();
+    }
     const workerResult = workerResults[L];
 
     const prevIslandLabels = L > 0 ? islandLabelsPerLayer[L - 1] : null;
@@ -190,6 +217,10 @@ async function runScanInternal(
   let prevTerritoryMap: RleLabels | null = null;
 
   for (let L = 0; L < numLayers; L++) {
+    if (L % YIELD_INTERVAL_LAYERS === 0) {
+      onProgress?.(L, numLayers, 'Tracking territories');
+      await yieldToEventLoop();
+    }
     const workerResult = workerResults[L];
 
     // Decode RLE solid mask to dense grid for TerritoryTracker -- NO LONGER NEEDED (RLE LOGIC)
@@ -243,6 +274,10 @@ async function runScanInternal(
 
   // Optimized RLE iteration for firstHit/lastHit and baseLabels
   for (let L = 0; L < results.length; L++) {
+    if (L % YIELD_INTERVAL_LAYERS === 0) {
+      onProgress?.(L, results.length, 'Compiling results');
+      await yieldToEventLoop();
+    }
     const rleLabels = results[L].islandLabels;
     // Iterate RLE rows
     for (let y = 0; y < rleLabels.height; y++) {

--- a/src/volumeAnalysis/IslandScan/ScanOrchestrator.ts
+++ b/src/volumeAnalysis/IslandScan/ScanOrchestrator.ts
@@ -1,4 +1,4 @@
-import { yieldToEventLoop } from '@/utils/yieldToEventLoop';
+import { createProgressThrottle, yieldToEventLoop } from '@/utils/yieldToEventLoop';
 import * as THREE from 'three';
 import { IslandTracker } from './islandTracker';
 import { type RleMask, type RleLabels, rleDecode, rleEncodeLabels } from './rle';
@@ -126,6 +126,7 @@ async function runScanInternal(
   let nextIndex = 0;
   let done = 0;
 
+  const reportProgress = createProgressThrottle();
   console.time('Total Scan');
   console.time('Slicing & Worker Dispatch');
 
@@ -147,7 +148,7 @@ async function runScanInternal(
 
         workerResults[idx] = { islandMaskRle, solidMaskRle, islandCount, islandLabelsRle, components, territoryLabelsRle };
         done++;
-        onProgress?.(done, numLayers, 'Slicing');
+        reportProgress(() => onProgress?.(done, numLayers, 'Slicing'));
         runNext();
       };
       w.addEventListener('message', onMessage);
@@ -176,7 +177,7 @@ async function runScanInternal(
   // Process layers sequentially to propagate island IDs
   for (let L = 0; L < numLayers; L++) {
     if (L % YIELD_INTERVAL_LAYERS === 0) {
-      onProgress?.(L, numLayers, 'Tracking islands');
+      reportProgress(() => onProgress?.(L, numLayers, 'Tracking islands'));
       await yieldToEventLoop();
     }
     const workerResult = workerResults[L];
@@ -207,7 +208,7 @@ async function runScanInternal(
 
   for (let L = 0; L < numLayers; L++) {
     if (L % YIELD_INTERVAL_LAYERS === 0) {
-      onProgress?.(L, numLayers, 'Tracking territories');
+      reportProgress(() => onProgress?.(L, numLayers, 'Tracking territories'));
       await yieldToEventLoop();
     }
     const workerResult = workerResults[L];
@@ -264,7 +265,7 @@ async function runScanInternal(
   // Optimized RLE iteration for firstHit/lastHit and baseLabels
   for (let L = 0; L < results.length; L++) {
     if (L % YIELD_INTERVAL_LAYERS === 0) {
-      onProgress?.(L, results.length, 'Compiling results');
+      reportProgress(() => onProgress?.(L, results.length, 'Compiling results'));
       await yieldToEventLoop();
     }
     const rleLabels = results[L].islandLabels;

--- a/src/volumeAnalysis/IslandScan/islandTracker.ts
+++ b/src/volumeAnalysis/IslandScan/islandTracker.ts
@@ -100,6 +100,7 @@ export class IslandTracker {
 
       // We can use the same RLE connected components logic on solidMask
       const { labels: solidLabels, components: solidComps } = this.rleLabelSolidComponents(solidMask);
+      const solidRowSpans = this.rowSpansByComponent(solidLabels);
 
       const solidCompIdToIslandId = new Map<number, number>();
 
@@ -108,7 +109,8 @@ export class IslandTracker {
         const prevIdOverlapCounts = this.findOverlappingIslandIdsRle(
           component.id,
           solidLabels,
-          prevIslandLabels
+          prevIslandLabels,
+          solidRowSpans.get(component.id)
         );
 
         const prevIds = new Set<number>();
@@ -140,10 +142,6 @@ export class IslandTracker {
           }
           return currentId;
         };
-
-        if (activePrevIds.size > 1) {
-          console.log(`Layer ${layerIndex}: Component overlaps with islands: ${Array.from(activePrevIds).join(', ')}`);
-        }
 
         const areaMm2 = component.area_px * this.px_mm * this.px_mm;
         let assignedId: number;
@@ -258,16 +256,45 @@ export class IslandTracker {
   /**
    * Find which previous island IDs overlap with a specific solid component.
    */
+  /**
+   * Rows spanned by each component label, in one pass over the RLE.
+   *
+   * Without it {@link findOverlappingIslandIdsRle} walks every row of the layer
+   * for every component, so a layer with C components costs C full-image scans
+   * even though each component usually occupies a handful of rows.
+   */
+  private rowSpansByComponent(solidLabels: RleLabels): Map<number, { minY: number; maxY: number }> {
+    const spans = new Map<number, { minY: number; maxY: number }>();
+    for (let y = 0; y < solidLabels.height; y++) {
+      const row = solidLabels.rows[y];
+      for (let i = 0; i < row.length; i += 3) {
+        const id = row[i + 2];
+        const span = spans.get(id);
+        if (span) {
+          span.maxY = y;
+        } else {
+          spans.set(id, { minY: y, maxY: y });
+        }
+      }
+    }
+    return spans;
+  }
+
   private findOverlappingIslandIdsRle(
     compId: number,
     solidLabels: RleLabels,
-    prevIslandLabels: RleLabels
+    prevIslandLabels: RleLabels,
+    rowSpan?: { minY: number; maxY: number },
   ): Map<number, number> {
     const prevIdOverlapCounts = new Map<number, number>();
     const { height } = solidLabels;
 
-    // Iterate all rows where this component exists
-    for (let y = 0; y < height; y++) {
+    // Only the rows this component actually occupies; the whole layer when the
+    // span is unknown.
+    const firstRow = rowSpan ? rowSpan.minY : 0;
+    const lastRow = rowSpan ? rowSpan.maxY : height - 1;
+
+    for (let y = firstRow; y <= lastRow; y++) {
       const solidRow = solidLabels.rows[y];
 
       if (solidRow.length === 0) continue;

--- a/src/volumeAnalysis/IslandScan/rle.ts
+++ b/src/volumeAnalysis/IslandScan/rle.ts
@@ -4,6 +4,20 @@ import { ComponentInfo } from './types';
 // Represents a single row of binary data.
 export type RleRow = Int32Array;
 
+/**
+ * The one empty row, shared by every row that has no spans.
+ *
+ * A layer is 1814 rows tall and a scan is 5292 layers deep, so the naive
+ * `new Int32Array(0)` per empty row produced 9.6 million typed arrays holding
+ * half a megabyte of data between them — over a gigabyte of pure object and
+ * buffer overhead, and most of the live object count.
+ *
+ * Sharing is safe because RLE rows are never written in place: every producer
+ * builds a fresh row and assigns it. Structured clone preserves identity within
+ * a message, so the sharing survives the trip from the worker.
+ */
+export const EMPTY_ROW: RleRow = new Int32Array(0);
+
 // RLE Mask: Array of rows
 export type RleMask = {
     rows: RleRow[];
@@ -44,7 +58,7 @@ export function rleEncode(data: Uint8Array, width: number, height: number): RleM
         if (runStart !== -1) {
             rowSpans.push(runStart, width - runStart);
         }
-        rows[y] = new Int32Array(rowSpans);
+        rows[y] = rowSpans.length === 0 ? EMPTY_ROW : new Int32Array(rowSpans);
     }
 
     return { rows, width, height };
@@ -88,7 +102,7 @@ export function rleEncodeLabels(data: Int32Array | Uint8Array, width: number, he
             rowSpans.push(runStart, width - runStart, currentId);
         }
 
-        rows[y] = new Int32Array(rowSpans);
+        rows[y] = rowSpans.length === 0 ? EMPTY_ROW : new Int32Array(rowSpans);
     }
 
     return { rows, width, height };
@@ -131,7 +145,7 @@ export function rleIntersectDilated(a: RleMask, b: RleMask, buffer: number): Rle
     for (let y = 0; y < height; y++) {
         const aRow = a.rows[y];
         if (aRow.length === 0) {
-            resultRows[y] = new Int32Array(0);
+            resultRows[y] = EMPTY_ROW;
             continue;
         }
 
@@ -151,7 +165,7 @@ export function rleIntersectDilated(a: RleMask, b: RleMask, buffer: number): Rle
         }
 
         if (relevantBRows.length === 0) {
-            resultRows[y] = new Int32Array(0);
+            resultRows[y] = EMPTY_ROW;
             continue;
         }
 
@@ -238,7 +252,7 @@ export function rleSubtract(a: RleMask, b: RleMask): RleMask {
         const bRow = b.rows[y];
 
         if (aRow.length === 0) {
-            resultRows[y] = new Int32Array(0);
+            resultRows[y] = EMPTY_ROW;
             continue;
         }
         if (bRow.length === 0) {

--- a/src/volumeAnalysis/IslandScan/useIslandManager.ts
+++ b/src/volumeAnalysis/IslandScan/useIslandManager.ts
@@ -21,7 +21,7 @@ interface IslandManagerProps {
 export function useIslandManager({ geom, transform, layerHeightMm }: IslandManagerProps) {
   // Scanning State
   const [scanning, setScanning] = useState<boolean>(false);
-  const [scanProgress, setScanProgress] = useState<{ done: number; total: number; phase?: string } | null>(null);
+  const [scanProgress, setScanProgress] = useState<{ done: number; total: number; phase?: string; phaseNumber?: number; phaseCount?: number } | null>(null);
   const [scanData, setScanData] = useState<ScanResults | null>(null);
   const [scanBBox, setScanBBox] = useState<THREE.Box3 | null>(null);
 
@@ -115,7 +115,7 @@ export function useIslandManager({ geom, transform, layerHeightMm }: IslandManag
           overlap_neighborhood_px: overlapNeighborhoodPx,
           useSurfaceContiguity,
         },
-        (done, total, phase) => setScanProgress({ done, total, phase })
+        (done, total, phase, phaseNumber, phaseCount) => setScanProgress({ done, total, phase, phaseNumber, phaseCount })
       );
       setScanData(res);
     } finally {
@@ -148,7 +148,7 @@ export function useIslandManager({ geom, transform, layerHeightMm }: IslandManag
           overlap_neighborhood_px: overlapNeighborhoodPx,
           useSurfaceContiguity,
         },
-        (done, total, phase) => setScanProgress({ done, total, phase })
+        (done, total, phase, phaseNumber, phaseCount) => setScanProgress({ done, total, phase, phaseNumber, phaseCount })
       );
       const endTime = performance.now();
       console.log(`Scanline Scan took ${(endTime - startTime).toFixed(2)}ms`);

--- a/src/volumeAnalysis/IslandScan/useIslandManager.ts
+++ b/src/volumeAnalysis/IslandScan/useIslandManager.ts
@@ -21,7 +21,7 @@ interface IslandManagerProps {
 export function useIslandManager({ geom, transform, layerHeightMm }: IslandManagerProps) {
   // Scanning State
   const [scanning, setScanning] = useState<boolean>(false);
-  const [scanProgress, setScanProgress] = useState<{ done: number; total: number } | null>(null);
+  const [scanProgress, setScanProgress] = useState<{ done: number; total: number; phase?: string } | null>(null);
   const [scanData, setScanData] = useState<ScanResults | null>(null);
   const [scanBBox, setScanBBox] = useState<THREE.Box3 | null>(null);
 
@@ -115,7 +115,7 @@ export function useIslandManager({ geom, transform, layerHeightMm }: IslandManag
           overlap_neighborhood_px: overlapNeighborhoodPx,
           useSurfaceContiguity,
         },
-        (done, total) => setScanProgress({ done, total })
+        (done, total, phase) => setScanProgress({ done, total, phase })
       );
       setScanData(res);
     } finally {
@@ -148,7 +148,7 @@ export function useIslandManager({ geom, transform, layerHeightMm }: IslandManag
           overlap_neighborhood_px: overlapNeighborhoodPx,
           useSurfaceContiguity,
         },
-        (done, total) => setScanProgress({ done, total })
+        (done, total, phase) => setScanProgress({ done, total, phase })
       );
       const endTime = performance.now();
       console.log(`Scanline Scan took ${(endTime - startTime).toFixed(2)}ms`);
@@ -183,7 +183,7 @@ export function useIslandManager({ geom, transform, layerHeightMm }: IslandManag
           min_overlap_px: minOverlapPx,
           overlap_neighborhood_px: overlapNeighborhoodPx,
         },
-        (done, total) => setScanProgress({ done, total })
+        (done: number, total: number) => setScanProgress({ done, total, phase: 'Slicing' })
       );
       const endTime = performance.now();
       console.log(`Native Island Scan took ${(endTime - startTime).toFixed(2)}ms`);

--- a/src/volumeAnalysis/IslandVolumes/buildVolumeHierarchy.ts
+++ b/src/volumeAnalysis/IslandVolumes/buildVolumeHierarchy.ts
@@ -1,4 +1,4 @@
-import { rleLabelComponents, type RleLabels, type RleMask } from '@/volumeAnalysis/IslandScan/rle';
+import { EMPTY_ROW, rleLabelComponents, type RleLabels, type RleMask } from '@/volumeAnalysis/IslandScan/rle';
 import type { ScanResults } from '@/volumeAnalysis/IslandScan/ScanOrchestrator';
 import type {
   BuildVolumeHierarchyOptions,
@@ -266,7 +266,7 @@ export function buildVolumeHierarchy(
     for (let y = 0; y < currLabels.height; y++) {
       const row = currLabels.rows[y];
       if (row.length === 0) {
-        nodeLabelRows[y] = new Int32Array(0);
+        nodeLabelRows[y] = EMPTY_ROW;
         continue;
       }
       const out: number[] = [];

--- a/src/volumeAnalysis/Islands/__tests__/contour.test.ts
+++ b/src/volumeAnalysis/Islands/__tests__/contour.test.ts
@@ -1,3 +1,4 @@
+import { footprintFromPoints } from '@/volumeAnalysis/Islands/voxelFootprint';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import * as THREE from 'three';
@@ -12,18 +13,18 @@ function mockVoxelIsland(id: string, areaMm2: number, contactVoxels?: { x: numbe
     baseZ: 1,
     areaMm2,
     class: 'voxelOnly',
-    contactVoxels,
+    contactVoxels: contactVoxels ? footprintFromPoints(contactVoxels) : undefined,
   };
 }
 
 test('generateContourMarkers: returns empty for empty voxels', () => {
-  const markers = generateContourMarkers([], 0.05, 1, 1.0, 3);
+  const markers = generateContourMarkers(footprintFromPoints([]), 0.05, 1, 1.0, 3);
   assert.equal(markers.length, 0);
 });
 
 test('generateContourMarkers: returns 1 marker for a single voxel', () => {
   const voxels = [{ x: 0, y: 0 }];
-  const markers = generateContourMarkers(voxels, 0.05, 1, 1.0, 3);
+  const markers = generateContourMarkers(footprintFromPoints(voxels), 0.05, 1, 1.0, 3);
   assert.equal(markers.length, 1);
   assert.equal(markers[0].centerX, 0);
   assert.equal(markers[0].centerY, 0);
@@ -36,7 +37,7 @@ test('generateContourMarkers: covers multiple close voxels with 1 marker', () =>
     { x: 0.02, y: 0.02 },
     { x: -0.02, y: -0.02 },
   ];
-  const markers = generateContourMarkers(voxels, 0.05, 1, 1.0, 3);
+  const markers = generateContourMarkers(footprintFromPoints(voxels), 0.05, 1, 1.0, 3);
   assert.equal(markers.length, 1);
 });
 
@@ -45,7 +46,7 @@ test('generateContourMarkers: covers distant voxels with multiple markers', () =
     { x: 0, y: 0 },
     { x: 10, y: 10 },
   ];
-  const markers = generateContourMarkers(voxels, 0.05, 1, 1.0, 3);
+  const markers = generateContourMarkers(footprintFromPoints(voxels), 0.05, 1, 1.0, 3);
   assert.equal(markers.length, 2);
 });
 
@@ -59,7 +60,7 @@ test('generateContourMarkers: uses large radius for interior core and small radi
     }
   }
 
-  const markers = generateContourMarkers(voxels, px, 1, 1.0, 3);
+  const markers = generateContourMarkers(footprintFromPoints(voxels), px, 1, 1.0, 3);
   // There should be a mix of R_large and R_small markers
   assert.ok(markers.length > 0);
   const hasLarge = markers.some(m => m.radius === px * 3.5);
@@ -137,7 +138,7 @@ test('consolidateVoxelIslands: dilates and bridges adjacent footprints if at lea
   assert.equal(consolidated.length, 1);
   const island = consolidated[0];
   assert.ok(island.contactVoxels);
-  assert.ok(island.contactVoxels.length > 2);
-  assert.equal(island.areaMm2, island.contactVoxels.length * 0.05 * 0.05);
+  assert.ok(island.contactVoxels.count > 2);
+  assert.equal(island.areaMm2, island.contactVoxels.count * 0.05 * 0.05);
 });
 

--- a/src/volumeAnalysis/Islands/__tests__/overhangMerge.test.ts
+++ b/src/volumeAnalysis/Islands/__tests__/overhangMerge.test.ts
@@ -1,3 +1,4 @@
+import { footprintFromPoints } from '@/volumeAnalysis/Islands/voxelFootprint';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import * as THREE from 'three';
@@ -39,7 +40,7 @@ function overhangIsland(
     contact: new THREE.Vector3((minX + maxX) / 2, (minY + maxY) / 2, minY),
     baseZ: minY,
     areaMm2,
-    contactVoxels,
+    contactVoxels: footprintFromPoints(contactVoxels),
   };
 }
 

--- a/src/volumeAnalysis/Islands/detect.ts
+++ b/src/volumeAnalysis/Islands/detect.ts
@@ -149,19 +149,27 @@ export async function detectVoxelIslands(
   // layer, so a tall model holds millions of small typed arrays, each with its
   // own object and buffer overhead — memory that lives outside the GC heap and
   // never showed up in the object counts we were chasing.
-  let rleRowCount = 0;
+  // Count rows that hold data, not row slots: the empty ones all point at the
+  // same shared array, so the slot count says nothing about how many objects
+  // actually exist. That distinction was invisible in the first version of this
+  // measurement, which made the sharing look like it had changed nothing.
+  let rowSlots = 0;
+  let nonEmptyRows = 0;
   let rleDataBytes = 0;
   for (const labels of candidateLayers) {
     if (!labels) continue;
     for (const row of labels.rows) {
-      rleRowCount++;
-      rleDataBytes += row.byteLength;
+      rowSlots++;
+      if (row.length > 0) {
+        nonEmptyRows++;
+        rleDataBytes += row.byteLength;
+      }
     }
   }
   await logToFile(
-    `[Islands] phase=union-done layers=${numLayers} rleArrays=${rleRowCount} `
+    `[Islands] phase=union-done layers=${numLayers} rowSlots=${rowSlots} `
+    + `liveRowArrays=${nonEmptyRows} `
     + `rleDataMiB=${(rleDataBytes / 1048576).toFixed(1)} `
-    + `rleOverheadMiB≈${(rleRowCount * 128 / 1048576).toFixed(0)} `
     + `candidates=${candidates.size}`,
   );
 

--- a/src/volumeAnalysis/Islands/detect.ts
+++ b/src/volumeAnalysis/Islands/detect.ts
@@ -51,6 +51,24 @@ interface GridRef {
  * voxels. (An earlier draft ran the point-in-polygon rasterizer on the main
  * thread — far slower; replaced.)
  */
+/** Layers processed between yields while unioning candidate voxels. */
+const YIELD_INTERVAL_LAYERS = 64;
+
+/** Voxels flooded between yields while building components. */
+const YIELD_INTERVAL_VOXELS = 200_000;
+
+/**
+ * Hands the thread back so React can paint and input can be handled.
+ *
+ * Everything after the worker pool finishes runs on the main thread: unioning
+ * the candidate voxels and the 3D flood fill are both single-threaded walks
+ * over the whole model, and without yielding they freeze the window with the
+ * progress bar stuck on the last layer it managed to paint.
+ */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => { setTimeout(resolve, 0); });
+}
+
 export async function detectVoxelIslands(
   input: VoxelDetectInput,
   layerHeightMm: number,
@@ -96,6 +114,10 @@ export async function detectVoxelIslands(
   const codec = gridCodec(width, height);
   const candidates = new Set<number>();
   for (let L = 0; L < numLayers; L++) {
+    if (L % YIELD_INTERVAL_LAYERS === 0) {
+      onProgress?.(L, numLayers, 'Collecting voxels');
+      await yieldToEventLoop();
+    }
     const labels = candidateLayers[L];
     if (!labels) continue;
     for (let y = 0; y < labels.height; y++) {
@@ -114,11 +136,12 @@ export async function detectVoxelIslands(
   console.log(`[Islands] candidate (unsupported) voxels: ${candidates.size.toLocaleString()}`);
 
   console.time('[Islands] 3D connected-components');
-  const allIslands = buildIslands(
+  const allIslands = await buildIslands(
     candidates,
     codec,
     { originX, originZ, px, minZ, layerHeightMm },
     params.diagonal3D !== false,
+    onProgress,
   );
   console.timeEnd('[Islands] 3D connected-components');
   const result = allIslands.filter(
@@ -199,19 +222,31 @@ interface GridGeom {
 }
 
 /** 3D connected components over the candidate voxel set → contact-region islands. */
-function buildIslands(
+async function buildIslands(
   candidates: Set<number>,
   codec: GridCodec,
   geom: GridGeom,
   diagonal: boolean,
-): DetectedIsland[] {
+  onProgress?: (done: number, total: number, phase: string) => void,
+): Promise<DetectedIsland[]> {
   const offsets = neighbourOffsets(diagonal);
   const visited = new Set<number>();
   const islands: DetectedIsland[] = [];
   let idx = 0;
+  const total = candidates.size;
+  let sinceYield = 0;
 
   for (const startKey of candidates) {
     if (visited.has(startKey)) continue;
+
+    // Yielding between components rather than inside a flood keeps the walk
+    // itself untouched; a single component can still be large, so this bounds
+    // responsiveness by the largest island, not by the whole model.
+    if (sinceYield >= YIELD_INTERVAL_VOXELS) {
+      sinceYield = 0;
+      onProgress?.(visited.size, total, 'Connecting islands');
+      await yieldToEventLoop();
+    }
 
     // Flood this component.
     const comp: number[] = [];
@@ -220,11 +255,12 @@ function buildIslands(
     while (stack.length) {
       const k = stack.pop()!;
       comp.push(k);
+      sinceYield++;
       const { col, row, layer } = codec.unpack(k);
-      for (const [dc, dr, dl] of offsets) {
-        const nc = col + dc;
-        const nr = row + dr;
-        const nl = layer + dl;
+      for (let o = 0; o < offsets.length; o += 3) {
+        const nc = col + offsets[o];
+        const nr = row + offsets[o + 1];
+        const nl = layer + offsets[o + 2];
         if (nc < 0 || nc >= codec.width || nr < 0 || nr >= codec.height || nl < 0) continue;
         const nk = codec.pack(nc, nr, nl);
         if (candidates.has(nk) && !visited.has(nk)) {
@@ -299,22 +335,30 @@ function gridCodec(width: number, height: number): GridCodec {
 }
 
 /** 6- or 26-connectivity neighbour offsets (excluding the origin). */
-function neighbourOffsets(diagonal: boolean): Array<readonly [number, number, number]> {
+/**
+ * Neighbour deltas flattened into one array of triples, read by index.
+ *
+ * The obvious shape is an array of `[dc, dr, dl]` tuples, but the flood fill
+ * destructures it once per neighbour per voxel — 26 array iterators per voxel
+ * at 26-connectivity, each one an allocation. Sampling a scan of a tall model
+ * put 8,090 samples in `operationNewArrayIterator` alone.
+ */
+function neighbourOffsets(diagonal: boolean): Int8Array {
   if (!diagonal) {
-    return [
-      [1, 0, 0], [-1, 0, 0],
-      [0, 1, 0], [0, -1, 0],
-      [0, 0, 1], [0, 0, -1],
-    ];
+    return Int8Array.from([
+      1, 0, 0, -1, 0, 0,
+      0, 1, 0, 0, -1, 0,
+      0, 0, 1, 0, 0, -1,
+    ]);
   }
-  const out: Array<readonly [number, number, number]> = [];
+  const out: number[] = [];
   for (let dc = -1; dc <= 1; dc++) {
     for (let dr = -1; dr <= 1; dr++) {
       for (let dl = -1; dl <= 1; dl++) {
         if (dc === 0 && dr === 0 && dl === 0) continue;
-        out.push([dc, dr, dl]);
+        out.push(dc, dr, dl);
       }
     }
   }
-  return out;
+  return Int8Array.from(out);
 }

--- a/src/volumeAnalysis/Islands/detect.ts
+++ b/src/volumeAnalysis/Islands/detect.ts
@@ -136,6 +136,31 @@ export async function detectVoxelIslands(
   console.timeEnd('[Islands] slice + candidate extraction');
   console.log(`[Islands] candidate (unsupported) voxels: ${candidates.size.toLocaleString()}`);
 
+  // What the per-layer RLE actually costs. `rows` is one Int32Array per row per
+  // layer, so a tall model holds millions of small typed arrays, each with its
+  // own object and buffer overhead — memory that lives outside the GC heap and
+  // never showed up in the object counts we were chasing.
+  let rleRowCount = 0;
+  let rleDataBytes = 0;
+  for (const labels of candidateLayers) {
+    if (!labels) continue;
+    for (const row of labels.rows) {
+      rleRowCount++;
+      rleDataBytes += row.byteLength;
+    }
+  }
+  console.log(
+    `[Islands] candidate RLE: ${rleRowCount.toLocaleString()} typed arrays, `
+    + `${(rleDataBytes / 1048576).toFixed(1)} MiB of data `
+    + `(+ roughly ${(rleRowCount * 128 / 1048576).toFixed(0)} MiB of per-array overhead)`,
+  );
+
+  // Release them before the flood fill. The union above is their last reader,
+  // but the binding stays in scope for the rest of the function, so without
+  // this the whole per-layer set is still reachable — and therefore still
+  // resident — while the 3D walk builds its own structures on top.
+  candidateLayers.length = 0;
+
   console.time('[Islands] 3D connected-components');
   const allIslands = await buildIslands(
     candidates,

--- a/src/volumeAnalysis/Islands/detect.ts
+++ b/src/volumeAnalysis/Islands/detect.ts
@@ -1,4 +1,5 @@
 import { createProgressThrottle, yieldToEventLoop } from '@/utils/yieldToEventLoop';
+import type { ScanProgressCallback } from '@/volumeAnalysis/IslandScan/ScanOrchestrator';
 import * as THREE from 'three';
 import { type DetectedIsland } from './types';
 import { VoxelFootprintBuilder } from './voxelFootprint';
@@ -53,6 +54,18 @@ interface GridRef {
  * voxels. (An earlier draft ran the point-in-polygon rasterizer on the main
  * thread — far slower; replaced.)
  */
+/**
+ * The scan's phases, in order. The count travels with every progress report so
+ * the UI can render "2 of 3" without hard-coding a number that differs between
+ * the two scan paths.
+ */
+const PHASES = ['Slicing', 'Collecting voxels', 'Connecting islands'] as const;
+
+function phaseNumber(phase: string): number {
+  const index = PHASES.indexOf(phase as typeof PHASES[number]);
+  return index < 0 ? 1 : index + 1;
+}
+
 /** Layers processed between yields while unioning candidate voxels. */
 const YIELD_INTERVAL_LAYERS = 64;
 
@@ -82,7 +95,7 @@ export async function detectVoxelIslands(
   input: VoxelDetectInput,
   layerHeightMm: number,
   params: VoxelDetectParams,
-  onProgress?: (done: number, total: number, phase: string) => void,
+  onProgress?: ScanProgressCallback,
 ): Promise<DetectedIsland[]> {
   const px = params.pxMm;
   const bb = input.bbox;
@@ -126,7 +139,7 @@ export async function detectVoxelIslands(
   const candidates = new Set<number>();
   for (let L = 0; L < numLayers; L++) {
     if (L % YIELD_INTERVAL_LAYERS === 0) {
-      reportProgress(() => onProgress?.(L, numLayers, 'Collecting voxels'));
+      reportProgress(() => onProgress?.(L, numLayers, 'Collecting voxels', phaseNumber('Collecting voxels'), PHASES.length));
       await yieldToEventLoop();
     }
     const labels = candidateLayers[L];
@@ -150,30 +163,6 @@ export async function detectVoxelIslands(
   // layer, so a tall model holds millions of small typed arrays, each with its
   // own object and buffer overhead — memory that lives outside the GC heap and
   // never showed up in the object counts we were chasing.
-  // Count rows that hold data, not row slots: the empty ones all point at the
-  // same shared array, so the slot count says nothing about how many objects
-  // actually exist. That distinction was invisible in the first version of this
-  // measurement, which made the sharing look like it had changed nothing.
-  let rowSlots = 0;
-  let nonEmptyRows = 0;
-  let rleDataBytes = 0;
-  for (const labels of candidateLayers) {
-    if (!labels) continue;
-    for (const row of labels.rows) {
-      rowSlots++;
-      if (row.length > 0) {
-        nonEmptyRows++;
-        rleDataBytes += row.byteLength;
-      }
-    }
-  }
-  await logToFile(
-    `[Islands] phase=union-done layers=${numLayers} rowSlots=${rowSlots} `
-    + `liveRowArrays=${nonEmptyRows} `
-    + `rleDataMiB=${(rleDataBytes / 1048576).toFixed(1)} `
-    + `candidates=${candidates.size}`,
-  );
-
   // Release them before the flood fill. The union above is their last reader,
   // but the binding stays in scope for the rest of the function, so without
   // this the whole per-layer set is still reachable — and therefore still
@@ -221,7 +210,7 @@ async function sliceCandidateLayers(
   numLayers: number,
   layerHeightMm: number,
   opts: { px_mm: number; support_buffer_mm: number; connectivity: 4 | 8 },
-  onProgress?: (done: number, total: number, phase: string) => void,
+  onProgress?: ScanProgressCallback,
 ): Promise<RleLabels[]> {
   const candidateLayers: RleLabels[] = new Array(numLayers);
 
@@ -257,7 +246,7 @@ async function sliceCandidateLayers(
               w.removeEventListener('message', onMessage);
               candidateLayers[idx] = msg.result!.islandLabelsRle;
               done++;
-              reportSliceProgress(() => onProgress?.(done, numLayers, 'Slicing'));
+              reportSliceProgress(() => onProgress?.(done, numLayers, 'Slicing', phaseNumber('Slicing'), PHASES.length));
               runNext();
             };
             w.addEventListener('message', onMessage);
@@ -292,7 +281,7 @@ async function buildIslands(
   codec: GridCodec,
   geom: GridGeom,
   diagonal: boolean,
-  onProgress?: (done: number, total: number, phase: string) => void,
+  onProgress?: ScanProgressCallback,
 ): Promise<DetectedIsland[]> {
   const offsets = neighbourOffsets(diagonal);
   const islands: DetectedIsland[] = [];
@@ -316,7 +305,7 @@ async function buildIslands(
     // responsiveness by the largest island, not by the whole model.
     if (sinceYield >= YIELD_INTERVAL_VOXELS) {
       sinceYield = 0;
-      reportProgress(() => onProgress?.(flooded, total, 'Connecting islands'));
+      reportProgress(() => onProgress?.(flooded, total, 'Connecting islands', phaseNumber('Connecting islands'), PHASES.length));
       await yieldToEventLoop();
     }
 

--- a/src/volumeAnalysis/Islands/detect.ts
+++ b/src/volumeAnalysis/Islands/detect.ts
@@ -1,4 +1,4 @@
-import { yieldToEventLoop } from '@/utils/yieldToEventLoop';
+import { createProgressThrottle, yieldToEventLoop } from '@/utils/yieldToEventLoop';
 import * as THREE from 'three';
 import { type DetectedIsland } from './types';
 import { VoxelFootprintBuilder } from './voxelFootprint';
@@ -121,11 +121,12 @@ export async function detectVoxelIslands(
   );
 
   // Union of all unsupported candidate voxels.
+  const reportProgress = createProgressThrottle();
   const codec = gridCodec(width, height);
   const candidates = new Set<number>();
   for (let L = 0; L < numLayers; L++) {
     if (L % YIELD_INTERVAL_LAYERS === 0) {
-      onProgress?.(L, numLayers, 'Collecting voxels');
+      reportProgress(() => onProgress?.(L, numLayers, 'Collecting voxels'));
       await yieldToEventLoop();
     }
     const labels = candidateLayers[L];
@@ -227,6 +228,7 @@ async function sliceCandidateLayers(
   const cores = typeof navigator !== 'undefined' ? (navigator.hardwareConcurrency || 4) : 4;
   const concurrency = Math.min(Math.max(2, cores), numLayers);
 
+  const reportSliceProgress = createProgressThrottle();
   const workers: Worker[] = Array.from(
     { length: concurrency },
     () => new Worker(new URL('@/volumeAnalysis/IslandScan/scanlineScan.worker.ts', import.meta.url), { type: 'module' }),
@@ -255,7 +257,7 @@ async function sliceCandidateLayers(
               w.removeEventListener('message', onMessage);
               candidateLayers[idx] = msg.result!.islandLabelsRle;
               done++;
-              onProgress?.(done, numLayers, 'Slicing');
+              reportSliceProgress(() => onProgress?.(done, numLayers, 'Slicing'));
               runNext();
             };
             w.addEventListener('message', onMessage);
@@ -296,6 +298,7 @@ async function buildIslands(
   const islands: DetectedIsland[] = [];
   let idx = 0;
   const total = candidates.size;
+  const reportProgress = createProgressThrottle();
   let flooded = 0;
   let sinceYield = 0;
 
@@ -313,7 +316,7 @@ async function buildIslands(
     // responsiveness by the largest island, not by the whole model.
     if (sinceYield >= YIELD_INTERVAL_VOXELS) {
       sinceYield = 0;
-      onProgress?.(flooded, total, 'Connecting islands');
+      reportProgress(() => onProgress?.(flooded, total, 'Connecting islands'));
       await yieldToEventLoop();
     }
 

--- a/src/volumeAnalysis/Islands/detect.ts
+++ b/src/volumeAnalysis/Islands/detect.ts
@@ -223,6 +223,12 @@ interface GridGeom {
 }
 
 /** 3D connected components over the candidate voxel set → contact-region islands. */
+/**
+ * Groups candidate voxels into islands by 3D flood fill.
+ *
+ * Consumes `candidates`: the Set is emptied as the walk proceeds and must not
+ * be read afterwards.
+ */
 async function buildIslands(
   candidates: Set<number>,
   codec: GridCodec,
@@ -231,31 +237,38 @@ async function buildIslands(
   onProgress?: (done: number, total: number, phase: string) => void,
 ): Promise<DetectedIsland[]> {
   const offsets = neighbourOffsets(diagonal);
-  const visited = new Set<number>();
   const islands: DetectedIsland[] = [];
   let idx = 0;
   const total = candidates.size;
+  let flooded = 0;
   let sinceYield = 0;
 
+  // `candidates` IS the unvisited set: each voxel is deleted as it is flooded,
+  // so no second Set of the same ten million boxed numbers has to exist beside
+  // it. That pair was most of a 17.5 GB peak, against WebKit's 16 GB ceiling.
+  //
+  // Deleting during iteration is well defined — entries removed before the
+  // iterator reaches them are skipped, which is exactly the "already visited"
+  // check this used to perform. The caller must treat the Set as consumed.
   for (const startKey of candidates) {
-    if (visited.has(startKey)) continue;
 
     // Yielding between components rather than inside a flood keeps the walk
     // itself untouched; a single component can still be large, so this bounds
     // responsiveness by the largest island, not by the whole model.
     if (sinceYield >= YIELD_INTERVAL_VOXELS) {
       sinceYield = 0;
-      onProgress?.(visited.size, total, 'Connecting islands');
+      onProgress?.(flooded, total, 'Connecting islands');
       await yieldToEventLoop();
     }
 
     // Flood this component.
     const comp: number[] = [];
     const stack = [startKey];
-    visited.add(startKey);
+    candidates.delete(startKey);
     while (stack.length) {
       const k = stack.pop()!;
       comp.push(k);
+      flooded++;
       sinceYield++;
       const { col, row, layer } = codec.unpack(k);
       for (let o = 0; o < offsets.length; o += 3) {
@@ -264,8 +277,9 @@ async function buildIslands(
         const nl = layer + offsets[o + 2];
         if (nc < 0 || nc >= codec.width || nr < 0 || nr >= codec.height || nl < 0) continue;
         const nk = codec.pack(nc, nr, nl);
-        if (candidates.has(nk) && !visited.has(nk)) {
-          visited.add(nk);
+        // `delete` reports whether it was there, so claiming a neighbour is one
+        // hash lookup rather than the previous three.
+        if (candidates.delete(nk)) {
           stack.push(nk);
         }
       }

--- a/src/volumeAnalysis/Islands/detect.ts
+++ b/src/volumeAnalysis/Islands/detect.ts
@@ -55,7 +55,7 @@ export async function detectVoxelIslands(
   input: VoxelDetectInput,
   layerHeightMm: number,
   params: VoxelDetectParams,
-  onProgress?: (done: number, total: number) => void,
+  onProgress?: (done: number, total: number, phase: string) => void,
 ): Promise<DetectedIsland[]> {
   const px = params.pxMm;
   const bb = input.bbox;
@@ -140,7 +140,7 @@ async function sliceCandidateLayers(
   numLayers: number,
   layerHeightMm: number,
   opts: { px_mm: number; support_buffer_mm: number; connectivity: 4 | 8 },
-  onProgress?: (done: number, total: number) => void,
+  onProgress?: (done: number, total: number, phase: string) => void,
 ): Promise<RleLabels[]> {
   const candidateLayers: RleLabels[] = new Array(numLayers);
 
@@ -175,7 +175,7 @@ async function sliceCandidateLayers(
               w.removeEventListener('message', onMessage);
               candidateLayers[idx] = msg.result!.islandLabelsRle;
               done++;
-              onProgress?.(done, numLayers);
+              onProgress?.(done, numLayers, 'Slicing');
               runNext();
             };
             w.addEventListener('message', onMessage);

--- a/src/volumeAnalysis/Islands/detect.ts
+++ b/src/volumeAnalysis/Islands/detect.ts
@@ -329,7 +329,9 @@ async function buildIslands(
       comp.push(k);
       flooded++;
       sinceYield++;
-      const { col, row, layer } = codec.unpack(k);
+      const col = codec.colOf(k);
+      const row = codec.rowOf(k);
+      const layer = codec.layerOf(k);
       for (let o = 0; o < offsets.length; o += 3) {
         const nc = col + offsets[o];
         const nr = row + offsets[o + 1];
@@ -348,7 +350,7 @@ async function buildIslands(
     let minLayer = Infinity;
     let maxLayer = -Infinity;
     for (const k of comp) {
-      const { layer } = codec.unpack(k);
+      const layer = codec.layerOf(k);
       if (layer < minLayer) minLayer = layer;
       if (layer > maxLayer) maxLayer = layer;
     }
@@ -358,8 +360,10 @@ async function buildIslands(
     let baseCount = 0;
     const contactVoxels = new VoxelFootprintBuilder(Math.min(comp.length, 1024));
     for (const k of comp) {
-      const { col, row, layer } = codec.unpack(k);
+      const layer = codec.layerOf(k);
       if (layer !== minLayer) continue;
+      const col = codec.colOf(k);
+      const row = codec.rowOf(k);
       const vx = geom.originX + col * geom.px + geom.px * VOXEL_OFFSET_X;
       const vy = -(geom.originZ + row * geom.px - geom.px * VOXEL_OFFSET_Y);
       sumX += vx;
@@ -391,6 +395,17 @@ interface GridCodec {
   height: number;
   pack: (col: number, row: number, layer: number) => number;
   unpack: (key: number) => { col: number; row: number; layer: number };
+  /**
+   * Component accessors, for the hot loops.
+   *
+   * `unpack` returns a fresh object, and the flood fill calls it once per voxel
+   * as it walks plus twice more per voxel in the passes that follow — around
+   * thirty million throwaway objects for a ten-million-voxel scan, all of it
+   * allocation and collection for three numbers.
+   */
+  colOf: (key: number) => number;
+  rowOf: (key: number) => number;
+  layerOf: (key: number) => number;
 }
 
 function gridCodec(width: number, height: number): GridCodec {
@@ -405,6 +420,9 @@ function gridCodec(width: number, height: number): GridCodec {
       const layer = (rest - row) / height;
       return { col, row, layer };
     },
+    colOf: (key) => key % width,
+    rowOf: (key) => Math.floor(key / width) % height,
+    layerOf: (key) => Math.floor(key / (width * height)),
   };
 }
 

--- a/src/volumeAnalysis/Islands/detect.ts
+++ b/src/volumeAnalysis/Islands/detect.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { type DetectedIsland } from './types';
+import { VoxelFootprintBuilder } from './voxelFootprint';
 // PORTABILITY: analysis-domain dependencies are confined to this file — the
 // scanline island worker (the fast RLE engine the Analysis-tab voxel rescan
 // uses) and the RleLabels type. If that infra is removed, this is the one
@@ -282,7 +283,7 @@ async function buildIslands(
     let sumX = 0;
     let sumY = 0;
     let baseCount = 0;
-    const contactVoxels: { x: number; y: number }[] = [];
+    const contactVoxels = new VoxelFootprintBuilder(Math.min(comp.length, 1024));
     for (const k of comp) {
       const { col, row, layer } = codec.unpack(k);
       if (layer !== minLayer) continue;
@@ -291,7 +292,7 @@ async function buildIslands(
       sumX += vx;
       sumY += vy;
       baseCount++;
-      contactVoxels.push({ x: vx, y: vy });
+      contactVoxels.push(vx, vy);
     }
 
     const contactX = sumX / baseCount;
@@ -305,7 +306,7 @@ async function buildIslands(
       baseZ,
       areaMm2: baseCount * geom.px * geom.px,
       layerSpan: [minLayer, maxLayer],
-      contactVoxels,
+      contactVoxels: contactVoxels.build(),
     });
   }
 

--- a/src/volumeAnalysis/Islands/detect.ts
+++ b/src/volumeAnalysis/Islands/detect.ts
@@ -70,6 +70,24 @@ function yieldToEventLoop(): Promise<void> {
   return new Promise((resolve) => { setTimeout(resolve, 0); });
 }
 
+/**
+ * Writes to the app log file, not just the devtools console.
+ *
+ * `attachConsole` mirrors Rust records INTO the webview console; nothing goes
+ * the other way, so a console.log here is invisible to anyone reading
+ * dragonfruit.log — including us, when the measurement is the whole point.
+ */
+async function logToFile(message: string): Promise<void> {
+  console.log(message);
+  if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) return;
+  try {
+    const { info } = await import('@tauri-apps/plugin-log');
+    await info(message);
+  } catch {
+    // Not a Tauri context, or the plugin is unavailable: the console line stands.
+  }
+}
+
 export async function detectVoxelIslands(
   input: VoxelDetectInput,
   layerHeightMm: number,
@@ -100,6 +118,7 @@ export async function detectVoxelIslands(
     connectivity: params.connectivity ?? 4,
   };
 
+  await logToFile(`[Islands] phase=slice-start grid=${width}x${height} layers=${numLayers}`);
   console.time('[Islands] slice + candidate extraction');
   const candidateLayers = await sliceCandidateLayers(
     input.positions,
@@ -149,10 +168,11 @@ export async function detectVoxelIslands(
       rleDataBytes += row.byteLength;
     }
   }
-  console.log(
-    `[Islands] candidate RLE: ${rleRowCount.toLocaleString()} typed arrays, `
-    + `${(rleDataBytes / 1048576).toFixed(1)} MiB of data `
-    + `(+ roughly ${(rleRowCount * 128 / 1048576).toFixed(0)} MiB of per-array overhead)`,
+  await logToFile(
+    `[Islands] phase=union-done layers=${numLayers} rleArrays=${rleRowCount} `
+    + `rleDataMiB=${(rleDataBytes / 1048576).toFixed(1)} `
+    + `rleOverheadMiB≈${(rleRowCount * 128 / 1048576).toFixed(0)} `
+    + `candidates=${candidates.size}`,
   );
 
   // Release them before the flood fill. The union above is their last reader,
@@ -161,6 +181,7 @@ export async function detectVoxelIslands(
   // resident — while the 3D walk builds its own structures on top.
   candidateLayers.length = 0;
 
+  await logToFile('[Islands] phase=flood-start');
   console.time('[Islands] 3D connected-components');
   const allIslands = await buildIslands(
     candidates,
@@ -172,6 +193,18 @@ export async function detectVoxelIslands(
   console.timeEnd('[Islands] 3D connected-components');
   const result = allIslands.filter(
     (island) => (island.areaMm2 ?? 0) >= (params.minAreaMm2 ?? 0.02)
+  );
+
+  let footprintBytes = 0;
+  for (const island of allIslands) {
+    if (island.contactVoxels) {
+      footprintBytes += island.contactVoxels.xy.byteLength
+        + (island.contactVoxels.z?.byteLength ?? 0);
+    }
+  }
+  await logToFile(
+    `[Islands] phase=flood-done islands=${allIslands.length} kept=${result.length} `
+    + `footprintMiB=${(footprintBytes / 1048576).toFixed(1)}`,
   );
   console.log(`[Islands] islands detected (pre-filter): ${allIslands.length}, post-filter: ${result.length}`);
   return result;

--- a/src/volumeAnalysis/Islands/detect.ts
+++ b/src/volumeAnalysis/Islands/detect.ts
@@ -1,3 +1,4 @@
+import { yieldToEventLoop } from '@/utils/yieldToEventLoop';
 import * as THREE from 'three';
 import { type DetectedIsland } from './types';
 import { VoxelFootprintBuilder } from './voxelFootprint';
@@ -58,17 +59,6 @@ const YIELD_INTERVAL_LAYERS = 64;
 /** Voxels flooded between yields while building components. */
 const YIELD_INTERVAL_VOXELS = 200_000;
 
-/**
- * Hands the thread back so React can paint and input can be handled.
- *
- * Everything after the worker pool finishes runs on the main thread: unioning
- * the candidate voxels and the 3D flood fill are both single-threaded walks
- * over the whole model, and without yielding they freeze the window with the
- * progress bar stuck on the last layer it managed to paint.
- */
-function yieldToEventLoop(): Promise<void> {
-  return new Promise((resolve) => { setTimeout(resolve, 0); });
-}
 
 /**
  * Writes to the app log file, not just the devtools console.

--- a/src/volumeAnalysis/Islands/spatialHashGrid2D.ts
+++ b/src/volumeAnalysis/Islands/spatialHashGrid2D.ts
@@ -1,16 +1,40 @@
+/**
+ * Uniform 2D spatial hash.
+ *
+ * Cells are keyed by a single number rather than a `"cx,cy"` string. The string
+ * form is the idiomatic one and reads better, but in the island pipeline this
+ * grid is filled with every contact voxel of every island, and a template
+ * literal allocates a rope string per insert and per probe. Profiling the
+ * island scan showed roughly a third of the time going to garbage collection,
+ * sweeping exactly those temporary keys. A number hashes without allocating.
+ */
+
+/**
+ * Cell coordinates are folded into one number as `(cx + OFFSET) * STRIDE + cy`.
+ * With OFFSET = 2^20 the addressable range is ±1,048,576 cells on each axis —
+ * 100 metres at a 0.1 mm cell — and the largest key stays below 2^42, well
+ * inside the range where integers are exact.
+ */
+const CELL_OFFSET = 1 << 20;
+const CELL_STRIDE = 1 << 21;
+
+export function cellKey(cx: number, cy: number): number {
+  return (cx + CELL_OFFSET) * CELL_STRIDE + (cy + CELL_OFFSET);
+}
+
 export class SpatialHashGrid2D<T> {
   private cellSize: number;
-  private grid: Map<string, T[]>;
+  private grid: Map<number, T[]>;
 
   constructor(cellSize: number) {
     this.cellSize = cellSize;
     this.grid = new Map();
   }
 
-  private getKey(x: number, y: number): string {
+  private getKey(x: number, y: number): number {
     const cx = Math.floor(x / this.cellSize);
     const cy = Math.floor(y / this.cellSize);
-    return `${cx},${cy}`;
+    return cellKey(cx, cy);
   }
 
   insert(x: number, y: number, item: T): void {
@@ -31,10 +55,12 @@ export class SpatialHashGrid2D<T> {
     const results: T[] = [];
     for (let cx = minX; cx <= maxX; cx++) {
       for (let cy = minY; cy <= maxY; cy++) {
-        const key = `${cx},${cy}`;
-        const cell = this.grid.get(key);
-        if (cell) {
-          results.push(...cell);
+        const cell = this.grid.get(cellKey(cx, cy));
+        if (!cell) continue;
+        // Appended one by one rather than with `push(...cell)`: a dense cell can
+        // hold more items than the engine's argument limit.
+        for (const item of cell) {
+          results.push(item);
         }
       }
     }

--- a/src/volumeAnalysis/Islands/types.ts
+++ b/src/volumeAnalysis/Islands/types.ts
@@ -1,3 +1,4 @@
+import type { VoxelFootprint } from './voxelFootprint';
 import type * as THREE from 'three';
 
 /**
@@ -74,7 +75,7 @@ export interface DetectedIsland {
   layerSpan?: readonly [number, number];
   /** Contact voxel 2D positions (x, y coordinates in world mm) at the base layer.
    *  Overhang regions also carry the surface Z at each voxel. */
-  contactVoxels?: { x: number; y: number; z?: number }[];
+  contactVoxels?: VoxelFootprint;
 
   // --- minima-detector extras (undefined for voxel) ---
   /** Source mesh vertex index. */

--- a/src/volumeAnalysis/Islands/useIslands.ts
+++ b/src/volumeAnalysis/Islands/useIslands.ts
@@ -159,7 +159,7 @@ async function reportSlowStep(label: string, elapsedMs: number): Promise<void> {
 
 export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ = 0, sourcePath, activeTab }: UseIslandsInput) {
   const [scanning, setScanning] = useState(false);
-  const [scanProgress, setScanProgress] = useState<{ done: number; total: number; phase?: string } | null>(null);
+  const [scanProgress, setScanProgress] = useState<{ done: number; total: number; phase?: string; phaseNumber?: number; phaseCount?: number } | null>(null);
   const [voxelIslands, setVoxelIslands] = useState<DetectedIsland[]>([]);
   const [minimaIslands, setMinimaIslands] = useState<DetectedIsland[]>([]);
   const [overhangIslands, setOverhangIslands] = useState<DetectedIsland[]>([]);
@@ -480,10 +480,15 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
           connectivity,
           minAreaMm2,
         };
-        const voxel = await detectVoxelIslands(world, layerHeightMm, params, (done, total, phase) => {
-          if (scanEpochRef.current !== epoch) return;
-          setScanProgress({ done, total, phase });
-        });
+        const voxel = await detectVoxelIslands(
+          world,
+          layerHeightMm,
+          params,
+          (done, total, phase, phaseNumber, phaseCount) => {
+            if (scanEpochRef.current !== epoch) return;
+            setScanProgress({ done, total, phase, phaseNumber, phaseCount });
+          },
+        );
         if (scanEpochRef.current !== epoch) return;
         setVoxelIslands(voxel);
 

--- a/src/volumeAnalysis/Islands/useIslands.ts
+++ b/src/volumeAnalysis/Islands/useIslands.ts
@@ -124,6 +124,39 @@ export interface UseIslandsInput {
 
 export type UseIslandsReturn = ReturnType<typeof useIslands>;
 
+/**
+ * Times a derived computation and reports the slow ones to the app log.
+ *
+ * The scan phases are instrumented in `detect.ts`, but the stretch *after* the
+ * scan — the memo cascade that turns raw islands into markers — was invisible,
+ * and measurement puts the peak memory and a good fifteen seconds of frozen UI
+ * right there. Only slow computations are reported, so the log stays readable.
+ */
+function timed<T>(label: string, compute: () => T): T {
+  const startedAt = performance.now();
+  const result = compute();
+  const elapsedMs = performance.now() - startedAt;
+  if (elapsedMs >= SLOW_STEP_MS) {
+    void reportSlowStep(label, elapsedMs);
+  }
+  return result;
+}
+
+/** Below this a step is not worth a log line. */
+const SLOW_STEP_MS = 150;
+
+async function reportSlowStep(label: string, elapsedMs: number): Promise<void> {
+  const message = `[Islands] step=${label} ms=${Math.round(elapsedMs)}`;
+  console.log(message);
+  if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) return;
+  try {
+    const { info } = await import('@tauri-apps/plugin-log');
+    await info(message);
+  } catch {
+    // Console line stands.
+  }
+}
+
 export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ = 0, sourcePath, activeTab }: UseIslandsInput) {
   const [scanning, setScanning] = useState(false);
   const [scanProgress, setScanProgress] = useState<{ done: number; total: number; phase?: string } | null>(null);
@@ -477,10 +510,10 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
   }, [geom, transform, sourcePath, prepareWorldGeom, layerHeightMm, pxMm, supportBufMm, connectivity, minAreaMm2, minimaK]);
 
   // Pass 1: Proposed consolidation & classification
-  const proposedConsolidated = useMemo(() => {
+  const proposedConsolidated = useMemo(() => timed('proposedConsolidated', () => {
     if (!consolidateVoxel) return voxelIslands;
     return consolidateVoxelIslands(voxelIslands, consolidationDistance, pxMm);
-  }, [voxelIslands, consolidateVoxel, consolidationDistance, pxMm]);
+  }), [voxelIslands, consolidateVoxel, consolidationDistance, pxMm]);
 
   const proposedClassified = useMemo(() => {
     return classifyIntersection(proposedConsolidated, minimaIslands, {
@@ -490,11 +523,11 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
   }, [proposedConsolidated, minimaIslands, layerHeightMm]);
 
   // Determine contoured IDs based on proposed list
-  const contouredIds = useMemo(() => {
+  const contouredIds = useMemo(() => timed('contouredIds', () => {
     return enableContourRegions
       ? determineContourThreshold(proposedClassified.islands, pxMm, maxContourRegions)
       : new Set<string>();
-  }, [proposedClassified.islands, enableContourRegions, pxMm, maxContourRegions]);
+  }), [proposedClassified.islands, enableContourRegions, pxMm, maxContourRegions]);
 
   // Pass 2: Revert non-contoured consolidated islands back to single voxel islands
   const finalVoxelIslands = useMemo(() => {
@@ -510,12 +543,12 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
     return list;
   }, [proposedConsolidated, contouredIds]);
 
-  const classifiedResult = useMemo(() => {
+  const classifiedResult = useMemo(() => timed('classifiedResult', () => {
     return classifyIntersection(finalVoxelIslands, minimaIslands, {
       xyToleranceMm: 0.5,
       zBandMm: layerHeightMm,
     });
-  }, [finalVoxelIslands, minimaIslands, layerHeightMm]);
+  }), [finalVoxelIslands, minimaIslands, layerHeightMm]);
 
   // Merge overhang regions into the classified set (dedupe + inclusion):
   // the mesh-normal classifier and the slice-growth detector flag the same
@@ -594,9 +627,9 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
   // Depends on the islands alone, so it survives every support placement.
   const islandContactGrid = useMemo(() => buildIslandContactGrid(allIslands), [allIslands]);
 
-  const annotatedIslands = useMemo(() => {
+  const annotatedIslands = useMemo(() => timed('annotatedIslands', () => {
     return annotateAndCountSupports(allIslands, islandContactGrid, mappedSupportTips, plateZ, areaPerSupport, layerHeightMm);
-  }, [allIslands, islandContactGrid, mappedSupportTips, plateZ, areaPerSupport, layerHeightMm]);
+  }), [allIslands, islandContactGrid, mappedSupportTips, plateZ, areaPerSupport, layerHeightMm]);
 
   const tableStats = useMemo(() => {
     const voxelTotal = annotatedIslands.filter(i => i.class === 'voxelOnly' && i.source === 'voxel').length;
@@ -721,7 +754,7 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
     return merged;
   }, [voxelOnlyPucks, minimaOnlyPucks, intersectionPucks, showIntersection, showVoxelOnly]);
 
-  const islandMarkers = useMemo(() => {
+  const islandMarkers = useMemo(() => timed('islandMarkers', () => {
     const markers: any[] = [];
 
     voxelOnlyPucks.markers.forEach(m => {
@@ -769,7 +802,7 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
     });
 
     return markers;
-  }, [
+  }), [
     voxelOnlyPucks,
     minimaOnlyPucks,
     intersectionPucks,

--- a/src/volumeAnalysis/Islands/useIslands.ts
+++ b/src/volumeAnalysis/Islands/useIslands.ts
@@ -581,9 +581,12 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
     });
   }, [supportTips]);
 
+  // Depends on the islands alone, so it survives every support placement.
+  const islandContactGrid = useMemo(() => buildIslandContactGrid(allIslands), [allIslands]);
+
   const annotatedIslands = useMemo(() => {
-    return annotateAndCountSupports(allIslands, mappedSupportTips, plateZ, areaPerSupport, layerHeightMm);
-  }, [allIslands, mappedSupportTips, plateZ, areaPerSupport, layerHeightMm]);
+    return annotateAndCountSupports(allIslands, islandContactGrid, mappedSupportTips, plateZ, areaPerSupport, layerHeightMm);
+  }, [allIslands, islandContactGrid, mappedSupportTips, plateZ, areaPerSupport, layerHeightMm]);
 
   const tableStats = useMemo(() => {
     const voxelTotal = annotatedIslands.filter(i => i.class === 'voxelOnly' && i.source === 'voxel').length;
@@ -1312,6 +1315,18 @@ interface ContourMarker {
   islandId: number;
 }
 
+/**
+ * Contours are a pure function of an island's own voxels and the four scalars
+ * below — never of the support tips, the visibility toggles or the other
+ * islands. But they were being regenerated inside the marker memo, so flipping
+ * any island checkbox re-contoured every island from scratch.
+ *
+ * Keyed by the voxel array's identity so a rescan invalidates naturally: a new
+ * scan produces new arrays, and the old entries die with them. Island ids alone
+ * would be unsafe, since a rescan reuses them for different geometry.
+ */
+const contourCache = new WeakMap<{ x: number; y: number }[], Map<string, ContourMarker[]>>();
+
 export function generateContourMarkers(
   voxels: { x: number; y: number }[],
   pxMm: number,
@@ -1319,8 +1334,34 @@ export function generateContourMarkers(
   baseZ: number,
   type: number
 ): ContourMarker[] {
+  if (voxels.length === 0) return [];
+
+  const variantKey = `${pxMm}|${islandId}|${baseZ}|${type}`;
+  let variants = contourCache.get(voxels);
+  const cached = variants?.get(variantKey);
+  // Copied out: at most 30 markers, and callers are free to mutate what they
+  // get without corrupting the cache.
+  if (cached) return cached.map((marker) => ({ ...marker }));
+
+  const markers = computeContourMarkers(voxels, pxMm, islandId, baseZ, type);
+
+  if (!variants) {
+    variants = new Map();
+    contourCache.set(voxels, variants);
+  }
+  variants.set(variantKey, markers);
+
+  return markers.map((marker) => ({ ...marker }));
+}
+
+function computeContourMarkers(
+  voxels: { x: number; y: number }[],
+  pxMm: number,
+  islandId: number,
+  baseZ: number,
+  type: number
+): ContourMarker[] {
   const markers: ContourMarker[] = [];
-  if (voxels.length === 0) return markers;
 
   const R_small = Math.max(0.12, pxMm * 1.5);
   const R_large = pxMm * 3.5;
@@ -1533,8 +1574,40 @@ export function generateContourMarkers(
   return markers;
 }
 
+interface IslandGridEntry {
+  islandIndex: number;
+  x: number;
+  y: number;
+  z: number;
+}
+
+/**
+ * Indexes every contact voxel of every island for tip proximity queries.
+ *
+ * Kept separate from {@link annotateAndCountSupports} because it depends only on
+ * the islands: placing a single support changes the tips, not the geometry, and
+ * rebuilding this grid over hundreds of thousands of voxels on every placement
+ * was the bulk of the freeze after each click. Entry indices refer to positions
+ * in `islands`, which `annotateAndCountSupports` preserves.
+ */
+function buildIslandContactGrid(islands: DetectedIsland[]): SpatialHashGrid2D<IslandGridEntry> {
+  const grid = new SpatialHashGrid2D<IslandGridEntry>(1.0);
+  islands.forEach((island, islandIndex) => {
+    const z = island.contact.z;
+    if (island.contactVoxels && island.contactVoxels.length > 0) {
+      for (const vox of island.contactVoxels) {
+        grid.insert(vox.x, vox.y, { islandIndex, x: vox.x, y: vox.y, z });
+      }
+    } else {
+      grid.insert(island.contact.x, island.contact.y, { islandIndex, x: island.contact.x, y: island.contact.y, z });
+    }
+  });
+  return grid;
+}
+
 function annotateAndCountSupports(
   islands: DetectedIsland[],
+  grid: SpatialHashGrid2D<IslandGridEntry>,
   supportTips: TipInfo[],
   plateZ: number,
   areaPerSupport: number,
@@ -1545,26 +1618,6 @@ function annotateAndCountSupports(
   for (const island of annotated) {
     island.supportCount = 0;
   }
-
-  interface IslandGridEntry {
-    islandIndex: number;
-    x: number;
-    y: number;
-    z: number;
-  }
-
-  // Build spatial grid over islands
-  const grid = new SpatialHashGrid2D<IslandGridEntry>(1.0);
-  annotated.forEach((island, islandIndex) => {
-    const z = island.contact.z;
-    if (island.contactVoxels && island.contactVoxels.length > 0) {
-      for (const vox of island.contactVoxels) {
-        grid.insert(vox.x, vox.y, { islandIndex, x: vox.x, y: vox.y, z });
-      }
-    } else {
-      grid.insert(island.contact.x, island.contact.y, { islandIndex, x: island.contact.x, y: island.contact.y, z });
-    }
-  });
 
   const supportedIslandsThisTip = new Set<number>();
   const zTolerance = layerHeightMm ? 2 * layerHeightMm : 0.5;

--- a/src/volumeAnalysis/Islands/useIslands.ts
+++ b/src/volumeAnalysis/Islands/useIslands.ts
@@ -116,7 +116,7 @@ export type UseIslandsReturn = ReturnType<typeof useIslands>;
 
 export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ = 0, sourcePath, activeTab }: UseIslandsInput) {
   const [scanning, setScanning] = useState(false);
-  const [scanProgress, setScanProgress] = useState<{ done: number; total: number } | null>(null);
+  const [scanProgress, setScanProgress] = useState<{ done: number; total: number; phase?: string } | null>(null);
   const [voxelIslands, setVoxelIslands] = useState<DetectedIsland[]>([]);
   const [minimaIslands, setMinimaIslands] = useState<DetectedIsland[]>([]);
   const [overhangIslands, setOverhangIslands] = useState<DetectedIsland[]>([]);
@@ -437,9 +437,9 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
           connectivity,
           minAreaMm2,
         };
-        const voxel = await detectVoxelIslands(world, layerHeightMm, params, (done, total) => {
+        const voxel = await detectVoxelIslands(world, layerHeightMm, params, (done, total, phase) => {
           if (scanEpochRef.current !== epoch) return;
-          setScanProgress({ done, total });
+          setScanProgress({ done, total, phase });
         });
         if (scanEpochRef.current !== epoch) return;
         setVoxelIslands(voxel);

--- a/src/volumeAnalysis/Islands/useIslands.ts
+++ b/src/volumeAnalysis/Islands/useIslands.ts
@@ -17,6 +17,14 @@ import { classifyIntersection } from './intersection';
 import { getSnapshot } from '@/supports/state';
 import { getSettings } from '@/supports/Settings/state';
 import { SpatialHashGrid2D, cellKey } from './spatialHashGrid2D';
+import {
+  type VoxelFootprint,
+  VoxelFootprintBuilder,
+  concatFootprints,
+  footprintX,
+  footprintY,
+  isEmptyFootprint,
+} from './voxelFootprint';
 
 /** Self-support angle for mesh-normal overhang detection (surfaces flatter
  *  than this from horizontal get supports). Tunable per resin later. */
@@ -60,16 +68,18 @@ export function mergeOverhangRegions(
  */
 function overhangCoversVoxel(region: DetectedIsland, voxel: DetectedIsland): boolean {
   const vox = region.contactVoxels;
-  if (!vox || vox.length === 0) return false;
+  if (isEmptyFootprint(vox) || !vox) return false;
   let minX = Infinity;
   let minY = Infinity;
   let maxX = -Infinity;
   let maxY = -Infinity;
-  for (const p of vox) {
-    if (p.x < minX) minX = p.x;
-    if (p.y < minY) minY = p.y;
-    if (p.x > maxX) maxX = p.x;
-    if (p.y > maxY) maxY = p.y;
+  for (let i = 0; i < vox.count; i++) {
+    const px = footprintX(vox, i);
+    const py = footprintY(vox, i);
+    if (px < minX) minX = px;
+    if (py < minY) minY = py;
+    if (px > maxX) maxX = px;
+    if (py > maxY) maxY = py;
   }
   const cx = voxel.contact.x;
   const cy = voxel.contact.y;
@@ -244,16 +254,16 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
    */
   const overhangRegionToIsland = (region: OverhangRegion, i: number): DetectedIsland => {
     const { width, height, originX, originY, pxMm, data, surfaceZ } = region.footprint;
-    const contactVoxels: { x: number; y: number; z?: number }[] = [];
+    const contactVoxels = new VoxelFootprintBuilder(Math.min(width * height, 4096), true);
     for (let row = 0; row < height; row++) {
       for (let col = 0; col < width; col++) {
         const idx = row * width + col;
         if (data[idx]) {
-          contactVoxels.push({
-            x: originX + (col + 0.5) * pxMm,
-            y: originY + (row + 0.5) * pxMm,
-            z: surfaceZ[idx],
-          });
+          contactVoxels.push(
+            originX + (col + 0.5) * pxMm,
+            originY + (row + 0.5) * pxMm,
+            surfaceZ[idx],
+          );
         }
       }
     }
@@ -270,7 +280,7 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
       overhangAngleDeg: region.angleDeg,
       triangleIds: region.triangleIds,
       surfaceNormal: { x: region.normal[0], y: region.normal[1], z: region.normal[2] },
-      contactVoxels,
+      contactVoxels: contactVoxels.build(),
     };
   };
 
@@ -725,8 +735,8 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
         ? 0.1
         : (scaleMarkersWithArea && area > 0 ? Math.max(0.1, Math.sqrt(area / Math.PI)) : 0.1);
 
-      if (island && !isOverhang && contouredIds.has(island.id) && island.contactVoxels && island.contactVoxels.length > 0) {
-        const contour = generateContourMarkers(island.contactVoxels, pxMm, m.id, m.baseZ, consolidateVoxel ? 3 : 0);
+      if (island && !isOverhang && contouredIds.has(island.id) && !isEmptyFootprint(island.contactVoxels)) {
+        const contour = generateContourMarkers(island.contactVoxels!, pxMm, m.id, m.baseZ, consolidateVoxel ? 3 : 0);
         markers.push(...contour);
       } else {
         markers.push({ ...m, radius, type: consolidateVoxel ? 3 : 0, islandId: m.id });
@@ -744,8 +754,8 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
 
       // 1. Generate and push the blue voxel blob (either contoured if binned or a single dot if not) as type 3 if showVoxelOnly is enabled
       if (showVoxelOnly) {
-        if (island && contouredIds.has(island.id) && island.contactVoxels && island.contactVoxels.length > 0) {
-          const contourBlue = generateContourMarkers(island.contactVoxels, pxMm, m.id, m.baseZ, 3);
+        if (island && contouredIds.has(island.id) && !isEmptyFootprint(island.contactVoxels)) {
+          const contourBlue = generateContourMarkers(island.contactVoxels!, pxMm, m.id, m.baseZ, 3);
           markers.push(...contourBlue);
         } else {
           markers.push({ ...m, radius, type: 3, islandId: m.id });
@@ -1074,16 +1084,16 @@ export function useIslands({ geom, transform, layerHeightMm, supportTips, plateZ
   };
 }
 
-function dilateVoxelGrid(voxels: { x: number; y: number }[], pxMm: number, consolidationDistance: number): { x: number; y: number }[] {
-  if (voxels.length === 0) return [];
+function dilateVoxelGrid(voxels: VoxelFootprint, pxMm: number, consolidationDistance: number): VoxelFootprint {
+  if (voxels.count === 0) return voxels;
 
-  const gridSet = new Set<string>();
+  const gridSet = new Set<number>();
   const originalCoords: { ix: number; iy: number }[] = [];
 
-  for (const v of voxels) {
-    const ix = Math.round(v.x / pxMm);
-    const iy = Math.round(v.y / pxMm);
-    const key = `${ix},${iy}`;
+  for (let i = 0; i < voxels.count; i++) {
+    const ix = Math.round(footprintX(voxels, i) / pxMm);
+    const iy = Math.round(footprintY(voxels, i) / pxMm);
+    const key = cellKey(ix, iy);
     if (!gridSet.has(key)) {
       gridSet.add(key);
       originalCoords.push({ ix, iy });
@@ -1091,8 +1101,8 @@ function dilateVoxelGrid(voxels: { x: number; y: number }[], pxMm: number, conso
   }
 
   const rPix = Math.max(1, Math.round(consolidationDistance / (2 * pxMm)));
-  const dilatedSet = new Set<string>();
-  const dilatedVoxels: { x: number; y: number }[] = [];
+  const dilatedSet = new Set<number>();
+  const dilatedVoxels = new VoxelFootprintBuilder(originalCoords.length);
 
   const offsets: { dx: number; dy: number }[] = [];
   for (let dx = -rPix; dx <= rPix; dx++) {
@@ -1107,15 +1117,15 @@ function dilateVoxelGrid(voxels: { x: number; y: number }[], pxMm: number, conso
     for (const offset of offsets) {
       const nix = coord.ix + offset.dx;
       const niy = coord.iy + offset.dy;
-      const nkey = `${nix},${niy}`;
+      const nkey = cellKey(nix, niy);
       if (!dilatedSet.has(nkey)) {
         dilatedSet.add(nkey);
-        dilatedVoxels.push({ x: nix * pxMm, y: niy * pxMm });
+        dilatedVoxels.push(nix * pxMm, niy * pxMm);
       }
     }
   }
 
-  return dilatedVoxels;
+  return dilatedVoxels.build();
 }
 
 export function consolidateVoxelIslands(islands: DetectedIsland[], epsilonMm: number, pxMm: number): DetectedIsland[] {
@@ -1126,10 +1136,10 @@ export function consolidateVoxelIslands(islands: DetectedIsland[], epsilonMm: nu
 
   if (n === 1) {
     const single = { ...islands[0] };
-    if ((single.areaMm2 ?? 0) >= minAreaForContour && single.contactVoxels && single.contactVoxels.length > 0) {
-      const dilated = dilateVoxelGrid(single.contactVoxels, pxMm, epsilonMm);
+    if ((single.areaMm2 ?? 0) >= minAreaForContour && !isEmptyFootprint(single.contactVoxels)) {
+      const dilated = dilateVoxelGrid(single.contactVoxels!, pxMm, epsilonMm);
       single.contactVoxels = dilated;
-      single.areaMm2 = dilated.length * pxMm * pxMm;
+      single.areaMm2 = dilated.count * pxMm * pxMm;
     }
     single.members = [{ ...islands[0] }];
     return [single];
@@ -1180,7 +1190,7 @@ export function consolidateVoxelIslands(islands: DetectedIsland[], epsilonMm: nu
 
       let sumX = 0, sumY = 0, totalArea = 0;
       let minFirstLayer = Infinity, maxLastLayer = -Infinity;
-      const contactVoxels: { x: number; y: number }[] = [];
+      const memberFootprints: VoxelFootprint[] = [];
       for (const m of members) {
         sumX += m.contact.x;
         sumY += m.contact.y;
@@ -1190,16 +1200,17 @@ export function consolidateVoxelIslands(islands: DetectedIsland[], epsilonMm: nu
           maxLastLayer = Math.max(maxLastLayer, m.layerSpan[1]);
         }
         if (m.contactVoxels) {
-          contactVoxels.push(...m.contactVoxels);
+          memberFootprints.push(m.contactVoxels);
         }
       }
 
-      const dilatedVoxels = contactVoxels.length > 0
-        ? dilateVoxelGrid(contactVoxels, pxMm, epsilonMm)
+      const mergedFootprint = concatFootprints(memberFootprints);
+      const dilatedVoxels = mergedFootprint.count > 0
+        ? dilateVoxelGrid(mergedFootprint, pxMm, epsilonMm)
         : undefined;
 
-      const finalArea = (dilatedVoxels && dilatedVoxels.length > 0)
-        ? dilatedVoxels.length * pxMm * pxMm
+      const finalArea = (dilatedVoxels && dilatedVoxels.count > 0)
+        ? dilatedVoxels.count * pxMm * pxMm
         : totalArea;
 
       const contact = lowest.contact.clone();
@@ -1235,8 +1246,7 @@ export function determineContourThreshold(
   const candidates = islands.filter(
     (i) =>
       (i.class === 'voxelOnly' || i.class === 'intersection') &&
-      i.contactVoxels &&
-      i.contactVoxels.length > 0
+      !isEmptyFootprint(i.contactVoxels)
   );
 
   if (candidates.length === 0) return contouredIds;
@@ -1325,16 +1335,16 @@ interface ContourMarker {
  * scan produces new arrays, and the old entries die with them. Island ids alone
  * would be unsafe, since a rescan reuses them for different geometry.
  */
-const contourCache = new WeakMap<{ x: number; y: number }[], Map<string, ContourMarker[]>>();
+const contourCache = new WeakMap<VoxelFootprint, Map<string, ContourMarker[]>>();
 
 export function generateContourMarkers(
-  voxels: { x: number; y: number }[],
+  voxels: VoxelFootprint,
   pxMm: number,
   islandId: number,
   baseZ: number,
   type: number
 ): ContourMarker[] {
-  if (voxels.length === 0) return [];
+  if (voxels.count === 0) return [];
 
   const variantKey = `${pxMm}|${islandId}|${baseZ}|${type}`;
   let variants = contourCache.get(voxels);
@@ -1355,7 +1365,7 @@ export function generateContourMarkers(
 }
 
 function computeContourMarkers(
-  voxels: { x: number; y: number }[],
+  voxels: VoxelFootprint,
   pxMm: number,
   islandId: number,
   baseZ: number,
@@ -1372,12 +1382,17 @@ function computeContourMarkers(
   // `"gx,gy"` strings: this Set is probed nine times per voxel just below, and
   // each template literal would allocate a rope string destined straight for the
   // garbage collector.
-  const voxelSet = new Set(voxels.map((v) => cellKey(Math.round(v.x / pxMm), Math.round(v.y / pxMm))));
+  const voxelSet = new Set<number>();
+  for (let i = 0; i < voxels.count; i++) {
+    voxelSet.add(cellKey(Math.round(footprintX(voxels, i) / pxMm), Math.round(footprintY(voxels, i) / pxMm)));
+  }
 
   // Classify into interior vs boundary
-  const classified = voxels.map((v) => {
-    const gx = Math.round(v.x / pxMm);
-    const gy = Math.round(v.y / pxMm);
+  const classified = Array.from({ length: voxels.count }, (_, i) => {
+    const vx = footprintX(voxels, i);
+    const vy = footprintY(voxels, i);
+    const gx = Math.round(vx / pxMm);
+    const gy = Math.round(vy / pxMm);
     let isInterior = true;
     for (let dx = -1; dx <= 1; dx++) {
       for (let dy = -1; dy <= 1; dy++) {
@@ -1389,7 +1404,7 @@ function computeContourMarkers(
       }
       if (!isInterior) break;
     }
-    return { x: v.x, y: v.y, isInterior, covered: false };
+    return { x: vx, y: vy, isInterior, covered: false };
   });
 
   // Build spatial grid with cell size = R_small for O(1) coverage marking
@@ -1594,9 +1609,12 @@ function buildIslandContactGrid(islands: DetectedIsland[]): SpatialHashGrid2D<Is
   const grid = new SpatialHashGrid2D<IslandGridEntry>(1.0);
   islands.forEach((island, islandIndex) => {
     const z = island.contact.z;
-    if (island.contactVoxels && island.contactVoxels.length > 0) {
-      for (const vox of island.contactVoxels) {
-        grid.insert(vox.x, vox.y, { islandIndex, x: vox.x, y: vox.y, z });
+    const footprint = island.contactVoxels;
+    if (footprint && footprint.count > 0) {
+      for (let i = 0; i < footprint.count; i++) {
+        const vx = footprintX(footprint, i);
+        const vy = footprintY(footprint, i);
+        grid.insert(vx, vy, { islandIndex, x: vx, y: vy, z });
       }
     } else {
       grid.insert(island.contact.x, island.contact.y, { islandIndex, x: island.contact.x, y: island.contact.y, z });

--- a/src/volumeAnalysis/Islands/useIslands.ts
+++ b/src/volumeAnalysis/Islands/useIslands.ts
@@ -1437,7 +1437,16 @@ function computeContourMarkers(
       }
       if (!isInterior) break;
     }
-    return { x: vx, y: vy, isInterior, covered: false };
+    return {
+      x: vx,
+      y: vy,
+      isInterior,
+      covered: false,
+      // Filled in with the bucket keys below, so marking a voxel covered can
+      // decrement the per-bucket tallies instead of forcing a rescan.
+      largeKey: 0,
+      smallKey: 0,
+    };
   });
 
   // Build spatial grid with cell size = R_small for O(1) coverage marking
@@ -1453,6 +1462,39 @@ function computeContourMarkers(
       grid.set(key, list);
     }
     list.push(v);
+  }
+
+  /**
+   * Uncovered voxels per placement bucket, kept current as coverage spreads.
+   *
+   * Choosing where to put the next marker means finding the bucket with the
+   * most uncovered voxels. Recomputing that by walking every voxel on every
+   * step cost up to forty-five full passes over the island — 11 seconds of
+   * frozen UI across a model's islands. Maintaining the tallies turns each
+   * step into a walk over buckets, of which there are orders of magnitude
+   * fewer.
+   */
+  const largeUncovered = new Map<number, number>();
+  const smallUncovered = new Map<number, number>();
+
+  function decrementBucket(tally: Map<number, number>, key: number): void {
+    const count = tally.get(key);
+    if (count === undefined) return;
+    if (count <= 1) tally.delete(key);
+    else tally.set(key, count - 1);
+  }
+
+  /** Bucket key with the highest tally, or null when everything is covered. */
+  function bestBucket(tally: Map<number, number>): { key: number; count: number } | null {
+    let bestKey: number | null = null;
+    let bestCount = 0;
+    for (const [key, count] of tally) {
+      if (count > bestCount) {
+        bestCount = count;
+        bestKey = key;
+      }
+    }
+    return bestKey === null ? null : { key: bestKey, count: bestCount };
   }
 
   // Helper to mark voxels as covered within a radius in O(1) time
@@ -1475,6 +1517,8 @@ function computeContourMarkers(
           if (dx * dx + dy * dy <= r2) {
             v.covered = true;
             newlyCovered++;
+            decrementBucket(largeUncovered, v.largeKey);
+            decrementBucket(smallUncovered, v.smallKey);
           }
         }
       }
@@ -1500,28 +1544,17 @@ function computeContourMarkers(
       largeGrid.set(key, list);
     }
     list.push(v);
+    v.largeKey = key;
+    largeUncovered.set(key, (largeUncovered.get(key) ?? 0) + 1);
   }
 
   for (let step = 0; step < maxLargeMarkers; step++) {
-    let bestKey: number | null = null;
-    let bestCount = 0;
-
-    for (const [key, list] of largeGrid.entries()) {
-      let count = 0;
-      for (const v of list) {
-        if (!v.covered) count++;
-      }
-      if (count > bestCount) {
-        bestCount = count;
-        bestKey = key;
-      }
-    }
-
-    if (bestCount === 0 || bestKey === null) {
+    const best = bestBucket(largeUncovered);
+    if (best === null) {
       break;
     }
 
-    const list = largeGrid.get(bestKey)!;
+    const list = largeGrid.get(best.key)!;
     let sumX = 0;
     let sumY = 0;
     let count = 0;
@@ -1565,29 +1598,22 @@ function computeContourMarkers(
       smallGrid.set(key, list);
     }
     list.push(v);
+    v.smallKey = key;
+    // Built after the large pass has already covered part of the island, so
+    // only voxels still uncovered may count towards the tally.
+    if (!v.covered) {
+      smallUncovered.set(key, (smallUncovered.get(key) ?? 0) + 1);
+    }
   }
 
   const maxSmallSteps = maxTotalMarkers - markers.length;
   for (let step = 0; step < maxSmallSteps; step++) {
-    let bestKey: number | null = null;
-    let bestCount = 0;
-
-    for (const [key, list] of smallGrid.entries()) {
-      let count = 0;
-      for (const v of list) {
-        if (!v.covered) count++;
-      }
-      if (count > bestCount) {
-        bestCount = count;
-        bestKey = key;
-      }
-    }
-
-    if (bestCount === 0 || bestKey === null) {
+    const best = bestBucket(smallUncovered);
+    if (best === null) {
       break;
     }
 
-    const list = smallGrid.get(bestKey)!;
+    const list = smallGrid.get(best.key)!;
     let sumX = 0;
     let sumY = 0;
     let count = 0;

--- a/src/volumeAnalysis/Islands/useIslands.ts
+++ b/src/volumeAnalysis/Islands/useIslands.ts
@@ -16,7 +16,7 @@ import { type DetectedIsland, type TipInfo, type OverhangRegion, SUPPORTED_RADIU
 import { classifyIntersection } from './intersection';
 import { getSnapshot } from '@/supports/state';
 import { getSettings } from '@/supports/Settings/state';
-import { SpatialHashGrid2D } from './spatialHashGrid2D';
+import { SpatialHashGrid2D, cellKey } from './spatialHashGrid2D';
 
 /** Self-support angle for mesh-normal overhang detection (surfaces flatter
  *  than this from horizontal get supports). Tunable per resin later. */
@@ -1327,8 +1327,11 @@ export function generateContourMarkers(
   const R_small2 = R_small * R_small;
   const R_large2 = R_large * R_large;
 
-  // Map voxels to a coordinate lookup Set for classification
-  const voxelSet = new Set(voxels.map((v) => `${Math.round(v.x / pxMm)},${Math.round(v.y / pxMm)}`));
+  // Map voxels to a coordinate lookup Set for classification. Numeric keys, not
+  // `"gx,gy"` strings: this Set is probed nine times per voxel just below, and
+  // each template literal would allocate a rope string destined straight for the
+  // garbage collector.
+  const voxelSet = new Set(voxels.map((v) => cellKey(Math.round(v.x / pxMm), Math.round(v.y / pxMm))));
 
   // Classify into interior vs boundary
   const classified = voxels.map((v) => {
@@ -1338,7 +1341,7 @@ export function generateContourMarkers(
     for (let dx = -1; dx <= 1; dx++) {
       for (let dy = -1; dy <= 1; dy++) {
         if (dx === 0 && dy === 0) continue;
-        if (!voxelSet.has(`${gx + dx},${gy + dy}`)) {
+        if (!voxelSet.has(cellKey(gx + dx, gy + dy))) {
           isInterior = false;
           break;
         }
@@ -1350,11 +1353,11 @@ export function generateContourMarkers(
 
   // Build spatial grid with cell size = R_small for O(1) coverage marking
   const cellSize = R_small;
-  const grid = new Map<string, typeof classified[number][]>();
+  const grid = new Map<number, typeof classified[number][]>();
   for (const v of classified) {
     const cx = Math.floor(v.x / cellSize);
     const cy = Math.floor(v.y / cellSize);
-    const key = `${cx},${cy}`;
+    const key = cellKey(cx, cy);
     let list = grid.get(key);
     if (!list) {
       list = [];
@@ -1374,8 +1377,7 @@ export function generateContourMarkers(
     let newlyCovered = 0;
     for (let cx = cxStart; cx <= cxEnd; cx++) {
       for (let cy = cyStart; cy <= cyEnd; cy++) {
-        const key = `${cx},${cy}`;
-        const list = grid.get(key);
+        const list = grid.get(cellKey(cx, cy));
         if (!list) continue;
         for (const v of list) {
           if (v.covered) continue;
@@ -1397,12 +1399,12 @@ export function generateContourMarkers(
   const maxLargeMarkers = 15;
 
   // Pass 1: Place large circles centered on uncovered interior voxels using large cells
-  const largeGrid = new Map<string, typeof classified[number][]>();
+  const largeGrid = new Map<number, typeof classified[number][]>();
   for (const v of classified) {
     if (!v.isInterior) continue;
     const cx = Math.floor(v.x / R_large);
     const cy = Math.floor(v.y / R_large);
-    const key = `${cx},${cy}`;
+    const key = cellKey(cx, cy);
     let list = largeGrid.get(key);
     if (!list) {
       list = [];
@@ -1412,7 +1414,7 @@ export function generateContourMarkers(
   }
 
   for (let step = 0; step < maxLargeMarkers; step++) {
-    let bestKey = '';
+    let bestKey: number | null = null;
     let bestCount = 0;
 
     for (const [key, list] of largeGrid.entries()) {
@@ -1426,7 +1428,7 @@ export function generateContourMarkers(
       }
     }
 
-    if (bestCount === 0 || bestKey === '') {
+    if (bestCount === 0 || bestKey === null) {
       break;
     }
 
@@ -1463,11 +1465,11 @@ export function generateContourMarkers(
   }
 
   // Pass 2: Place small circles centered on uncovered voxels using small cells
-  const smallGrid = new Map<string, typeof classified[number][]>();
+  const smallGrid = new Map<number, typeof classified[number][]>();
   for (const v of classified) {
     const cx = Math.floor(v.x / R_small);
     const cy = Math.floor(v.y / R_small);
-    const key = `${cx},${cy}`;
+    const key = cellKey(cx, cy);
     let list = smallGrid.get(key);
     if (!list) {
       list = [];
@@ -1478,7 +1480,7 @@ export function generateContourMarkers(
 
   const maxSmallSteps = maxTotalMarkers - markers.length;
   for (let step = 0; step < maxSmallSteps; step++) {
-    let bestKey = '';
+    let bestKey: number | null = null;
     let bestCount = 0;
 
     for (const [key, list] of smallGrid.entries()) {
@@ -1492,7 +1494,7 @@ export function generateContourMarkers(
       }
     }
 
-    if (bestCount === 0 || bestKey === '') {
+    if (bestCount === 0 || bestKey === null) {
       break;
     }
 

--- a/src/volumeAnalysis/Islands/voxelFootprint.ts
+++ b/src/volumeAnalysis/Islands/voxelFootprint.ts
@@ -1,0 +1,133 @@
+/**
+ * An island's contact footprint, stored as flat typed arrays.
+ *
+ * The natural shape is `{ x, y, z? }[]`, and that is what this replaced. On a
+ * tall model the island scan produces around ten million contact voxels, and
+ * one object per voxel put roughly a hundred million live objects on the JS
+ * heap — WebKit's own statistics at the moment it killed the process read
+ * `javascript_gc_object_count: 99,593,201` against a hard 16 GB ceiling for the
+ * content process.
+ *
+ * Two floats in a shared buffer cost eight bytes and nothing for the collector
+ * to trace. Coordinates are millimetres in world space, well inside the range
+ * where `Float32Array` keeps sub-micron precision.
+ */
+export interface VoxelFootprint {
+    /** Interleaved x, y pairs: voxel `i` is at `xy[i * 2]`, `xy[i * 2 + 1]`. */
+    readonly xy: Float32Array;
+    /** Per-voxel surface Z, or null when the detector produced none. */
+    readonly z: Float32Array | null;
+    /** Number of voxels, not the length of `xy`. */
+    readonly count: number;
+}
+
+export function footprintX(footprint: VoxelFootprint, index: number): number {
+    return footprint.xy[index * 2];
+}
+
+export function footprintY(footprint: VoxelFootprint, index: number): number {
+    return footprint.xy[index * 2 + 1];
+}
+
+/** Surface Z for a voxel, or null when this footprint carries no Z data. */
+export function footprintZ(footprint: VoxelFootprint, index: number): number | null {
+    return footprint.z ? footprint.z[index] : null;
+}
+
+export function isEmptyFootprint(footprint: VoxelFootprint | undefined): boolean {
+    return !footprint || footprint.count === 0;
+}
+
+/**
+ * Accumulates voxels when the count is not known up front.
+ *
+ * Grows geometrically like a plain array would, but over one buffer instead of
+ * one object per element.
+ */
+export class VoxelFootprintBuilder {
+    private xy: Float32Array;
+    private z: Float32Array | null;
+    private size = 0;
+
+    constructor(initialCapacity = 64, withZ = false) {
+        const capacity = Math.max(1, initialCapacity);
+        this.xy = new Float32Array(capacity * 2);
+        this.z = withZ ? new Float32Array(capacity) : null;
+    }
+
+    get count(): number {
+        return this.size;
+    }
+
+    push(x: number, y: number, z?: number): void {
+        if (this.size * 2 >= this.xy.length) this.grow();
+        this.xy[this.size * 2] = x;
+        this.xy[this.size * 2 + 1] = y;
+        if (this.z) this.z[this.size] = z ?? 0;
+        this.size++;
+    }
+
+    private grow(): void {
+        const nextCapacity = Math.max(1, this.xy.length);
+        const nextXy = new Float32Array(nextCapacity * 2);
+        nextXy.set(this.xy);
+        this.xy = nextXy;
+        if (this.z) {
+            const nextZ = new Float32Array(nextCapacity);
+            nextZ.set(this.z);
+            this.z = nextZ;
+        }
+    }
+
+    /** Trims to size. The builder must not be used afterwards. */
+    build(): VoxelFootprint {
+        return {
+            xy: this.xy.subarray(0, this.size * 2),
+            z: this.z ? this.z.subarray(0, this.size) : null,
+            count: this.size,
+        };
+    }
+}
+
+/** Builds a footprint from coordinate pairs, for tests and small call sites. */
+export function footprintFromPoints(points: Array<{ x: number; y: number; z?: number }>): VoxelFootprint {
+    const withZ = points.some((point) => point.z != null);
+    const builder = new VoxelFootprintBuilder(points.length, withZ);
+    for (const point of points) builder.push(point.x, point.y, point.z);
+    return builder.build();
+}
+
+/** Concatenates footprints; the result carries Z only if every input does. */
+export function concatFootprints(footprints: VoxelFootprint[]): VoxelFootprint {
+    const total = footprints.reduce((sum, f) => sum + f.count, 0);
+    const withZ = footprints.length > 0 && footprints.every((f) => f.z !== null);
+    const xy = new Float32Array(total * 2);
+    const z = withZ ? new Float32Array(total) : null;
+
+    let offset = 0;
+    for (const footprint of footprints) {
+        xy.set(footprint.xy.subarray(0, footprint.count * 2), offset * 2);
+        if (z && footprint.z) z.set(footprint.z.subarray(0, footprint.count), offset);
+        offset += footprint.count;
+    }
+    return { xy, z, count: total };
+}
+
+/**
+ * Materialises a footprint as point objects.
+ *
+ * For the transient boundary with algorithms that want `{ x, y, z? }` — the
+ * auto-support placement helpers, which are unit-tested against plain arrays
+ * and whose output lives only for the duration of a placement run. Never store
+ * the result on an island: the packed form exists precisely so that millions of
+ * voxels are not millions of objects.
+ */
+export function footprintToPoints(footprint: VoxelFootprint): Array<{ x: number; y: number; z?: number }> {
+    const points: Array<{ x: number; y: number; z?: number }> = new Array(footprint.count);
+    for (let i = 0; i < footprint.count; i++) {
+        points[i] = footprint.z
+            ? { x: footprint.xy[i * 2], y: footprint.xy[i * 2 + 1], z: footprint.z[i] }
+            : { x: footprint.xy[i * 2], y: footprint.xy[i * 2 + 1] };
+    }
+    return points;
+}

--- a/src/volumeAnalysis/islandVolume/steps/voxelization/rle.ts
+++ b/src/volumeAnalysis/islandVolume/steps/voxelization/rle.ts
@@ -4,6 +4,9 @@ import { ComponentInfo } from './types';
 // Represents a single row of binary data.
 export type RleRow = Int32Array;
 
+/** See the note on the same constant in `IslandScan/rle.ts`. */
+export const EMPTY_ROW: RleRow = new Int32Array(0);
+
 // RLE Mask: Array of rows
 export type RleMask = {
     rows: RleRow[];
@@ -44,7 +47,7 @@ export function rleEncode(data: Uint8Array, width: number, height: number): RleM
         if (runStart !== -1) {
             rowSpans.push(runStart, width - runStart);
         }
-        rows[y] = new Int32Array(rowSpans);
+        rows[y] = rowSpans.length === 0 ? EMPTY_ROW : new Int32Array(rowSpans);
     }
 
     return { rows, width, height };
@@ -88,7 +91,7 @@ export function rleEncodeLabels(data: Int32Array | Uint8Array, width: number, he
             rowSpans.push(runStart, width - runStart, currentId);
         }
 
-        rows[y] = new Int32Array(rowSpans);
+        rows[y] = rowSpans.length === 0 ? EMPTY_ROW : new Int32Array(rowSpans);
     }
 
     return { rows, width, height };
@@ -131,7 +134,7 @@ export function rleIntersectDilated(a: RleMask, b: RleMask, buffer: number): Rle
     for (let y = 0; y < height; y++) {
         const aRow = a.rows[y];
         if (aRow.length === 0) {
-            resultRows[y] = new Int32Array(0);
+            resultRows[y] = EMPTY_ROW;
             continue;
         }
 
@@ -151,7 +154,7 @@ export function rleIntersectDilated(a: RleMask, b: RleMask, buffer: number): Rle
         }
 
         if (relevantBRows.length === 0) {
-            resultRows[y] = new Int32Array(0);
+            resultRows[y] = EMPTY_ROW;
             continue;
         }
 
@@ -238,7 +241,7 @@ export function rleSubtract(a: RleMask, b: RleMask): RleMask {
         const bRow = b.rows[y];
 
         if (aRow.length === 0) {
-            resultRows[y] = new Int32Array(0);
+            resultRows[y] = EMPTY_ROW;
             continue;
         }
         if (bRow.length === 0) {


### PR DESCRIPTION
The Islands analysis could take the WebKit content process to 27 GB and get it
killed against WebKit's hard 16 GB ceiling: the effect is a grey window with nothing
to explain it. Nothing leaked; the peak alone was fatal, and every structure
involved was written the idiomatic way. See ADR-0039 for why the shapes below
are load-bearing rather than stylistic.

**Measured on a 5292-layer scan of a 3647×1814 grid (10.3M candidate voxels):**

| | before | after |
|---|---|---|
| Peak footprint (sampled continuously) | 14.0 GB (27 GB at the crash) | **5.1 GB** |
| Live JS objects at peak | 99,593,201 | **~11,000,000** |
| Live RLE row arrays | 9,599,688 | **32,304** |
| Total scan | ~1:13 | **~0:45** |
| UI frozen during the scan | most of it | none |

### Memory: voxels live in buffers, not in objects
* Contact footprints are interleaved `Float32Array`s behind accessors, not
  `{ x, y }[]` — one object per voxel was most of those 99M objects.
* Empty RLE rows all share one array. A 1814-row layer over 5292 layers was
  allocating 9.6M typed arrays to hold half a megabyte between them.
* The 3D flood fill consumes its candidate set instead of keeping a second
  `Set` of the same ten million boxed numbers beside it. Claiming a neighbour
  went from three hash lookups to one.
* Grid coordinates are read with accessors instead of `unpack`, which returned
  a fresh object: about 30M throwaway objects per scan to carry three numbers.
* The per-layer RLE is released before the flood fill instead of staying
  reachable until the function returns.

### Strings out of the hot paths
* Spatial hash cells are keyed by number, folded as `(cx + 2^20) * 2^21 + cy`,
  not `"cx,cy"`. Sampling showed roughly a third of the scan in GC, sweeping
  the rope strings built as map keys.  Previously we were **trashing** the GC.
* Same for the contour classification set and the dilation grids.

### Things recomputed for no reason
* The contact-voxel grid depends on the islands, not the support tips, so it is
  built once per scan instead of on every support placement — that alone was a
  12+-second freeze after each click.
* Contours are cached by voxel-array identity, so toggling a checkbox no longer
  re-contours every island.
* Contour placement keeps per-bucket tallies instead of rescanning every voxel
  to pick each marker site, up to 45 full passes per island. `islandMarkers`
  went from 11.1 s to 5.0 s.

### The UI stops freezing
* The post-scan passes yield every 64 layers and report which phase is running.
  They are inherently sequential, so they cannot be parallelized, but they no
  longer hold the main thread for tens of seconds in silence.
* Yielding goes through a `MessageChannel`, not `setTimeout`: WebKit throttles
  timers to ~1 Hz in a background window, which turned 80 yields into 80
  seconds whenever the user switched away.
* Progress reporting is throttled independently of yielding. Every report is a
  state update that re-renders a tree with the 3D scene in it; reporting on
  every yield had added ~20 s to a 40-second scan.

### Progress reporting
* The panel's button no longer duplicates the modal's numbers from behind a
  full-screen blur: it just reads `Scanning…` and is disabled.
* Both modals get a determinate bar: which pass is running out of how many, a
  percentage and the counts, instead of an indeterminate stripe.
* The phase count travels with each report rather than being hard-coded: the
  Islands panel has three phases and the Analysis tab has four.

### Diagnostics left behind
The scan writes its phases to `dragonfruit.log`, and any post-scan step over
150 ms logs its duration. That is what found `islandMarkers` after a lot of
guessing, and it costs two `performance.now()` calls when nothing is wrong.
`docs/dev/performance-debugging.md` covers how to read it.