### PR TITLE
Make model and support actions operate on selection sets

### DIFF
--- a/docs/dev/history-and-undo-redo.md
+++ b/docs/dev/history-and-undo-redo.md
@@ -117,6 +117,44 @@ this is the **stranded-stack hazard** (see below).
 
 ## Payload shapes
 
+### Live scene transform batches
+
+`useSceneCollectionManager` normally pushes one scene snapshot whenever
+`updateModelTransforms` runs. Controls that emit multiple live updates during a
+single gesture may pass `{ pushHistory: false }`, capture the original model and
+support transforms before the first update, and call
+`commitModelTransformsHistory` once when the gesture ends.
+
+```ts
+const beforeTransforms = scene.models.map(({ id, transform }) => ({
+  id,
+  transform: {
+    position: transform.position.clone(),
+    rotation: transform.rotation.clone(),
+    scale: transform.scale.clone(),
+  },
+}));
+const supportBefore = captureTransformSupportSnapshot();
+
+scene.updateModelTransforms(liveUpdates, { pushHistory: false });
+
+const supportAfter = captureTransformSupportSnapshot();
+scene.commitModelTransformsHistory(beforeTransforms, 'Move Selected Models', {
+  includeSupportState: true,
+  supportBefore: supportBefore.support,
+  supportAfter: supportAfter.support,
+  kickstandBefore: supportBefore.kickstand,
+  kickstandAfter: supportAfter.kickstand,
+});
+```
+
+Transient updates are intentionally absent from undo history. The gesture-end
+commit records the original and final states as the one reversible action.
+Attached support and kickstand snapshots must cover that same before/after
+gesture so undo restores the complete selection atomically. Capture every model
+that the gesture may move, including linked peers; models omitted from
+`beforeTransforms` cannot be restored by the resulting entry.
+
 Three payload patterns exist:
 
 - **Inline state** — the common case for supports: the payload carries the full

--- a/docs/dev/support-system.md
+++ b/docs/dev/support-system.md
@@ -33,6 +33,22 @@ The vocabulary — and the distinctions people get wrong, like knot versus joint
 
 **Cascades are one history action.** Deleting a trunk rehosts or removes its dependents; that whole cascade is a single entry with before/after state, so undo restores a consistent graph rather than half of one. See [History and Undo/Redo](history-and-undo-redo.md).
 
+## Multi-support settings
+
+`applySettingsToSelectedSupports` in
+`src/supports/Settings/applySettingsToSelectedSupports.ts` is the mutation path
+for editing settings when one or more supports are selected. It reads the
+current support selection, resolves every selected support to its editable
+target, and batches all store mutations into one notification. When no
+multi-selection exists, it falls back to the primary selected support.
+
+The settings sidebar shows the last selected support's values. Changing a value
+applies those settings to the complete selection. The sidebar captures one
+before/after support edit snapshot around the editing session, so undo restores
+the whole selection in one step. Selection controllers must therefore keep a
+primary selected support alongside the selected-ID set; clearing the primary
+representative makes the sidebar non-editable even when IDs remain selected.
+
 ## Placing supports
 
 - By hand: modifier keys choose the family, the first click's target chooses the type — [Support Placement Modifiers](../reference/support-placement-modifiers.md).

--- a/docs/dev/support-system.md
+++ b/docs/dev/support-system.md
@@ -49,9 +49,10 @@ the whole selection in one step. Selection controllers must therefore keep a
 primary selected support alongside the selected-ID set; clearing the primary
 representative makes the sidebar non-editable even when IDs remain selected.
 Shift-click toggles one support without disturbing the rest of the set. Detailed
-primitive renderers must let Shift-click bubble to the parent support instead
-of selecting a shaft, joint, knot, or contact cone and clearing support
-multi-selection.
+primitive renderers must defer to the parent support while a multi-selection is
+active: a normal click replaces the set with that support, while Shift-click
+toggles only that support. Selecting a shaft, joint, knot, or contact cone in
+either case would clear the support selection set.
 
 ## Placing supports
 

--- a/docs/dev/support-system.md
+++ b/docs/dev/support-system.md
@@ -48,6 +48,10 @@ before/after support edit snapshot around the editing session, so undo restores
 the whole selection in one step. Selection controllers must therefore keep a
 primary selected support alongside the selected-ID set; clearing the primary
 representative makes the sidebar non-editable even when IDs remain selected.
+Shift-click toggles one support without disturbing the rest of the set. Detailed
+primitive renderers must let Shift-click bubble to the parent support instead
+of selecting a shaft, joint, knot, or contact cone and clearing support
+multi-selection.
 
 ## Placing supports
 

--- a/docs/workflows/place-on-face-and-mirror.md
+++ b/docs/workflows/place-on-face-and-mirror.md
@@ -25,6 +25,8 @@ Use **On-Face** and **Mirror** in Prepare mode for fast orientation and symmetry
 
 ### Behavior notes
 
+- Mirror operates on one model. Entering Mirror with multiple models selected
+	keeps only the last model pressed selected.
 - Mirror uses a preview/session flow and then finalizes geometry when leaving the tool.
 - Z-axis mirror may require destructive-operation confirmation if supports are present.
 - Finalization updates model geometry and transform state together.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -78,6 +78,10 @@ import {
   resolveModelActionTargetIds,
 } from '@/features/scene/modelActionTargets';
 import { buildLiftDropUpdates } from '@/features/scene/selectionLiftDrop';
+import {
+  buildCenterSelectionUpdates,
+  buildSelectionPositionUpdates,
+} from '@/features/scene/selectionPosition';
 import { HollowingPanel, type HollowingPanelState } from '../features/hollowing';
 import { HolePunchPanel, type HolePunchPanelState } from '../features/hole-punching/HolePunchPanel';
 import { PlaceOnFaceTool } from '@/features/placeOnFace/PlaceOnFaceTool';
@@ -8523,6 +8527,63 @@ export default function Home() {
     transformMgr.setAutoLift(enabled);
   }, [scene, transformMgr]);
 
