### PR TITLE
Skip the update check on Linux and fix Flatpak packager bug

### DIFF
--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -238,6 +238,15 @@ channel."
   stable feed by default; `src-tauri/src/updater_channel.rs` overrides the
   endpoint at runtime based on the user's saved channel preference
   (`STABLE_ENDPOINT` / `DEV_ENDPOINT`), independent of the static config.
+- **Linux never runs the check.** The release job builds only a `.flatpak`
+  (`build_kind: flatpak`, `--no-bundle`), so `latest.json` / `latest-dev.json`
+  have no `linux-x86_64` key — and the updater could not install over a running
+  Flatpak anyway, since `/app` is read-only inside the sandbox. `check_updates`
+  returns `None` early on Linux and the Settings → Updates tab shows a
+  "Managed by Flatpak" card with the `flatpak update` command instead of the
+  channel picker (`updatesAreExternal()` in
+  `src/features/updater/updateBridge.ts`). Adding a Linux entry to the feed
+  would only make sense alongside an AppImage build.
 - The plugin's default version comparator is a plain `release.version >
   current_version` using `semver::Version::Ord` — no custom comparator is
   registered. This means there's no downgrade support: a user who updates to

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -66,6 +66,14 @@ const filteredPassThroughArgs = noBundles
   ? passThroughArgs.filter((_, i) => i !== bundlesIdx && i !== bundlesIdx + 1)
   : passThroughArgs;
 
+// `--target <triple>` makes cargo write to target/<triple>/release instead of
+// target/release. The Flatpak staging below has to look where THIS build wrote.
+const explicitTargetIdx = filteredPassThroughArgs.indexOf("--target");
+const explicitTarget =
+  explicitTargetIdx !== -1
+    ? filteredPassThroughArgs[explicitTargetIdx + 1]
+    : (process.env.CARGO_BUILD_TARGET ?? null);
+
 const cmdArgs = ["tauri", "build", ...filteredPassThroughArgs];
 const hasBundlesArg = filteredPassThroughArgs.includes("--bundles");
 
@@ -183,13 +191,16 @@ if (isLinux) {
           console.error("[tauri-build] desktop-file-validate failed — skipping Flatpak bundle.");
           console.error(desktopValid.stdout?.toString());
         } else {
-          // (d) Find CEF binary — we just built it, so search known paths
+          // (d) Find CEF binary — we just built it, so search known paths.
+          // Search this build's own output layout first: a leftover binary from
+          // the other layout would otherwise be packaged instead, silently.
           const rel = path.join(repoRoot, "src-tauri", "target", "release");
           const tripleRel = path.join(
-            repoRoot, "src-tauri", "target", "x86_64-unknown-linux-gnu", "release"
+            repoRoot, "src-tauri", "target",
+            explicitTarget ?? "x86_64-unknown-linux-gnu", "release"
           );
           const binaryName = "dragonfruit-desktop";
-          const releaseDir = [rel, tripleRel]
+          const releaseDir = (explicitTarget ? [tripleRel, rel] : [rel, tripleRel])
             .map((dir) => ({ dir, binPath: path.join(dir, binaryName) }))
             .find(({ binPath }) => existsSync(binPath))?.dir;
           const binPath = releaseDir

--- a/src-tauri/src/updater_channel.rs
+++ b/src-tauri/src/updater_channel.rs
@@ -53,11 +53,15 @@ fn cached_update() -> &'static Mutex<Option<tauri_plugin_updater::Update>> {
 // Endpoint URLs per channel
 // ---------------------------------------------------------------------------
 
+// Unused on Linux, where the check is skipped entirely (see `check_updates`).
+#[cfg(not(target_os = "linux"))]
 const STABLE_ENDPOINT: &str =
     "https://open-resin-alliance.github.io/DragonFruit/latest.json";
+#[cfg(not(target_os = "linux"))]
 const DEV_ENDPOINT: &str =
     "https://open-resin-alliance.github.io/DragonFruit/latest-dev.json";
 
+#[cfg(not(target_os = "linux"))]
 fn endpoint_for_channel(channel: &str) -> &'static str {
     match channel {
         "dev" | "prerelease" => DEV_ENDPOINT,
@@ -73,6 +77,27 @@ fn endpoint_for_channel(channel: &str) -> &'static str {
 /// Returns `null` (None) if no update is available.
 #[tauri::command]
 pub async fn check_updates(
+    app_handle: UpdaterAppHandle,
+    channel: Option<String>,
+) -> Result<Option<UpdateCheckResult>, String> {
+    // Linux ships only as a Flatpak bundle, so the updater feed has no
+    // `linux-x86_64` key — and even with one, the plugin cannot install over a
+    // running sandboxed app (`/app` is read-only). Flatpak updates come from
+    // the remote. Skip the check instead of letting it fail with a warning
+    // that reads as a broken updater.
+    #[cfg(target_os = "linux")]
+    {
+        let _ = (app_handle, channel);
+        info!("[updater] Linux build is distributed as a Flatpak — skipping the update check");
+        Ok(None)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    check_updates_impl(app_handle, channel).await
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn check_updates_impl(
     app_handle: UpdaterAppHandle,
     channel: Option<String>,
 ) -> Result<Option<UpdateCheckResult>, String> {

--- a/src/features/updater/GlobalUpdateIndicator.tsx
+++ b/src/features/updater/GlobalUpdateIndicator.tsx
@@ -6,7 +6,7 @@ import { useLingui } from '@lingui/react';
 import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import ReactMarkdown from 'react-markdown';
-import { fetchUpdateInfo, downloadAndInstall, getUpdateChannel, type UpdateInfo, type DownloadProgress, type UpdateChannel } from '@/features/updater/updateBridge';
+import { fetchUpdateInfo, downloadAndInstall, getUpdateChannel, updatesAreExternal, type UpdateInfo, type DownloadProgress, type UpdateChannel } from '@/features/updater/updateBridge';
 import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
 
 // ---------------------------------------------------------------------------
@@ -46,6 +46,9 @@ export function GlobalUpdateIndicator() {
 
   // ── Silent background check ──────────────────────────────────────────
   useEffect(() => {
+    // Linux installs updates through Flatpak — nothing to check or offer here.
+    if (updatesAreExternal()) return;
+
     let channel: UpdateChannel = 'stable';
 
     const runCheck = () => {

--- a/src/features/updater/UpdateCheckerSection.tsx
+++ b/src/features/updater/UpdateCheckerSection.tsx
@@ -9,8 +9,10 @@ import {
   Download,
   ExternalLink,
   Loader2,
+  Package,
   RotateCcw,
 } from 'lucide-react';
+import { FLATPAK_APP_ID, LINUX_RELEASES_URL } from '@/features/updater/updateBridge';
 import { useUpdateChecker } from '@/features/updater/useUpdateChecker';
 import type { UpdateState } from '@/features/updater/useUpdateChecker';
 
@@ -22,6 +24,15 @@ function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+async function openExternal(url: string): Promise<void> {
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('open_external_url', { url });
+  } catch {
+    window.open(url, '_blank');
+  }
 }
 
 function ProgressBar({ pct }: { pct: number }) {
@@ -229,14 +240,10 @@ function AvailableState({
         </button>
 
         <button
-          onClick={async () => {
-            const url = `https://github.com/Open-Resin-Alliance/DragonFruit/releases/tag/v${info.version}`;
-            try {
-              const { invoke } = await import('@tauri-apps/api/core');
-              await invoke('open_external_url', { url });
-            } catch {
-              window.open(url, '_blank');
-            }
+          onClick={() => {
+            void openExternal(
+              `https://github.com/Open-Resin-Alliance/DragonFruit/releases/tag/v${info.version}`,
+            );
           }}
           className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[12px] transition-all duration-150"
           style={{
@@ -370,6 +377,62 @@ function InstalledState() {
   );
 }
 
+function ExternalState() {
+  return (
+    <div
+      className="w-full rounded-md border p-2.5"
+      style={{
+        borderColor: 'var(--border-subtle)',
+        background: 'var(--surface-0)',
+      }}
+    >
+      <div className="flex items-center gap-2.5">
+        <span
+          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
+          style={{
+            borderColor: 'var(--border-subtle)',
+            background: 'color-mix(in srgb, var(--surface-2), transparent 8%)',
+          }}
+        >
+          <Package className="h-4 w-4" style={{ color: 'var(--accent)' }} />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
+            Managed by Flatpak
+          </span>
+          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
+            DragonFruit for Linux ships as a Flatpak, so updates are installed
+            outside the app.
+          </span>
+        </span>
+        <button
+          type="button"
+          onClick={() => void openExternal(LINUX_RELEASES_URL)}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-all duration-150"
+          style={{
+            color: 'var(--text-muted)',
+            borderColor: 'var(--border-subtle)',
+            background: 'var(--surface-2)',
+          }}
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+          Releases
+        </button>
+      </div>
+      <code
+        className="mt-2 block rounded-md border px-2 py-1.5 text-[11px]"
+        style={{
+          borderColor: 'var(--border-subtle)',
+          background: 'var(--surface-1)',
+          color: 'var(--text-muted)',
+        }}
+      >
+        flatpak update {FLATPAK_APP_ID}
+      </code>
+    </div>
+  );
+}
+
 function ErrorState({
   message,
   onRetry,
@@ -441,6 +504,7 @@ export function UpdateCheckerSection({
 
   return (
     <div className={className}>
+      {state.status === 'external' && <ExternalState />}
       {state.status === 'idle' && <IdleState onCheck={checkForUpdates} />}
       {state.status === 'checking' && <CheckingState />}
       {state.status === 'up-to-date' && <UpToDateState onCheck={checkForUpdates} />}

--- a/src/features/updater/UpdatesSettingsTab.tsx
+++ b/src/features/updater/UpdatesSettingsTab.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback } from 'react';
 import { CloudDownload, GitBranch } from 'lucide-react';
+import { useIsLinux } from '@/hooks/usePlatform';
 import { UpdateCheckerSection } from '@/features/updater/UpdateCheckerSection';
 import { setUpdateChannel } from '@/features/updater/updateBridge';
 import type { UpdateChannel } from '@/features/updater/updateBridge';
@@ -15,6 +16,9 @@ export function UpdatesSettingsTab({
   channel,
   onChannelChange,
 }: UpdatesSettingsTabProps) {
+  // Linux updates through Flatpak, so the feed the app would poll is moot.
+  const isLinux = useIsLinux();
+
   const handleChannelSelect = useCallback(
     (newChannel: UpdateChannel) => {
       onChannelChange(newChannel);
@@ -26,81 +30,83 @@ export function UpdatesSettingsTab({
   return (
     <div className="space-y-3">
       {/* Release Channel */}
-      <section
-        className="rounded-lg border p-3"
-        style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
-      >
-        <div className="flex items-start gap-2.5">
-          <span
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
-            style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-2), transparent 8%)' }}
-          >
-            <GitBranch className="h-4 w-4" style={{ color: 'var(--accent)' }} />
-          </span>
-          <div className="min-w-0 flex-1">
-            <h3 className="text-xs font-semibold" style={{ color: 'var(--text-strong)' }}>
-              Release Channel
-            </h3>
-            <p className="mt-0.5 text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
-              Choose which update feed to check for new versions.
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-2 rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => handleChannelSelect('stable')}
-              className="flex-1 rounded-md border px-3 py-2 text-left transition-all duration-150"
-              style={
-                channel === 'stable'
-                  ? {
-                      borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 35%)',
-                      background: 'color-mix(in srgb, var(--accent), var(--surface-0) 84%)',
-                      boxShadow: '0 0 0 1px color-mix(in srgb, var(--accent), transparent 76%) inset',
-                    }
-                  : {
-                      borderColor: 'var(--border-subtle)',
-                      background: 'var(--surface-1)',
-                    }
-              }
+      {!isLinux && (
+        <section
+          className="rounded-lg border p-3"
+          style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+        >
+          <div className="flex items-start gap-2.5">
+            <span
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
+              style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-2), transparent 8%)' }}
             >
-              <div className="text-sm font-semibold" style={{ color: channel === 'stable' ? 'var(--accent)' : 'var(--text-strong)' }}>
-                Stable
-              </div>
-              <div className="mt-0.5 text-[10px]" style={{ color: 'var(--text-muted)' }}>
-                Production releases only. Recommended for most users.
-              </div>
-            </button>
-
-            <button
-              type="button"
-              onClick={() => handleChannelSelect('dev')}
-              className="flex-1 rounded-md border px-3 py-2 text-left transition-all duration-150"
-              style={
-                channel === 'dev'
-                  ? {
-                      borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 35%)',
-                      background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-0) 84%)',
-                      boxShadow: '0 0 0 1px color-mix(in srgb, var(--accent-secondary), transparent 76%) inset',
-                    }
-                  : {
-                      borderColor: 'var(--border-subtle)',
-                      background: 'var(--surface-1)',
-                    }
-              }
-            >
-              <div className="text-sm font-semibold" style={{ color: channel === 'dev' ? 'var(--accent-secondary)' : 'var(--text-strong)' }}>
-                Dev
-              </div>
-              <div className="mt-0.5 text-[10px]" style={{ color: 'var(--text-muted)' }}>
-                Pre-release builds from the dev branch. May be unstable.
-              </div>
-            </button>
+              <GitBranch className="h-4 w-4" style={{ color: 'var(--accent)' }} />
+            </span>
+            <div className="min-w-0 flex-1">
+              <h3 className="text-xs font-semibold" style={{ color: 'var(--text-strong)' }}>
+                Release Channel
+              </h3>
+              <p className="mt-0.5 text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+                Choose which update feed to check for new versions.
+              </p>
+            </div>
           </div>
-        </div>
-      </section>
+
+          <div className="mt-2 rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => handleChannelSelect('stable')}
+                className="flex-1 rounded-md border px-3 py-2 text-left transition-all duration-150"
+                style={
+                  channel === 'stable'
+                    ? {
+                        borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 35%)',
+                        background: 'color-mix(in srgb, var(--accent), var(--surface-0) 84%)',
+                        boxShadow: '0 0 0 1px color-mix(in srgb, var(--accent), transparent 76%) inset',
+                      }
+                    : {
+                        borderColor: 'var(--border-subtle)',
+                        background: 'var(--surface-1)',
+                      }
+                }
+              >
+                <div className="text-sm font-semibold" style={{ color: channel === 'stable' ? 'var(--accent)' : 'var(--text-strong)' }}>
+                  Stable
+                </div>
+                <div className="mt-0.5 text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                  Production releases only. Recommended for most users.
+                </div>
+              </button>
+
+              <button
+                type="button"
+                onClick={() => handleChannelSelect('dev')}
+                className="flex-1 rounded-md border px-3 py-2 text-left transition-all duration-150"
+                style={
+                  channel === 'dev'
+                    ? {
+                        borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 35%)',
+                        background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-0) 84%)',
+                        boxShadow: '0 0 0 1px color-mix(in srgb, var(--accent-secondary), transparent 76%) inset',
+                      }
+                    : {
+                        borderColor: 'var(--border-subtle)',
+                        background: 'var(--surface-1)',
+                      }
+                }
+              >
+                <div className="text-sm font-semibold" style={{ color: channel === 'dev' ? 'var(--accent-secondary)' : 'var(--text-strong)' }}>
+                  Dev
+                </div>
+                <div className="mt-0.5 text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                  Pre-release builds from the dev branch. May be unstable.
+                </div>
+              </button>
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* Update Checker */}
       <section