+  const applySelectionPositionUpdates = React.useCallback((updates: Array<{ id: string; transform: ModelTransform }>) => {
+    if (updates.length === 0) return;
+
+    invalidatePendingTransformHistory();
+    const result = scene.updateModelTransforms(updates);
+    if (!result.updated) return;
+
+    const activeUpdate = scene.activeModelId
+      ? updates.find((update) => update.id === scene.activeModelId)
+      : undefined;
+    if (activeUpdate) {
+      suppressTransformPersistenceCycles();
+      const { position, rotation, scale } = activeUpdate.transform;
+      transformMgr.transformHook.setPosition(position.x, position.y, position.z);
+      transformMgr.transformHook.setRotation(rotation.x, rotation.y, rotation.z);
+      transformMgr.transformHook.setScale(scale.x, scale.y, scale.z);
+    }
+
+    setSupportRenderRefreshNonce((value) => value + 1);
+  }, [invalidatePendingTransformHistory, scene, suppressTransformPersistenceCycles, transformMgr.transformHook]);
+
+  const handlePositionSelectedModels = React.useCallback((x: number, y: number, z: number) => {
+    if (!scene.activeModelId) return;
+
+    const targetIds = resolveModelActionTargetIds({
+      modelIds: scene.models.map((model) => model.id),
+      selectedModelIds: scene.selectedModelIds,
+      activeModelId: scene.activeModelId,
+    });
+    applySelectionPositionUpdates(buildSelectionPositionUpdates(
+      scene.models,
+      targetIds,
+      scene.activeModelId,
+      new THREE.Vector3(x, y, z),
+    ));
+  }, [applySelectionPositionUpdates, scene.activeModelId, scene.models, scene.selectedModelIds]);
+
+  const handleCenterSelectedModels = React.useCallback(() => {
+    const targetIds = resolveModelActionTargetIds({
+      modelIds: scene.models.map((model) => model.id),
+      selectedModelIds: scene.selectedModelIds,
+      activeModelId: scene.activeModelId,
+    });
+    const targetCenter = scene.view3dSettings.originMode === 'front_left'
+      ? new THREE.Vector2(scene.view3dSettings.widthMm * 0.5, scene.view3dSettings.depthMm * 0.5)
+      : new THREE.Vector2(0, 0);
+    applySelectionPositionUpdates(buildCenterSelectionUpdates(scene.models, targetIds, targetCenter));
+  }, [
+    applySelectionPositionUpdates,
+    scene.activeModelId,
+    scene.models,
+    scene.selectedModelIds,
+    scene.view3dSettings.depthMm,
+    scene.view3dSettings.originMode,
+    scene.view3dSettings.widthMm,
+  ]);
+
   const placeSelectedModelsAtWorldZ = React.useCallback((targetLowestWorldZ: number) => {
     const targetIds = resolveModelActionTargetIds({
       modelIds: scene.models.map((model) => model.id),
@@ -9887,6 +9948,8 @@ export default function Home() {
               requestDestructiveTransformSupportDeletion: requestDestructiveTransformSupportDeletion,
               handleRotationComplete: handleRotationComplete,
               handleAutoLiftChange: handleAutoLiftChange,
+              handlePositionSelectedModels: handlePositionSelectedModels,
+              handleCenterSelectedModels: handleCenterSelectedModels,
               handleLiftSelectedModels: handleLiftSelectedModels,
               handleDropSelectedModels: handleDropSelectedModels,
               scheduleCommitPendingTransformHistory: scheduleCommitPendingTransformHistory,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,6 +73,7 @@ import { SliceMetricsDebugModal } from '@/features/slicing/components/SliceMetri
 import { MeshSmoothingSettingsPanel } from '@/features/mesh-smoothing/MeshSmoothingSettingsPanel';
 import { MeshSmoothingBrushCursor } from '@/features/mesh-smoothing/MeshSmoothingBrushCursor';
 import {
+  dispatchCutModelAction,
   dispatchDeleteModelAction,
   resolveModelActionTargetIds,
 } from '@/features/scene/modelActionTargets';
@@ -5953,9 +5954,11 @@ export default function Home() {
         }
         break;
       case 'cut':
-        if (scene.activeModelId) {
-          scene.cutModel(scene.activeModelId);
-        }
+        dispatchCutModelAction({
+          modelIds: scene.models.map((model) => model.id),
+          selectedModelIds: scene.selectedModelIds,
+          activeModelId: scene.activeModelId,
+        }, scene.cutSelectedModels);
         break;
       case 'paste': {
         const pastedIds = scene.pasteCopiedModelsAutoArrange(arrangeSpacingMm);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -81,6 +81,7 @@ import { buildLiftDropUpdates } from '@/features/scene/selectionLiftDrop';
 import {
   buildCenterSelectionUpdates,
   buildSelectionPositionUpdates,
+  getSelectionPositionOrigin,
 } from '@/features/scene/selectionPosition';
 import { HollowingPanel, type HollowingPanelState } from '../features/hollowing';
 import { HolePunchPanel, type HolePunchPanelState } from '../features/hole-punching/HolePunchPanel';
@@ -795,6 +796,12 @@ export default function Home() {
     supportAfter?: ReturnType<typeof getSupportSnapshot>;
     kickstandBefore?: ReturnType<typeof getKickstandSnapshot>;
     kickstandAfter?: ReturnType<typeof getKickstandSnapshot>;
+  } | null>(null);
+  const pendingSelectionPositionHistoryRef = React.useRef<{
+    targetIdsKey: string;
+    beforeTransforms: Array<{ id: string; transform: ModelTransform }>;
+    supportBefore: ReturnType<typeof getSupportSnapshot>;
+    kickstandBefore: ReturnType<typeof getKickstandSnapshot>;
   } | null>(null);
   const transformHistoryCommitRequestedRef = React.useRef(false);
   const transformHistoryCommitNonceRef = React.useRef(0);
@@ -8527,11 +8534,33 @@ export default function Home() {
     transformMgr.setAutoLift(enabled);
   }, [scene, transformMgr]);
 
-  const applySelectionPositionUpdates = React.useCallback((updates: Array<{ id: string; transform: ModelTransform }>) => {
+  const commitPendingSelectionPositionHistory = React.useCallback(() => {
+    const pending = pendingSelectionPositionHistoryRef.current;
+    if (!pending) return;
+
+    pendingSelectionPositionHistoryRef.current = null;
+    const afterSupportSnapshot = captureTransformSupportSnapshot();
+    scene.commitModelTransformsHistory(
+      pending.beforeTransforms,
+      'Move Selected Models',
+      {
+        includeSupportState: true,
+        supportBefore: pending.supportBefore,
+        supportAfter: afterSupportSnapshot.support,
+        kickstandBefore: pending.kickstandBefore,
+        kickstandAfter: afterSupportSnapshot.kickstand,
+      },
+    );
+  }, [captureTransformSupportSnapshot, scene]);
+
+  const applySelectionPositionUpdates = React.useCallback((
+    updates: Array<{ id: string; transform: ModelTransform }>,
+    options?: { pushHistory?: boolean },
+  ) => {
     if (updates.length === 0) return;
 
-    invalidatePendingTransformHistory();
-    const result = scene.updateModelTransforms(updates);
+    if (options?.pushHistory !== false) invalidatePendingTransformHistory();
+    const result = scene.updateModelTransforms(updates, options);
     if (!result.updated) return;
 
     const activeUpdate = scene.activeModelId
@@ -8549,20 +8578,62 @@ export default function Home() {
   }, [invalidatePendingTransformHistory, scene, suppressTransformPersistenceCycles, transformMgr.transformHook]);
 
   const handlePositionSelectedModels = React.useCallback((x: number, y: number, z: number) => {
-    if (!scene.activeModelId) return;
-
     const targetIds = resolveModelActionTargetIds({
       modelIds: scene.models.map((model) => model.id),
       selectedModelIds: scene.selectedModelIds,
       activeModelId: scene.activeModelId,
     });
+    if (targetIds.length === 0) return;
+
+    const targetIdsKey = targetIds.join('\0');
+    if (
+      pendingSelectionPositionHistoryRef.current
+      && pendingSelectionPositionHistoryRef.current.targetIdsKey !== targetIdsKey
+    ) {
+      commitPendingSelectionPositionHistory();
+    }
+    if (!pendingSelectionPositionHistoryRef.current) {
+      invalidatePendingTransformHistory();
+      const beforeSupportSnapshot = captureTransformSupportSnapshot();
+      pendingSelectionPositionHistoryRef.current = {
+        targetIdsKey,
+        beforeTransforms: scene.models.map((model) => ({
+          id: model.id,
+          transform: {
+            position: model.transform.position.clone(),
+            rotation: model.transform.rotation.clone(),
+            scale: model.transform.scale.clone(),
+          },
+        })),
+        supportBefore: beforeSupportSnapshot.support,
+        kickstandBefore: beforeSupportSnapshot.kickstand,
+      };
+    }
+
     applySelectionPositionUpdates(buildSelectionPositionUpdates(
       scene.models,
       targetIds,
-      scene.activeModelId,
       new THREE.Vector3(x, y, z),
-    ));
-  }, [applySelectionPositionUpdates, scene.activeModelId, scene.models, scene.selectedModelIds]);
+    ), { pushHistory: false });
+  }, [
+    applySelectionPositionUpdates,
+    captureTransformSupportSnapshot,
+    commitPendingSelectionPositionHistory,
+    invalidatePendingTransformHistory,
+    scene.activeModelId,
+    scene.models,
+    scene.selectedModelIds,
+  ]);
+
+  const selectionPositionOrigin = React.useMemo(() => {
+    const targetIds = resolveModelActionTargetIds({
+      modelIds: scene.models.map((model) => model.id),
+      selectedModelIds: scene.selectedModelIds,
+      activeModelId: scene.activeModelId,
+    });
+    return getSelectionPositionOrigin(scene.models, targetIds)
+      ?? transformMgr.transform.position;
+  }, [scene.activeModelId, scene.models, scene.selectedModelIds, transformMgr.transform.position]);
 
   const handleCenterSelectedModels = React.useCallback(() => {
     const targetIds = resolveModelActionTargetIds({
@@ -9948,7 +10019,9 @@ export default function Home() {
               requestDestructiveTransformSupportDeletion: requestDestructiveTransformSupportDeletion,
               handleRotationComplete: handleRotationComplete,
               handleAutoLiftChange: handleAutoLiftChange,
+              selectionPositionOrigin: selectionPositionOrigin,
               handlePositionSelectedModels: handlePositionSelectedModels,
+              commitPendingSelectionPositionHistory: commitPendingSelectionPositionHistory,
               handleCenterSelectedModels: handleCenterSelectedModels,
               handleLiftSelectedModels: handleLiftSelectedModels,
               handleDropSelectedModels: handleDropSelectedModels,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7918,6 +7918,17 @@ export default function Home() {
   }, [scene.mode, transformMgr.transformMode, scene.models, scene.activeModelId, scene.selectedModelIds, scene.selectModel]);
 
   React.useEffect(() => {
+    if (scene.mode !== 'prepare') return;
+    if (transformMgr.transformMode !== 'mirror') return;
+    if (!scene.activeModelId) return;
+    if (
+      scene.selectedModelIds.length === 1
+      && scene.selectedModelIds[0] === scene.activeModelId
+    ) return;
+    scene.selectModel(scene.activeModelId, 'single');
+  }, [scene.mode, transformMgr.transformMode, scene.activeModelId, scene.selectedModelIds, scene.selectModel]);
+
+  React.useEffect(() => {
     if (!hasActivePrinterProfile) return;
     if (!allowPrepareWithoutPrinter) return;
     setAllowPrepareWithoutPrinter(false);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -72,6 +72,10 @@ import { ScanProgressBar } from '@/components/scene/ScanProgressBar';
 import { SliceMetricsDebugModal } from '@/features/slicing/components/SliceMetricsDebugModal';
 import { MeshSmoothingSettingsPanel } from '@/features/mesh-smoothing/MeshSmoothingSettingsPanel';
 import { MeshSmoothingBrushCursor } from '@/features/mesh-smoothing/MeshSmoothingBrushCursor';
+import {
+  dispatchDeleteModelAction,
+  resolveModelActionTargetIds,
+} from '@/features/scene/modelActionTargets';
 import { HollowingPanel, type HollowingPanelState } from '../features/hollowing';
 import { HolePunchPanel, type HolePunchPanelState } from '../features/hole-punching/HolePunchPanel';
 import { PlaceOnFaceTool } from '@/features/placeOnFace/PlaceOnFaceTool';
@@ -2233,7 +2237,11 @@ export default function Home() {
     const canSplitSupports = !!activeModel?.geometry.meshDefects?.nativeRepairReport?.model_triangle_count;
     const canMergeSupports = scene.selectedModelIds.length === 2;
 
-    const hasTargetModel = !!scene.activeModelId || scene.selectedModelIds.length > 0;
+    const hasTargetModel = resolveModelActionTargetIds({
+      modelIds: scene.models.map((model) => model.id),
+      selectedModelIds: scene.selectedModelIds,
+      activeModelId: scene.activeModelId,
+    }).length > 0;
     const canLink = scene.selectedModelIds.length >= 2;
     const selectedOrActiveModels = scene.selectedModelIds.length > 0
       ? scene.models.filter((m) => scene.selectedModelIds.includes(m.id))
@@ -2241,7 +2249,8 @@ export default function Home() {
     const canUnlink = selectedOrActiveModels.some((m) => !!m.linkGroupId);
 
     return [
-      ...(!scene.activeModelId ? (['delete', 'cut', 'copy', 'repair'] as const) : []),
+      ...(!hasTargetModel ? (['delete'] as const) : []),
+      ...(!scene.activeModelId ? (['cut', 'copy', 'repair'] as const) : []),
       ...(!hasTargetModel ? (['mark-as-support-geometry', 'mark-as-model-geometry'] as const) : []),
       ...(!canLink ? (['link-models'] as const) : []),
       ...(!canUnlink ? (['unlink-models'] as const) : []),
@@ -5930,9 +5939,11 @@ export default function Home() {
         return;
       }
       case 'delete':
-        if (scene.activeModelId) {
-          scene.deleteModel(scene.activeModelId);
-        }
+        dispatchDeleteModelAction({
+          modelIds: scene.models.map((model) => model.id),
+          selectedModelIds: scene.selectedModelIds,
+          activeModelId: scene.activeModelId,
+        }, scene.deleteModels);
         break;
       case 'copy':
         if (scene.selectedModelIds.length > 0) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,6 +77,7 @@ import {
   dispatchDeleteModelAction,
   resolveModelActionTargetIds,
 } from '@/features/scene/modelActionTargets';
+import { buildLiftDropUpdates } from '@/features/scene/selectionLiftDrop';
 import { HollowingPanel, type HollowingPanelState } from '../features/hollowing';
 import { HolePunchPanel, type HolePunchPanelState } from '../features/hole-punching/HolePunchPanel';
 import { PlaceOnFaceTool } from '@/features/placeOnFace/PlaceOnFaceTool';
@@ -8522,6 +8523,41 @@ export default function Home() {
     transformMgr.setAutoLift(enabled);
   }, [scene, transformMgr]);
 
+  const placeSelectedModelsAtWorldZ = React.useCallback((targetLowestWorldZ: number) => {
+    const targetIds = resolveModelActionTargetIds({
+      modelIds: scene.models.map((model) => model.id),
+      selectedModelIds: scene.selectedModelIds,
+      activeModelId: scene.activeModelId,
+    });
+    const updates = buildLiftDropUpdates(scene.models, targetIds, targetLowestWorldZ);
+    if (updates.length === 0) return;
+
+    invalidatePendingTransformHistory();
+    const result = scene.updateModelTransforms(updates);
+    if (!result.updated) return;
+
+    const activeUpdate = scene.activeModelId
+      ? updates.find((update) => update.id === scene.activeModelId)
+      : undefined;
+    if (activeUpdate) {
+      suppressTransformPersistenceCycles();
+      const { position, rotation, scale } = activeUpdate.transform;
+      transformMgr.transformHook.setPosition(position.x, position.y, position.z);
+      transformMgr.transformHook.setRotation(rotation.x, rotation.y, rotation.z);
+      transformMgr.transformHook.setScale(scale.x, scale.y, scale.z);
+    }
+
+    setSupportRenderRefreshNonce((value) => value + 1);
+  }, [invalidatePendingTransformHistory, scene, suppressTransformPersistenceCycles, transformMgr.transformHook]);
+
+  const handleLiftSelectedModels = React.useCallback(() => {
+    placeSelectedModelsAtWorldZ(transformMgr.liftDistance);
+  }, [placeSelectedModelsAtWorldZ, transformMgr.liftDistance]);
+
+  const handleDropSelectedModels = React.useCallback(() => {
+    placeSelectedModelsAtWorldZ(0);
+  }, [placeSelectedModelsAtWorldZ]);
+
   const disableAutoLiftForManualZMove = React.useCallback(() => {
     if (!scene.activeModelId) return;
     scene.setModelManualZMoveOverride(scene.activeModelId, true);
@@ -9851,6 +9887,8 @@ export default function Home() {
               requestDestructiveTransformSupportDeletion: requestDestructiveTransformSupportDeletion,
               handleRotationComplete: handleRotationComplete,
               handleAutoLiftChange: handleAutoLiftChange,
+              handleLiftSelectedModels: handleLiftSelectedModels,
+              handleDropSelectedModels: handleDropSelectedModels,
               scheduleCommitPendingTransformHistory: scheduleCommitPendingTransformHistory,
               uniformScaling: uniformScaling,
               setUniformScaling: setUniformScaling,

--- a/src/components/controls/TransformControls.tsx
+++ b/src/components/controls/TransformControls.tsx
@@ -21,7 +21,7 @@ interface TransformControlsProps {
   // Position
   position: THREE.Vector3;
   onPositionChange: (x: number, y: number, z: number) => void;
-  deferPositionChanges?: boolean;
+  onPositionCommit?: () => void;
   onCenter: () => void;
   onPlatform: (bbox: THREE.Box3) => void;
   
@@ -58,7 +58,7 @@ interface TransformControlsProps {
 export function TransformControls({
   position,
   onPositionChange,
-  deferPositionChanges = false,
+  onPositionCommit,
   onCenter,
   onPlatform,
   rotation,
@@ -169,10 +169,10 @@ export function TransformControls({
     onPositionChange(newPos.x, newPos.y, newPos.z);
   };
 
-  const handlePositionBlur = (axis: 'x' | 'y' | 'z', event: React.FocusEvent<HTMLInputElement>) => {
-    if (deferPositionChanges) {
-      const value = Number.parseFloat(event.currentTarget.value);
-      if (Number.isFinite(value)) handlePositionChange(axis, value);
+  const handlePositionBlur = () => {
+    if (onPositionCommit) {
+      onPositionCommit();
+      return;
     }
     onTransformCommit?.();
   };
@@ -238,10 +238,8 @@ export function TransformControls({
                     <div className="relative">
                       <NumberInput
                         value={parseFloat(position.x.toFixed(2))}
-                        onChange={(val) => {
-                          if (!deferPositionChanges) handlePositionChange('x', val);
-                        }}
-                        onBlur={(event) => handlePositionBlur('x', event)}
+                        onChange={(val) => handlePositionChange('x', val)}
+                        onBlur={handlePositionBlur}
                         className={valueInputClass}
                         showStepper={false}
                       />
@@ -253,10 +251,8 @@ export function TransformControls({
                     <div className="relative">
                       <NumberInput
                         value={parseFloat(position.y.toFixed(2))}
-                        onChange={(val) => {
-                          if (!deferPositionChanges) handlePositionChange('y', val);
-                        }}
-                        onBlur={(event) => handlePositionBlur('y', event)}
+                        onChange={(val) => handlePositionChange('y', val)}
+                        onBlur={handlePositionBlur}
                         className={valueInputClass}
                         showStepper={false}
                       />
@@ -268,10 +264,8 @@ export function TransformControls({
                     <div className="relative">
                       <NumberInput
                         value={parseFloat(position.z.toFixed(2))}
-                        onChange={(val) => {
-                          if (!deferPositionChanges) handlePositionChange('z', val);
-                        }}
-                        onBlur={(event) => handlePositionBlur('z', event)}
+                        onChange={(val) => handlePositionChange('z', val)}
+                        onBlur={handlePositionBlur}
                         className={valueInputClass}
                         showStepper={false}
                       />

--- a/src/components/controls/TransformControls.tsx
+++ b/src/components/controls/TransformControls.tsx
@@ -21,6 +21,7 @@ interface TransformControlsProps {
   // Position
   position: THREE.Vector3;
   onPositionChange: (x: number, y: number, z: number) => void;
+  deferPositionChanges?: boolean;
   onCenter: () => void;
   onPlatform: (bbox: THREE.Box3) => void;
   
@@ -57,6 +58,7 @@ interface TransformControlsProps {
 export function TransformControls({
   position,
   onPositionChange,
+  deferPositionChanges = false,
   onCenter,
   onPlatform,
   rotation,
@@ -167,6 +169,14 @@ export function TransformControls({
     onPositionChange(newPos.x, newPos.y, newPos.z);
   };
 
+  const handlePositionBlur = (axis: 'x' | 'y' | 'z', event: React.FocusEvent<HTMLInputElement>) => {
+    if (deferPositionChanges) {
+      const value = Number.parseFloat(event.currentTarget.value);
+      if (Number.isFinite(value)) handlePositionChange(axis, value);
+    }
+    onTransformCommit?.();
+  };
+
   // Rotation handlers
   const handleRotationChange = (axis: 'x' | 'y' | 'z', value: number) => {
     const radians = toRadians(wrapRotationDegrees(value));
@@ -228,8 +238,10 @@ export function TransformControls({
                     <div className="relative">
                       <NumberInput
                         value={parseFloat(position.x.toFixed(2))}
-                        onChange={(val) => handlePositionChange('x', val)}
-                        onBlur={() => onTransformCommit?.()}
+                        onChange={(val) => {
+                          if (!deferPositionChanges) handlePositionChange('x', val);
+                        }}
+                        onBlur={(event) => handlePositionBlur('x', event)}
                         className={valueInputClass}
                         showStepper={false}
                       />
@@ -241,8 +253,10 @@ export function TransformControls({
                     <div className="relative">
                       <NumberInput
                         value={parseFloat(position.y.toFixed(2))}
-                        onChange={(val) => handlePositionChange('y', val)}
-                        onBlur={() => onTransformCommit?.()}
+                        onChange={(val) => {
+                          if (!deferPositionChanges) handlePositionChange('y', val);
+                        }}
+                        onBlur={(event) => handlePositionBlur('y', event)}
                         className={valueInputClass}
                         showStepper={false}
                       />
@@ -254,8 +268,10 @@ export function TransformControls({
                     <div className="relative">
                       <NumberInput
                         value={parseFloat(position.z.toFixed(2))}
-                        onChange={(val) => handlePositionChange('z', val)}
-                        onBlur={() => onTransformCommit?.()}
+                        onChange={(val) => {
+                          if (!deferPositionChanges) handlePositionChange('z', val);
+                        }}
+                        onBlur={(event) => handlePositionBlur('z', event)}
                         className={valueInputClass}
                         showStepper={false}
                       />
@@ -263,6 +279,14 @@ export function TransformControls({
                     </div>
                   </div>
                 </div>
+
+                <button
+                  type="button"
+                  onClick={onCenter}
+                  className={compactButtonClass + ' w-full'}
+                >
+                  Center Selection
+                </button>
 
               </div>
           </div>

--- a/src/components/organisms/panels/PreparePanelStack.tsx
+++ b/src/components/organisms/panels/PreparePanelStack.tsx
@@ -45,7 +45,9 @@ export type PreparePanelStackProps = {
   requestDestructiveTransformSupportDeletion: (operationLabel: string) => boolean;
   handleRotationComplete: () => void;
   handleAutoLiftChange: (enabled: boolean) => void;
+  selectionPositionOrigin: React.ComponentProps<typeof TransformControls>['position'];
   handlePositionSelectedModels: (x: number, y: number, z: number) => void;
+  commitPendingSelectionPositionHistory: () => void;
   handleCenterSelectedModels: () => void;
   handleLiftSelectedModels: () => void;
   handleDropSelectedModels: () => void;
@@ -92,7 +94,9 @@ export function PreparePanelStack({
   requestDestructiveTransformSupportDeletion,
   handleRotationComplete,
   handleAutoLiftChange,
+  selectionPositionOrigin,
   handlePositionSelectedModels,
+  commitPendingSelectionPositionHistory,
   handleCenterSelectedModels,
   handleLiftSelectedModels,
   handleDropSelectedModels,
@@ -226,11 +230,15 @@ export function PreparePanelStack({
       {scene.geom && transformMgr.transformMode === 'transform' && (
         <TransformControls
           key="prepare-transform-controls"
-          position={transformMgr.transform.position}
+          position={scene.selectedModelIds.length > 1
+            ? selectionPositionOrigin
+            : transformMgr.transform.position}
           onPositionChange={scene.selectedModelIds.length > 1
             ? handlePositionSelectedModels
             : transformMgr.transformHook.setPosition}
-          deferPositionChanges={scene.selectedModelIds.length > 1}
+          onPositionCommit={scene.selectedModelIds.length > 1
+            ? commitPendingSelectionPositionHistory
+            : scheduleCommitPendingTransformHistory}
           onCenter={handleCenterSelectedModels}
           onPlatform={transformMgr.transformHook.setPlatformZ}
           rotation={transformMgr.transform.rotation}

--- a/src/components/organisms/panels/PreparePanelStack.tsx
+++ b/src/components/organisms/panels/PreparePanelStack.tsx
@@ -45,6 +45,8 @@ export type PreparePanelStackProps = {
   requestDestructiveTransformSupportDeletion: (operationLabel: string) => boolean;
   handleRotationComplete: () => void;
   handleAutoLiftChange: (enabled: boolean) => void;
+  handleLiftSelectedModels: () => void;
+  handleDropSelectedModels: () => void;
   scheduleCommitPendingTransformHistory: (frameDelay?: number) => void;
   uniformScaling: boolean;
   setUniformScaling: (value: boolean) => void;
@@ -88,6 +90,8 @@ export function PreparePanelStack({
   requestDestructiveTransformSupportDeletion,
   handleRotationComplete,
   handleAutoLiftChange,
+  handleLiftSelectedModels,
+  handleDropSelectedModels,
   scheduleCommitPendingTransformHistory,
   uniformScaling,
   setUniformScaling,
@@ -272,14 +276,8 @@ export function PreparePanelStack({
           onAutoLiftChange={handleAutoLiftChange}
           liftDistance={transformMgr.liftDistance}
           onLiftDistanceChange={transformMgr.setLiftDistance}
-          onLift={() => {
-            const lowestWorldZ = transformMgr.getLowestWorldZ();
-            if (lowestWorldZ !== null) transformMgr.transformHook.snapToLift(lowestWorldZ, transformMgr.liftDistance);
-          }}
-          onDrop={() => {
-            const lowestWorldZ = transformMgr.getLowestWorldZ();
-            if (lowestWorldZ !== null) transformMgr.transformHook.snapToPlatform(lowestWorldZ);
-          }}
+          onLift={handleLiftSelectedModels}
+          onDrop={handleDropSelectedModels}
           onTransformCommit={scheduleCommitPendingTransformHistory}
         />
       )}

--- a/src/components/organisms/panels/PreparePanelStack.tsx
+++ b/src/components/organisms/panels/PreparePanelStack.tsx
@@ -45,6 +45,8 @@ export type PreparePanelStackProps = {
   requestDestructiveTransformSupportDeletion: (operationLabel: string) => boolean;
   handleRotationComplete: () => void;
   handleAutoLiftChange: (enabled: boolean) => void;
+  handlePositionSelectedModels: (x: number, y: number, z: number) => void;
+  handleCenterSelectedModels: () => void;
   handleLiftSelectedModels: () => void;
   handleDropSelectedModels: () => void;
   scheduleCommitPendingTransformHistory: (frameDelay?: number) => void;
@@ -90,6 +92,8 @@ export function PreparePanelStack({
   requestDestructiveTransformSupportDeletion,
   handleRotationComplete,
   handleAutoLiftChange,
+  handlePositionSelectedModels,
+  handleCenterSelectedModels,
   handleLiftSelectedModels,
   handleDropSelectedModels,
   scheduleCommitPendingTransformHistory,
@@ -223,8 +227,11 @@ export function PreparePanelStack({
         <TransformControls
           key="prepare-transform-controls"
           position={transformMgr.transform.position}
-          onPositionChange={transformMgr.transformHook.setPosition}
-          onCenter={transformMgr.transformHook.centerXY}
+          onPositionChange={scene.selectedModelIds.length > 1
+            ? handlePositionSelectedModels
+            : transformMgr.transformHook.setPosition}
+          deferPositionChanges={scene.selectedModelIds.length > 1}
+          onCenter={handleCenterSelectedModels}
           onPlatform={transformMgr.transformHook.setPlatformZ}
           rotation={transformMgr.transform.rotation}
           onRotationChange={(x, y, z) => {

--- a/src/components/scene/SceneCanvas/SceneCanvas.tsx
+++ b/src/components/scene/SceneCanvas/SceneCanvas.tsx
@@ -174,6 +174,7 @@ import {
 } from '@/supports/PlacementLogic/Pathfinding/pathfindingDebugState';
 import { applyScaleFactor } from '@/components/gizmo/scale/applyScaleFactor';
 import { createWheelDeviceClassifier, type WheelDevice } from '@/components/scene/SceneCanvas/wheelDeviceClassifier';
+import { getSelectionGizmoCenter } from '@/features/scene/selectionPosition';
 
 const Canvas = dynamic(() => import('@react-three/fiber').then(m => m.Canvas), { ssr: false });
 
@@ -2596,19 +2597,10 @@ export function SceneCanvas({
   const multiGizmoAnchorRef = React.useRef<THREE.Group | null>(null);
 
   const computeCenterFromTransforms = React.useCallback((byModelId: Record<string, ModelTransform>) => {
-    const ids = selectedTransformableModelIds;
-    if (ids.length === 0) return null;
-
-    const sum = new THREE.Vector3();
-    let count = 0;
-    for (const modelId of ids) {
-      const t = byModelId[modelId];
-      if (!t) continue;
-      sum.add(t.position);
-      count += 1;
-    }
-    if (count === 0) return null;
-    return sum.multiplyScalar(1 / count);
+    return getSelectionGizmoCenter(
+      selectedTransformableModelIds,
+      (modelId) => byModelId[modelId]?.position,
+    );
   }, [selectedTransformableModelIds]);
 
   const setMultiGizmoAnchorPosition = React.useCallback((position: THREE.Vector3 | null) => {
@@ -3566,28 +3558,17 @@ export function SceneCanvas({
   const multiGizmoCenter = React.useMemo(() => {
     if (!isMultiGizmoSelection || selectedTransformableModelIds.length === 0) return null;
 
-    const sum = new THREE.Vector3();
-    let count = 0;
-
-    for (const modelId of selectedTransformableModelIds) {
+    return getSelectionGizmoCenter(selectedTransformableModelIds, (modelId) => {
       const preview = multiGizmoPreviewTransformsById[modelId];
-      if (preview) {
-        sum.add(preview.position);
-        count += 1;
-        continue;
-      }
+      if (preview) return preview.position;
 
       const model = models.find((entry) => entry.id === modelId);
-      if (!model) continue;
+      if (!model) return undefined;
       const sourceTransform = (modelId === activeModelId && liveActiveTransformForMultiPreview)
         ? liveActiveTransformForMultiPreview
         : model.transform;
-      sum.add(sourceTransform.position);
-      count += 1;
-    }
-
-    if (count === 0) return null;
-    return sum.multiplyScalar(1 / count);
+      return sourceTransform.position;
+    });
   }, [
     activeModelId,
     isMultiGizmoSelection,

--- a/src/features/scene/__tests__/modelActionTargets.test.ts
+++ b/src/features/scene/__tests__/modelActionTargets.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  dispatchCutModelAction,
   dispatchDeleteModelAction,
   resolveModelActionTargetIds,
 } from '@/features/scene/modelActionTargets';
@@ -64,6 +65,44 @@ test('single-selection Delete uses one fallback and missing targets do not dispa
     selectedModelIds: ['missing'],
     activeModelId: 'missing',
   }, deleteModels), false);
+
+  assert.deepEqual(calls, [['model-a']]);
+});
+
+test('multi-selection Cut invokes one ordered batch command', () => {
+  const calls: string[][] = [];
+
+  const dispatched = dispatchCutModelAction({
+    modelIds: ['model-a', 'model-b', 'model-c'],
+    selectedModelIds: ['model-c', 'model-a'],
+    activeModelId: 'model-a',
+  }, (ids) => {
+    calls.push(ids);
+    return true;
+  });
+
+  assert.equal(dispatched, true);
+  assert.deepEqual(calls, [['model-c', 'model-a']]);
+});
+
+test('single-selection Cut uses one fallback and missing targets do not dispatch', () => {
+  const calls: string[][] = [];
+  const cutSelectedModels = (ids: string[]) => {
+    calls.push(ids);
+    return true;
+  };
+
+  assert.equal(dispatchCutModelAction({
+    modelIds: ['model-a'],
+    selectedModelIds: [],
+    activeModelId: 'model-a',
+  }, cutSelectedModels), true);
+
+  assert.equal(dispatchCutModelAction({
+    modelIds: ['model-a'],
+    selectedModelIds: ['missing'],
+    activeModelId: 'missing',
+  }, cutSelectedModels), false);
 
   assert.deepEqual(calls, [['model-a']]);
 });

--- a/src/features/scene/__tests__/modelActionTargets.test.ts
+++ b/src/features/scene/__tests__/modelActionTargets.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  dispatchDeleteModelAction,
+  resolveModelActionTargetIds,
+} from '@/features/scene/modelActionTargets';
+
+test('selected models take precedence over active and context fallbacks', () => {
+  const targets = resolveModelActionTargetIds({
+    modelIds: ['model-a', 'model-b', 'model-c'],
+    selectedModelIds: ['model-a', 'missing', 'model-b', 'model-a'],
+    activeModelId: 'model-c',
+    contextModelId: 'model-c',
+  });
+
+  assert.deepEqual(targets, ['model-a', 'model-b']);
+});
+
+test('context and active models are single-target fallbacks', () => {
+  assert.deepEqual(resolveModelActionTargetIds({
+    modelIds: ['model-a', 'model-b'],
+    selectedModelIds: [],
+    activeModelId: 'model-a',
+    contextModelId: 'model-b',
+  }), ['model-b']);
+
+  assert.deepEqual(resolveModelActionTargetIds({
+    modelIds: ['model-a'],
+    selectedModelIds: ['missing'],
+    activeModelId: 'model-a',
+  }), ['model-a']);
+});
+
+test('multi-selection Delete invokes the history-bearing batch command once', () => {
+  const calls: string[][] = [];
+
+  const dispatched = dispatchDeleteModelAction({
+    modelIds: ['model-a', 'model-b', 'model-c'],
+    selectedModelIds: ['model-a', 'model-b'],
+    activeModelId: 'model-b',
+  }, (ids) => {
+    calls.push(ids);
+  });
+
+  assert.equal(dispatched, true);
+  assert.deepEqual(calls, [['model-a', 'model-b']]);
+});
+
+test('single-selection Delete uses one fallback and missing targets do not dispatch', () => {
+  const calls: string[][] = [];
+  const deleteModels = (ids: string[]) => {
+    calls.push(ids);
+  };
+
+  assert.equal(dispatchDeleteModelAction({
+    modelIds: ['model-a'],
+    selectedModelIds: [],
+    activeModelId: 'model-a',
+  }, deleteModels), true);
+
+  assert.equal(dispatchDeleteModelAction({
+    modelIds: ['model-a'],
+    selectedModelIds: ['missing'],
+    activeModelId: 'missing',
+  }, deleteModels), false);
+
+  assert.deepEqual(calls, [['model-a']]);
+});

--- a/src/features/scene/__tests__/modelCut.test.ts
+++ b/src/features/scene/__tests__/modelCut.test.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  performModelCut,
+  selectModelsForClipboard,
+} from '@/features/scene/modelCut';
+
+test('clipboard sources preserve scene order and attached support payloads', () => {
+  const models = [
+    { id: 'model-a', supportClipboard: ['support-a'] },
+    { id: 'model-b', supportClipboard: ['support-b'] },
+    { id: 'model-c', supportClipboard: ['support-c'] },
+  ];
+
+  const selected = selectModelsForClipboard(models, ['model-c', 'missing', 'model-a']);
+
+  assert.deepEqual(selected, [models[0], models[2]]);
+});
+
+test('batch Cut copies before one full-selection deletion and restores in one step', () => {
+  const initialModels = [
+    { id: 'model-a' },
+    { id: 'model-b' },
+    { id: 'model-c' },
+  ];
+  const initialSupports = new Map([
+    ['model-a', ['support-a']],
+    ['model-b', ['support-b']],
+  ]);
+  let models = [...initialModels];
+  let supports = new Map(initialSupports);
+  let clipboard: Array<{ id: string; supports: string[] }> = [];
+  const undo: Array<() => void> = [];
+  const events: string[] = [];
+
+  const cut = performModelCut(['model-b', 'model-a'], (ids) => {
+    events.push('copy');
+    clipboard = selectModelsForClipboard(models, ids).map((model) => ({
+      id: model.id,
+      supports: [...(supports.get(model.id) ?? [])],
+    }));
+    return true;
+  }, (ids) => {
+    events.push('delete');
+    const beforeModels = [...models];
+    const beforeSupports = new Map(supports);
+    const idSet = new Set(ids);
+    models = models.filter((model) => !idSet.has(model.id));
+    supports = new Map([...supports].filter(([id]) => !idSet.has(id)));
+    undo.push(() => {
+      models = beforeModels;
+      supports = beforeSupports;
+    });
+  });
+
+  assert.equal(cut, true);
+  assert.deepEqual(events, ['copy', 'delete']);
+  assert.deepEqual(clipboard, [
+    { id: 'model-a', supports: ['support-a'] },
+    { id: 'model-b', supports: ['support-b'] },
+  ]);
+  assert.deepEqual(models, [{ id: 'model-c' }]);
+  assert.deepEqual([...supports], []);
+  assert.equal(undo.length, 1);
+
+  undo[0]();
+  assert.deepEqual(models, initialModels);
+  assert.deepEqual([...supports], [...initialSupports]);
+});
+
+test('failed clipboard capture prevents deletion', () => {
+  let deleteCalls = 0;
+
+  assert.equal(performModelCut(['missing'], () => false, () => {
+    deleteCalls += 1;
+  }), false);
+  assert.equal(deleteCalls, 0);
+});

--- a/src/features/scene/__tests__/selectionLiftDrop.test.ts
+++ b/src/features/scene/__tests__/selectionLiftDrop.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as THREE from 'three';
+
+import type { GeometryWithBounds } from '@/hooks/useStlGeometry';
+import {
+  buildLiftDropUpdates,
+  getModelLowestWorldZ,
+  type LiftDropModel,
+} from '@/features/scene/selectionLiftDrop';
+
+function model(
+  id: string,
+  geometry: THREE.BufferGeometry,
+  position: THREE.Vector3,
+  rotation = new THREE.Euler(),
+  scale = new THREE.Vector3(1, 1, 1),
+): LiftDropModel {
+  geometry.computeBoundingBox();
+  const boundingBox = geometry.boundingBox!.clone();
+
+  return {
+    id,
+    geometry: {
+      geometry,
+      bbox: boundingBox,
+      size: boundingBox.getSize(new THREE.Vector3()),
+    } as GeometryWithBounds,
+    transform: { position, rotation, scale },
+  };
+}
+
+test('Lift places each selected model bottom independently at the requested distance', () => {
+  const models = [
+    model('model-a', new THREE.BoxGeometry(2, 4, 6), new THREE.Vector3(3, 4, 10)),
+    model(
+      'model-b',
+      new THREE.BoxGeometry(2, 4, 6),
+      new THREE.Vector3(-5, 7, 20),
+      new THREE.Euler(Math.PI / 2, 0, 0),
+      new THREE.Vector3(1, 2, 1),
+    ),
+  ];
+
+  const updates = buildLiftDropUpdates(models, ['model-b', 'model-a'], 5);
+
+  assert.deepEqual(updates.map((update) => update.id), ['model-a', 'model-b']);
+  updates.forEach((update, index) => {
+    assert.ok(Math.abs(getModelLowestWorldZ({ ...models[index], transform: update.transform }) - 5) < 1e-6);
+    assert.equal(update.transform.position.x, models[index].transform.position.x);
+    assert.equal(update.transform.position.y, models[index].transform.position.y);
+  });
+  assert.notEqual(updates[0].transform.position.z, updates[1].transform.position.z);
+});
+
+test('Drop places every selected bottom at zero and skips unselected models', () => {
+  const models = [
+    model('model-a', new THREE.BoxGeometry(4, 4, 4), new THREE.Vector3(0, 0, 15)),
+    model('model-b', new THREE.BoxGeometry(4, 4, 4), new THREE.Vector3(8, 0, 25)),
+    model('model-c', new THREE.BoxGeometry(4, 4, 4), new THREE.Vector3(16, 0, 35)),
+  ];
+
+  const updates = buildLiftDropUpdates(models, ['model-a', 'model-c'], 0);
+
+  assert.deepEqual(updates.map((update) => update.id), ['model-a', 'model-c']);
+  assert.ok(Math.abs(getModelLowestWorldZ({ ...models[0], transform: updates[0].transform })) < 1e-6);
+  assert.ok(Math.abs(getModelLowestWorldZ({ ...models[2], transform: updates[1].transform })) < 1e-6);
+});

--- a/src/features/scene/__tests__/selectionPosition.test.ts
+++ b/src/features/scene/__tests__/selectionPosition.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import * as THREE from 'three';
+
+import {
+  buildCenterSelectionUpdates,
+  buildSelectionPositionUpdates,
+  type SelectionPositionModel,
+} from '@/features/scene/selectionPosition';
+import type { GeometryWithBounds } from '@/hooks/useStlGeometry';
+import { computePreciseModelWorldBounds } from '@/utils/modelBounds';
+
+function model(
+  id: string,
+  geometry: THREE.BufferGeometry,
+  position: THREE.Vector3,
+  rotation = new THREE.Euler(),
+  scale = new THREE.Vector3(1, 1, 1),
+): SelectionPositionModel {
+  geometry.computeBoundingBox();
+  const boundingBox = geometry.boundingBox!.clone();
+
+  return {
+    id,
+    geometry: {
+      geometry,
+      bbox: boundingBox,
+      center: boundingBox.getCenter(new THREE.Vector3()),
+      size: boundingBox.getSize(new THREE.Vector3()),
+    } as GeometryWithBounds,
+    transform: { position, rotation, scale },
+  };
+}
+
+test('Position translates the selection by the active model delta', () => {
+  const models = [
+    model('model-a', new THREE.BoxGeometry(2, 2, 2), new THREE.Vector3(4, 7, 10)),
+    model('model-b', new THREE.BoxGeometry(2, 2, 2), new THREE.Vector3(14, 27, 30)),
+    model('model-c', new THREE.BoxGeometry(2, 2, 2), new THREE.Vector3(40, 50, 60)),
+  ];
+
+  const updates = buildSelectionPositionUpdates(
+    models,
+    ['model-b', 'model-a'],
+    'model-b',
+    new THREE.Vector3(20, 25, 35),
+  );
+
+  assert.deepEqual(updates.map((update) => update.id), ['model-a', 'model-b']);
+  assert.deepEqual(updates[0].transform.position.toArray(), [10, 5, 15]);
+  assert.deepEqual(updates[1].transform.position.toArray(), [20, 25, 35]);
+});
+
+test('Center moves the combined transformed bounds to the plate center as one set', () => {
+  const models = [
+    model('model-a', new THREE.BoxGeometry(2, 4, 6), new THREE.Vector3(5, 10, 8)),
+    model(
+      'model-b',
+      new THREE.BoxGeometry(8, 2, 4),
+      new THREE.Vector3(20, 30, 12),
+      new THREE.Euler(0, 0, Math.PI / 4),
+      new THREE.Vector3(1.5, 1, 2),
+    ),
+  ];
+  const originalOffset = models[1].transform.position.clone().sub(models[0].transform.position);
+  const targetCenter = new THREE.Vector2(96, 60);
+
+  const updates = buildCenterSelectionUpdates(models, ['model-a', 'model-b'], targetCenter);
+  const centeredBounds = new THREE.Box3().makeEmpty();
+  updates.forEach((update, index) => {
+    centeredBounds.union(computePreciseModelWorldBounds(models[index].geometry, update.transform));
+    assert.equal(update.transform.position.z, models[index].transform.position.z);
+    assert.ok(update.transform.rotation.equals(models[index].transform.rotation));
+    assert.ok(update.transform.scale.equals(models[index].transform.scale));
+  });
+
+  const centered = centeredBounds.getCenter(new THREE.Vector3());
+  assert.ok(Math.abs(centered.x - targetCenter.x) < 1e-6);
+  assert.ok(Math.abs(centered.y - targetCenter.y) < 1e-6);
+  assert.ok(
+    updates[1].transform.position.clone().sub(updates[0].transform.position).distanceTo(originalOffset) < 1e-6,
+  );
+});
+
+test('Center preserves single-model pivot centering behavior', () => {
+  const models = [
+    model(
+      'model-a',
+      new THREE.BoxGeometry(2, 4, 6),
+      new THREE.Vector3(5, 10, 8),
+      new THREE.Euler(0, 0, Math.PI / 4),
+    ),
+  ];
+
+  const updates = buildCenterSelectionUpdates(models, ['model-a'], new THREE.Vector2(96, 60));
+
+  assert.deepEqual(updates[0].transform.position.toArray(), [96, 60, 8]);
+});

--- a/src/features/scene/__tests__/selectionPosition.test.ts
+++ b/src/features/scene/__tests__/selectionPosition.test.ts
@@ -5,11 +5,11 @@ import * as THREE from 'three';
 import {
   buildCenterSelectionUpdates,
   buildSelectionPositionUpdates,
+  getSelectionGizmoCenter,
   getSelectionPositionOrigin,
   type SelectionPositionModel,
 } from '@/features/scene/selectionPosition';
 import type { GeometryWithBounds } from '@/hooks/useStlGeometry';
-import { computePreciseModelWorldBounds } from '@/utils/modelBounds';
 
 function model(
   id: string,
@@ -33,7 +33,7 @@ function model(
   };
 }
 
-test('Position translates the selection by its precise combined-bounds center delta', () => {
+test('Position translates the selection by the same center used for the gizmo', () => {
   const models = [
     model('model-a', new THREE.BoxGeometry(2, 2, 2), new THREE.Vector3(4, 7, 10)),
     model('model-b', new THREE.BoxGeometry(6, 6, 6), new THREE.Vector3(14, 27, 30)),
@@ -47,21 +47,25 @@ test('Position translates the selection by its precise combined-bounds center de
     new THREE.Vector3(20, 25, 35),
   );
 
-  assert.deepEqual(getSelectionPositionOrigin(models, targetIds)?.toArray(), [10, 18, 21]);
+  assert.deepEqual(getSelectionPositionOrigin(models, targetIds)?.toArray(), [9, 17, 20]);
+  assert.deepEqual(getSelectionGizmoCenter(
+    targetIds,
+    (modelId) => models.find((entry) => entry.id === modelId)?.transform.position,
+  )?.toArray(), [9, 17, 20]);
   assert.deepEqual(updates.map((update) => update.id), ['model-a', 'model-b']);
-  assert.deepEqual(updates[0].transform.position.toArray(), [14, 14, 24]);
-  assert.deepEqual(updates[1].transform.position.toArray(), [24, 34, 44]);
+  assert.deepEqual(updates[0].transform.position.toArray(), [15, 15, 25]);
+  assert.deepEqual(updates[1].transform.position.toArray(), [25, 35, 45]);
 
   const updatedModels = models.map((entry) => {
     const update = updates.find((candidate) => candidate.id === entry.id);
     return update ? { ...entry, transform: update.transform } : entry;
   });
   const nextUpdates = buildSelectionPositionUpdates(updatedModels, targetIds, new THREE.Vector3(21, 25, 35));
-  assert.deepEqual(nextUpdates[0].transform.position.toArray(), [15, 14, 24]);
-  assert.deepEqual(nextUpdates[1].transform.position.toArray(), [25, 34, 44]);
+  assert.deepEqual(nextUpdates[0].transform.position.toArray(), [16, 15, 25]);
+  assert.deepEqual(nextUpdates[1].transform.position.toArray(), [26, 35, 45]);
 });
 
-test('Center moves the combined transformed bounds to the plate center as one set', () => {
+test('Center moves the gizmo center to the plate center as one set', () => {
   const models = [
     model('model-a', new THREE.BoxGeometry(2, 4, 6), new THREE.Vector3(5, 10, 8)),
     model(
@@ -76,15 +80,14 @@ test('Center moves the combined transformed bounds to the plate center as one se
   const targetCenter = new THREE.Vector2(96, 60);
 
   const updates = buildCenterSelectionUpdates(models, ['model-a', 'model-b'], targetCenter);
-  const centeredBounds = new THREE.Box3().makeEmpty();
   updates.forEach((update, index) => {
-    centeredBounds.union(computePreciseModelWorldBounds(models[index].geometry, update.transform));
     assert.equal(update.transform.position.z, models[index].transform.position.z);
     assert.ok(update.transform.rotation.equals(models[index].transform.rotation));
     assert.ok(update.transform.scale.equals(models[index].transform.scale));
   });
 
-  const centered = centeredBounds.getCenter(new THREE.Vector3());
+  const centeredModels = models.map((entry, index) => ({ ...entry, transform: updates[index].transform }));
+  const centered = getSelectionPositionOrigin(centeredModels, ['model-a', 'model-b'])!;
   assert.ok(Math.abs(centered.x - targetCenter.x) < 1e-6);
   assert.ok(Math.abs(centered.y - targetCenter.y) < 1e-6);
   assert.ok(

--- a/src/features/scene/__tests__/selectionPosition.test.ts
+++ b/src/features/scene/__tests__/selectionPosition.test.ts
@@ -33,10 +33,10 @@ function model(
   };
 }
 
-test('Position translates the selection by its shared origin delta', () => {
+test('Position translates the selection by its precise combined-bounds center delta', () => {
   const models = [
     model('model-a', new THREE.BoxGeometry(2, 2, 2), new THREE.Vector3(4, 7, 10)),
-    model('model-b', new THREE.BoxGeometry(2, 2, 2), new THREE.Vector3(14, 27, 30)),
+    model('model-b', new THREE.BoxGeometry(6, 6, 6), new THREE.Vector3(14, 27, 30)),
     model('model-c', new THREE.BoxGeometry(2, 2, 2), new THREE.Vector3(40, 50, 60)),
   ];
   const targetIds = ['model-b', 'model-a'];
@@ -47,18 +47,18 @@ test('Position translates the selection by its shared origin delta', () => {
     new THREE.Vector3(20, 25, 35),
   );
 
-  assert.deepEqual(getSelectionPositionOrigin(models, targetIds)?.toArray(), [9, 17, 20]);
+  assert.deepEqual(getSelectionPositionOrigin(models, targetIds)?.toArray(), [10, 18, 21]);
   assert.deepEqual(updates.map((update) => update.id), ['model-a', 'model-b']);
-  assert.deepEqual(updates[0].transform.position.toArray(), [15, 15, 25]);
-  assert.deepEqual(updates[1].transform.position.toArray(), [25, 35, 45]);
+  assert.deepEqual(updates[0].transform.position.toArray(), [14, 14, 24]);
+  assert.deepEqual(updates[1].transform.position.toArray(), [24, 34, 44]);
 
   const updatedModels = models.map((entry) => {
     const update = updates.find((candidate) => candidate.id === entry.id);
     return update ? { ...entry, transform: update.transform } : entry;
   });
   const nextUpdates = buildSelectionPositionUpdates(updatedModels, targetIds, new THREE.Vector3(21, 25, 35));
-  assert.deepEqual(nextUpdates[0].transform.position.toArray(), [16, 15, 25]);
-  assert.deepEqual(nextUpdates[1].transform.position.toArray(), [26, 35, 45]);
+  assert.deepEqual(nextUpdates[0].transform.position.toArray(), [15, 14, 24]);
+  assert.deepEqual(nextUpdates[1].transform.position.toArray(), [25, 34, 44]);
 });
 
 test('Center moves the combined transformed bounds to the plate center as one set', () => {

--- a/src/features/scene/__tests__/selectionPosition.test.ts
+++ b/src/features/scene/__tests__/selectionPosition.test.ts
@@ -5,6 +5,7 @@ import * as THREE from 'three';
 import {
   buildCenterSelectionUpdates,
   buildSelectionPositionUpdates,
+  getSelectionPositionOrigin,
   type SelectionPositionModel,
 } from '@/features/scene/selectionPosition';
 import type { GeometryWithBounds } from '@/hooks/useStlGeometry';
@@ -32,23 +33,32 @@ function model(
   };
 }
 
-test('Position translates the selection by the active model delta', () => {
+test('Position translates the selection by its shared origin delta', () => {
   const models = [
     model('model-a', new THREE.BoxGeometry(2, 2, 2), new THREE.Vector3(4, 7, 10)),
     model('model-b', new THREE.BoxGeometry(2, 2, 2), new THREE.Vector3(14, 27, 30)),
     model('model-c', new THREE.BoxGeometry(2, 2, 2), new THREE.Vector3(40, 50, 60)),
   ];
+  const targetIds = ['model-b', 'model-a'];
 
   const updates = buildSelectionPositionUpdates(
     models,
-    ['model-b', 'model-a'],
-    'model-b',
+    targetIds,
     new THREE.Vector3(20, 25, 35),
   );
 
+  assert.deepEqual(getSelectionPositionOrigin(models, targetIds)?.toArray(), [9, 17, 20]);
   assert.deepEqual(updates.map((update) => update.id), ['model-a', 'model-b']);
-  assert.deepEqual(updates[0].transform.position.toArray(), [10, 5, 15]);
-  assert.deepEqual(updates[1].transform.position.toArray(), [20, 25, 35]);
+  assert.deepEqual(updates[0].transform.position.toArray(), [15, 15, 25]);
+  assert.deepEqual(updates[1].transform.position.toArray(), [25, 35, 45]);
+
+  const updatedModels = models.map((entry) => {
+    const update = updates.find((candidate) => candidate.id === entry.id);
+    return update ? { ...entry, transform: update.transform } : entry;
+  });
+  const nextUpdates = buildSelectionPositionUpdates(updatedModels, targetIds, new THREE.Vector3(21, 25, 35));
+  assert.deepEqual(nextUpdates[0].transform.position.toArray(), [16, 15, 25]);
+  assert.deepEqual(nextUpdates[1].transform.position.toArray(), [26, 35, 45]);
 });
 
 test('Center moves the combined transformed bounds to the plate center as one set', () => {

--- a/src/features/scene/modelActionTargets.ts
+++ b/src/features/scene/modelActionTargets.ts
@@ -1,0 +1,38 @@
+export type ModelActionTargetInput = {
+  modelIds: readonly string[];
+  selectedModelIds: readonly string[];
+  activeModelId?: string | null;
+  contextModelId?: string | null;
+};
+
+export function resolveModelActionTargetIds({
+  modelIds,
+  selectedModelIds,
+  activeModelId,
+  contextModelId,
+}: ModelActionTargetInput): string[] {
+  const validIds = new Set(modelIds);
+  const seen = new Set<string>();
+  const selectedIds = selectedModelIds.filter((id) => {
+    if (!validIds.has(id) || seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+
+  if (selectedIds.length > 0) return selectedIds;
+
+  const fallbackId = [contextModelId, activeModelId]
+    .find((id): id is string => typeof id === 'string' && validIds.has(id));
+  return fallbackId ? [fallbackId] : [];
+}
+
+export function dispatchDeleteModelAction(
+  targets: ModelActionTargetInput,
+  deleteModels: (ids: string[]) => void | Promise<void>,
+): boolean {
+  const targetIds = resolveModelActionTargetIds(targets);
+  if (targetIds.length === 0) return false;
+
+  void deleteModels(targetIds);
+  return true;
+}

--- a/src/features/scene/modelActionTargets.ts
+++ b/src/features/scene/modelActionTargets.ts
@@ -36,3 +36,13 @@ export function dispatchDeleteModelAction(
   void deleteModels(targetIds);
   return true;
 }
+
+export function dispatchCutModelAction(
+  targets: ModelActionTargetInput,
+  cutSelectedModels: (ids: string[]) => boolean,
+): boolean {
+  const targetIds = resolveModelActionTargetIds(targets);
+  if (targetIds.length === 0) return false;
+
+  return cutSelectedModels(targetIds);
+}

--- a/src/features/scene/modelCut.ts
+++ b/src/features/scene/modelCut.ts
@@ -1,0 +1,18 @@
+export function selectModelsForClipboard<T extends { id: string }>(
+  models: readonly T[],
+  ids: readonly string[],
+): T[] {
+  const idSet = new Set(ids);
+  return models.filter((model) => idSet.has(model.id));
+}
+
+export function performModelCut(
+  ids: string[],
+  copySelectedModels: (targetIds: string[]) => boolean,
+  deleteModels: (targetIds: string[]) => void | Promise<void>,
+): boolean {
+  if (!copySelectedModels(ids)) return false;
+
+  void deleteModels(ids);
+  return true;
+}

--- a/src/features/scene/selectionLiftDrop.ts
+++ b/src/features/scene/selectionLiftDrop.ts
@@ -1,0 +1,58 @@
+import * as THREE from 'three';
+
+import type { GeometryWithBounds } from '@/hooks/useStlGeometry';
+import type { ModelTransform } from '@/hooks/useModelTransform';
+import { computeLowestZ } from '@/utils/geometry';
+import { quaternionFromGlobalEuler } from '@/utils/rotation';
+
+export type LiftDropModel = {
+  id: string;
+  geometry: GeometryWithBounds;
+  transform: ModelTransform;
+};
+
+export function getModelLowestWorldZ(model: LiftDropModel): number {
+  const geometry = model.geometry.geometry;
+  const boundingBox = geometry.boundingBox
+    ?? new THREE.Box3().setFromBufferAttribute(geometry.getAttribute('position') as THREE.BufferAttribute);
+  const center = boundingBox.getCenter(new THREE.Vector3());
+
+  const matrix = new THREE.Matrix4().makeTranslation(
+    model.transform.position.x,
+    model.transform.position.y,
+    model.transform.position.z,
+  );
+  matrix.multiply(new THREE.Matrix4().compose(
+    new THREE.Vector3(),
+    quaternionFromGlobalEuler(model.transform.rotation),
+    model.transform.scale,
+  ));
+  matrix.multiply(new THREE.Matrix4().makeTranslation(-center.x, -center.y, -center.z));
+
+  return computeLowestZ(geometry, matrix);
+}
+
+export function buildLiftDropUpdates(
+  models: readonly LiftDropModel[],
+  targetIds: readonly string[],
+  targetLowestWorldZ: number,
+): Array<{ id: string; transform: ModelTransform }> {
+  const targetIdSet = new Set(targetIds);
+
+  return models
+    .filter((model) => targetIdSet.has(model.id))
+    .map((model) => {
+      const lowestWorldZ = getModelLowestWorldZ(model);
+      const position = model.transform.position.clone();
+      position.z += targetLowestWorldZ - lowestWorldZ;
+
+      return {
+        id: model.id,
+        transform: {
+          position,
+          rotation: model.transform.rotation.clone(),
+          scale: model.transform.scale.clone(),
+        },
+      };
+    });
+}

--- a/src/features/scene/selectionPosition.ts
+++ b/src/features/scene/selectionPosition.ts
@@ -1,0 +1,75 @@
+import * as THREE from 'three';
+
+import type { GeometryWithBounds } from '@/hooks/useStlGeometry';
+import type { ModelTransform } from '@/hooks/useModelTransform';
+import { computePreciseModelWorldBounds } from '@/utils/modelBounds';
+
+export type SelectionPositionModel = {
+  id: string;
+  geometry: GeometryWithBounds;
+  transform: ModelTransform;
+};
+
+function translateModels(
+  models: readonly SelectionPositionModel[],
+  targetIds: readonly string[],
+  delta: THREE.Vector3,
+): Array<{ id: string; transform: ModelTransform }> {
+  const targetIdSet = new Set(targetIds);
+
+  return models
+    .filter((model) => targetIdSet.has(model.id))
+    .map((model) => ({
+      id: model.id,
+      transform: {
+        position: model.transform.position.clone().add(delta),
+        rotation: model.transform.rotation.clone(),
+        scale: model.transform.scale.clone(),
+      },
+    }));
+}
+
+export function buildSelectionPositionUpdates(
+  models: readonly SelectionPositionModel[],
+  targetIds: readonly string[],
+  activeModelId: string,
+  nextActivePosition: THREE.Vector3,
+): Array<{ id: string; transform: ModelTransform }> {
+  const activeModel = models.find((model) => model.id === activeModelId && targetIds.includes(model.id));
+  if (!activeModel) return [];
+
+  const delta = nextActivePosition.clone().sub(activeModel.transform.position);
+  return translateModels(models, targetIds, delta);
+}
+
+export function buildCenterSelectionUpdates(
+  models: readonly SelectionPositionModel[],
+  targetIds: readonly string[],
+  targetCenter: THREE.Vector2,
+): Array<{ id: string; transform: ModelTransform }> {
+  const targetIdSet = new Set(targetIds);
+  const targetModels = models.filter((model) => targetIdSet.has(model.id));
+  if (targetModels.length === 1) {
+    const position = targetModels[0].transform.position;
+    return translateModels(
+      models,
+      targetIds,
+      new THREE.Vector3(targetCenter.x - position.x, targetCenter.y - position.y, 0),
+    );
+  }
+
+  const selectionBounds = new THREE.Box3().makeEmpty();
+
+  targetModels.forEach((model) => {
+    selectionBounds.union(computePreciseModelWorldBounds(model.geometry, model.transform));
+  });
+
+  if (selectionBounds.isEmpty()) return [];
+
+  const currentCenter = selectionBounds.getCenter(new THREE.Vector3());
+  return translateModels(
+    models,
+    targetIds,
+    new THREE.Vector3(targetCenter.x - currentCenter.x, targetCenter.y - currentCenter.y, 0),
+  );
+}

--- a/src/features/scene/selectionPosition.ts
+++ b/src/features/scene/selectionPosition.ts
@@ -2,7 +2,6 @@ import * as THREE from 'three';
 
 import type { GeometryWithBounds } from '@/hooks/useStlGeometry';
 import type { ModelTransform } from '@/hooks/useModelTransform';
-import { computePreciseModelWorldBounds } from '@/utils/modelBounds';
 
 export type SelectionPositionModel = {
   id: string;
@@ -10,21 +9,32 @@ export type SelectionPositionModel = {
   transform: ModelTransform;
 };
 
+export function getSelectionGizmoCenter(
+  targetIds: readonly string[],
+  getPosition: (modelId: string) => THREE.Vector3 | undefined,
+): THREE.Vector3 | null {
+  const center = new THREE.Vector3();
+  let count = 0;
+
+  targetIds.forEach((modelId) => {
+    const position = getPosition(modelId);
+    if (!position) return;
+    center.add(position);
+    count += 1;
+  });
+
+  return count > 0 ? center.multiplyScalar(1 / count) : null;
+}
+
 export function getSelectionPositionOrigin(
   models: readonly SelectionPositionModel[],
   targetIds: readonly string[],
 ): THREE.Vector3 | null {
-  const targetIdSet = new Set(targetIds);
-  const selectionBounds = new THREE.Box3().makeEmpty();
-
-  models.forEach((model) => {
-    if (!targetIdSet.has(model.id)) return;
-    selectionBounds.union(computePreciseModelWorldBounds(model.geometry, model.transform));
-  });
-
-  return selectionBounds.isEmpty()
-    ? null
-    : selectionBounds.getCenter(new THREE.Vector3());
+  const modelById = new Map(models.map((model) => [model.id, model]));
+  return getSelectionGizmoCenter(
+    targetIds,
+    (modelId) => modelById.get(modelId)?.transform.position,
+  );
 }
 
 function translateModels(

--- a/src/features/scene/selectionPosition.ts
+++ b/src/features/scene/selectionPosition.ts
@@ -10,6 +10,23 @@ export type SelectionPositionModel = {
   transform: ModelTransform;
 };
 
+export function getSelectionPositionOrigin(
+  models: readonly SelectionPositionModel[],
+  targetIds: readonly string[],
+): THREE.Vector3 | null {
+  const targetIdSet = new Set(targetIds);
+  const origin = new THREE.Vector3();
+  let count = 0;
+
+  models.forEach((model) => {
+    if (!targetIdSet.has(model.id)) return;
+    origin.add(model.transform.position);
+    count += 1;
+  });
+
+  return count > 0 ? origin.multiplyScalar(1 / count) : null;
+}
+
 function translateModels(
   models: readonly SelectionPositionModel[],
   targetIds: readonly string[],
@@ -32,13 +49,12 @@ function translateModels(
 export function buildSelectionPositionUpdates(
   models: readonly SelectionPositionModel[],
   targetIds: readonly string[],
-  activeModelId: string,
-  nextActivePosition: THREE.Vector3,
+  nextSelectionOrigin: THREE.Vector3,
 ): Array<{ id: string; transform: ModelTransform }> {
-  const activeModel = models.find((model) => model.id === activeModelId && targetIds.includes(model.id));
-  if (!activeModel) return [];
+  const currentOrigin = getSelectionPositionOrigin(models, targetIds);
+  if (!currentOrigin) return [];
 
-  const delta = nextActivePosition.clone().sub(activeModel.transform.position);
+  const delta = nextSelectionOrigin.clone().sub(currentOrigin);
   return translateModels(models, targetIds, delta);
 }
 

--- a/src/features/scene/selectionPosition.ts
+++ b/src/features/scene/selectionPosition.ts
@@ -15,16 +15,16 @@ export function getSelectionPositionOrigin(
   targetIds: readonly string[],
 ): THREE.Vector3 | null {
   const targetIdSet = new Set(targetIds);
-  const origin = new THREE.Vector3();
-  let count = 0;
+  const selectionBounds = new THREE.Box3().makeEmpty();
 
   models.forEach((model) => {
     if (!targetIdSet.has(model.id)) return;
-    origin.add(model.transform.position);
-    count += 1;
+    selectionBounds.union(computePreciseModelWorldBounds(model.geometry, model.transform));
   });
 
-  return count > 0 ? origin.multiplyScalar(1 / count) : null;
+  return selectionBounds.isEmpty()
+    ? null
+    : selectionBounds.getCenter(new THREE.Vector3());
 }
 
 function translateModels(
@@ -74,15 +74,8 @@ export function buildCenterSelectionUpdates(
     );
   }
 
-  const selectionBounds = new THREE.Box3().makeEmpty();
-
-  targetModels.forEach((model) => {
-    selectionBounds.union(computePreciseModelWorldBounds(model.geometry, model.transform));
-  });
-
-  if (selectionBounds.isEmpty()) return [];
-
-  const currentCenter = selectionBounds.getCenter(new THREE.Vector3());
+  const currentCenter = getSelectionPositionOrigin(models, targetIds);
+  if (!currentCenter) return [];
   return translateModels(
     models,
     targetIds,

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -2633,7 +2633,59 @@ export function useSceneCollectionManager() {
     return true;
   }, [pushSceneSnapshotHistory]);
 
-  const updateModelTransforms = useCallback((updates: Array<{ id: string; transform: ModelTransform }>) => {
+  const commitModelTransformsHistory = useCallback((
+    beforeTransforms: Array<{ id: string; transform: ModelTransform }>,
+    description?: string,
+    supportSnapshotOptions?: TransformHistorySupportSnapshotOptions,
+  ) => {
+    const currentModels = modelsRef.current;
+    const currentActiveModelId = activeModelIdRef.current;
+    const currentSelectedModelIds = selectedModelIdsRef.current;
+    const beforeTransformMap = new Map(beforeTransforms.map((entry) => [entry.id, entry.transform]));
+    const changedIds = currentModels
+      .filter((model) => {
+        const beforeTransform = beforeTransformMap.get(model.id);
+        return beforeTransform && !transformsEqual(beforeTransform, model.transform);
+      })
+      .map((model) => model.id);
+    if (changedIds.length === 0) return false;
+
+    const beforeModels = currentModels.map((model) => {
+      const beforeTransform = beforeTransformMap.get(model.id);
+      return beforeTransform
+        ? { ...model, transform: cloneTransform(beforeTransform) }
+        : model;
+    });
+    const includeSupportByOption = supportSnapshotOptions?.includeSupportState === true
+      || !!supportSnapshotOptions?.supportBefore
+      || !!supportSnapshotOptions?.supportAfter
+      || !!supportSnapshotOptions?.kickstandBefore
+      || !!supportSnapshotOptions?.kickstandAfter;
+    const supportStateNow = getSnapshot();
+    const kickstandStateNow = getKickstandSnapshot();
+    const includeSupportByState = changedIds.some((id) => (
+      hasSupportsOrKickstandsForModel(id, supportStateNow, kickstandStateNow)
+    ));
+    const includeSupportHistory = includeSupportByOption || includeSupportByState;
+
+    const before = captureSceneSnapshot(beforeModels, currentActiveModelId, currentSelectedModelIds, {
+      includeSupportState: includeSupportHistory,
+      supportStateOverride: supportSnapshotOptions?.supportBefore,
+      kickstandStateOverride: supportSnapshotOptions?.kickstandBefore,
+    });
+    const after = captureSceneSnapshot(currentModels, currentActiveModelId, currentSelectedModelIds, {
+      includeSupportState: includeSupportHistory,
+      supportStateOverride: supportSnapshotOptions?.supportAfter,
+      kickstandStateOverride: supportSnapshotOptions?.kickstandAfter,
+    });
+    pushSceneSnapshotHistory(before, after, description ?? 'Update Model Transforms');
+    return true;
+  }, [pushSceneSnapshotHistory]);
+
+  const updateModelTransforms = useCallback((
+    updates: Array<{ id: string; transform: ModelTransform }>,
+    options?: { pushHistory?: boolean },
+  ) => {
     if (updates.length === 0) {
       return {
         updated: false,
@@ -2686,11 +2738,14 @@ export function useSceneCollectionManager() {
     const allUpdatedIds = Array.from(updateMap.keys());
     const includeSupportHistory = allUpdatedIds.some((id) => hasSupportsOrKickstandsForModel(id, supportStateBefore, kickstandStateBefore));
 
-    const before = captureSceneSnapshot(currentModels, currentActiveModelId, currentSelectedModelIds, {
-      includeSupportState: includeSupportHistory,
-      supportStateOverride: includeSupportHistory ? supportStateBefore : undefined,
-      kickstandStateOverride: includeSupportHistory ? kickstandStateBefore : undefined,
-    });
+    const shouldPushHistory = options?.pushHistory !== false;
+    const before = shouldPushHistory
+      ? captureSceneSnapshot(currentModels, currentActiveModelId, currentSelectedModelIds, {
+          includeSupportState: includeSupportHistory,
+          supportStateOverride: includeSupportHistory ? supportStateBefore : undefined,
+          kickstandStateOverride: includeSupportHistory ? kickstandStateBefore : undefined,
+        })
+      : null;
 
     let supportsChanged = false;
     let kickstandsChanged = false;
@@ -2718,16 +2773,19 @@ export function useSceneCollectionManager() {
       return nextTransform ? { ...m, transform: nextTransform } : m;
     });
 
+    if (!shouldPushHistory) modelsRef.current = nextModels;
     setModels(nextModels);
 
-    const supportStateAfter = includeSupportHistory ? getSnapshot() : undefined;
-    const kickstandStateAfter = includeSupportHistory ? getKickstandSnapshot() : undefined;
-    const after = captureSceneSnapshot(nextModels, currentActiveModelId, currentSelectedModelIds, {
-      includeSupportState: includeSupportHistory,
-      supportStateOverride: supportStateAfter,
-      kickstandStateOverride: kickstandStateAfter,
-    });
-    pushSceneSnapshotHistory(before, after, updates.length === 1 ? 'Update Model Transform' : 'Update Model Transforms');
+    if (shouldPushHistory && before) {
+      const supportStateAfter = includeSupportHistory ? getSnapshot() : undefined;
+      const kickstandStateAfter = includeSupportHistory ? getKickstandSnapshot() : undefined;
+      const after = captureSceneSnapshot(nextModels, currentActiveModelId, currentSelectedModelIds, {
+        includeSupportState: includeSupportHistory,
+        supportStateOverride: supportStateAfter,
+        kickstandStateOverride: kickstandStateAfter,
+      });
+      pushSceneSnapshotHistory(before, after, updates.length === 1 ? 'Update Model Transform' : 'Update Model Transforms');
+    }
 
     return {
       updated,
@@ -5749,6 +5807,7 @@ export function useSceneCollectionManager() {
     onFileChange,
     updateModelTransform,
     commitModelTransformHistory,
+    commitModelTransformsHistory,
     updateModelTransforms,
     setModelTransformRaw,
     replaceModelGeometry,

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -47,6 +47,7 @@ import {
   applyModelGroupUngrouping,
   applyModelUngrouping,
 } from '@/features/scene/modelGroupingHistory';
+import { performModelCut, selectModelsForClipboard } from '@/features/scene/modelCut';
 
 type PersistedMeshAppearance = {
   v: 1;
@@ -3932,10 +3933,10 @@ export function useSceneCollectionManager() {
   }, [models]);
 
   const copySelectedModels = useCallback((ids?: string[]) => {
-    const idSet = new Set((ids && ids.length > 0) ? ids : selectedModelIds);
-    if (idSet.size === 0) return false;
+    const targetIds = (ids && ids.length > 0) ? ids : selectedModelIds;
+    if (targetIds.length === 0) return false;
 
-    const selected = models.filter((m) => idSet.has(m.id));
+    const selected = selectModelsForClipboard(models, targetIds);
     if (selected.length === 0) return false;
 
     setModelClipboard(selected.map((source) => {
@@ -3962,12 +3963,13 @@ export function useSceneCollectionManager() {
     return true;
   }, [models, selectedModelIds]);
 
+  const cutSelectedModels = useCallback((ids: string[]) => {
+    return performModelCut(ids, copySelectedModels, deleteModels);
+  }, [copySelectedModels, deleteModels]);
+
   const cutModel = useCallback((id: string) => {
-    const copied = copyModel(id);
-    if (!copied) return false;
-    deleteModel(id);
-    return true;
-  }, [copyModel, deleteModel]);
+    return cutSelectedModels([id]);
+  }, [cutSelectedModels]);
 
   const pasteModel = useCallback(() => {
     if (modelClipboard.length === 0) return null;
@@ -5774,6 +5776,7 @@ export function useSceneCollectionManager() {
     deleteSupportsForModels,
     copyModel,
     copySelectedModels,
+    cutSelectedModels,
     cutModel,
     pasteModel,
     pasteCopiedModelsAutoArrange,

--- a/src/supports/Renderers/BezierRenderer.tsx
+++ b/src/supports/Renderers/BezierRenderer.tsx
@@ -1,4 +1,4 @@
-import { isSupportSelectionShiftActive } from '../interaction/clickHandlers';
+import { shouldDeferSupportPrimitiveSelection } from '../interaction/clickHandlers';
 import React, { useMemo, useEffect, useState, useRef } from 'react';
 import * as THREE from 'three';
 import { Vec3 } from '../types';
@@ -165,7 +165,7 @@ export function BezierRenderer({
 
         const altDown = !!(e?.nativeEvent?.altKey || e?.altKey);
         const ctrlDown = !!(e?.nativeEvent?.ctrlKey || e?.ctrlKey);
-        if (isSupportSelectionShiftActive(e)) return;
+        if (shouldDeferSupportPrimitiveSelection(e)) return;
 
         // If Alt is held, this click is intended for placement tools.
         // Stop propagation so it does not fall through to the canvas/model click handlers.

--- a/src/supports/Renderers/BezierRenderer.tsx
+++ b/src/supports/Renderers/BezierRenderer.tsx
@@ -1,3 +1,4 @@
+import { isSupportSelectionShiftActive } from '../interaction/clickHandlers';
 import React, { useMemo, useEffect, useState, useRef } from 'react';
 import * as THREE from 'three';
 import { Vec3 } from '../types';
@@ -164,6 +165,7 @@ export function BezierRenderer({
 
         const altDown = !!(e?.nativeEvent?.altKey || e?.altKey);
         const ctrlDown = !!(e?.nativeEvent?.ctrlKey || e?.ctrlKey);
+        if (isSupportSelectionShiftActive(e)) return;
 
         // If Alt is held, this click is intended for placement tools.
         // Stop propagation so it does not fall through to the canvas/model click handlers.

--- a/src/supports/Settings/SupportSidebar.tsx
+++ b/src/supports/Settings/SupportSidebar.tsx
@@ -24,14 +24,11 @@ import {
     getSnapshot as getSupportSnapshot,
     resolveEditableSupportTarget,
     getSupportSettingsForTarget,
-    applySettingsToSupportTarget,
-    beginSupportStateBatch,
-    endSupportStateBatch,
     type EditableSupportTarget,
 } from '../state';
-import { getSelectedSupportIds } from '../interaction/supportMultiSelection';
 import { checkPresetDrift, findMatchingPresetIdForSettings, getPresetById } from './presets';
 import { createDefaultSettings, type SupportSettings } from './types';
+import { applySettingsToSelectedSupports } from './applySettingsToSelectedSupports';
 import { areSupportGeometrySettingsEqual } from './supportSettingsCodec';
 import { captureSupportEditSnapshot, pushSupportEditHistory, type SupportEditHistorySnapshot } from '../history/supportEditHistory';
 import {
@@ -168,40 +165,6 @@ function fieldFocusProps(
         onBlurCapture: onBlur,
         'data-setting-key': key,
     };
-}
-
-/** Apply settings to all currently selected supports (multi-selection aware). */
-function applySettingsToAllSelectedSupports(settings: SupportSettings): void {
-    const snap = getSupportSnapshot();
-    const selectedIds = getSelectedSupportIds();
-    const idsToApply = selectedIds.length > 0
-        ? selectedIds
-        : (snap.selectedId ? [snap.selectedId] : []);
-
-    if (idsToApply.length === 0) return;
-
-    // Batch all mutations so notify() only fires once after the loop,
-    // preventing cascading re-renders from useSyncExternalStore listeners.
-    beginSupportStateBatch();
-    try {
-        for (const id of idsToApply) {
-            let target: EditableSupportTarget | null = null;
-            if (snap.trunks[id]) {
-                target = { kind: 'trunk', id };
-            } else if (snap.branches[id]) {
-                target = { kind: 'branch', id };
-            } else if (snap.leaves[id]) {
-                target = { kind: 'leaf', id };
-            } else {
-                target = resolveEditableSupportTarget(id, snap.selectedCategory ?? undefined);
-            }
-            if (target) {
-                applySettingsToSupportTarget(target, settings);
-            }
-        }
-    } finally {
-        endSupportStateBatch();
-    }
 }
 
 /**
@@ -417,7 +380,7 @@ export function SupportSidebar() {
         const latestSettings = editSessionLatestSettingsRef.current ?? getSettings();
         const persisted = getSupportSettingsForTarget(target);
         if (!persisted || !areSupportGeometrySettingsEqual(persisted, latestSettings)) {
-            applySettingsToAllSelectedSupports(latestSettings);
+            applySettingsToSelectedSupports(latestSettings);
         }
 
         if (before) {
@@ -558,7 +521,7 @@ export function SupportSidebar() {
 
         supportEditSessionDirtyRef.current = true;
         editSessionLatestSettingsRef.current = settings;
-        applySettingsToAllSelectedSupports(settings);
+        applySettingsToSelectedSupports(settings);
     }, [editableTarget, settings]);
 
     React.useEffect(() => {
@@ -1336,7 +1299,7 @@ export function SupportSidebar() {
                                                         };
                                                         editSessionLatestSettingsRef.current = nextSettings;
                                                         setSettings(nextSettings);
-                                                        applySettingsToAllSelectedSupports(nextSettings);
+                                                        applySettingsToSelectedSupports(nextSettings);
                                                         setOptimisticPresetId(presetId);
                                                     }}
                                                 />

--- a/src/supports/Settings/applySettingsToSelectedSupports.ts
+++ b/src/supports/Settings/applySettingsToSelectedSupports.ts
@@ -1,0 +1,41 @@
+import { getSelectedSupportIds } from '@/supports/interaction/supportMultiSelection';
+import {
+    applySettingsToSupportTarget,
+    beginSupportStateBatch,
+    endSupportStateBatch,
+    getSnapshot,
+    resolveEditableSupportTarget,
+    type EditableSupportTarget,
+} from '@/supports/state';
+import type { SupportSettings } from './types';
+
+export function applySettingsToSelectedSupports(settings: SupportSettings): void {
+    const snapshot = getSnapshot();
+    const selectedIds = getSelectedSupportIds();
+    const idsToApply = selectedIds.length > 0
+        ? selectedIds
+        : (snapshot.selectedId ? [snapshot.selectedId] : []);
+
+    if (idsToApply.length === 0) return;
+
+    beginSupportStateBatch();
+    try {
+        for (const id of idsToApply) {
+            let target: EditableSupportTarget | null = null;
+            if (snapshot.trunks[id]) {
+                target = { kind: 'trunk', id };
+            } else if (snapshot.branches[id]) {
+                target = { kind: 'branch', id };
+            } else if (snapshot.leaves[id]) {
+                target = { kind: 'leaf', id };
+            } else {
+                target = resolveEditableSupportTarget(id, snapshot.selectedCategory ?? undefined);
+            }
+            if (target) {
+                applySettingsToSupportTarget(target, settings);
+            }
+        }
+    } finally {
+        endSupportStateBatch();
+    }
+}

--- a/src/supports/SupportPrimitives/Shaft/ShaftRenderer.tsx
+++ b/src/supports/SupportPrimitives/Shaft/ShaftRenderer.tsx
@@ -1,3 +1,4 @@
+import { isSupportSelectionShiftActive } from '../../interaction/clickHandlers';
 import React, { useEffect, useState } from 'react';
 import * as THREE from 'three';
 import { Vec3 } from '../../types';
@@ -135,6 +136,7 @@ export function ShaftRenderer({
         });
 
         if (rayIntersectsJointOrKnot(e)) return;
+    if (isSupportSelectionShiftActive(e)) return;
 
         // If Alt is held, this click is intended for placement tools (Brace/Branch/etc.).
         // Stop propagation so it does not fall through to the canvas/model click handlers.

--- a/src/supports/SupportPrimitives/Shaft/ShaftRenderer.tsx
+++ b/src/supports/SupportPrimitives/Shaft/ShaftRenderer.tsx
@@ -1,4 +1,4 @@
-import { isSupportSelectionShiftActive } from '../../interaction/clickHandlers';
+import { shouldDeferSupportPrimitiveSelection } from '../../interaction/clickHandlers';
 import React, { useEffect, useState } from 'react';
 import * as THREE from 'three';
 import { Vec3 } from '../../types';
@@ -136,7 +136,7 @@ export function ShaftRenderer({
         });
 
         if (rayIntersectsJointOrKnot(e)) return;
-    if (isSupportSelectionShiftActive(e)) return;
+    if (shouldDeferSupportPrimitiveSelection(e)) return;
 
         // If Alt is held, this click is intended for placement tools (Brace/Branch/etc.).
         // Stop propagation so it does not fall through to the canvas/model click handlers.

--- a/src/supports/interaction/clickHandlers.ts
+++ b/src/supports/interaction/clickHandlers.ts
@@ -2,6 +2,7 @@ import { applySupportSelectionClick, selectJointById, selectPrimitiveById } from
 import { isContactDiskHudInteractionActive } from '../SupportPrimitives/ContactDisk/contactDiskHudInteraction';
 import { getSnapshot } from '../state';
 import { isKeyPressedSync } from '@/hotkeys/hotkeyStore';
+import { getSelectedSupportIds } from './supportMultiSelection';
 
 let hoverGuardInitialized = false;
 let orbitInteractionActive = false;
@@ -41,6 +42,10 @@ export function isSupportSelectionShiftActive(e: any) {
         || e?.sourceEvent?.shiftKey
         || isKeyPressedSync('shift')
     );
+}
+
+export function shouldDeferSupportPrimitiveSelection(e: any) {
+    return isSupportSelectionShiftActive(e) || getSelectedSupportIds().length > 1;
 }
 
 export function emitSupportModelPointerHover(modelId: string | null) {
@@ -115,7 +120,7 @@ export function handleJointClick(
     onSelect?: (id: string) => void
 ) {
     if (!isInteractable) return;
-    if (isSupportSelectionShiftActive(e)) return;
+    if (shouldDeferSupportPrimitiveSelection(e)) return;
     
     // If parent is NOT selected and THIS joint is NOT selected, 
     // let the click bubble to the parent (Trunk/Branch) to select the support first.
@@ -148,7 +153,7 @@ export function handleKnotClick(
     onSelect?: (id: string) => void
  ) {
     if (!isInteractable) return;
-    if (isSupportSelectionShiftActive(e)) return;
+     if (shouldDeferSupportPrimitiveSelection(e)) return;
 
     if (!isParentSelected && !isKnotSelected) {
         return;
@@ -197,7 +202,7 @@ export function handleContactDiskClick(
     onSelect?: (id: string) => void
 ) {
     if (!isInteractable) return;
-    if (isSupportSelectionShiftActive(e)) return;
+    if (shouldDeferSupportPrimitiveSelection(e)) return;
 
     if (!isParentSelected && !isContactDiskSelected) {
         return;

--- a/src/supports/interaction/clickHandlers.ts
+++ b/src/supports/interaction/clickHandlers.ts
@@ -34,7 +34,7 @@ function initializeHoverGuards() {
     document.addEventListener('visibilitychange', markOrbitInactiveFromPointer);
 }
 
-function isShiftActiveFromEvent(e: any) {
+export function isSupportSelectionShiftActive(e: any) {
     return !!(
         e?.shiftKey
         || e?.nativeEvent?.shiftKey
@@ -80,7 +80,7 @@ export function emitSupportModelPointerSelect(modelId: string | null) {
  * Enforces interactability check and stops DOM propagation to prevent canvas deselection.
  */
 export function handleSupportClick(e: any, id: string, isInteractable: boolean) {
-    const shiftDown = isShiftActiveFromEvent(e);
+    const shiftDown = isSupportSelectionShiftActive(e);
 
     if (!isInteractable) {
         return;
@@ -115,6 +115,7 @@ export function handleJointClick(
     onSelect?: (id: string) => void
 ) {
     if (!isInteractable) return;
+    if (isSupportSelectionShiftActive(e)) return;
     
     // If parent is NOT selected and THIS joint is NOT selected, 
     // let the click bubble to the parent (Trunk/Branch) to select the support first.
@@ -147,6 +148,7 @@ export function handleKnotClick(
     onSelect?: (id: string) => void
  ) {
     if (!isInteractable) return;
+    if (isSupportSelectionShiftActive(e)) return;
 
     if (!isParentSelected && !isKnotSelected) {
         return;
@@ -195,6 +197,7 @@ export function handleContactDiskClick(
     onSelect?: (id: string) => void
 ) {
     if (!isInteractable) return;
+    if (isSupportSelectionShiftActive(e)) return;
 
     if (!isParentSelected && !isContactDiskSelected) {
         return;

--- a/src/supports/interaction/shared/selection/__tests__/selectionController.test.ts
+++ b/src/supports/interaction/shared/selection/__tests__/selectionController.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { clearHistory, getUndoCount, undo } from '@/history/historyStore';
+import { captureSupportEditSnapshot, pushSupportEditHistory } from '@/supports/history/supportEditHistory';
+import { registerSupportHistoryHandlers } from '@/supports/history/useSupportHistoryHandlers';
+import { applySettingsToSelectedSupports } from '@/supports/Settings/applySettingsToSelectedSupports';
+import { createDefaultSettings } from '@/supports/Settings/types';
+import type { Roots, SupportState, Trunk } from '@/supports/types';
+import {
+    getSnapshot,
+    resetStore,
+    setSnapshot,
+} from '@/supports/state';
+import {
+    clearSupportSelection,
+    getResolvedPrimarySelection,
+    selectSupportById,
+} from '../selectionController';
+
+function makeTrunk(id: string): Trunk {
+    return {
+        id,
+        modelId: 'model-a',
+        rootId: `root-${id}`,
+        segments: [],
+    };
+}
+
+function makeRoot(trunkId: string): Roots {
+    return {
+        id: `root-${trunkId}`,
+        modelId: 'model-a',
+        transform: {
+            pos: { x: 0, y: 0, z: 0 },
+            rot: { x: 0, y: 0, z: 0, w: 1 },
+        },
+        diameter: 3,
+        diskHeight: 0.5,
+        coneHeight: 0.5,
+    };
+}
+
+function seedTrunks(...ids: string[]) {
+    const snapshot: SupportState = {
+        roots: Object.fromEntries(ids.map((id) => [`root-${id}`, makeRoot(id)])),
+        trunks: Object.fromEntries(ids.map((id) => [id, makeTrunk(id)])),
+        branches: {},
+        leaves: {},
+        twigs: {},
+        sticks: {},
+        braces: {},
+        anchors: {},
+        knots: {},
+        selectedId: null,
+        hoveredId: null,
+        selectedCategory: null,
+        hoveredCategory: 'none',
+        interactionWarning: null,
+    };
+    setSnapshot(snapshot);
+}
+
+test('Shift-click keeps the last clicked support as the editable representative', () => {
+    resetStore();
+    clearSupportSelection();
+    seedTrunks('trunk-a', 'trunk-b');
+
+    selectSupportById('trunk-a', false);
+    selectSupportById('trunk-b', true);
+
+    const selection = getResolvedPrimarySelection();
+    assert.deepEqual(selection.selectedIds, ['trunk-a', 'trunk-b']);
+    assert.equal(selection.selectedId, 'trunk-b');
+    assert.equal(selection.selectedCategory, 'trunk');
+
+    clearSupportSelection();
+    resetStore();
+});
+
+
+test('a settings edit changes every Shift-click-selected support in one undo step', async () => {
+    resetStore();
+    clearSupportSelection();
+    clearHistory();
+    seedTrunks('trunk-a', 'trunk-b');
+    const unregisterHistory = registerSupportHistoryHandlers();
+
+    try {
+        selectSupportById('trunk-a', false);
+        selectSupportById('trunk-b', true);
+
+        const before = captureSupportEditSnapshot();
+        const settings = createDefaultSettings();
+        settings.shaft.diameterMm = 2.75;
+
+        applySettingsToSelectedSupports(settings);
+
+        const after = captureSupportEditSnapshot();
+        pushSupportEditHistory('Adjust selected support settings', before, after);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        assert.equal(getSnapshot().trunks['trunk-a'].baseDiameterMm, 2.75);
+        assert.equal(getSnapshot().trunks['trunk-b'].baseDiameterMm, 2.75);
+        assert.equal(getUndoCount(), 1);
+
+        undo();
+        assert.equal(getSnapshot().trunks['trunk-a'].baseDiameterMm, undefined);
+        assert.equal(getSnapshot().trunks['trunk-b'].baseDiameterMm, undefined);
+    } finally {
+        unregisterHistory();
+        clearHistory();
+        clearSupportSelection();
+        resetStore();
+    }
+});
+
+test('Shift-click removal promotes a remaining support as the editable representative', () => {
+    resetStore();
+    clearSupportSelection();
+    seedTrunks('trunk-a', 'trunk-b');
+
+    selectSupportById('trunk-a', false);
+    selectSupportById('trunk-b', true);
+    selectSupportById('trunk-b', true);
+
+    const selection = getResolvedPrimarySelection();
+    assert.deepEqual(selection.selectedIds, ['trunk-a']);
+    assert.equal(selection.selectedId, 'trunk-a');
+    assert.equal(selection.selectedCategory, 'trunk');
+
+    clearSupportSelection();
+    resetStore();
+});

--- a/src/supports/interaction/shared/selection/__tests__/selectionController.test.ts
+++ b/src/supports/interaction/shared/selection/__tests__/selectionController.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import { clearHistory, getUndoCount, undo } from '@/history/historyStore';
 import { captureSupportEditSnapshot, pushSupportEditHistory } from '@/supports/history/supportEditHistory';
 import { registerSupportHistoryHandlers } from '@/supports/history/useSupportHistoryHandlers';
+import { handleContactDiskClick } from '@/supports/interaction/clickHandlers';
 import { applySettingsToSelectedSupports } from '@/supports/Settings/applySettingsToSelectedSupports';
 import { createDefaultSettings } from '@/supports/Settings/types';
 import type { Roots, SupportState, Trunk } from '@/supports/types';
@@ -61,7 +62,7 @@ function seedTrunks(...ids: string[]) {
     setSnapshot(snapshot);
 }
 
-test('Shift-click keeps the last clicked support as the editable representative', () => {
+test('Shift-click adds a support and keeps it as the editable representative', () => {
     resetStore();
     clearSupportSelection();
     seedTrunks('trunk-a', 'trunk-b');
@@ -78,6 +79,23 @@ test('Shift-click keeps the last clicked support as the editable representative'
     resetStore();
 });
 
+test('normal click replaces the selection set with the clicked support', () => {
+    resetStore();
+    clearSupportSelection();
+    seedTrunks('trunk-a', 'trunk-b');
+
+    selectSupportById('trunk-a', false);
+    selectSupportById('trunk-b', true);
+    selectSupportById('trunk-a', false);
+
+    const selection = getResolvedPrimarySelection();
+    assert.deepEqual(selection.selectedIds, ['trunk-a']);
+    assert.equal(selection.selectedId, 'trunk-a');
+    assert.equal(selection.selectedCategory, 'trunk');
+
+    clearSupportSelection();
+    resetStore();
+});
 
 test('a settings edit changes every Shift-click-selected support in one undo step', async () => {
     resetStore();
@@ -115,7 +133,7 @@ test('a settings edit changes every Shift-click-selected support in one undo ste
     }
 });
 
-test('Shift-click removal promotes a remaining support as the editable representative', () => {
+test('Shift-clicking a selected support removes only that support from the selection set', () => {
     resetStore();
     clearSupportSelection();
     seedTrunks('trunk-a', 'trunk-b');
@@ -128,6 +146,31 @@ test('Shift-click removal promotes a remaining support as the editable represent
     assert.deepEqual(selection.selectedIds, ['trunk-a']);
     assert.equal(selection.selectedId, 'trunk-a');
     assert.equal(selection.selectedCategory, 'trunk');
+
+    clearSupportSelection();
+    resetStore();
+});
+
+test('Shift-click on a selected primitive defers to the parent support toggle', () => {
+    resetStore();
+    clearSupportSelection();
+    seedTrunks('trunk-a', 'trunk-b');
+
+    selectSupportById('trunk-a', false);
+    selectSupportById('trunk-b', true);
+
+    let propagationStopped = false;
+    handleContactDiskClick({
+        stopPropagation: () => { propagationStopped = true; },
+        nativeEvent: {
+            shiftKey: true,
+            stopPropagation: () => { propagationStopped = true; },
+            stopImmediatePropagation: () => { propagationStopped = true; },
+        },
+    }, 'contact-disk-b', true, true, false);
+
+    assert.equal(propagationStopped, false);
+    assert.deepEqual(getResolvedPrimarySelection().selectedIds, ['trunk-a', 'trunk-b']);
 
     clearSupportSelection();
     resetStore();

--- a/src/supports/interaction/shared/selection/__tests__/selectionController.test.ts
+++ b/src/supports/interaction/shared/selection/__tests__/selectionController.test.ts
@@ -4,7 +4,7 @@ import test from 'node:test';
 import { clearHistory, getUndoCount, undo } from '@/history/historyStore';
 import { captureSupportEditSnapshot, pushSupportEditHistory } from '@/supports/history/supportEditHistory';
 import { registerSupportHistoryHandlers } from '@/supports/history/useSupportHistoryHandlers';
-import { handleContactDiskClick } from '@/supports/interaction/clickHandlers';
+import { handleContactDiskClick, handleSupportClick } from '@/supports/interaction/clickHandlers';
 import { applySettingsToSelectedSupports } from '@/supports/Settings/applySettingsToSelectedSupports';
 import { createDefaultSettings } from '@/supports/Settings/types';
 import type { Roots, SupportState, Trunk } from '@/supports/types';
@@ -171,6 +171,45 @@ test('Shift-click on a selected primitive defers to the parent support toggle', 
 
     assert.equal(propagationStopped, false);
     assert.deepEqual(getResolvedPrimarySelection().selectedIds, ['trunk-a', 'trunk-b']);
+
+    clearSupportSelection();
+    resetStore();
+});
+
+test('normal click exits a selection set before Shift starts a new set', () => {
+    resetStore();
+    clearSupportSelection();
+    seedTrunks('trunk-a', 'trunk-b', 'trunk-c');
+
+    selectSupportById('trunk-a', false);
+    selectSupportById('trunk-b', true);
+
+    let propagationStopped = false;
+    const normalClickEvent = {
+        stopPropagation: () => { propagationStopped = true; },
+        nativeEvent: {
+            shiftKey: false,
+            stopPropagation: () => { propagationStopped = true; },
+            stopImmediatePropagation: () => { propagationStopped = true; },
+        },
+    };
+    handleContactDiskClick(normalClickEvent, 'contact-disk-a', true, true, false);
+    assert.equal(propagationStopped, false);
+    handleSupportClick(normalClickEvent, 'trunk-a', true);
+
+    handleSupportClick({
+        stopPropagation: () => undefined,
+        nativeEvent: {
+            shiftKey: true,
+            stopPropagation: () => undefined,
+            stopImmediatePropagation: () => undefined,
+        },
+    }, 'trunk-c', true);
+
+    const selection = getResolvedPrimarySelection();
+    assert.deepEqual(selection.selectedIds, ['trunk-a', 'trunk-c']);
+    assert.equal(selection.selectedId, 'trunk-c');
+    assert.equal(selection.selectedCategory, 'trunk');
 
     clearSupportSelection();
     resetStore();

--- a/src/supports/interaction/shared/selection/selectionController.ts
+++ b/src/supports/interaction/shared/selection/selectionController.ts
@@ -79,11 +79,6 @@ export function selectSupportById(id: string, toggle: boolean) {
         return;
     }
 
-    if (next.length > 1) {
-        setSelectedId(null);
-        return;
-    }
-
     setSelectedId(id);
 }
 


### PR DESCRIPTION
Until now most transform and edit actions only ever touched the active model or the primary selected support. This branch extends them to the whole selection set, with one shared target-resolution rule: use the selection when there is one, otherwise fall back to the context model, otherwise the active model.

## Models

- Context-menu **delete** and **cut** now act on every selected model (#576, #577). The menu's disabled state is derived from the resolved targets instead of `activeModelId`, so delete stays enabled on a selection with no active model.
- **Lift / drop** applies to the whole selection, each model keeping its own offset from the target plate Z (#305).
- **Move-to-position** and **Center** operate on the selection (#574). The numeric position fields show the selection's gizmo center and update live; each model moves by its own delta from that origin. `Center Selection` is now an explicit button in the transform panel.
- **Mirror** stays single-model: entering Mirror with several models selected collapses the set to the active model (#575).
- Live position edits no longer spam undo history: `updateModelTransforms` accepts `{ pushHistory: false }`, and the new `commitModelTransformsHistory` records one before/after entry (`Move Selected Models`) at the end of the gesture, including the support and kickstand snapshots so undo restores the selection atomically.

## Supports

- Settings edits apply to every selected support at once, batched into a single store notification (#190). The logic moved out of `SupportSidebar` into `applySettingsToSelectedSupports`.
- Shift-clicking a selected support removes it from the set instead of re-selecting it.
- Detailed primitive renderers (shaft, bezier) defer to the parent support while a multi-selection is active, so clicking a shaft no longer wipes the set.

## Shape of the change

New pure modules under `src/features/scene/`, each with unit tests: `modelActionTargets` (target resolution + delete/cut dispatch), `modelCut`, `selectionLiftDrop`, `selectionPosition`. `SceneCanvas` now reuses `getSelectionGizmoCenter` for the multi-gizmo center instead of two hand-rolled averaging loops. Docs updated: history/undo (live transform batches), support system (multi-support settings), and the mirror workflow note.

## Testing

New unit suites: `modelActionTargets`, `modelCut`, `selectionLiftDrop`, `selectionPosition`, `selectionController`.

Closes #190, #305, #574, #575, #576, #577.