--- a/src/features/updater/updateBridge.ts
+++ b/src/features/updater/updateBridge.ts
@@ -7,6 +7,7 @@
 
 import { Channel, invoke } from '@tauri-apps/api/core';
 import { relaunch } from '@tauri-apps/plugin-process';
+import { detectPlatform } from '@/hooks/usePlatform';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,6 +33,28 @@ export type UpdateChannel = 'stable' | 'dev';
 
 function isTauriAvailable(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+}
+
+// ---------------------------------------------------------------------------
+// Platform delivery
+// ---------------------------------------------------------------------------
+
+/** Where the latest DragonFruit release is published for Linux users. */
+export const LINUX_RELEASES_URL =
+  'https://github.com/Open-Resin-Alliance/DragonFruit/releases';
+
+/** Flatpak application id, for the `flatpak update` hint shown on Linux. */
+export const FLATPAK_APP_ID = 'org.openresinalliance.dragonfruit';
+
+/**
+ * True when updates are installed outside the app.
+ *
+ * Linux ships only as a Flatpak bundle: the updater feed has no Linux entry,
+ * and the sandbox cannot write over a running install anyway. Those users
+ * update through Flatpak instead.
+ */
+export function updatesAreExternal(): boolean {
+  return detectPlatform() === 'linux';
 }
 
 // ---------------------------------------------------------------------------
@@ -80,6 +103,10 @@ export async function fetchUpdateInfo(
   channel?: UpdateChannel,
 ): Promise<UpdateInfo | null> {
   if (!isTauriAvailable()) {
+    return null;
+  }
+  if (updatesAreExternal()) {
+    console.log('[updater] Linux ships as a Flatpak — skipping the update check');
     return null;
   }
   console.log('[updater] fetchUpdateInfo called, channel:', channel ?? 'null (Rust default)');

--- a/src/features/updater/useUpdateChecker.ts
+++ b/src/features/updater/useUpdateChecker.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { useIsLinux } from '@/hooks/usePlatform';
 import {
   fetchUpdateInfo,
   downloadAndInstall,
@@ -22,7 +23,8 @@ export type UpdateState =
   | { status: 'error'; message: string }
   | { status: 'downloading'; progress: DownloadProgress }
   | { status: 'installing' }
-  | { status: 'installed' };
+  | { status: 'installed' }
+  | { status: 'external' };
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -31,9 +33,13 @@ export type UpdateState =
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // once per day
 const STORAGE_KEY_LAST_CHECK = 'dragonfruit-updater-last-check';
 
+const EXTERNAL_STATE: UpdateState = { status: 'external' };
+
 export function useUpdateChecker() {
-  const [state, setState] = useState<UpdateState>({ status: 'idle' });
+  const [internalState, setState] = useState<UpdateState>({ status: 'idle' });
   const [autoCheckEnabled, setAutoCheckEnabled] = useState(true);
+  // Linux updates through Flatpak, not through the app.
+  const isExternal = useIsLinux();
   const [channel, setChannel] = useState<UpdateChannel>('stable');
   const [channelLoaded, setChannelLoaded] = useState(false);
 
@@ -45,7 +51,12 @@ export function useUpdateChecker() {
     });
   }, []);
 
+  const state = isExternal ? EXTERNAL_STATE : internalState;
+
   const handleCheck = useCallback(async () => {
+    // Nothing to check: Flatpak installs the update, not the app.
+    if (isExternal) return;
+
     setState({ status: 'checking' });
     console.log('[updater] checking for updates on channel:', channel);
 
@@ -79,7 +90,7 @@ export function useUpdateChecker() {
         err instanceof Error ? err.message : 'Unknown error checking for updates.';
       setState({ status: 'error', message });
     }
-  }, [channel]);
+  }, [channel, isExternal]);
 
   const handleDownloadAndInstall = useCallback(async () => {
     setState({ status: 'downloading', progress: { contentLength: 0, downloaded: 0 } });
@@ -105,7 +116,7 @@ export function useUpdateChecker() {
 
   // Auto-check once the channel is loaded from disk and enough time has passed.
   useEffect(() => {
-    if (!autoCheckEnabled || !channelLoaded) return;
+    if (!autoCheckEnabled || !channelLoaded || isExternal) return;
 
     const lastCheck = (() => {
       if (typeof window === 'undefined') return 0;
@@ -121,7 +132,7 @@ export function useUpdateChecker() {
     if (elapsed >= CHECK_INTERVAL_MS || lastCheck === 0) {
       handleCheck();
     }
-  }, [autoCheckEnabled, channelLoaded, handleCheck]);
+  }, [autoCheckEnabled, channelLoaded, isExternal, handleCheck]);
 
   return {
     state,


### PR DESCRIPTION
Given that the Linux build are only distribute in Flatpak format, there's no need for `updater` in Linux.  Replaced it with a simple line with the instructions to update and a link to our Releases.

Also fixed a Flatpak bug where an old build would be preferred to a fresh one for packaging.

Closes #594.