### PR TITLE
feat: sponsors tiered rings, updater and notifications refresh with settings polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,5 +185,8 @@ Whenever you change one of these crates, **bump its `version`** in that crate's
 - `patch` for bug fixes, `minor` for new features (semver).
 - If another crate or the shell pins it by version, update that requirement to
   match.
-- Run `cargo check` (or `cargo build`) afterwards so `Cargo.lock` picks up the
-  bump before committing.
+- Run `cargo check` (or `cargo build`) afterwards so `Cargo.lock` picks up the bump before committing.
+
+## App version — do not bump unprompted
+
+NEVER bump the DragonFruit main app version unprompted — `package.json` `version`, `src-tauri/tauri.conf.json` `version`, and `src-tauri/Cargo.toml` `[package] version` must stay on the current release (currently `0.1.15`) unless the user explicitly asks for a release/version bump. The `rust/*` crate bumps above are allowed; the main app version is release-driven and user-controlled.

--- a/docs/dev/system-notifications.md
+++ b/docs/dev/system-notifications.md
@@ -1,0 +1,102 @@
+# System Notifications
+
+Top-right, frosted-glass **System Notifications** for cross-cutting, out-of-flow events that should not block the editor: update available, print done, long-running printer errors. They are the fourth notification path in the app — distinct from the three bottom-corner toast paths documented in [Notifications and Toasts](notifications.md).
+
+Reach for System Notifications when the message is **system-level, not editor-state**: the user can be in any mode or tab and still needs to see it, and the action is to open a destination (Settings → Updates, printer monitor) rather than to undo an editor operation. For editor-state feedback (saving, undo/redo, import report, per-component validation) use the existing `useEditorToasts` / `SupportToasts` / inline `ToastViewport` paths instead.
+
+## Public surface
+
+All system notifications flow through a single store and a single stack. The stack is mounted once at the app root and renders every notification that is currently pushed.
+
+| File | Role |
+| ---- | ---- |
+| `src/features/notifications/systemNotificationStore.ts` | Store and API. Holds the `SystemNotification[]` array, `expiryMs` timers, and `isAllowSameVersionEnabled` flag for the updater debug path. |
+| `src/components/organisms/SystemNotificationStack.tsx` | Rendering. Fixed `bottom-6 right-6 z-[130] w-[22rem]` frosted glass (`backdrop-blur-2xl 32px saturate 1.5`) stack with `df-fly-in-right` / `df-fly-out-right` (0.2s in / 0.18s out) and `df-system-expiry` progress bar. |
+| `src/features/updater/GlobalUpdateIndicator.tsx` | Updater integration. Silent background check via `fetchUpdateInfo(channel, allowSame)` and pushes `update-available` via the store. |
+| `src/app/page.tsx` | Mount point. Renders `<SystemNotificationStack />` alongside `<NotificationStack />` so system notifications are visible in every mode. |
+
+Types in `systemNotificationStore.ts`:
+
+| Symbol | Purpose |
+| ------ | ------- |
+| `SystemNotificationTone` | `'info' \| 'success' \| 'warning' \| 'error' \| 'accent' \| 'accent-secondary'` — controls icon border/bg/color. |
+| `SystemNotificationAction` | `{ label, icon?, variant?: 'secondary' \| 'accent' \| 'accent-secondary' \| 'danger', onClick, closeOnClick? }` — rendered as `ui-button` row below the body. |
+| `SystemNotification` | `{ id, title, subtitle?, tone?, icon?, hideIcon?, expiryMs?, dismissible?, progressPct?, versionChip?, onClose?, actions? }` — `id` is the dedup key; `expiryMs` drives both the `df-system-expiry` `h-0.5` bar and the `setTimeout` that calls `onClose` and `dismissSystemNotification`. Set `hideIcon: true` or `icon: null` to hide the `h-8 w-8` icon (e.g. `Update Available!` has no icon). |
+| `pushSystemNotification(notification)` | Upsert by `id`. If `expiryMs` is set, starts/clears a `window.setTimeout` that dismisses and calls `onClose`. |
+| `dismissSystemNotification(id)` | Removes by `id` and clears its timer. |
+| `subscribeSystemNotifications(listener)` / `getSystemNotificationsSnapshot()` | `useSyncExternalStore` contract for `SystemNotificationStack`. |
+| `isAllowSameVersionEnabled()` / `enableAllowSameVersionForSession()` | Per-session `Ctrl+Shift+U` flag until reload that makes updater checks use `allow_same_version=true` so `0.1.15 → 0.1.15` returns real `body_len=5461` changelog. |
+
+## Minimal usage
+
+System notifications are **leaf-module safe**: the store imports nothing from `@/features/*` or `@/components/*`, so any feature can depend on it without cycles. Keep it that way — never import from `GlobalUpdateIndicator` or printer code into the store.
+
+Update available (existing, now via store):
+
+```ts
+import { pushSystemNotification } from '@/features/notifications/systemNotificationStore';
+import { openSettingsModal } from '@/components/settings/settingsModalEvents';
+
+pushSystemNotification({
+  id: 'update-available',
+  title: 'Update Available!',
+  subtitle: 'Release August 29, 2026',
+  tone: 'accent-secondary',
+  hideIcon: true,
+  versionChip: `Version ${info.version}`,
+  expiryMs: 30_000,
+  onClose: handleClose,
+  actions: [
+    { label: 'Remind me later', variant: 'secondary', onClick: handleDismiss },
+    { label: 'View in Settings', variant: 'accent-secondary', onClick: () => { openSettingsModal('updates'); handleClose(); } },
+  ],
+});
+```
+
+Print done (future, printer networking):
+
+```ts
+import { pushSystemNotification } from '@/features/notifications/systemNotificationStore';
+
+pushSystemNotification({
+  id: `print-done-${buildPlateId}`,
+  title: 'Print is Done',
+  subtitle: `${printerName} • ${durationLabel}`,
+  tone: 'success',
+  expiryMs: 15_000,
+  actions: [
+    { label: 'View', variant: 'accent', onClick: () => openPrinterMonitor(printerId) },
+  ],
+});
+```
+
+Downloading progress reuses the same `id` with `progressPct` and no `expiryMs`:
+
+```ts
+pushSystemNotification({
+  id: 'update-available',
+  title: 'Downloading update',
+  subtitle: `${pct}%`,
+  tone: 'accent',
+  progressPct: pct,
+  expiryMs: null,
+  actions: [],
+});
+```
+
+Suppression when already in `Settings → Updates` is done by the *caller* (`GlobalUpdateIndicator` checks `isSettingsOpen()` via `div.fixed.inset-0.z-[50] h2` before pushing) — the store does not know about UI state.
+
+## Constraints
+
+- **One stack, one expiry bar.** `SystemNotificationStack` renders a `h-0.5` `df-system-expiry` bar only when `expiryMs` is set. Downloading/error use `progressPct` instead and `expiryMs: null` so the bar and the `30s` timer do not compete. Do not set both at once.
+- **Id is the contract.** `pushSystemNotification` upserts by `id`. Re-pushing `update-available` with a new `progressPct` updates the same card; a new `print-done` id creates a second card stacked below with `gap-3`. Use stable ids (`print-done-${plateId}`) so a second completion for the same plate replaces rather than duplicates.
+- **Leaf store.** `systemNotificationStore.ts` must stay a leaf — no imports from `@/features/updater/*`, `@/features/printing/*`, or `@/components/*`. Features import from the store, not the other way around. This is what lets the updater, printer monitor, and any future system-level feature share the same stack without cycles.
+- **Reload semantics.** `isAllowSameVersionEnabled` is in-memory until reload (not `localStorage`). `Ctrl+Shift+U` enables it for the session so `fetchUpdateInfo(channel, true)` via `src-tauri/src/updater_channel.rs` `version_comparator >=` returns `current → current` with real GitHub `body` (`body_len=5461` dev) and `Update & Restart` flushes `window.__df_flushAutosave` before `downloadAndInstall`. A reload clears the flag.
+- **Boundaries.** Do not use System Notifications for editor toasts (saving, undo/redo, import report, `SupportToasts`). Those stay bottom-center with `Toast`/`ToastViewport` and `useEditorToasts` as documented in `notifications.md`. System Notifications are top-right, frosted, and for destinations.
+
+## Related pages
+
+- [Notifications and Toasts](notifications.md) — the three bottom-corner toast paths this system complements
+- [Tauri IPC and Native Bridge](tauri-ipc-bridge.md) — `check_updates` / `perform_update` and `allow_same_version` plumbing
+- [State and Stores](state-and-stores.md) — external-store pattern used by `SystemNotificationStack`
+- [History and Undo/Redo](history-and-undo-redo.md) — why `pushSystemNotification` upserts by `id` instead of queuing

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,7 +115,7 @@ nav:
           - Tauri IPC and Native Bridge: dev/tauri-ipc-bridge.md
           - Hotkeys: dev/hotkeys.md
           - Notifications and Toasts: dev/notifications.md
-      - Support System:
+          - System Notifications: dev/system-notifications.md
           - Support System: dev/support-system.md
           - Auto-Supports: dev/auto-supports.md
           - Auto-Orientation (Pre-Plan): dev/auto-orientation.md

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -70,6 +70,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use tauri::ipc::{InvokeBody, Response};
 use tauri::Emitter;
 use tauri::Manager;
+use base64::Engine as _;
 
 // Runtime type aliases — the feat/cef branch requires an explicit runtime
 // generic. These select Cef or Wry based on the active cargo feature.
@@ -3928,6 +3929,80 @@ async fn launch_external_process(exe_path: String, file_arg: String) -> Result<(
 
     Ok(())
 }
+/// Fetch a sponsor avatar via Rust (bypasses WebView CORS).
+/// Only `https` URLs from the Open Collective avatar hosts are allowed,
+/// mirroring the allowlist in `src/app/api/sponsor-avatar/route.ts`.
+/// Returns a `data:` URL so the frontend can render it without further network.
+#[tauri::command]
+async fn fetch_sponsor_avatar(url: String) -> Result<String, String> {
+    let trimmed = url.trim().to_string();
+    if trimmed.is_empty() {
+        return Err("URL is empty".to_string());
+    }
+    let parsed = url::Url::parse(&trimmed).map_err(|e| format!("Invalid url: {e}"))?;
+    if parsed.scheme() != "https" {
+        return Err("Only https URLs are allowed".to_string());
+    }
+    let host = parsed.host_str().ok_or("Missing host")?.to_ascii_lowercase();
+    const ALLOWED_HOSTS: &[&str] = &[
+        "opencollective-production.s3.us-west-1.amazonaws.com",
+        "opencollective-production.s3-us-west-1.amazonaws.com",
+        "images.opencollective.com",
+        "avatars.githubusercontent.com",
+    ];
+    if !ALLOWED_HOSTS.contains(&host.as_str()) {
+        return Err(format!("Host not allowed: {host}"));
+    }
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(trimmed)
+        .header("Accept", "image/*,*/*")
+        .send()
+        .await
+        .map_err(|e| format!("Fetch failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("Upstream {}", resp.status()));
+    }
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("image/png")
+        .to_string();
+    let bytes = resp.bytes().await.map_err(|e| format!("Read failed: {e}"))?;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+    Ok(format!("data:{content_type};base64,{b64}"))
+}
+/// Fetch external JSON/text via Rust (bypasses WebView CORS) for sponsors list.
+/// Only `https` URLs from `opencollective.com` are allowed.
+#[tauri::command]
+async fn fetch_external_text(url: String) -> Result<String, String> {
+    let trimmed = url.trim().to_string();
+    if trimmed.is_empty() {
+        return Err("URL is empty".to_string());
+    }
+    let parsed = url::Url::parse(&trimmed).map_err(|e| format!("Invalid url: {e}"))?;
+    if parsed.scheme() != "https" {
+        return Err("Only https URLs are allowed".to_string());
+    }
+    let host = parsed.host_str().ok_or("Missing host")?.to_ascii_lowercase();
+    const ALLOWED_HOSTS: &[&str] = &["opencollective.com", "www.opencollective.com", "api.opencollective.com"];
+    if !ALLOWED_HOSTS.contains(&host.as_str()) {
+        return Err(format!("Host not allowed: {host}"));
+    }
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(trimmed)
+        .header("Accept", "application/json,*/*")
+        .send()
+        .await
+        .map_err(|e| format!("Fetch failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("Upstream {}", resp.status()));
+    }
+    let text = resp.text().await.map_err(|e| format!("Read failed: {e}"))?;
+    Ok(text)
+}
 
 /// Returns the path to the log-level preference file.
 /// This is intentionally computed with raw env vars so it can be called
@@ -4332,7 +4407,8 @@ fn main() {
             pick_save_path,
             pick_open_files,
             experiments::set_experiment_overrides,
-            get_launch_scene_files,
+            fetch_sponsor_avatar,
+            fetch_external_text,
             get_slicer_engine_version,
             notify_launch_scene_handoff,
             focus_main_window_command,
@@ -4362,6 +4438,7 @@ fn main() {
             reveal_in_file_manager,
             open_external_url,
             launch_external_process,
+            fetch_sponsor_avatar,
             discover_uvtools_path,
             set_log_level_pref,
             read_log_tail,

--- a/src-tauri/src/updater_channel.rs
+++ b/src-tauri/src/updater_channel.rs
@@ -79,7 +79,10 @@ fn endpoint_for_channel(channel: &str) -> &'static str {
 pub async fn check_updates(
     app_handle: UpdaterAppHandle,
     channel: Option<String>,
+    allow_same_version: Option<bool>,
+    #[allow(non_snake_case)] allowSameVersion: Option<bool>,
 ) -> Result<Option<UpdateCheckResult>, String> {
+    let allow_same_version = allow_same_version.or(allowSameVersion);
     // Linux ships only as a Flatpak bundle, so the updater feed has no
     // `linux-x86_64` key — and even with one, the plugin cannot install over a
     // running sandboxed app (`/app` is read-only). Flatpak updates come from
@@ -87,24 +90,25 @@ pub async fn check_updates(
     // that reads as a broken updater.
     #[cfg(target_os = "linux")]
     {
-        let _ = (app_handle, channel);
+        let _ = (app_handle, channel, allow_same_version, allowSameVersion);
         info!("[updater] Linux build is distributed as a Flatpak — skipping the update check");
         Ok(None)
     }
 
     #[cfg(not(target_os = "linux"))]
-    check_updates_impl(app_handle, channel).await
+    check_updates_impl(app_handle, channel, allow_same_version.unwrap_or(false)).await
 }
 
 #[cfg(not(target_os = "linux"))]
 async fn check_updates_impl(
     app_handle: UpdaterAppHandle,
     channel: Option<String>,
+    allow_same_version: bool,
 ) -> Result<Option<UpdateCheckResult>, String> {
     let channel = channel.as_deref().unwrap_or("stable");
     let endpoint_str = endpoint_for_channel(channel);
 
-    info!("[updater] check_updates called — channel={channel} endpoint={endpoint_str}");
+    info!("[updater] check_updates called — channel={channel} endpoint={endpoint_str} allow_same_version={allow_same_version}");
 
     let endpoint_url: url::Url = endpoint_str
         .parse()
@@ -132,6 +136,16 @@ async fn check_updates_impl(
         builder = builder.target("darwin-universal");
     }
 
+    // Debug: allow same-version reinstall (0.1.15 -> 0.1.15) via Ctrl+Shift+U in Updates.
+    // The default comparator treats equal as NotGreater, so same version is "no update".
+    // When allow_same_version, treat >= as available so the current version's installer
+    // is returned as an available update for in-place reinstall testing.
+    if allow_same_version {
+        builder = builder.version_comparator(|current, remote: tauri_plugin_updater::RemoteRelease| {
+            remote.version >= current
+        });
+    }
+
     let updater = builder.build().map_err(|e| {
         warn!("[updater] Failed to build updater: {e}");
         format!("Failed to build updater: {e}")
@@ -150,7 +164,26 @@ async fn check_updates_impl(
             // Cache the full Update object so perform_update can use it.
             let version = update.version.clone();
             let current_version = update.current_version.clone();
-            let body = update.body.clone();
+            let mut body = update.body.clone();
+            // If same-version reinstall has no body (feed has no notes or empty), fetch from GitHub release for changelog
+            if body.as_ref().map_or(true, |b| b.trim().is_empty()) && allow_same_version {
+                let tag = version.to_string();
+                let gh_url = format!("https://api.github.com/repos/Open-Resin-Alliance/DragonFruit/releases/tags/v{tag}");
+                if let Ok(client) = reqwest::Client::builder().user_agent("DragonFruit-updater").build() {
+                    if let Ok(resp) = client.get(&gh_url).send().await {
+                        if let Ok(json) = resp.json::<serde_json::Value>().await {
+                            if let Some(b) = json.get("body").and_then(|v| v.as_str()) {
+                                if !b.trim().is_empty() {
+                                    body = Some(b.to_string());
+                                }
+                            }
+                            if let Some(pub_at) = json.get("published_at").and_then(|v| v.as_str()) {
+                                // Try to keep date from GitHub if updater date is None
+                            }
+                        }
+                    }
+                }
+            }
             // RFC 3339, not Display: `time` renders as "2026-07-06 4:55:17.703
             // +00:00:00", which `new Date()` on the frontend cannot parse.
             let date = update
@@ -158,7 +191,7 @@ async fn check_updates_impl(
                 .and_then(|d| d.format(&time::format_description::well_known::Rfc3339).ok());
             let download_url = Some(update.download_url.to_string());
 
-            info!("[updater] Update available: current={current_version} → new={version} url={}", download_url.as_deref().unwrap_or("?"));
+            info!("[updater] Update available: current={current_version} → new={version} url={} body_len={}", download_url.as_deref().unwrap_or("?"), body.as_ref().map(|b| b.len()).unwrap_or(0));
 
             let mut cache = cached_update()
                 .lock()
@@ -175,6 +208,57 @@ async fn check_updates_impl(
             }))
         }
         None => {
+            if allow_same_version {
+                // No newer version, but debug wants in-place reinstall of current version.
+                // Fabricate an available update with version == currentVersion using real release notes.
+                let current_version = app_handle.package_info().version.to_string();
+                let version = current_version.clone();
+                // Try to get real body/date from the current version's GitHub release via the updater's
+                // endpoint for the current version's tag. Fallback to minimal body if fetch fails.
+                let (body, date, download_url) = {
+                    // Re-use the same feed endpoint but ensure allow_same_version path via dbg_builder
+                    // (the primary check already used allow_same_version, but if it still returned None due to transient, retry explicitly)
+                    let feed_url: Result<url::Url, _> = endpoint_str.parse();
+                    if let Ok(url) = feed_url {
+                        if let Ok(mut dbg_builder) = app_handle.updater_builder().endpoints(vec![url]) {
+                            #[cfg(target_os = "macos")]
+                            {
+                                dbg_builder = dbg_builder.target("darwin-universal");
+                            }
+                            dbg_builder = dbg_builder.version_comparator(|cur, rem: tauri_plugin_updater::RemoteRelease| rem.version >= cur);
+                            if let Ok(updater) = dbg_builder.build() {
+                                if let Ok(Some(dbg_update)) = updater.check().await {
+                                    let body = dbg_update.body.clone();
+                                    let date = dbg_update.date.and_then(|d| d.format(&time::format_description::well_known::Rfc3339).ok());
+                                    let dl = Some(dbg_update.download_url.to_string());
+                                    if let Ok(mut cache) = cached_update().lock() {
+                                        *cache = Some(dbg_update);
+                                    }
+                                    return Ok(Some(UpdateCheckResult {
+                                        update_available: true,
+                                        version: version.clone(),
+                                        current_version: current_version.clone(),
+                                        body,
+                                        date,
+                                        download_url: dl,
+                                    }));
+                                }
+                            }
+                        }
+                    }
+                    // Final fallback: fabricated without download URL
+                    (None, None, None)
+                };
+                info!("[updater] Debug same-version reinstall fabricated: current={current_version} → new={version}");
+                return Ok(Some(UpdateCheckResult {
+                    update_available: true,
+                    version,
+                    current_version,
+                    body,
+                    date,
+                    download_url,
+                }));
+            }
             info!("[updater] No update available on channel={channel}");
             Ok(None)
         }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,7 @@ import { PrintingPanelStack } from '@/components/organisms/panels/PrintingPanelS
 import { SharedPanelStack } from '@/components/organisms/panels/SharedPanelStack';
 import { TopBar } from '@/components/layout/TopBar';
 import { NotificationStack } from '@/components/organisms/NotificationStack';
+import { SystemNotificationStack } from '@/components/organisms/SystemNotificationStack';
 import { EditorLayout } from '@/components/templates/EditorLayout';
 import { PrintingPreviewPane } from '@/components/organisms/PrintingPreviewPane';
 import { DiagnosticsModals } from '@/components/organisms/modals/DiagnosticsModals';
@@ -10962,6 +10963,8 @@ export default function Home() {
         exportErrorToast={exportErrorToast}
         isExportErrorToastVisible={isExportErrorToastVisible}
       />
+
+      <SystemNotificationStack />
 
       {islandsPoc.scanning && !autoSupportDrivingScan && (
         <div className="absolute inset-0 z-[121] flex items-center justify-center bg-black/45 backdrop-blur-[1px]">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -939,6 +939,12 @@ export default function Home() {
     onSceneFormatUpgraded: React.useCallback(() => setSceneFormatChunked(true), []),
   });
 
+  // Expose flush for updater's pre-restart autosave (force trigger before Update & Restart)
+  React.useEffect(() => {
+    (window as unknown as Record<string, unknown>).__df_flushAutosave = flushAutosave;
+    return () => { delete (window as unknown as Record<string, unknown>).__df_flushAutosave; };
+  }, [flushAutosave]);
+
   /**
    * User-facing scene-save failure (Ph0.1 sub-phase D).
    *
@@ -4580,10 +4586,29 @@ export default function Home() {
       return;
     }
     if (typeof window === 'undefined' || !('__TAURI_INTERNALS__' in window)) return;
+    // Don't show recovery when the app was launched with a scene file (double-click VOXL etc.).
+    // In that case DragonFruit is already in a loading state (pendingStartupSceneHandoff).
+    if (pendingStartupSceneHandoff) {
+      setAutosaveRecovery(null);
+      return;
+    }
 
     let cancelled = false;
     void (async () => {
       try {
+        // If launched with a file, suppress recovery even if the pending flag wasn't yet set
+        // when this effect first ran (race between launch-file fetch and recovery fetch).
+        try {
+          const core = await import('@tauri-apps/api/core');
+          const launchEntries = await core.invoke<unknown[]>('get_launch_scene_files');
+          if (Array.isArray(launchEntries) && launchEntries.length > 0) {
+            if (!cancelled) setAutosaveRecovery(null);
+            return;
+          }
+        } catch {
+          // Non-Tauri or invoke not available — fall through to normal recovery check.
+        }
+
         // Discovery, not a bare manifest read: the payload may be a sidecar
         // beside the project, the generic location, or a legacy `scene.voxl`
         // from before Ph0.1. `resolveAutosaveRecovery` validates that whichever
@@ -4591,6 +4616,11 @@ export default function Home() {
         // never offered for a payload that cannot be restored.
         const candidate = await resolveAutosaveRecovery();
         if (!cancelled && candidate && !candidate.clean) {
+          // Re-check pending handoff after async fetch — it may have become pending while we were fetching.
+          if (pendingStartupSceneHandoff) {
+            setAutosaveRecovery(null);
+            return;
+          }
           setAutosaveRecovery({
             savedAt: candidate.savedAt ?? new Date().toISOString(),
             voxlPath: candidate.voxlPath,
@@ -4605,7 +4635,15 @@ export default function Home() {
     return () => {
       cancelled = true;
     };
-  }, [sceneAutosaveSettings.recoveryPromptEnabled]);
+  }, [sceneAutosaveSettings.recoveryPromptEnabled, pendingStartupSceneHandoff]);
+
+  // If a launch file arrives after the recovery prompt is already shown, dismiss it
+  // — the app is already loading a scene, so recovery would be a confusing fork.
+  React.useEffect(() => {
+    if (pendingStartupSceneHandoff && autosaveRecovery) {
+      setAutosaveRecovery(null);
+    }
+  }, [pendingStartupSceneHandoff, autosaveRecovery]);
 
   const isDesktopRuntime = React.useCallback(() => {
     if (typeof window === 'undefined') return false;

--- a/src/components/controls/AutoSupportPanel.tsx
+++ b/src/components/controls/AutoSupportPanel.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { Settings } from 'lucide-react';
-import { Card, CardHeader, IconButton, Button } from '@/components/atoms';
+import { Card, CardHeader, IconButton } from '@/components/atoms';
 import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
 import { useFloatingPanelCollapse } from '@/components/layout/FloatingPanelStack';
 import type { UseIslandsReturn } from '@/volumeAnalysis/Islands/useIslands';
@@ -541,7 +541,6 @@ export function AutoSupportPanel({ islands, hasGeometry, activeModelId }: AutoSu
         )}
       </Card>
 
-      {/* Forest Report Modal */}
       <StructuredDialogModal
         open={showForestReport}
         ariaLabel="Forest report"
@@ -553,15 +552,24 @@ export function AutoSupportPanel({ islands, hasGeometry, activeModelId }: AutoSu
         onBackdropClick={() => setShowForestReport(false)}
         actions={
           <>
-            <Button
+            <button
+              type="button"
               onClick={() => {
                 if (forestReport) {
                   void navigator.clipboard?.writeText(forestReportToText(forestReport));
                 }
               }}
-              variant="secondary" size="sm" className="!h-9 text-[12px]"
-            >Copy</Button>
-            <Button onClick={() => setShowForestReport(false)} variant="primary" size="sm" className="!h-9 text-[12px]">Close</Button>
+              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+            >
+              Copy
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowForestReport(false)}
+              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+            >
+              Close
+            </button>
           </>
         }
       >
@@ -577,7 +585,6 @@ export function AutoSupportPanel({ islands, hasGeometry, activeModelId }: AutoSu
         )}
       </StructuredDialogModal>
 
-      {/* Settings Modal */}
       <StructuredDialogModal
         open={showSettings}
         ariaLabel="Auto-support settings"
@@ -589,8 +596,25 @@ export function AutoSupportPanel({ islands, hasGeometry, activeModelId }: AutoSu
         onBackdropClick={() => setShowSettings(false)}
         actions={
           <>
-            <Button onClick={() => setShowSettings(false)} variant="secondary" size="sm" className="!h-9 text-[12px]">Cancel</Button>
-            <Button onClick={applySettings} variant="primary" size="sm" className="!h-9 text-[12px]">Apply</Button>
+            <button
+              type="button"
+              onClick={() => setShowSettings(false)}
+              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={applySettings}
+              className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+              style={{
+                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                color: 'var(--accent)',
+              }}
+            >
+              Apply
+            </button>
           </>
         }
       >
@@ -674,7 +698,6 @@ export function AutoSupportPanel({ islands, hasGeometry, activeModelId }: AutoSu
         </div>
       </StructuredDialogModal>
 
-      {/* Replace / Add dialog */}
       <StructuredDialogModal
         open={showReplaceDialog}
         ariaLabel="Existing supports detected"
@@ -685,9 +708,32 @@ export function AutoSupportPanel({ islands, hasGeometry, activeModelId }: AutoSu
         onBackdropClick={() => setShowReplaceDialog(false)}
         actions={
           <>
-            <Button onClick={() => setShowReplaceDialog(false)} variant="secondary" size="sm" className="!h-9 text-[12px]">Cancel</Button>
-            <Button onClick={() => { setShowReplaceDialog(false); doRun(false); }} variant="secondary" size="sm" className="!h-9 text-[12px]">Add to existing</Button>
-            <Button onClick={() => { setShowReplaceDialog(false); doRun(true); }} variant="primary" size="sm" className="!h-9 text-[12px]">Replace all</Button>
+            <button
+              type="button"
+              onClick={() => setShowReplaceDialog(false)}
+              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowReplaceDialog(false); doRun(false); }}
+              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+            >
+              Add to existing
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowReplaceDialog(false); doRun(true); }}
+              className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+              style={{
+                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                color: 'var(--accent)',
+              }}
+            >
+              Replace all
+            </button>
           </>
         }
       >

--- a/src/components/controls/IslandsPanel.tsx
+++ b/src/components/controls/IslandsPanel.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { Settings, RotateCcw } from 'lucide-react';
-import { Button, Card, CardHeader, IconButton } from '@/components/atoms';
+import { Card, CardHeader, IconButton } from '@/components/atoms';
 import { NumberInput } from '@/components/ui/NumberInput';
 import { Tooltip } from '@/components/ui/Tooltip';
 import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
@@ -307,18 +307,26 @@ export function IslandsPanel({ islands, hasGeometry, bottomClearancePx = 88 }: I
         onBackdropClick={() => setShowSettings(false)}
         actions={
           <>
-            <Button onClick={() => setShowSettings(false)} variant="secondary" size="sm" className="!h-9 text-[12px]">
+            <button
+              type="button"
+              onClick={() => setShowSettings(false)}
+              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+            >
               Cancel
-            </Button>
-            <Button
+            </button>
+            <button
+              type="button"
               onClick={() => { applySettings(); setShowSettings(false); }}
-              variant="primary"
-              size="sm"
-              className="!h-9 text-[12px]"
               disabled={!hasPendingChanges}
+              className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                color: 'var(--accent)',
+              }}
             >
               Apply
-            </Button>
+            </button>
           </>
         }
       >

--- a/src/components/layout/EmptySceneState.tsx
+++ b/src/components/layout/EmptySceneState.tsx
@@ -583,10 +583,9 @@ export function EmptySceneState({
                   <span>{_(msg`Load Mesh`)}</span>
                 </div>
                 <div className="text-[11px]" style={{ color: 'color-mix(in srgb, var(--accent-contrast), black 16%)' }}>
-                  {_(msg`Mesh files (.stl, .obj, .3mf)`)}
+                  {MESH_DROP_EXTENSIONS.join(' • ')}
                 </div>
               </button>
-
               {onImportSceneChange && (
                 <button
                   type="button"
@@ -602,7 +601,7 @@ export function EmptySceneState({
                     <span>{_(msg`Import Scene`)}</span>
                   </div>
                   <div className="text-[11px]" style={{ color: 'color-mix(in srgb, var(--accent-secondary-contrast), black 18%)' }}>
-                    {_(msg`Scene files (.voxl, .lys)`)}
+                    {sceneExtensionLabels.map((label) => `.${label.toLowerCase()}`).join(' • ')}
                   </div>
                 </button>
               )}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -472,14 +472,20 @@ export function TopBar({
   React.useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    const handleOpenSettings = () => {
-      setSettingsInitialTab('general');
+    const handleOpenSettings = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { tab?: string } | undefined;
+      const tab = detail?.tab as SettingsTabKey | undefined;
+      if (tab && ['general', 'camera', 'workspaces', 'mesh', 'performance', 'spacemouse', 'ui', 'hotkeys', 'plugins', 'experiments', 'sceneAutosave', 'backups', 'uvtools', 'logging', 'updates', 'about'].includes(tab)) {
+        setSettingsInitialTab(tab as SettingsTabKey);
+      } else {
+        setSettingsInitialTab('general');
+      }
       setIsSettingsOpen(true);
     };
 
-    window.addEventListener(OPEN_SETTINGS_MODAL_EVENT, handleOpenSettings);
+    window.addEventListener(OPEN_SETTINGS_MODAL_EVENT, handleOpenSettings as EventListener);
     return () => {
-      window.removeEventListener(OPEN_SETTINGS_MODAL_EVENT, handleOpenSettings);
+      window.removeEventListener(OPEN_SETTINGS_MODAL_EVENT, handleOpenSettings as EventListener);
     };
   }, []);
 

--- a/src/components/modals/AaSupportWarningModal.tsx
+++ b/src/components/modals/AaSupportWarningModal.tsx
@@ -33,14 +33,19 @@ export function AaSupportWarningModal({
         <>
           <button
             type="button"
-            className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
+            className="ui-button ui-button-secondary !h-9 px-3 text-xs"
             onClick={onCancel}
           >
             Cancel
           </button>
           <button
             type="button"
-            className="ui-button ui-button-accent !h-9 w-full px-3 text-xs"
+            className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+              background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+              color: 'var(--accent)',
+            }}
             onClick={onProceed}
           >
             Use Anyway

--- a/src/components/modals/DestructiveTransformModal.tsx
+++ b/src/components/modals/DestructiveTransformModal.tsx
@@ -1,8 +1,6 @@
-'use client';
-
 import React from 'react';
 import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
-import { AlertTriangle, X } from 'lucide-react';
+import { AlertTriangle, Trash2, X } from 'lucide-react';
 
 type DestructiveTransformModalProps = {
   isOpen: boolean;
@@ -105,16 +103,22 @@ export function DestructiveTransformModal({
           <div className="grid grid-cols-2 gap-2 pt-1">
             <button
               type="button"
-              className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
+              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
               onClick={onCancel}
             >
               Cancel
             </button>
             <button
               type="button"
-              className="ui-button ui-button-accent !h-9 w-full px-3 text-xs"
+              className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+              style={{
+                borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
+                color: 'var(--danger)',
+              }}
               onClick={onConfirm}
             >
+              <Trash2 className="w-3.5 h-3.5" />
               Delete & Continue
             </button>
           </div>

--- a/src/components/modals/ManifoldWarningModal.tsx
+++ b/src/components/modals/ManifoldWarningModal.tsx
@@ -28,7 +28,12 @@ export function ManifoldWarningModal({
       actions={(
         <button
           type="button"
-          className="ui-button ui-button-accent !h-9 w-full px-3 text-xs"
+          className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+          style={{
+            borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+            background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+            color: 'var(--accent)',
+          }}
           onClick={onAcknowledge}
         >
           OK

--- a/src/components/modals/PrintingResliceModal.tsx
+++ b/src/components/modals/PrintingResliceModal.tsx
@@ -31,14 +31,19 @@ export function PrintingResliceModal({
         <>
           <button
             type="button"
-            className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs"
+            className="ui-button ui-button-secondary !h-9 px-3 text-xs"
             onClick={onCancel}
           >
             Back
           </button>
           <button
             type="button"
-            className="ui-button ui-button-accent !h-9 w-full px-3 text-xs"
+            className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+              background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+              color: 'var(--accent)',
+            }}
             onClick={onResliceNow}
           >
             Re-Slice Now

--- a/src/components/modals/SliceCompletedModal.tsx
+++ b/src/components/modals/SliceCompletedModal.tsx
@@ -65,7 +65,12 @@ export function SliceCompletedModal({
             type="button"
             onClick={() => filePath && onOpenInUvTools(filePath)}
             disabled={!filePath}
-            className="ui-button ui-button-accent !h-9 px-3 text-sm inline-flex items-center gap-1.5 disabled:opacity-45"
+            className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5 disabled:opacity-45"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+              background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+              color: 'var(--accent)',
+            }}
           >
             <ExternalLink className="w-4 h-4" />
             Open in UVTools
@@ -74,7 +79,12 @@ export function SliceCompletedModal({
             type="button"
             onClick={handleOpenDirectory}
             disabled={!filePath}
-            className="ui-button ui-button-secondary !h-9 px-3 text-sm inline-flex items-center gap-1.5 disabled:opacity-45"
+            className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5 disabled:opacity-45"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+              background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+              color: 'var(--accent)',
+            }}
           >
             <FolderOpen className="w-4 h-4" />
             Open Directory
@@ -85,7 +95,7 @@ export function SliceCompletedModal({
           <button
             type="button"
             onClick={onClose}
-            className="ui-button ui-button-secondary !h-9 px-3 text-sm"
+            className="ui-button ui-button-secondary !h-9 px-3 text-xs"
           >
             Close
           </button>
@@ -93,7 +103,12 @@ export function SliceCompletedModal({
             type="button"
             onClick={handleOpenDirectory}
             disabled={!filePath}
-            className="ui-button ui-button-accent !h-9 px-3 text-sm inline-flex items-center gap-1.5 disabled:opacity-45"
+            className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5 disabled:opacity-45"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+              background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+              color: 'var(--accent)',
+            }}
           >
             <FolderOpen className="w-4 h-4" />
             Open Directory

--- a/src/components/organisms/SystemNotificationStack.tsx
+++ b/src/components/organisms/SystemNotificationStack.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import React, { useSyncExternalStore } from 'react';
+import { AlertTriangle, CheckCircle2, CloudDownload } from 'lucide-react';
+import {
+  getSystemNotificationsSnapshot,
+  subscribeSystemNotifications,
+  dismissSystemNotification,
+  type SystemNotification,
+  type SystemNotificationAction,
+} from '@/features/notifications/systemNotificationStore';
+
+function toneStyles(tone?: SystemNotification['tone']) {
+  switch (tone) {
+    case 'error':
+      return {
+        border: 'color-mix(in srgb, #ef4444, var(--border-subtle) 40%)',
+        bg: 'color-mix(in srgb, #ef4444, var(--surface-1) 85%)',
+        color: '#ef4444',
+        icon: <AlertTriangle className="h-4 w-4" />,
+      };
+    case 'warning':
+      return {
+        border: 'color-mix(in srgb, #f59e0b, var(--border-subtle) 40%)',
+        bg: 'color-mix(in srgb, #f59e0b, var(--surface-1) 85%)',
+        color: '#f59e0b',
+        icon: <AlertTriangle className="h-4 w-4" />,
+      };
+    case 'success':
+      return {
+        border: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 40%)',
+        bg: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 85%)',
+        color: 'var(--accent-secondary)',
+        icon: <CheckCircle2 className="h-4 w-4" />,
+      };
+    case 'accent':
+      return {
+        border: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)',
+        bg: 'color-mix(in srgb, var(--accent), var(--surface-1) 85%)',
+        color: 'var(--accent)',
+        icon: <CloudDownload className="h-4 w-4" />,
+      };
+    default:
+      return {
+        border: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 40%)',
+        bg: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 85%)',
+        color: 'var(--accent-secondary)',
+        icon: <CloudDownload className="h-4 w-4" />,
+      };
+  }
+}
+
+function ActionButton({ action, onClose }: { action: SystemNotificationAction; onClose?: () => void }) {
+  const handleClick = () => {
+    action.onClick();
+    if (action.closeOnClick !== false) onClose?.();
+  };
+  const variant = action.variant ?? 'secondary';
+  if (variant === 'secondary') {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        className="flex-1 ui-button ui-button-secondary !h-9 px-4 text-sm inline-flex items-center justify-center gap-1.5"
+      >
+        {action.icon}
+        {action.label}
+      </button>
+    );
+  }
+  const styleMap: Record<string, React.CSSProperties> = {
+    accent: {
+      borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+      background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+      color: 'var(--accent)',
+    },
+    'accent-secondary': {
+      borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 45%)',
+      background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 86%)',
+      color: 'var(--accent-secondary)',
+    },
+    danger: {
+      borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
+      background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
+      color: 'var(--danger)',
+    },
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="flex-1 ui-button !h-9 px-4 text-sm inline-flex items-center justify-center gap-1.5"
+      style={styleMap[variant] ?? styleMap.accent}
+    >
+      {action.icon}
+      {action.label}
+    </button>
+  );
+}
+
+export function SystemNotificationStack() {
+  const notifications = useSyncExternalStore(
+    subscribeSystemNotifications,
+    getSystemNotificationsSnapshot,
+    getSystemNotificationsSnapshot,
+  );
+
+  if (notifications.length === 0) return null;
+
+  return (
+    <>
+      <style>{`@keyframes df-system-expiry { from { transform: scaleX(1); } to { transform: scaleX(0); } } @keyframes df-fly-in-right { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }`}</style>
+      <div className="fixed bottom-6 right-6 z-[130] flex flex-col gap-3 pointer-events-none">
+        {notifications.map((n) => {
+          const tone = toneStyles(n.tone);
+          const showExpiry = !!n.expiryMs && n.expiryMs > 0;
+          return (
+            <div
+              key={n.id}
+              className="pointer-events-auto w-[22rem]"
+              style={{ animation: 'df-fly-in-right 0.2s ease-out forwards' } as React.CSSProperties}
+            >
+              <div
+                className="relative overflow-hidden rounded-xl border shadow-2xl backdrop-blur-2xl"
+                style={{
+                  background: 'color-mix(in srgb, var(--surface-0), transparent 12%)',
+                  borderColor: 'color-mix(in srgb, var(--border-subtle), transparent 8%)',
+                  boxShadow: '0 18px 48px rgba(0,0,0,0.42)',
+                  backdropFilter: 'blur(32px) saturate(1.5)',
+                  WebkitBackdropFilter: 'blur(32px) saturate(1.5)',
+                } as React.CSSProperties}
+                role="alert"
+                aria-live="polite"
+              >
+                <div className="flex flex-col items-center gap-1.5 p-3.5 text-center">
+                  {n.hideIcon || n.icon === null ? null : (
+                    <span
+                      className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
+                      style={{ borderColor: tone.border, background: tone.bg, color: tone.color }}
+                    >
+                      {n.icon ?? tone.icon}
+                    </span>
+                  )}
+                  <div className="min-w-0">
+                    <div className="text-base font-bold leading-tight" style={{ color: n.tone === 'accent-secondary' || n.tone === 'success' ? 'var(--accent-secondary)' : 'var(--text-strong)' }}>
+                      {n.title}
+                    </div>
+                    {n.subtitle && (
+                      <div className="mt-1 text-xs font-medium" style={{ color: 'var(--text-muted)' }}>
+                        {n.subtitle}
+                      </div>
+                    )}
+                  </div>
+                </div>
+                {n.versionChip && (
+                  <div className="px-3.5 pb-2 -mt-1 text-center">
+                    <span
+                      className="inline-flex items-center justify-center rounded-full border px-2.5 py-1 text-[11px] font-semibold"
+                      style={{
+                        borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)',
+                        background: 'color-mix(in srgb, var(--accent), var(--surface-1) 85%)',
+                        color: 'var(--accent)',
+                      }}
+                    >
+                      {n.versionChip}
+                    </span>
+                  </div>
+                )}
+                {n.progressPct != null && (
+                  <div className="px-3.5 pb-2">
+                    <div className="h-1.5 w-full overflow-hidden rounded-full" style={{ background: 'var(--surface-1)' }}>
+                      <div className="h-full rounded-full transition-all duration-300" style={{ width: `${n.progressPct}%`, background: 'var(--accent)' }} />
+                    </div>
+                  </div>
+                )}
+                <div
+                  className="relative flex items-center gap-3 border-t px-4 py-3 overflow-hidden"
+                  style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+                >
+                  {showExpiry && (
+                    <div className="absolute inset-x-0 top-0 h-0.5 overflow-hidden" style={{ background: 'transparent' }}>
+                      <div
+                        className="h-full w-full origin-left"
+                        style={{ background: 'var(--accent)', animation: `df-system-expiry ${n.expiryMs}ms linear forwards` }}
+                      />
+                    </div>
+                  )}
+                  {n.actions?.map((a, idx) => (
+                    <ActionButton key={idx} action={a} onClose={() => dismissSystemNotification(n.id)} />
+                  ))}
+                  {(!n.actions || n.actions.length === 0) && n.dismissible !== false && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        dismissSystemNotification(n.id);
+                        n.onClose?.();
+                      }}
+                      className="flex-1 ui-button ui-button-secondary !h-9 px-4 text-sm"
+                    >
+                      Dismiss
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/components/organisms/modals/MeshRepairModals.tsx
+++ b/src/components/organisms/modals/MeshRepairModals.tsx
@@ -45,7 +45,12 @@ export function MeshRepairModals({
         actions={(
           <button
             type="button"
-            className="ui-button ui-button-accent !h-9 px-3 text-xs"
+            className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+              background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+              color: 'var(--accent)',
+            }}
             onClick={() => setShowDamagedModelDialog(false)}
           >
             Got it
@@ -176,7 +181,12 @@ export function MeshRepairModals({
                   </button>
                   <button
                     type="button"
-                    className="ui-button ui-button-accent !h-9 w-full px-3 text-xs flex items-center justify-center gap-1.5 disabled:opacity-60"
+                    className="ui-button !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
+                    style={{
+                      borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                      background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                      color: 'var(--accent)',
+                    }}
                     disabled={isManualRepairing}
                     onClick={() => {
                       const id = manualRepairModelId;

--- a/src/components/organisms/modals/ModifierModals.tsx
+++ b/src/components/organisms/modals/ModifierModals.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Trash2 } from 'lucide-react';
 import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
 import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { DestructiveTransformModal } from '@/components/modals/DestructiveTransformModal';
@@ -81,7 +81,12 @@ export function ModifierModals({
             </button>
             <button
               type="button"
-              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+              className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+              style={{
+                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                color: 'var(--accent)',
+              }}
               onClick={() => {
                 unappliedHolePunchResolveRef.current = null;
                 handleGoToHollowTool();
@@ -91,7 +96,12 @@ export function ModifierModals({
             </button>
             <button
               type="button"
-              className="ui-button ui-button-accent !h-9 px-3 text-xs"
+              className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+              style={{
+                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                color: 'var(--accent)',
+              }}
               onClick={() => {
                 unappliedHolePunchResolveRef.current = null;
                 // Defer so the modal closes before apply starts.
@@ -137,14 +147,15 @@ export function ModifierModals({
             </button>
             <button
               type="button"
-              className="ui-button !h-9 px-3 text-xs"
+              className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
               style={{
-                borderColor: 'color-mix(in srgb, var(--danger), var(--border-subtle) 36%)',
-                background: 'color-mix(in srgb, var(--danger), transparent 86%)',
+                borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
                 color: 'var(--danger)',
               }}
               onClick={handleConfirmModifierReset}
             >
+              <Trash2 className="w-3.5 h-3.5" />
               {pendingModifierResetAction === 'hollowing' ? 'Remove Hollowing' : 'Remove All Holes'}
             </button>
           </>
@@ -184,14 +195,15 @@ export function ModifierModals({
             </button>
             <button
               type="button"
-              className="ui-button !h-9 px-3 text-xs"
+              className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
               style={{
-                borderColor: 'color-mix(in srgb, var(--danger), var(--border-subtle) 36%)',
-                background: 'color-mix(in srgb, var(--danger), transparent 86%)',
+                borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
                 color: 'var(--danger)',
               }}
               onClick={handleConfirmBlockerReset}
             >
+              <Trash2 className="w-3.5 h-3.5" />
               Reset Blockers
             </button>
           </>

--- a/src/components/organisms/modals/PrintingModals.tsx
+++ b/src/components/organisms/modals/PrintingModals.tsx
@@ -705,7 +705,12 @@ export function PrintingModals({
                 </button>
                 <button
                   type="button"
-                  className="ui-button ui-button-accent !h-9 px-3 text-xs"
+                  className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                  style={{
+                    borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                    background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                    color: 'var(--accent)',
+                  }}
                   onClick={() => {
                     setPreSlicePrintConfirmOpen(false);
                     if (preSlicePrintConfirmResolverRef.current) {
@@ -950,7 +955,12 @@ export function PrintingModals({
                 </button>
                 <button
                   type="button"
-                  className="ui-button ui-button-accent !h-9 px-3 text-xs"
+                  className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                  style={{
+                    borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                    background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                    color: 'var(--accent)',
+                  }}
                   disabled={
                     printingSendBusy
                     || isPrintingTargetMaterialsLoading
@@ -1151,18 +1161,27 @@ export function PrintingModals({
                 {printingUploadDialogStage === 'failed' && (
                   <button
                     type="button"
-                    className="ui-button ui-button-accent !h-9 px-3 text-xs"
+                    className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                    style={{
+                      borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                      background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                      color: 'var(--accent)',
+                    }}
                     onClick={() => { void handleSendToPrinter(); }}
                     disabled={printingSendBusy || printingPrintNowBusy || !canSendToPrinter}
                   >
                     Retry Upload
                   </button>
                 )}
-
                 {printingUploadDialogStage === 'ready' && (
                   <button
                     type="button"
-                    className="ui-button ui-button-accent !h-9 px-3 text-xs"
+                    className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                    style={{
+                      borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                      background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                      color: 'var(--accent)',
+                    }}
                     onClick={handlePrintNow}
                     disabled={!canPrintNow || printingPrintNowBusy || printingSendBusy}
                   >
@@ -1173,7 +1192,12 @@ export function PrintingModals({
                 {printingUploadDialogStage === 'started' && (
                   <button
                     type="button"
-                    className="ui-button ui-button-accent !h-9 px-3 text-xs"
+                    className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                    style={{
+                      borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                      background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                      color: 'var(--accent)',
+                    }}
                     onClick={() => openPrintingMonitorForTargetDevice(printingTargetDevice?.id ?? null)}
                     disabled={printingSendBusy || printingPrintNowBusy}
                   >

--- a/src/components/organisms/modals/SceneFileModals.tsx
+++ b/src/components/organisms/modals/SceneFileModals.tsx
@@ -95,7 +95,12 @@ export function SceneFileModals({
         actions={
           <button
             type="button"
-            className="ui-button ui-button-accent !h-9 px-4 text-xs font-semibold"
+            className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+              background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+              color: 'var(--accent)',
+            }}
             onClick={() => dismissSceneSaveError?.()}
           >
             OK
@@ -205,7 +210,12 @@ export function SceneFileModals({
                 </button>
                 <button
                   type="button"
-                  className="ui-button ui-button-accent !h-9 w-full px-3 text-xs"
+                  className="ui-button !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                  style={{
+                    borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                    background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                    color: 'var(--accent)',
+                  }}
                   onClick={() => scene.resolveSceneImportPlacementPrompt('auto_arrange')}
                 >
                   Auto-Arrange
@@ -496,7 +506,12 @@ export function SceneFileModals({
                 </button>
                 <button
                   type="button"
-                  className="ui-button ui-button-accent !h-9 px-3 text-xs whitespace-nowrap"
+                  className="ui-button !h-9 px-3 text-xs whitespace-nowrap inline-flex items-center justify-center gap-1.5"
+                  style={{
+                    borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                    background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                    color: 'var(--accent)',
+                  }}
                   disabled={!sceneSaveChoicePath}
                   onClick={() => resolveSceneSaveChoice('overwrite')}
                 >

--- a/src/components/scene/MeshRepairConfirmModal.tsx
+++ b/src/components/scene/MeshRepairConfirmModal.tsx
@@ -134,7 +134,12 @@ export function MeshRepairConfirmModal({ prompt, onRepair, onLoadAsIs, onCancelI
             </button>
             <button
               type="button"
-              className="ui-button ui-button-accent !h-9 w-full px-3 text-xs flex items-center justify-center gap-1.5"
+              className="ui-button !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
+              style={{
+                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                color: 'var(--accent)',
+              }}
               onClick={onRepair}
             >
               <Wrench className="h-3.5 w-3.5" />

--- a/src/components/scene/SceneAutosaveRecoveryModal.tsx
+++ b/src/components/scene/SceneAutosaveRecoveryModal.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useLingui } from '@lingui/react';
 import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
-import { AlertTriangle, ArchiveRestore, Trash2, X } from 'lucide-react';
+import { AlertTriangle, ArchiveRestore, Trash2 } from 'lucide-react';
 import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 
 type Props = {
@@ -73,7 +73,7 @@ export function SceneAutosaveRecoveryModal({ savedAt, voxlPath, origin, onRestor
       >
         {/* Header */}
         <div
-          className="flex items-center justify-between gap-4 border-b px-5 py-4"
+          className="flex items-center gap-4 border-b px-5 py-4"
           style={{ borderColor: 'var(--border-subtle)' }}
         >
           <div className="flex min-w-0 items-center gap-3">
@@ -96,21 +96,6 @@ export function SceneAutosaveRecoveryModal({ savedAt, voxlPath, origin, onRestor
               </p>
             </div>
           </div>
-
-          <button
-            type="button"
-            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border transition-colors"
-            style={{
-              borderColor: 'var(--border-subtle)',
-              background: 'var(--surface-1)',
-              color: 'var(--text-muted)',
-            }}
-            aria-label={_(msg`Dismiss`)}
-            disabled={busy !== 'none'}
-            onClick={() => { void handleDiscard(); }}
-          >
-            <X className="w-4 h-4" />
-          </button>
         </div>
 
         {/* Body */}
@@ -119,41 +104,48 @@ export function SceneAutosaveRecoveryModal({ savedAt, voxlPath, origin, onRestor
             <Trans>It looks like DragonFruit quit before you saved your last session. You can restore the autosaved scene or discard it and start fresh.</Trans>
           </p>
 
-          <div
-            className="rounded-lg border px-3 py-2.5"
-            style={{
-              borderColor: 'var(--border-subtle)',
-              background: 'color-mix(in srgb, var(--surface-1), black 8%)',
-            }}
-          >
-            <div className="text-[11px] uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-              <Trans>Last autosave</Trans>
+          <div className="grid grid-cols-2 gap-2">
+            <div
+              className="rounded-lg border px-3 py-2.5"
+              style={{
+                borderColor: 'var(--border-subtle)',
+                background: 'color-mix(in srgb, var(--surface-1), black 8%)',
+              }}
+            >
+              <div className="text-[11px] uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+                <Trans>Last autosave</Trans>
+              </div>
+              <div className="mt-1 text-sm font-semibold leading-tight" style={{ color: 'var(--text-strong)' }}>
+                {formattedDate}
+              </div>
             </div>
-            <div className="mt-1 text-sm font-semibold leading-tight" style={{ color: 'var(--text-strong)' }}>
-              {formattedDate}
-            </div>
-            {voxlPath && (
-              <>
-                <div className="mt-2.5 text-[11px] uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-                  {origin === 'sidecar'
-                    ? _(msg`Saved beside your project`)
-                    : _(msg`Saved in the recovery folder`)}
+            {voxlPath ? (
+              <div
+                className="rounded-lg border px-3 py-2.5"
+                style={{
+                  borderColor: 'var(--border-subtle)',
+                  background: 'color-mix(in srgb, var(--surface-1), black 8%)',
+                }}
+              >
+                <div className="text-[11px] uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+                  <Trans>Name</Trans>
                 </div>
-                <div
-                  className="mt-1 break-all text-[11px] leading-snug"
-                  style={{ color: 'var(--text-muted)' }}
-                  title={voxlPath}
-                >
-                  {voxlPath}
+                <div className="mt-1 truncate text-sm font-semibold leading-tight" style={{ color: 'var(--text-strong)' }} title={voxlPath}>
+                  {voxlPath.split(/[\\/]/).pop() || voxlPath}
                 </div>
-              </>
-            )}
+              </div>
+            ) : null}
           </div>
 
-          <div className="flex shrink-0 items-center justify-end gap-2 pt-1">
+          <div className="grid grid-cols-2 gap-2 pt-1">
             <button
               type="button"
-              className="ui-button ui-button-secondary !h-9 px-3 text-xs inline-flex items-center gap-1.5"
+              className="ui-button !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
+              style={{
+                borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
+                color: 'var(--danger)',
+              }}
               disabled={busy !== 'none'}
               onClick={() => { void handleDiscard(); }}
             >
@@ -162,7 +154,7 @@ export function SceneAutosaveRecoveryModal({ savedAt, voxlPath, origin, onRestor
             </button>
             <button
               type="button"
-              className="ui-button !h-9 px-3 text-xs inline-flex items-center gap-1.5"
+              className="ui-button !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
               style={{
                 borderColor: 'color-mix(in srgb, #22c55e, var(--border-subtle) 45%)',
                 background: 'color-mix(in srgb, #22c55e, var(--surface-1) 86%)',
@@ -172,7 +164,7 @@ export function SceneAutosaveRecoveryModal({ savedAt, voxlPath, origin, onRestor
               onClick={() => { void handleRestore(); }}
             >
               <ArchiveRestore className="h-3.5 w-3.5" />
-              <Trans>Restore Scene</Trans>
+              <Trans>Restore</Trans>
             </button>
           </div>
         </div>

--- a/src/components/settings/BackupsSettingsTab.tsx
+++ b/src/components/settings/BackupsSettingsTab.tsx
@@ -1279,16 +1279,15 @@ export function BackupsSettingsTab() {
               </button>
             </div>
 
-            <div className="mt-2">
-              <div className="max-h-64 overflow-auto rounded-md border custom-scrollbar" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-                {historyItems.length === 0 ? (
-                  <div className="px-3 py-3 text-xs" style={{ color: 'var(--text-muted)' }}>
-                    <Trans>No history snapshots yet. New syncs will appear here.</Trans>
-                  </div>
-                ) : (
-                  <ul className="p-1.5 space-y-1.5">
-                    {historyItems.map((item) => (
-                      <li key={item.id} className="flex items-center justify-between gap-2 rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
+          <div className="mt-2 max-h-64 overflow-auto custom-scrollbar">
+            {historyItems.length === 0 ? (
+              <div className="px-3 py-3 text-xs" style={{ color: 'var(--text-muted)' }}>
+                <Trans>No history snapshots yet. New syncs will appear here.</Trans>
+              </div>
+            ) : (
+              <ul className="space-y-1.5">
+                {historyItems.map((item) => (
+                  <li key={item.id} className="flex items-center justify-between gap-2 rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
                         <button
                           type="button"
                           onClick={() => { void handleViewHistory(item.id); }}
@@ -1327,7 +1326,6 @@ export function BackupsSettingsTab() {
                 )}
               </div>
             </div>
-          </div>
         </section>
       )}
 

--- a/src/components/settings/ExperimentsSettingsTab.tsx
+++ b/src/components/settings/ExperimentsSettingsTab.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { useEscapeToClose } from '@/hotkeys/useEscapeToClose';
 import { createPortal } from 'react-dom';
-import { AlertTriangle, FlaskConical, X } from 'lucide-react';
+import { AlertTriangle, FlaskConical } from 'lucide-react';
 import {
   getExperimentDefinitions,
   isExperimentEnabled,
@@ -52,7 +52,7 @@ function ExperimentsDisclaimer({ onAcknowledge, onExit }: ExperimentsDisclaimerP
         aria-modal="true"
         aria-label="Experiments disclaimer"
       >
-        <div className="flex items-center justify-between gap-4 border-b px-5 py-4" style={{ borderColor: 'var(--border-subtle)' }}>
+        <div className="flex items-center gap-4 border-b px-5 py-4" style={{ borderColor: 'var(--border-subtle)' }}>
           <div className="flex min-w-0 items-center gap-3">
             <span
               className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border"
@@ -75,19 +75,6 @@ function ExperimentsDisclaimer({ onAcknowledge, onExit }: ExperimentsDisclaimerP
             </div>
           </div>
 
-          <button
-            type="button"
-            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border transition-colors"
-            style={{
-              borderColor: 'var(--border-subtle)',
-              background: 'var(--surface-1)',
-              color: 'var(--text-muted)',
-            }}
-            aria-label="Close experiments disclaimer"
-            onClick={onExit}
-          >
-            <X className="w-4 h-4" />
-          </button>
         </div>
 
         <div className="space-y-4 p-5">
@@ -100,10 +87,17 @@ function ExperimentsDisclaimer({ onAcknowledge, onExit }: ExperimentsDisclaimerP
           <p className="text-xs leading-relaxed" style={{ color: '#fca5a5', fontWeight: 600 }}>
             Enable and use them at your own risk.
           </p>
-          <div className="flex justify-end pt-1">
+          <div className="grid grid-cols-2 gap-2 pt-1">
             <button
               type="button"
-              className="ui-button !h-9 px-3 text-xs"
+              className="ui-button ui-button-secondary !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
+              onClick={onExit}
+            >
+              Take me back!
+            </button>
+            <button
+              type="button"
+              className="ui-button !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
               style={{
                 borderColor: 'color-mix(in srgb, #f59e0b, var(--border-subtle) 45%)',
                 background: 'color-mix(in srgb, #f59e0b, var(--surface-1) 86%)',
@@ -111,7 +105,7 @@ function ExperimentsDisclaimer({ onAcknowledge, onExit }: ExperimentsDisclaimerP
               }}
               onClick={onAcknowledge}
             >
-              I Understand
+              I understand
             </button>
           </div>
         </div>
@@ -120,8 +114,8 @@ function ExperimentsDisclaimer({ onAcknowledge, onExit }: ExperimentsDisclaimerP
   );
 }
 
-// Module-level so the disclaimer is shown at most once per app launch, no matter
-// how many times the tab is entered (the tab remounts on each entry).
+// Module-level so the disclaimer is shown until acknowledged with I understand;
+// Take me back keeps it for next entry, so it can reappear within the same launch.
 let disclaimerSeenThisLaunch = false;
 
 export function ExperimentsSettingsTab({ onExit }: { onExit: () => void }) {
@@ -133,9 +127,9 @@ export function ExperimentsSettingsTab({ onExit }: { onExit: () => void }) {
   }, []);
 
   React.useEffect(() => {
-    // Show the ORA disclaimer on the first tab entry of this launch only.
+    // Show the ORA disclaimer if not yet acknowledged this launch.
+    // Only I understand marks it as seen — Take me back keeps it for next entry.
     if (!disclaimerSeenThisLaunch) {
-      disclaimerSeenThisLaunch = true;
       setShowDisclaimer(true);
     }
   }, []);
@@ -151,8 +145,15 @@ export function ExperimentsSettingsTab({ onExit }: { onExit: () => void }) {
       ? null
       : createPortal(
           <ExperimentsDisclaimer
-            onAcknowledge={() => setShowDisclaimer(false)}
-            onExit={onExit}
+            onAcknowledge={() => {
+              disclaimerSeenThisLaunch = true;
+              setShowDisclaimer(false);
+            }}
+            onExit={() => {
+              // Keep disclaimer for next entry — don't mark as seen
+              setShowDisclaimer(false);
+              onExit();
+            }}
           />,
           document.body,
         );
@@ -187,7 +188,7 @@ export function ExperimentsSettingsTab({ onExit }: { onExit: () => void }) {
             <div
               key={experiment.id}
               className="rounded-md border px-2.5 py-2 flex items-center justify-between gap-3"
-              style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}
+              style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
             >
               <div className="min-w-0 flex-1">
                 <span className="text-xs font-semibold" style={{ color: 'var(--text-strong)' }}>{experiment.name}</span>

--- a/src/components/settings/LocalBackupsSettingsTab.tsx
+++ b/src/components/settings/LocalBackupsSettingsTab.tsx
@@ -700,10 +700,11 @@ export function LocalBackupsSettingsTab() {
     background: 'var(--accent-secondary-action-bg-92)',
   };
   const dangerActionStyle92: React.CSSProperties = {
-    color: 'color-mix(in srgb, var(--danger), var(--text-strong) 22%)',
-    borderColor: 'color-mix(in srgb, var(--danger), var(--border-subtle) 45%)',
-    background: 'color-mix(in srgb, var(--danger), var(--surface-1) 88%)',
+    color: 'var(--danger)',
+    borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
+    background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
   };
+  const isUsingDefault = !defaultDirectory || selectedDirectory.trim().toLowerCase() === defaultDirectory.trim().toLowerCase();
 
   return (
     <div className="space-y-3">
@@ -720,61 +721,66 @@ export function LocalBackupsSettingsTab() {
           </div>
         </div>
 
-        <div className="mt-2 rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
-          {loadingStatus ? (
-            <div className="text-xs inline-flex items-center gap-1.5" style={{ color: 'var(--text-muted)' }}>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              <Trans>Loading backup status…</Trans>
-            </div>
-          ) : (
-            <div className="grid gap-2 sm:grid-cols-2">
-              <div className="rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-                <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}><Trans>Default directory</Trans></div>
-                <div className="mt-1 text-xs font-medium break-all" style={{ color: 'var(--text-strong)' }}>
-                  {defaultDirectory || <Trans>Resolving...</Trans>}
-                </div>
-              </div>
-
-              <div className="rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-                <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}><Trans>Selected directory</Trans></div>
-                <div className="mt-1 text-xs font-medium break-all" style={{ color: 'var(--text-strong)' }}>
-                  {selectedDirectory || <Trans>Not selected</Trans>}
-                </div>
-              </div>
-
-              <div className="rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-                <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}><Trans>Last backup on disk</Trans></div>
-                <div className="mt-1 text-xs" style={{ color: 'var(--text-strong)' }}>
-                  {stateUpdatedAt ? new Date(stateUpdatedAt).toLocaleString() : <Trans>Never</Trans>}
-                </div>
-              </div>
-
-              <div className="rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-                <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}><Trans>Last local sync</Trans></div>
-                <div className="mt-1 text-xs" style={{ color: 'var(--text-strong)' }}>
-                  {lastLocalSyncAt ? new Date(lastLocalSyncAt).toLocaleString() : <Trans>Never</Trans>}
-                </div>
+        {loadingStatus ? (
+          <div className="mt-2 text-xs inline-flex items-center gap-1.5" style={{ color: 'var(--text-muted)' }}>
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <Trans>Loading backup status…</Trans>
+          </div>
+        ) : (
+          <div className="mt-2 grid gap-2 sm:grid-cols-2">
+            <div className="rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
+              <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}><Trans>Default directory</Trans></div>
+              <div className="mt-1 text-xs font-medium break-all" style={{ color: 'var(--text-strong)' }}>
+                {defaultDirectory || <Trans>Resolving...</Trans>}
               </div>
             </div>
-          )}
-        </div>
 
-        <div className="mt-2 grid gap-2 sm:grid-cols-3">
-          <button
-            type="button"
-            onClick={() => { void handleUseDefaultDirectory(); }}
-            disabled={!defaultDirectory || busy !== 'none'}
-            className="ui-button ui-button-secondary !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
-          >
-            <CheckCircle2 className="h-4 w-4" />
-            <Trans>Use Default Path</Trans>
-          </button>
+            <div className="rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
+              <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}><Trans>Selected directory</Trans></div>
+              <div className="mt-1 text-xs font-medium break-all" style={{ color: 'var(--text-strong)' }}>
+                {selectedDirectory || <Trans>Not selected</Trans>}
+              </div>
+            </div>
+
+            <div className="rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
+              <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}><Trans>Last backup on disk</Trans></div>
+              <div className="mt-1 text-xs" style={{ color: 'var(--text-strong)' }}>
+                {stateUpdatedAt ? new Date(stateUpdatedAt).toLocaleString() : <Trans>Never</Trans>}
+              </div>
+            </div>
+
+            <div className="rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
+              <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}><Trans>Last local sync</Trans></div>
+              <div className="mt-1 text-xs" style={{ color: 'var(--text-strong)' }}>
+                {lastLocalSyncAt ? new Date(lastLocalSyncAt).toLocaleString() : <Trans>Never</Trans>}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className={isUsingDefault ? 'mt-2 grid gap-2 sm:grid-cols-2' : 'mt-2 grid gap-2 sm:grid-cols-3'}>
+          {!isUsingDefault && defaultDirectory ? (
+            <button
+              type="button"
+              onClick={() => { void handleUseDefaultDirectory(); }}
+              disabled={busy !== 'none'}
+              className="ui-button ui-button-secondary !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
+            >
+              <CheckCircle2 className="h-4 w-4" style={{ color: 'var(--text-muted)' }} />
+              <Trans>Use Default Path</Trans>
+            </button>
+          ) : null}
 
           <button
             type="button"
             onClick={() => { void handleChooseDirectory(); }}
             disabled={busy !== 'none'}
-            className="ui-button ui-button-secondary !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
+            className="ui-button !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+              background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+              color: 'var(--accent)',
+            }}
           >
             {busy === 'choose-directory' ? <Loader2 className="h-4 w-4 animate-spin" /> : <FolderOpen className="h-4 w-4" />}
             <Trans>Choose Folder</Trans>
@@ -784,7 +790,12 @@ export function LocalBackupsSettingsTab() {
             type="button"
             onClick={() => { void handleRevealDirectory(); }}
             disabled={!selectedDirectory || busy !== 'none'}
-            className="ui-button ui-button-secondary !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
+            className="ui-button !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 45%)',
+              background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 86%)',
+              color: 'var(--accent-secondary)',
+            }}
           >
             {busy === 'reveal' ? <Loader2 className="h-4 w-4 animate-spin" /> : <FolderOpen className="h-4 w-4" />}
             <Trans>Open Folder</Trans>
@@ -818,7 +829,12 @@ export function LocalBackupsSettingsTab() {
               type="button"
               onClick={() => { void runSync(); }}
               disabled={busy !== 'none' || !selectedDirectory}
-              className="ui-button ui-button-primary !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
+              className="ui-button !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
+              style={{
+                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                color: 'var(--accent)',
+              }}
             >
               {busy === 'sync' ? <Loader2 className="h-4 w-4 animate-spin" /> : <UploadCloud className="h-4 w-4" />}
               <Trans>Backup Now</Trans>
@@ -917,18 +933,17 @@ export function LocalBackupsSettingsTab() {
             </button>
           </div>
 
-          <div className="mt-2">
-            <div className="max-h-64 overflow-auto rounded-md border custom-scrollbar" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-              {historyItems.length === 0 ? (
-                <div className="px-3 py-3 text-xs" style={{ color: 'var(--text-muted)' }}>
-                  {hasAnySync
-                    ? <Trans>No history snapshots found in this folder.</Trans>
-                    : <Trans>No snapshots yet. Run &quot;Backup Now&quot; to create your first local snapshot.</Trans>}
-                </div>
-              ) : (
-                <ul className="p-1.5 space-y-1.5">
+          <div className="mt-2 max-h-64 overflow-auto custom-scrollbar">
+            {historyItems.length === 0 ? (
+              <div className="px-3 py-3 text-xs" style={{ color: 'var(--text-muted)' }}>
+                {hasAnySync
+                  ? <Trans>No history snapshots found in this folder.</Trans>
+                  : <Trans>No snapshots yet. Run &quot;Backup Now&quot; to create your first local snapshot.</Trans>}
+              </div>
+            ) : (
+              <ul className="space-y-1.5">
                   {historyItems.map((item) => (
-                    <li key={item.id} className="flex items-center justify-between gap-2 rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
+                    <li key={item.id} className="flex items-center justify-between gap-2 rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
                       <button
                         type="button"
                         onClick={() => { void handleViewHistory(item.id); }}
@@ -966,7 +981,6 @@ export function LocalBackupsSettingsTab() {
                 </ul>
               )}
             </div>
-          </div>
         </div>
       </section>
 
@@ -992,7 +1006,11 @@ export function LocalBackupsSettingsTab() {
             <button
               type="button"
               className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
-              style={dangerActionStyle92}
+              style={{
+                borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
+                color: 'var(--danger)',
+              }}
               disabled={busy !== 'none'}
               onClick={() => {
                 const id = confirmDeleteId;

--- a/src/components/settings/MeshSettingsTab.tsx
+++ b/src/components/settings/MeshSettingsTab.tsx
@@ -515,8 +515,8 @@ export function MeshSettingsTab({
                       type="color"
                       value={selectionColor}
                       onChange={(e) => onSelectionColorChange(e.target.value)}
-                      className="h-8 w-10 shrink-0 rounded border"
-                      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+                      className="h-8 w-10 shrink-0 cursor-pointer appearance-none overflow-hidden rounded border p-0 [&::-webkit-color-swatch]:border-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-moz-color-swatch]:border-0"
+                      style={{ borderColor: 'var(--border-subtle)' }}
                     />
                     <input
                       type="text"
@@ -534,8 +534,8 @@ export function MeshSettingsTab({
                       type="color"
                       value={hoverColor}
                       onChange={(e) => onHoverColorChange(e.target.value)}
-                      className="h-8 w-10 shrink-0 rounded border"
-                      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+                      className="h-8 w-10 shrink-0 cursor-pointer appearance-none overflow-hidden rounded border p-0 [&::-webkit-color-swatch]:border-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-moz-color-swatch]:border-0"
+                      style={{ borderColor: 'var(--border-subtle)' }}
                     />
                     <input
                       type="text"

--- a/src/components/settings/PerformanceSettingsTab.tsx
+++ b/src/components/settings/PerformanceSettingsTab.tsx
@@ -10,8 +10,10 @@ const SLICING_ENGINE_VERSION_FALLBACK = '3.2.1';
 
 
 export type SlicingThumbnailRenderSettings = {
+  includeGradient: boolean;
+  includeBuildPlate: boolean;
+  includeGrid: boolean;
 };
-
 interface PerformanceSettingsTabProps {
   settings: SlicingPerformanceSettings;
   onChange: (settings: SlicingPerformanceSettings) => void;

--- a/src/components/settings/PerformanceSettingsTab.tsx
+++ b/src/components/settings/PerformanceSettingsTab.tsx
@@ -6,12 +6,10 @@ import type { SlicingPerformanceSettings } from '@/components/settings/performan
 import { cleanupAllPrintTempArtifacts, cleanupStalePrintTempArtifacts } from '@/features/slicing/tauri/nativeSlicerBridge';
 
 const SLICING_ENGINE_CRATE = 'dragonfruit-slicing-engine';
-const SLICING_ENGINE_VERSION = '3.1.0';
+const SLICING_ENGINE_VERSION_FALLBACK = '3.2.1';
+
 
 export type SlicingThumbnailRenderSettings = {
-  includeGradient: boolean;
-  includeBuildPlate: boolean;
-  includeGrid: boolean;
 };
 
 interface PerformanceSettingsTabProps {
@@ -40,6 +38,18 @@ export function PerformanceSettingsTab({
     });
   }, [onThumbnailSettingsChange, thumbnailSettings]);
 
+  const [engineVersion, setEngineVersion] = React.useState(SLICING_ENGINE_VERSION_FALLBACK);
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { invoke } = await import('@tauri-apps/api/core');
+        const v = await invoke<string>('get_slicer_engine_version');
+        if (!cancelled && typeof v === 'string' && v.trim()) setEngineVersion(v.trim());
+      } catch {}
+    })();
+    return () => { cancelled = true; };
+  }, []);
   const pngCompressionMode: 'auto' | 'on' | 'off' = settings.pngCompressionStrategy === 'auto'
     ? 'auto'
     : settings.pngCompressionStrategy === 'fastest'
@@ -84,7 +94,7 @@ export function PerformanceSettingsTab({
             </div>
             <div>
               <div style={{ color: 'var(--text-muted)' }}>Version</div>
-              <div className="font-semibold" style={{ color: 'var(--text-strong)' }}>{SLICING_ENGINE_VERSION}</div>
+              <div className="font-semibold" style={{ color: 'var(--text-strong)' }}>{engineVersion}</div>
             </div>
           </div>
         </div>

--- a/src/components/settings/SceneAutosaveSettingsTab.tsx
+++ b/src/components/settings/SceneAutosaveSettingsTab.tsx
@@ -303,8 +303,11 @@ export function SceneAutosaveSettingsTab() {
       </section>
 
       <section className="rounded-lg border p-3" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-        <div className="flex items-center justify-between gap-2">
-          <div>
+        <div className="flex items-start gap-2">
+          <span className="inline-flex h-8 w-8 items-center justify-center rounded-md border shrink-0" style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-2), transparent 8%)' }}>
+            <HardDrive className="h-4 w-4" style={{ color: 'var(--accent)' }} />
+          </span>
+          <div className="min-w-0 flex-1">
             <h4 className="text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>{_(msg`Autosave Status`)}</h4>
             <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
               <Trans>Desktop-only diagnostics for autosave files and recovery state.</Trans>
@@ -314,77 +317,80 @@ export function SceneAutosaveSettingsTab() {
             type="button"
             onClick={() => { void handleRefresh(); }}
             disabled={!desktopAvailable || busy !== 'none'}
-            className="ui-button ui-button-secondary !h-8 !px-2.5 !py-0 text-xs inline-flex items-center gap-1.5 disabled:opacity-60"
+            className="ui-button ui-button-secondary !h-8 !px-2.5 !py-0 text-xs inline-flex items-center gap-1.5 disabled:opacity-60 shrink-0"
           >
             {busy === 'refresh' || loadingStatus ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
             <Trans>Refresh</Trans>
           </button>
         </div>
 
-        <div className="mt-2 rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
-          {!desktopAvailable ? (
-            <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
-              <Trans>Autosave files are available in the DragonFruit desktop build.</Trans>
-            </div>
-          ) : loadingStatus ? (
-            <div className="text-xs inline-flex items-center gap-1.5" style={{ color: 'var(--text-muted)' }}>
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              <Trans>Loading autosave status…</Trans>
-            </div>
-          ) : (
-            <div className="grid gap-2 sm:grid-cols-2">
-              <div className="rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-                <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}>{_(msg`Recovery state`)}</div>
-                <div className="mt-1 text-xs" style={{ color: 'var(--text-strong)' }}>
-                  {manifest == null
-                    ? _(msg`No autosave manifest found`)
-                    : manifest.clean
-                      ? _(msg`Clean (no pending recovery)`)
-                      : _(msg`Recovery available`)}
-                </div>
-              </div>
-
-              <div className="rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-                <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}>{_(msg`Last autosave timestamp`)}</div>
-                <div className="mt-1 text-xs" style={{ color: 'var(--text-strong)' }}>
-                  {manifest?.savedAt
-                    ? new Date(manifest.savedAt).toLocaleString(i18n.locale)
-                    : _(msg({ message: 'Unknown', comment: 'Placeholder when the autosave timestamp could not be read.' }))}
-                </div>
-              </div>
-
-              {manifest?.lastError && (
-                <div className="rounded-md border px-2.5 py-2 sm:col-span-2 border-amber-500/40 bg-amber-500/10">
-                  <div className="text-[11px] uppercase tracking-wide font-semibold text-amber-400">{_(msg`Standing Autosave Error`)}</div>
-                  <div className="mt-1 text-xs text-amber-200">{manifest.lastError}</div>
-                </div>
-              )}
-
-              <div className="rounded-md border px-2.5 py-2 sm:col-span-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-                <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}>{_(msg`Autosave scene file`)}</div>
-                <div className="mt-1 text-xs break-all" style={{ color: 'var(--text-strong)' }}>
-                  {resolvedAutosavePath ?? _(msg({ message: 'Unavailable', comment: 'Placeholder when the autosave file path could not be resolved.' }))}
-                </div>
-                <div className="mt-1.5 text-xs leading-snug" style={{ color: 'var(--text-muted)' }}>
-                  {resolvedAutosaveOrigin === 'sidecar'
-                    ? _(msg({
-                        message: 'A recovery copy is written beside each saved project, as <name>_autosave.voxl. It uses roughly as much disk as the project itself.',
-                        comment: '<name> is a literal placeholder in the filename, not markup — leave it as-is.',
-                      }))
-                    : _(msg`Recovery copies are written to the app data folder above.`)}
-                  {resolvedFallbackReason ? ` ${formatFallbackNotice(_, resolvedFallbackReason)}` : ''}
-                </div>
+        {!desktopAvailable ? (
+          <div className="mt-2 text-xs" style={{ color: 'var(--text-muted)' }}>
+            <Trans>Autosave files are available in the DragonFruit desktop build.</Trans>
+          </div>
+        ) : loadingStatus ? (
+          <div className="mt-2 text-xs inline-flex items-center gap-1.5" style={{ color: 'var(--text-muted)' }}>
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <Trans>Loading autosave status…</Trans>
+          </div>
+        ) : (
+          <div className="mt-2 grid gap-2 sm:grid-cols-2">
+            <div className="rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
+              <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}>{_(msg`Recovery state`)}</div>
+              <div className="mt-1 text-xs" style={{ color: 'var(--text-strong)' }}>
+                {manifest == null
+                  ? _(msg`No autosave manifest found`)
+                  : manifest.clean
+                    ? _(msg`Clean (no pending recovery)`)
+                    : _(msg`Recovery available`)}
               </div>
             </div>
-          )}
-        </div>
+
+            <div className="rounded-md border px-2.5 py-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
+              <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}>{_(msg`Last autosave timestamp`)}</div>
+              <div className="mt-1 text-xs" style={{ color: 'var(--text-strong)' }}>
+                {manifest?.savedAt
+                  ? new Date(manifest.savedAt).toLocaleString(i18n.locale)
+                  : _(msg({ message: 'Unknown', comment: 'Placeholder when the autosave timestamp could not be read.' }))}
+              </div>
+            </div>
+
+            {manifest?.lastError && (
+              <div className="rounded-md border px-2.5 py-2 sm:col-span-2 border-amber-500/40 bg-amber-500/10">
+                <div className="text-[11px] uppercase tracking-wide font-semibold text-amber-400">{_(msg`Standing Autosave Error`)}</div>
+                <div className="mt-1 text-xs text-amber-200">{manifest.lastError}</div>
+              </div>
+            )}
+
+            <div className="rounded-md border px-2.5 py-2 sm:col-span-2" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
+              <div className="text-[11px] uppercase tracking-wide font-semibold" style={{ color: 'var(--text-muted)' }}>{_(msg`Autosave scene file`)}</div>
+              <div className="mt-1 text-xs break-all" style={{ color: 'var(--text-strong)' }}>
+                {resolvedAutosavePath ?? _(msg({ message: 'Unavailable', comment: 'Placeholder when the autosave file path could not be resolved.' }))}
+              </div>
+              <div className="mt-1.5 text-xs leading-snug" style={{ color: 'var(--text-muted)' }}>
+                {resolvedAutosaveOrigin === 'sidecar'
+                  ? _(msg({
+                      message: 'A recovery copy is written beside each saved project, as <name>_autosave.voxl. It uses roughly as much disk as the project itself.',
+                      comment: '<name> is a literal placeholder in the filename, not markup — leave it as-is.',
+                    }))
+                  : _(msg`Recovery copies are written to the app data folder above.`)}
+                {resolvedFallbackReason ? ` ${formatFallbackNotice(_, resolvedFallbackReason)}` : ''}
+              </div>
+            </div>
+          </div>
+        )}
 
         <div className="mt-2 grid gap-2 sm:grid-cols-2">
           <button
             type="button"
             onClick={() => { void handleMarkClean(); }}
             disabled={!desktopAvailable || busy !== 'none'}
-            className="ui-button ui-button-secondary !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
+            className="ui-button !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
+            style={{
+              borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
+              background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
+              color: 'var(--danger)',
+            }}
           >
             {busy === 'mark-clean' ? <Loader2 className="h-4 w-4 animate-spin" /> : <AlertTriangle className="h-4 w-4" />}
             <Trans>Mark Recovery Clean</Trans>
@@ -393,7 +399,12 @@ export function SceneAutosaveSettingsTab() {
             type="button"
             onClick={() => { void handleRevealAutosave(); }}
             disabled={!desktopAvailable || !resolvedAutosavePath || busy !== 'none'}
-            className="ui-button ui-button-secondary !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
+            className="ui-button !h-9 !px-3 !py-0 text-sm inline-flex items-center justify-center gap-1.5 disabled:opacity-60"
+            style={{
+              borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+              background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+              color: 'var(--accent)',
+            }}
           >
             {busy === 'reveal' ? <Loader2 className="h-4 w-4 animate-spin" /> : <HardDrive className="h-4 w-4" />}
             <Trans>Open Autosave Location</Trans>

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -1905,8 +1905,12 @@ export function SettingsModal({
                 <button
                   type="button"
                   onClick={handleConfirmRestoreDefaults}
-                  className="ui-button !h-9 px-3 text-xs inline-flex items-center gap-1.5"
-                  style={accentSecondaryActionStyle92}
+                  className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                  style={{
+                    borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                    background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                    color: 'var(--accent)',
+                  }}
                 >
                   <RotateCcw className="h-3.5 w-3.5" />
                   Restore Defaults
@@ -1985,8 +1989,12 @@ export function SettingsModal({
                 <button
                   type="button"
                   onClick={reloadToApplyExperiments}
-                  className="ui-button !h-9 px-3 text-xs inline-flex items-center gap-1.5"
-                  style={accentSecondaryActionStyle92}
+                  className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                  style={{
+                    borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                    background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                    color: 'var(--accent)',
+                  }}
                 >
                   <RotateCcw className="h-3.5 w-3.5" />
                   Reload Now
@@ -2019,8 +2027,12 @@ export function SettingsModal({
             <button
               type="button"
               onClick={handleConfirmSaveCurrentCustomTheme}
-              className="ui-button !h-9 px-3 text-xs inline-flex items-center gap-1.5"
-              style={accentSecondaryActionStyle92}
+              className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+              style={{
+                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                color: 'var(--accent)',
+              }}
             >
               <Save className="h-3.5 w-3.5" />
               Save Theme
@@ -2055,11 +2067,11 @@ export function SettingsModal({
             <button
               type="button"
               onClick={handleConfirmDeleteCurrentCustomTheme}
-              className="ui-button ui-button-secondary !h-9 px-3 text-xs inline-flex items-center gap-1.5"
+              className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
               style={{
+                borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
                 color: 'var(--danger)',
-                borderColor: 'color-mix(in srgb, var(--danger), var(--border-subtle) 40%)',
-                background: 'color-mix(in srgb, var(--danger), var(--surface-1) 92%)',
               }}
             >
               <Trash2 className="h-3.5 w-3.5" />
@@ -2095,8 +2107,12 @@ export function SettingsModal({
             <button
               type="button"
               onClick={handleConfirmRenameCurrentCustomTheme}
-              className="ui-button !h-9 px-3 text-xs inline-flex items-center gap-1.5"
-              style={accentSecondaryActionStyle92}
+              className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+              style={{
+                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                color: 'var(--accent)',
+              }}
               disabled={draftThemeRenameName.trim().length === 0}
             >
               <Check className="h-3.5 w-3.5" />

--- a/src/components/settings/SettingsModal.tsx
+++ b/src/components/settings/SettingsModal.tsx
@@ -415,7 +415,11 @@ export function SettingsModal({
   const [draftPerspectiveFov, setDraftPerspectiveFov] = useState<number>(() => getSavedCameraFovSettings().fov);
   const [draftThemePreference, setDraftThemePreference] = useState(getSavedThemePreference());
   const [draftThemePreset, setDraftThemePreset] = useState<ThemePreset>(getSavedThemePreset());
-  const [draftThemeColors, setDraftThemeColors] = useState<ThemeCustomColors>(getSavedThemeCustomColors());
+  const [draftThemeColors, setDraftThemeColors] = useState<ThemeCustomColors>(() => {
+    const preset = getSavedThemePreset();
+    const profile = getThemeProfile(preset, getSavedCustomThemeProfiles());
+    return { ...profile.colors };
+  });
   const [draftThemeProfiles, setDraftThemeProfiles] = useState<SavedCustomThemeProfile[]>(() => getSavedCustomThemeProfiles());
   const [draftCustomThemeName, setDraftCustomThemeName] = useState<string>(() => {
     const savedPreset = getSavedThemePreset();
@@ -1058,12 +1062,6 @@ export function SettingsModal({
     applyThemeCustomColors(draftThemeColors);
   }, [draftThemeColors, draftThemePreference, isOpen]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-
-    setDraftSelectionColor(draftThemeColors.accent);
-    setDraftHoverColor(draftThemeColors.accentHover);
-  }, [draftThemeColors.accent, draftThemeColors.accentHover, isOpen]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/src/components/settings/SponsorsCarousel.tsx
+++ b/src/components/settings/SponsorsCarousel.tsx
@@ -15,6 +15,32 @@ export type Sponsor = {
   totalAmountDonated?: number;
 };
 
+// Donation-rank ring colors — Siraya Tech ($200) → gold, next tiers silver/bronze.
+// Thresholds are totalAmountDonated from Open Collective (lifetime total, not monthly).
+// Adjust thresholds if sponsor amounts shift; gold >=100 (Siraya 200, WickedGrey 100), silver >=30, bronze >=10.
+export function getSponsorRank(total?: number | null): { tier: string; borderColor: string; gradient?: string; glow: string } {
+  if (total == null) return { tier: 'supporter', borderColor: 'var(--border-subtle)', glow: 'none' };
+  if (total >= 100) return {
+    tier: 'gold',
+    borderColor: '#D4AF37',
+    gradient: 'conic-gradient(from 0deg at 50% 50%, #BF953F 0deg, #FCF6BA 45deg, #B38728 90deg, #FBF5B7 135deg, #AA771C 180deg, #BF953F 225deg, #FCF6BA 270deg, #B38728 315deg, #BF953F 360deg)',
+    glow: '0 0 6px rgba(212, 175, 55, 0.35), 0 0 12px rgba(212, 175, 55, 0.18), inset 0 1px 1px rgba(255,255,255,0.5)',
+  };
+  if (total >= 30) return {
+    tier: 'silver',
+    borderColor: '#C0C0C0',
+    gradient: 'conic-gradient(from 0deg at 50% 50%, #71706E 0deg, #E8E8E8 45deg, #A8A8A8 90deg, #F5F5F5 135deg, #9B9B9B 180deg, #71706E 225deg, #E8E8E8 270deg, #A8A8A8 315deg, #71706E 360deg)',
+    glow: '0 0 6px rgba(192, 192, 192, 0.3), inset 0 1px 1px rgba(255,255,255,0.4)',
+  };
+  if (total >= 10) return {
+    tier: 'bronze',
+    borderColor: '#CD7F32',
+    gradient: 'conic-gradient(from 0deg at 50% 50%, #6B3A1F 0deg, #CD7F32 45deg, #E9BB83 90deg, #8C4A2A 135deg, #5C3317 180deg, #6B3A1F 225deg, #CD7F32 270deg, #E9BB83 315deg, #6B3A1F 360deg)',
+    glow: '0 0 6px rgba(205, 127, 50, 0.25), inset 0 1px 1px rgba(255,255,255,0.3)',
+  };
+  return { tier: 'supporter', borderColor: 'var(--border-subtle)', glow: 'none' };
+}
+
 // Open Collective collectives for Open Resin Alliance.
 // Sponsors are aggregated from both:
 // - https://opencollective.com/openresinalliance (Siraya Tech, Cunabula)
@@ -57,14 +83,69 @@ function dedupeSponsors(list: Sponsor[]): Sponsor[] {
 // Avatars are tiny (CP_Icon_250.png ~ 50KB), well within localStorage limits for the 2-·-N sponsors we have.
 const AVATAR_STORAGE_PREFIX = 'sponsor-avatar:';
 const avatarCache = new Map<string, string>();
+// Sponsors list cache — so we don't flash baked-in fallback on every cold open.
+// Avatars are already cached per-image; this caches the *list* (names, amounts, tiers).
+const SPONSORS_CACHE_KEY = 'dragonfruit:sponsors-cache-v1';
+const SPONSORS_CACHE_TTL_MS = 1000 * 60 * 60 * 6; // 6h — stale cache still better than baked-in
 
+function readCachedSponsors(): Sponsor[] | null {
+  try {
+    if (typeof window === 'undefined') return null;
+    const raw = window.localStorage.getItem(SPONSORS_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { sponsors?: unknown; fetchedAt?: unknown };
+    if (!parsed || !Array.isArray(parsed.sponsors)) return null;
+    // Keep stale cache usable; just avoid showing baked-in until fetch proves otherwise.
+    return parsed.sponsors as Sponsor[];
+  } catch {
+    return null;
+  }
+}
+function writeCachedSponsors(sponsors: Sponsor[]) {
+  try {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(SPONSORS_CACHE_KEY, JSON.stringify({ sponsors, fetchedAt: Date.now() }));
+  } catch {
+    // ignore quota
+  }
+}
 function blobToDataURL(blob: Blob): Promise<string> {
+
   const { promise, resolve, reject } = Promise.withResolvers<string>();
   const reader = new FileReader();
   reader.onloadend = () => resolve(reader.result as string);
   reader.onerror = () => reject(reader.error);
   reader.readAsDataURL(blob);
   return promise;
+}
+
+function toHighResUrl(src: string, profile?: string | null): string {
+  if (!src) return src;
+  // For S3 direct URLs (e.g. GGGAvatar3.png 250px), the S3 host ignores ?height, so keep S3 but try to get high-res via OC proxy only as fallback
+  // We prefer S3 with height param (no-op but still returns image) over proxy which may 404 for some slugs; proxy is used only for images.opencollective.com hosts
+  try {
+    const u = new URL(src);
+    if (u.host.includes('images.opencollective.com')) {
+      if (!u.searchParams.has('height') && !u.searchParams.has('width')) {
+        u.searchParams.set('height', '512');
+        u.searchParams.set('width', '512');
+      }
+      return u.toString();
+    }
+    if (u.host.includes('githubusercontent')) {
+      if (!u.searchParams.has('s')) u.searchParams.set('s', '512');
+      return u.toString();
+    }
+    if (u.host.includes('s3')) {
+      // S3 direct - add height (ignored but harmless) and keep original; don't use proxy which 404s for some
+      if (!u.searchParams.has('height')) {
+        u.searchParams.set('height', '512');
+        u.searchParams.set('width', '512');
+      }
+      return u.toString();
+    }
+  } catch {}
+  return src;
 }
 
 function readCachedAvatar(src: string): string | null {
@@ -90,15 +171,17 @@ function writeCachedAvatar(src: string, dataUrl: string) {
   }
 }
 
-function CachedAvatar({ src, alt, className }: { src: string; alt: string; className: string }) {
+function CachedAvatar({ src, profile, alt, className, totalAmountDonated }: { src: string; profile?: string | null; alt: string; className: string; totalAmountDonated?: number | null }) {
+  const highResSrc = toHighResUrl(src, profile);
   const [url, setUrl] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
-
+  const rank = getSponsorRank(totalAmountDonated);
+  const isGold = rank.tier === 'gold';
   // Hydrate from persistent cache before paint — avoids flash of spinner when already cached.
   // useLayoutEffect runs before browser paint, so a cached data URL appears instantly with no spinner.
   useLayoutEffect(() => {
-    if (!src) return;
-    const cached = readCachedAvatar(src);
+    if (!highResSrc) return;
+    const cached = readCachedAvatar(highResSrc);
     if (cached) {
       setUrl(cached);
       setLoaded(true);
@@ -106,34 +189,57 @@ function CachedAvatar({ src, alt, className }: { src: string; alt: string; class
   }, [src]);
 
   useEffect(() => {
-    if (!src) return;
-    if (readCachedAvatar(src)) return; // already cached, no fetch needed
+    if (!highResSrc) return;
+    if (readCachedAvatar(highResSrc)) return; // already cached, no fetch needed
 
     let cancelled = false;
     const load = async () => {
       try {
+        // Tauri production: Next.js proxy not available, S3 CORS blocks fetch().
+        // Use Rust (reqwest) to bypass WebView CORS and return a data URL.
+        try {
+          const { invoke } = await import('@tauri-apps/api/core');
+          const dataUrl = await invoke<string>('fetch_sponsor_avatar', { url: highResSrc });
+          if (!cancelled && dataUrl && typeof dataUrl === 'string' && dataUrl.startsWith('data:')) {
+            writeCachedAvatar(highResSrc, dataUrl);
+            setUrl(dataUrl);
+            return;
+          }
+        } catch {
+          // Not in Tauri (web) or host not allowed — fall through to HTTP proxy.
+        }
         // Use same-origin proxy to bypass S3 CORS (No 'Access-Control-Allow-Origin').
         // In Tauri production the proxy won't exist, so we fallback to direct fetch.
-        const proxyUrl = `/api/sponsor-avatar?url=${encodeURIComponent(src)}`;
+        const proxyUrl = `/api/sponsor-avatar?url=${encodeURIComponent(highResSrc)}`;
         let res: Response | null = null;
         try {
           res = await fetch(proxyUrl, { cache: 'force-cache' });
           if (!res.ok) throw new Error(`proxy ${res.status}`);
         } catch {
           // Fallback: direct S3 fetch may be blocked by CORS, but try anyway (works for <img>, not for fetch).
-          res = await fetch(src, { cache: 'force-cache', mode: 'cors' });
+          try {
+            res = await fetch(highResSrc, { cache: 'force-cache', mode: 'cors' });
+            if (!res || !res.ok) throw new Error(`highRes ${res?.status}`);
+          } catch {
+            // High-res proxy/S3 height param failed (e.g. 404 for gggames proxy), fallback to original src without height param
+            try {
+              res = await fetch(src, { cache: 'force-cache', mode: 'cors' });
+            } catch {
+              res = null;
+            }
+          }
         }
         if (!res || !res.ok) {
-          if (!cancelled) setUrl(src);
+          if (!cancelled) setUrl(highResSrc);
           return;
         }
         const blob = await res.blob();
         const dataUrl = await blobToDataURL(blob);
         if (cancelled) return;
-        writeCachedAvatar(src, dataUrl);
+        writeCachedAvatar(highResSrc, dataUrl);
         setUrl(dataUrl);
       } catch {
-        if (!cancelled) setUrl(src);
+        if (!cancelled) setUrl(highResSrc);
       }
     };
     void load();
@@ -144,71 +250,110 @@ function CachedAvatar({ src, alt, className }: { src: string; alt: string; class
 
   // Still fetching blob → show small circular progress in place of the avatar.
   if (!url) {
+    const hasRing = !!rank.gradient;
+    const ringPad = '3px';
     return (
       <span
-        className="inline-flex shrink-0 items-center justify-center rounded-full border"
+        className="inline-flex shrink-0 items-center justify-center rounded-full"
         style={{
           width: '3rem',
+          boxSizing: 'content-box',
           height: '3rem',
-          background: 'color-mix(in srgb, var(--surface-1), transparent 20%)',
-          borderColor: 'var(--border-subtle)',
-          color: 'var(--text-muted)',
+          padding: hasRing ? ringPad : undefined,
+          background: hasRing ? rank.gradient : undefined,
+          boxShadow: hasRing && rank.glow !== 'none' ? rank.glow : undefined,
+          borderRadius: '9999px',
         }}
         aria-label="Loading avatar"
       >
-        <span className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+        <span
+          className="inline-flex h-full w-full items-center justify-center rounded-full border"
+          style={{
+            background: 'color-mix(in srgb, var(--surface-1), transparent 20%)',
+            borderColor: hasRing ? 'transparent' : 'var(--border-subtle)',
+            color: 'var(--text-muted)',
+          }}
+        >
+          <span className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+        </span>
       </span>
     );
   }
 
   return (
-    <span className="relative inline-flex shrink-0" style={{ width: '3rem', height: '3rem' }}>
-      {!loaded && (
-        <span
-          className="absolute inset-0 inline-flex items-center justify-center rounded-full border"
+    <span
+      className="relative inline-flex shrink-0"
+      style={{
+        width: '3rem',
+          boxSizing: 'content-box',
+        height: '3rem',
+        borderRadius: '9999px',
+        padding: rank.gradient ? '3px' : undefined,
+        background: rank.gradient ?? undefined,
+        boxShadow: rank.glow !== 'none' ? rank.glow : undefined,
+      }}
+    >
+      <span className="relative inline-flex h-full w-full overflow-hidden rounded-full" style={{ background: 'var(--surface-1)', transform: 'translateZ(0)', isolation: 'isolate' } as React.CSSProperties}>
+        {!loaded && (
+          <span
+            className="absolute inset-0 inline-flex items-center justify-center rounded-full border"
+            style={{
+              background: 'color-mix(in srgb, var(--surface-1), transparent 20%)',
+              borderColor: 'var(--border-subtle)',
+              color: 'var(--text-muted)',
+            }}
+            aria-hidden="true"
+          >
+            <span className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+          </span>
+        )}
+        <div
+          className={`${className} ${!loaded ? 'opacity-0' : 'opacity-100'} transition-opacity`}
           style={{
-            background: 'color-mix(in srgb, var(--surface-1), transparent 20%)',
-            borderColor: 'var(--border-subtle)',
-            color: 'var(--text-muted)',
+            width: '512px',
+            height: '512px',
+            backgroundImage: `url("${url}")`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+            backgroundRepeat: 'no-repeat',
+            display: 'block',
+            position: 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%) scale(0.09375)',
+            transformOrigin: 'center',
+            willChange: 'transform',
           }}
-          aria-hidden="true"
-        >
-          <span className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-        </span>
-      )}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={url}
-        alt={alt}
-        aria-hidden={alt === '' ? true : undefined}
-        className={`${className} ${!loaded ? 'opacity-0' : 'opacity-100'} transition-opacity`}
-        decoding="async"
-        fetchPriority="low"
-        referrerPolicy="no-referrer"
-        onLoad={() => setLoaded(true)}
-        onError={(e) => {
-          (e.currentTarget as HTMLImageElement).style.display = 'none';
-        }}
-      />
+          aria-hidden={alt === '' ? true : undefined}
+        />
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={url}
+          alt={alt}
+          aria-hidden
+          style={{ display: 'none' }}
+          onLoad={() => setLoaded(true)}
+          onError={() => setLoaded(true)}
+        />
+      </span>
     </span>
   );
 }
 
 export function SponsorsCarousel() {
-  const [sponsors, setSponsors] = useState<Sponsor[]>(() => {
-    const initial = Array.isArray(fallbackSponsors) ? (fallbackSponsors as Sponsor[]) : [];
-    return initial;
+  const [sponsors, setSponsors] = useState<Sponsor[] | null>(() => {
+    const cached = readCachedSponsors();
+    if (cached && cached.length >= 0) return cached;
+    return null;
   });
   const containerRef = useRef<HTMLDivElement>(null);
   const trackRef = useRef<HTMLDivElement>(null);
   const [shouldMarquee, setShouldMarquee] = useState(false);
 
-  // Live sponsors — not just per-build `sponsors.json`. The fallback JSON is only the initial paint
-  // (offline-first); we immediately revalidate from Open Collective and keep it fresh while the
-  // About tab is open. We aggregate both collectives:
-  // - https://opencollective.com/openresinalliance
-  // - https://opencollective.com/openresinalliance/projects/dragonfruit-slicer (slug `dragonfruit-slicer`)
-  // No HTTP cache: `no-store` + focus/visibility + 5min poll. Sponsors are merged & deduped.
+  // Live sponsors — cached, not just baked-in fallback. Initial paint is cached
+  // sponsors if available (instant, no flash), otherwise null → loading spinner
+  // until fetch completes. Only after fetch fails with no cache do we fall back
+  // to the baked-in `sponsors.json`.
   useEffect(() => {
     let cancelled = false;
     const controller = new AbortController();
@@ -218,6 +363,17 @@ export function SponsorsCarousel() {
         const settled = await Promise.all(
           OPENCOLLECTIVE_MEMBERS_URLS.map(async (url) => {
             try {
+              // Tauri production: WebView fetch to opencollective.com is blocked by CORS (no ACAO for tauri://localhost).
+              // Try Rust (reqwest) first when in Tauri; falls through to fetch on web or on error.
+              try {
+                const { invoke } = await import('@tauri-apps/api/core');
+                const text = await invoke<string>('fetch_external_text', { url });
+                const data = JSON.parse(text) as unknown;
+                if (!Array.isArray(data)) return null;
+                return data.map(mapOCMemberToSponsor).filter((x): x is Sponsor => x !== null);
+              } catch {
+                // Not in Tauri (web) or host not allowed — fall through to HTTP fetch
+              }
               const res = await fetch(url, {
                 signal: controller.signal,
                 cache: 'no-store',
@@ -235,11 +391,17 @@ export function SponsorsCarousel() {
         );
         if (cancelled) return;
         const successful = settled.filter((x): x is Sponsor[] => x !== null);
-        if (successful.length === 0) return; // all fetches failed → keep fallback
+        if (successful.length === 0) {
+          if (!cancelled) {
+            setSponsors((prev) => {
+              if (prev !== null) return prev;
+              const fallback = Array.isArray(fallbackSponsors) ? (fallbackSponsors as Sponsor[]) : [];
+              return fallback;
+            });
+          }
+          return;
+        }
         const merged = successful.flat();
-        // Always reflect live state (even if 0 → shows “No sponsors yet” CTA).
-        // Sort like `scripts/sync-sponsors.mjs` so the live revalidate doesn't reshuffle Cunabula
-        // (fallback is Siraya 200 > WickedGrey 100 > Cunabula 5; live merge without sort was Siraya, Cunabula, WickedGrey).
         const deduped = dedupeSponsors(merged);
         deduped.sort((a, b) => {
           const da = a.totalAmountDonated ?? 0;
@@ -247,11 +409,20 @@ export function SponsorsCarousel() {
           if (db !== da) return db - da;
           return a.name.localeCompare(b.name);
         });
-        setSponsors(deduped);
+        if (!cancelled) {
+          setSponsors(deduped);
+          writeCachedSponsors(deduped);
+        }
       } catch (err) {
         if (cancelled) return;
         if (err instanceof DOMException && err.name === 'AbortError') return;
-        // keep fallback silently on error
+        if (!cancelled) {
+          setSponsors((prev) => {
+            if (prev !== null) return prev;
+            const fallback = Array.isArray(fallbackSponsors) ? (fallbackSponsors as Sponsor[]) : [];
+            return fallback;
+          });
+        }
       }
     }
 
@@ -272,7 +443,8 @@ export function SponsorsCarousel() {
     };
   }, []);
 
-  const hasSponsors = sponsors.length > 0;
+  const hasSponsors = Array.isArray(sponsors) && sponsors.length > 0;
+  const isLoadingSponsors = sponsors === null;
 
   // Only spin when the single sponsor row overflows the container.
   // With 2 sponsors (Siraya Tech, Cunabula) the pills fit easily, so we
@@ -342,7 +514,12 @@ export function SponsorsCarousel() {
         </button>
       </div>
 
-      {!hasSponsors ? (
+      {isLoadingSponsors ? (
+        <div className="mt-2 flex items-center justify-center gap-2 rounded-md border px-3 py-6" style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-1), transparent 20%)', color: 'var(--text-muted)' }}>
+          <span className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+          <span className="text-[11px]">Loading sponsors…</span>
+        </div>
+      ) : !hasSponsors ? (
         <div className="mt-2 flex items-center gap-2 rounded-md border border-dashed px-3 py-2" style={{ borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 40%)', background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-0) 94%)' }}>
           <span className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full" style={{ background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 85%)', color: 'var(--accent-secondary)' }}>
             <Heart className="h-3 w-3" aria-hidden="true" />
@@ -404,16 +581,35 @@ export function SponsorsCarousel() {
                   {s.image ? (
                     <CachedAvatar
                       src={s.image}
+                      profile={s.profile}
                       alt=""
                       className="h-12 w-12 rounded-full object-cover shrink-0"
+                      totalAmountDonated={s.totalAmountDonated}
                     />
                   ) : (
                     <span
-                      className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-full border"
-                      style={{ background: 'color-mix(in srgb, var(--accent), var(--surface-1) 80%)', color: 'var(--accent)', borderColor: 'var(--border-subtle)' }}
+                      className="inline-flex shrink-0 items-center justify-center rounded-full"
+                      style={{
+                        width: '3rem',
+          boxSizing: 'content-box',
+                        height: '3rem',
+                        padding: getSponsorRank(s.totalAmountDonated).gradient ? '3px' : undefined,
+                        background: getSponsorRank(s.totalAmountDonated).gradient ?? undefined,
+                        boxShadow: getSponsorRank(s.totalAmountDonated).glow !== 'none' ? getSponsorRank(s.totalAmountDonated).glow : undefined,
+                        borderRadius: '9999px',
+                      }}
                       aria-hidden="true"
                     >
-                      <Heart className="h-6 w-6" />
+                      <span
+                        className="inline-flex h-full w-full items-center justify-center rounded-full border"
+                        style={{
+                          background: 'var(--surface-1)',
+                          color: getSponsorRank(s.totalAmountDonated).gradient ? getSponsorRank(s.totalAmountDonated).borderColor : 'var(--accent)',
+                          borderColor: 'transparent',
+                        }}
+                      >
+                        <Heart className="h-6 w-6" />
+                      </span>
                     </span>
                   )}
                   <span className="w-full truncate text-center text-[11px] font-medium leading-tight">{label}</span>
@@ -443,16 +639,35 @@ export function SponsorsCarousel() {
                   {s.image ? (
                     <CachedAvatar
                       src={s.image}
+                      profile={s.profile}
                       alt=""
                       className="h-12 w-12 rounded-full object-cover shrink-0"
+                      totalAmountDonated={s.totalAmountDonated}
                     />
                   ) : (
                     <span
-                      className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-full border"
-                      style={{ background: 'color-mix(in srgb, var(--accent), var(--surface-1) 80%)', color: 'var(--accent)', borderColor: 'var(--border-subtle)' }}
+                      className="inline-flex shrink-0 items-center justify-center rounded-full"
+                      style={{
+                        width: '3rem',
+          boxSizing: 'content-box',
+                        height: '3rem',
+                        padding: getSponsorRank(s.totalAmountDonated).gradient ? '3px' : undefined,
+                        background: getSponsorRank(s.totalAmountDonated).gradient ?? undefined,
+                        boxShadow: getSponsorRank(s.totalAmountDonated).glow !== 'none' ? getSponsorRank(s.totalAmountDonated).glow : undefined,
+                        borderRadius: '9999px',
+                      }}
                       aria-hidden="true"
                     >
-                      <Heart className="h-6 w-6" />
+                      <span
+                        className="inline-flex h-full w-full items-center justify-center rounded-full border"
+                        style={{
+                          background: 'var(--surface-1)',
+                          color: getSponsorRank(s.totalAmountDonated).gradient ? getSponsorRank(s.totalAmountDonated).borderColor : 'var(--accent)',
+                          borderColor: 'transparent',
+                        }}
+                      >
+                        <Heart className="h-6 w-6" />
+                      </span>
                     </span>
                   )}
                   <span className="w-full truncate text-center text-[11px] font-medium leading-tight">{s.name}</span>

--- a/src/components/settings/UISettingsTab.tsx
+++ b/src/components/settings/UISettingsTab.tsx
@@ -230,8 +230,8 @@ export function UISettingsTab({
 						value={getDisplayThemeColor(row.key)}
 						onChange={(event) => handleThemeColorPickerDraftChange(row.key, event.target.value)}
 						onBlur={() => commitThemeColorPickerChange(row.key)}
-						className="h-7 w-8 shrink-0 rounded border"
-						style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+						className="h-7 w-8 shrink-0 cursor-pointer appearance-none overflow-hidden rounded border p-0 [&::-webkit-color-swatch]:border-0 [&::-webkit-color-swatch-wrapper]:p-0 [&::-moz-color-swatch]:border-0"
+						style={{ borderColor: 'var(--border-subtle)' }}
 					/>
 					<input
 						type="text"

--- a/src/components/settings/settingsModalEvents.ts
+++ b/src/components/settings/settingsModalEvents.ts
@@ -1,6 +1,6 @@
 export const OPEN_SETTINGS_MODAL_EVENT = 'dragonfruit:open-settings-modal';
 
-export function openSettingsModal(): void {
+export function openSettingsModal(tab?: string): void {
   if (typeof window === 'undefined') return;
-  window.dispatchEvent(new CustomEvent(OPEN_SETTINGS_MODAL_EVENT));
+  window.dispatchEvent(new CustomEvent(OPEN_SETTINGS_MODAL_EVENT, { detail: { tab } }));
 }

--- a/src/features/notifications/systemNotificationStore.ts
+++ b/src/features/notifications/systemNotificationStore.ts
@@ -1,0 +1,88 @@
+import type React from 'react';
+
+export type SystemNotificationTone = 'info' | 'success' | 'warning' | 'error' | 'accent' | 'accent-secondary';
+
+export type SystemNotificationAction = {
+  label: React.ReactNode;
+  icon?: React.ReactNode;
+  variant?: 'secondary' | 'accent' | 'accent-secondary' | 'danger';
+  onClick: () => void;
+  closeOnClick?: boolean;
+};
+
+export type SystemNotification = {
+  id: string;
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  tone?: SystemNotificationTone;
+  icon?: React.ReactNode | null;
+  hideIcon?: boolean;
+  expiryMs?: number | null;
+  dismissible?: boolean;
+  progressPct?: number | null;
+  versionChip?: string | null;
+  onClose?: () => void;
+  actions?: SystemNotificationAction[];
+};
+
+type Listener = () => void;
+let notifications: SystemNotification[] = [];
+let expiryTimers = new Map<string, number>();
+const listeners = new Set<Listener>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+export function subscribeSystemNotifications(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getSystemNotificationsSnapshot(): SystemNotification[] {
+  return notifications;
+}
+
+export function pushSystemNotification(notification: SystemNotification): void {
+  const existingIdx = notifications.findIndex((n) => n.id === notification.id);
+  if (existingIdx !== -1) {
+    notifications = [...notifications.slice(0, existingIdx), notification, ...notifications.slice(existingIdx + 1)];
+  } else {
+    notifications = [...notifications, notification];
+  }
+  const id = notification.id;
+  if (expiryTimers.has(id)) {
+    window.clearTimeout(expiryTimers.get(id)!);
+    expiryTimers.delete(id);
+  }
+  if (notification.expiryMs && notification.expiryMs > 0) {
+    const t = window.setTimeout(() => {
+      dismissSystemNotification(id);
+      notification.onClose?.();
+    }, notification.expiryMs);
+    expiryTimers.set(id, t);
+  }
+  emit();
+}
+
+export function dismissSystemNotification(id: string): void {
+  const next = notifications.filter((n) => n.id !== id);
+  if (next.length === notifications.length) return;
+  notifications = next;
+  if (expiryTimers.has(id)) {
+    window.clearTimeout(expiryTimers.get(id)!);
+    expiryTimers.delete(id);
+  }
+  emit();
+}
+
+export function clearSystemNotifications(): void {
+  for (const t of expiryTimers.values()) window.clearTimeout(t);
+  expiryTimers.clear();
+  notifications = [];
+  emit();
+}
+
+// Example future use: printer networking "Print is Done"
+// Call from printer monitor: pushSystemNotification({ id: 'print-done-42', title: 'Print is Done', subtitle: 'Build plate XYZ • 2h 13m', tone: 'success', expiryMs: 15_000, actions: [{ label: 'View', variant: 'accent', onClick: () => openSettingsModal('printing') }] })
+

--- a/src/features/scene/useSceneCollectionManager.ts
+++ b/src/features/scene/useSceneCollectionManager.ts
@@ -1567,6 +1567,35 @@ export function useSceneCollectionManager() {
     setView3dSettingsState(getSavedView3DSettings());
   }, []);
 
+  useEffect(() => {
+    const prev = readMeshAppearanceFromLocalStorage();
+    if (!prev) {
+      writeMeshAppearanceToLocalStorage({
+        v: 1,
+        shaderType,
+        matcapVariant,
+        flatUseVertexColors,
+        toonSteps,
+        ambientIntensity,
+        directionalIntensity,
+        materialRoughness,
+        wireframeThicknessPx,
+        xrayOpacity,
+        heatmapMinAngle,
+        heatmapMaxAngle,
+        heatmapColors,
+        meshColor: preferredMeshColor,
+        hoverTintStrength,
+        selectedTintStrength,
+        selectionColor,
+        hoverColor,
+      });
+      return;
+    }
+    if (prev.selectionColor === selectionColor && prev.hoverColor === hoverColor) return;
+    writeMeshAppearanceToLocalStorage({ ...prev, selectionColor, hoverColor });
+  }, [selectionColor, hoverColor]);
+
   const setView3dSettings = useCallback((next: View3DSettings) => {
     const normalized = normalizeView3DSettings(next);
     setView3dSettingsState(normalized);

--- a/src/features/slicing/components/LutCurveEditor.tsx
+++ b/src/features/slicing/components/LutCurveEditor.tsx
@@ -1559,9 +1559,9 @@ export function LutCurveEditorModal({
               onClick={handleConfirmCreate}
               className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
               style={{
-                borderColor: 'var(--accent-secondary-action-border)',
-                background: 'var(--accent-secondary-action-bg-92)',
-                color: 'var(--accent-secondary-action-color)',
+                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                color: 'var(--accent)',
               }}
             >
               <Check className="h-3.5 w-3.5" />
@@ -1707,9 +1707,9 @@ export function LutCurveEditorModal({
               disabled={draftRenameName.trim().length === 0}
               className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5 disabled:opacity-45 disabled:cursor-not-allowed"
               style={{
-                borderColor: 'var(--accent-secondary-action-border)',
-                background: 'var(--accent-secondary-action-bg-92)',
-                color: 'var(--accent-secondary-action-color)',
+                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                color: 'var(--accent)',
               }}
             >
               <Check className="h-3.5 w-3.5" />

--- a/src/features/updater/GlobalUpdateIndicator.tsx
+++ b/src/features/updater/GlobalUpdateIndicator.tsx
@@ -1,16 +1,14 @@
 'use client';
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { CloudDownload, Download, Loader2, RotateCcw, ScrollText, X } from 'lucide-react';
+import { AlertTriangle, CloudDownload, Download, Loader2, RotateCcw, ScrollText, X } from 'lucide-react';
 import { useLingui } from '@lingui/react';
 import { msg } from '@lingui/core/macro';
 import { Trans } from '@lingui/react/macro';
 import ReactMarkdown from 'react-markdown';
 import { fetchUpdateInfo, downloadAndInstall, getUpdateChannel, updatesAreExternal, type UpdateInfo, type DownloadProgress, type UpdateChannel } from '@/features/updater/updateBridge';
-import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
-
-// ---------------------------------------------------------------------------
-// Types
+import { openSettingsModal } from '@/components/settings/settingsModalEvents';
+import { isAllowSameVersionEnabled, enableAllowSameVersionForSession } from '@/features/updater/debugForceSession';
 // ---------------------------------------------------------------------------
 
 type IndicatorState =
@@ -43,6 +41,20 @@ export function GlobalUpdateIndicator() {
   const { _, i18n } = useLingui();
   const [state, setState] = useState<IndicatorState>({ status: 'idle' });
   const [showReleaseNotesModal, setShowReleaseNotesModal] = useState(false);
+  const [isExiting, setIsExiting] = useState(false);
+
+  const isSettingsOpen = () => {
+    try {
+      return !!document.querySelector('div.fixed.inset-0.z-\\[50\\] h2');
+    } catch {
+      return false;
+    }
+  };
+
+  const triggerExit = useCallback((after: () => void) => {
+    setIsExiting(true);
+    window.setTimeout(after, 190);
+  }, []);
 
   // ── Silent background check ──────────────────────────────────────────
   useEffect(() => {
@@ -50,12 +62,23 @@ export function GlobalUpdateIndicator() {
     if (updatesAreExternal()) return;
 
     let channel: UpdateChannel = 'stable';
-
     const runCheck = () => {
+      const allowSame = isAllowSameVersionEnabled();
+      if (allowSame) console.log('[updater] runCheck with allow_same_version=true (session debug)');
       setState({ status: 'checking' });
 
-      fetchUpdateInfo(channel)
-        .then((info) => {
+      fetchUpdateInfo(channel, allowSame)
+        .then(async (info) => {
+          if (info && !info.body) {
+            try {
+              const ghRes = await fetch(`https://api.github.com/repos/Open-Resin-Alliance/DragonFruit/releases/tags/v${info.version}`);
+              if (ghRes.ok) {
+                const gh = await ghRes.json() as { body?: string; published_at?: string };
+                if (gh.body) info.body = gh.body as string;
+                if (gh.published_at && !info.date) info.date = gh.published_at as string;
+              }
+            } catch {}
+          }
           if (info) {
             const suppressed = (() => {
               try {
@@ -66,6 +89,7 @@ export function GlobalUpdateIndicator() {
             })();
 
             if (suppressed !== info.version) {
+              if (isSettingsOpen()) return;
               setState({ status: 'available', info });
               return;
             }
@@ -93,29 +117,30 @@ export function GlobalUpdateIndicator() {
     };
   }, []);
 
-  // ── Dev shortcut: Ctrl+Shift+U ──────────────────────────────────────
+  // ── Dev shortcut: Ctrl+Shift+U ── just enables allow_same_version for regular logic until reload
   useEffect(() => {
-    const handleKeyDown = (e: CustomEvent) => {
-      const { key, ctrlKey, shiftKey } = e.detail;
-      if (ctrlKey && shiftKey && key.toLowerCase() === 'u') {
-        setState({
-          status: 'available',
-          info: {
-            version: '9.9.9',
-            currentVersion: '0.1.7',
-            body: '## Dev fake release\n\nThis is a fake update triggered via Ctrl+Shift+U for testing the update notification UI.\n\n- Test item 1\n- Test item 2',
-            date: new Date().toISOString(),
-          },
-        });
-      }
+    const handleKeyDown = async (e: CustomEvent) => {
+      console.log('[updater] hotkey raw', (e as CustomEvent).detail);
+      const { key, ctrlKey, shiftKey } = (e.detail as { key: unknown; ctrlKey: unknown; shiftKey: unknown }) as { key: string; ctrlKey: boolean; shiftKey: boolean };
+      if (!(ctrlKey && shiftKey && typeof key === 'string' && key.toLowerCase() === 'u')) return;
+      enableAllowSameVersionForSession();
+      console.log('[updater] Ctrl+Shift+U -> allow_same_version enabled for session, re-checking');
+      try {
+        const channel = await getUpdateChannel();
+        const info = await fetchUpdateInfo(channel, true);
+        if (info && !isSettingsOpen()) setState({ status: 'available', info });
+      } catch {}
     };
-    window.addEventListener('app-hotkey-keydown', handleKeyDown as EventListener);
-    return () => window.removeEventListener('app-hotkey-keydown', handleKeyDown as EventListener);
+    window.addEventListener('app-hotkey-keydown', handleKeyDown as unknown as EventListener);
+    return () => window.removeEventListener('app-hotkey-keydown', handleKeyDown as unknown as EventListener);
   }, []);
 
   // ── Handlers ────────────────────────────────────────────────────────
   const handleDownloadAndInstall = useCallback(async () => {
     if (state.status !== 'available') return;
+    // Force autosave before restart (don't trust user to have saved)
+    try { await (window as unknown as { __df_flushAutosave?: () => Promise<void> }).__df_flushAutosave?.(); } catch {}
+    try { await new Promise<void>((r) => setTimeout(r, 400)); } catch {}
     setState({ status: 'downloading', pct: 0 });
 
     try {
@@ -136,35 +161,46 @@ export function GlobalUpdateIndicator() {
 
   const handleDismiss = useCallback(() => {
     if (state.status !== 'available') return;
-    try {
-      window.localStorage.setItem(STORAGE_KEY_SUPPRESSED, state.info.version);
-    } catch {
-      // ignore
-    }
-    setState({ status: 'idle' });
-  }, [state]);
+    triggerExit(() => {
+      try {
+        window.localStorage.setItem(STORAGE_KEY_SUPPRESSED, (state as { status: 'available'; info: UpdateInfo }).info.version);
+      } catch {
+        // ignore
+      }
+      setState({ status: 'idle' });
+      setIsExiting(false);
+    });
+  }, [state, triggerExit]);
 
   const handleClose = useCallback(() => {
-    setState({ status: 'idle' });
-  }, []);
+    triggerExit(() => {
+      setState({ status: 'idle' });
+      setIsExiting(false);
+    });
+  }, [triggerExit]);
+
+  // Auto-exit after 30s expiry bar
+  useEffect(() => {
+    if (state.status !== 'available' || isExiting) return;
+    if (isSettingsOpen()) return;
+    const timer = window.setTimeout(() => {
+      handleDismiss();
+    }, 30_000);
+    return () => window.clearTimeout(timer);
+  }, [state.status, isExiting, handleDismiss]);
+
 
   // ── Render ──────────────────────────────────────────────────────────
-  const isModalOpen = state.status === 'available'
-    || state.status === 'downloading'
-    || state.status === 'error';
-
-  if (!isModalOpen) return null;
+  const isNotificationVisible = state.status === 'available' || state.status === 'downloading' || state.status === 'error';
+  if (!isNotificationVisible) return null;
+  // Don't show global notification when already in Settings → Updates (handled in-page)
+  if (isSettingsOpen()) return null;
 
   const info = state.status === 'available' ? state.info : null;
   const isDownloading = state.status === 'downloading';
   const isError = state.status === 'error';
   const errorMessage = state.status === 'error' ? state.message : null;
   const pct = state.status === 'downloading' ? state.pct : 0;
-
-  // Format the release date in the app's own locale, not the browser's — the
-  // language switcher must move the whole dialog, dates included.
-  // An unparseable date yields "Invalid Date" from toLocaleDateString, so drop
-  // the subtitle entirely rather than showing that to the user.
   const parsedDate = info?.date ? new Date(info.date) : null;
   const releaseDate = parsedDate && !Number.isNaN(parsedDate.getTime())
     ? parsedDate.toLocaleDateString(i18n.locale, { year: 'numeric', month: 'long', day: 'numeric' })
@@ -172,238 +208,118 @@ export function GlobalUpdateIndicator() {
   const subtitle = releaseDate ? _(msg`Released ${releaseDate}`) : undefined;
   const version = info?.version ?? '?';
 
-  return (    <>    <StructuredDialogModal
-      open={isModalOpen}
-      ariaLabel={_(msg`Update available`)}
-      title={isDownloading
-        ? _(msg`Downloading update`)
-        : isError
-          ? _(msg`Update failed`)
-          : _(msg`Update available — v${version}`)}
-      subtitle={subtitle}
-      icon={isDownloading
-        ? <Loader2 className="h-4 w-4 animate-spin" />
-        : <CloudDownload className="h-4 w-4" />}
-      iconTone="accent"
-      zIndexClassName="z-[130]"
-      maxWidthClassName="max-w-lg"
-      closeAriaLabel={_(msg`Close update dialog`)}
-      onClose={isDownloading ? undefined : handleClose}
-      onBackdropClick={isDownloading ? undefined : handleClose}
-      actions={isError ? (
-        <>
-          <button
-            type="button"
-            onClick={handleClose}
-            className="ui-button ui-button-secondary !h-9 px-3 text-sm"
-          >
-            <Trans>Close</Trans>
-          </button>
-          <button
-            type="button"
-            onClick={handleClose}
-            className="ui-button ui-button-accent !h-9 px-3 text-sm inline-flex items-center gap-1.5"
-          >
-            <RotateCcw className="w-4 h-4" />
-            <Trans>Try again</Trans>
-          </button>
-        </>
-      ) : isDownloading ? (
-        <>
-          <button
-            type="button"
-            disabled
-            className="ui-button ui-button-accent !h-9 px-3 text-sm inline-flex items-center gap-1.5 opacity-60"
-          >
-            <Loader2 className="w-4 h-4 animate-spin" />
-            <Trans>Downloading… {pct}%</Trans>
-          </button>
-        </>
-      ) : (
-        <>
+  const openSettingsUpdates = () => {
+    openSettingsModal('updates');
+    handleClose();
+  };
+
+  return (
+    <>
+      <style>{`@keyframes df-update-expiry { from { transform: scaleX(1); } to { transform: scaleX(0); } } @keyframes df-fly-in-right { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } } @keyframes df-fly-out-right { from { transform: translateX(0); opacity: 1; } to { transform: translateX(100%); opacity: 0; } }`}</style>
+      <div className="fixed bottom-6 right-6 z-[130] w-[22rem]" style={{ animation: isExiting ? 'df-fly-out-right 0.18s ease-in forwards' : 'df-fly-in-right 0.2s ease-out forwards' }}>
+        <div
+          className="relative overflow-hidden rounded-xl border shadow-2xl backdrop-blur-2xl supports-[backdrop-filter]:backdrop-blur-2xl"
+          style={{
+            background: 'color-mix(in srgb, var(--surface-0), transparent 12%)',
+            borderColor: 'color-mix(in srgb, var(--border-subtle), transparent 8%)',
+            boxShadow: '0 18px 48px rgba(0,0,0,0.42)',
+            backdropFilter: 'blur(32px) saturate(1.5)',
+            WebkitBackdropFilter: 'blur(32px) saturate(1.5)',
+          }}
+        >
+          <div className="flex flex-col items-center gap-1.5 p-3.5 text-center">
+            <div className="min-w-0">
+              <div className="text-base font-bold leading-tight" style={{ color: isDownloading || isError ? 'var(--text-strong)' : 'var(--accent-secondary)' }}>
+                {isDownloading ? _(msg`Downloading update`) : isError ? _(msg`Update failed`) : _(msg`Update Available!`)}
+              </div>
+              {subtitle && !isDownloading && !isError && (
+                <div className="mt-1 text-xs font-medium" style={{ color: 'var(--text-muted)' }}>
+                  {subtitle.replace('Released ', 'Release ')}
+                </div>
+              )}
+              {isDownloading && (
+                <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full" style={{ background: 'var(--surface-1)' }}>
+                  <div className="h-full rounded-full transition-all duration-300" style={{ width: `${pct}%`, background: 'var(--accent)' }} />
+                </div>
+              )}
+              {isError && errorMessage && (
+                <div className="mt-1 text-xs" style={{ color: '#fca5a5' }}>
+                  {errorMessage}
+                </div>
+              )}
+            </div>
+          </div>
+        {!isDownloading && !isError && info && (
+          <div className="px-3.5 pb-2 -mt-1 text-center">
+            <span className="inline-flex items-center justify-center rounded-full border px-2.5 py-1 text-[11px] font-semibold" style={{ borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)', background: 'color-mix(in srgb, var(--accent), var(--surface-1) 85%)', color: 'var(--accent)' }}>
+              Version {info.version}
+            </span>
+          </div>
+        )}
+        <div className="relative flex items-center gap-3 border-t px-4 py-3 overflow-hidden" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
+          {!isDownloading && !isError && (
+            <div className="absolute inset-x-0 top-0 h-0.5 overflow-hidden" style={{ background: 'transparent' }}>
+              <div
+                className="h-full w-full origin-left"
+                style={{
+                  background: 'var(--accent)',
+                  animation: 'df-update-expiry 30s linear forwards',
+                }}
+              />
+            </div>
+          )}
           <button
             type="button"
             onClick={handleDismiss}
-            className="ui-button ui-button-secondary !h-9 px-3 text-sm"
+            className="flex-1 ui-button ui-button-secondary !h-9 px-4 text-sm inline-flex items-center justify-center gap-1.5"
           >
             <Trans>Remind me later</Trans>
           </button>
           <button
             type="button"
-            onClick={handleDownloadAndInstall}
-            className="ui-button ui-button-accent !h-9 px-3 text-sm inline-flex items-center gap-1.5"
+            onClick={isDownloading || isError ? handleClose : isError ? handleClose : openSettingsUpdates}
+            className="flex-1 ui-button !h-9 px-4 text-sm inline-flex items-center justify-center gap-1.5"
+            style={
+              isError
+                ? {
+                    borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
+                    background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
+                    color: 'var(--danger)',
+                  }
+                : isDownloading
+                  ? {
+                      borderColor: 'var(--border-subtle)',
+                      background: 'var(--surface-1)',
+                      color: 'var(--text-muted)',
+                    }
+                  : {
+                      borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 45%)',
+                      background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 86%)',
+                      color: 'var(--accent-secondary)',
+                    }
+            }
+            disabled={isDownloading}
           >
-            <Download className="w-4 h-4" />
-            <Trans>Download &amp; install</Trans>
+            {isError ? (
+              <>
+                <RotateCcw className="h-3.5 w-3.5" />
+                <Trans>Try again</Trans>
+              </>
+            ) : isDownloading ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <Trans>Downloading… {pct}%</Trans>
+              </>
+            ) : (
+              <>
+                <Download className="h-3.5 w-3.5" />
+                <Trans>View in Settings</Trans>
+              </>
+            )}
           </button>
-        </>
-      )}
-    >
-      {isError && (
-        <div
-          className="rounded-md border px-2.5 py-2 text-[11px] leading-snug"
-          style={{
-            borderColor: 'color-mix(in srgb, var(--danger), var(--border-subtle) 45%)',
-            background: 'color-mix(in srgb, var(--danger), var(--surface-1) 92%)',
-            color: 'var(--danger)',
-          }}
-        >
-          <Trans>The update download or install failed.</Trans>
-          {errorMessage && (
-            <div className="mt-1 font-mono text-[10px] opacity-80 break-all">{errorMessage}</div>
-          )}
         </div>
-      )}
-
-      {isDownloading && (
-        <div className="space-y-2">
-          <div
-            className="w-full h-2 rounded-full overflow-hidden"
-            style={{ background: 'color-mix(in srgb, var(--surface-2), transparent 20%)' }}
-          >
-            <div
-              className="h-full rounded-full transition-all duration-200 ease-out"
-              style={{
-                width: `${Math.min(pct, 100)}%`,
-                background: 'linear-gradient(90deg, var(--accent), var(--accent-secondary))',
-              }}
-            />
-          </div>
-          <div className="text-center text-[11px]" style={{ color: 'var(--text-muted)' }}>
-            <Trans>{pct}% — Downloading update, please wait…</Trans>
-          </div>
-        </div>
-      )}
-
-      {info && !isDownloading && !isError && (
-        <div className="space-y-3">
-          {/* Version info */}
-          <div className="flex items-center gap-3">
-            <div
-              className="rounded-lg border px-3 py-2 flex-1"
-              style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
-            >
-              <div className="text-[10px] uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
-                <Trans>Current version</Trans>
-              </div>
-              <div className="text-sm font-semibold mt-0.5" style={{ color: 'var(--text-strong)' }}>
-                v{info.currentVersion}
-              </div>
-            </div>
-            <div className="text-lg" style={{ color: 'var(--text-muted)' }}>→</div>
-            <div
-              className="rounded-lg border px-3 py-2 flex-1"
-              style={{
-                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)',
-                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 90%)',
-              }}
-            >
-              <div className="text-[10px] uppercase tracking-wide" style={{ color: 'var(--accent)' }}>
-                <Trans>New version</Trans>
-              </div>
-              <div className="text-sm font-semibold mt-0.5" style={{ color: 'var(--accent)' }}>
-                v{info.version}
-              </div>
-            </div>
-          </div>
-
-          {/* Release notes — opens a popup */}
-          {info.body && (
-            <button
-              type="button"
-              onClick={() => setShowReleaseNotesModal(true)}
-              className="w-full rounded-lg border px-3 py-2 text-left transition-all duration-150 hover:brightness-110"
-              style={{
-                borderColor: 'var(--border-subtle)',
-                background: 'color-mix(in srgb, var(--surface-1), transparent 8%)',
-              }}
-            >
-              <div className="flex items-center gap-2">
-                <ScrollText className="h-3.5 w-3.5 shrink-0" style={{ color: 'var(--text-muted)' }} />
-                <span className="text-xs font-semibold" style={{ color: 'var(--text-muted)' }}>
-                  <Trans>Show release notes</Trans>
-                </span>
-              </div>
-            </button>
-          )}
-
-        </div>
-      )}
-    </StructuredDialogModal>
-
-      {/* ── Release notes popup ── */}
-      {showReleaseNotesModal && info?.body && (
-        <div
-          className="fixed inset-0 z-[160] flex items-center justify-center bg-black/55 backdrop-blur-sm px-3"
-          onMouseDown={(e) => {
-            if (e.target === e.currentTarget) setShowReleaseNotesModal(false);
-          }}
-        >
-          <div
-            className="w-full max-w-xl max-h-[80vh] flex flex-col overflow-hidden rounded-xl border shadow-2xl"
-            style={{
-              background: 'var(--surface-0)',
-              borderColor: 'var(--border-subtle)',
-              boxShadow: '0 24px 46px rgba(0,0,0,0.42)',
-            }}
-          >
-            {/* Header — matching StructuredDialogModal */}
-            <div
-              className="flex items-center justify-between gap-4 border-b px-5 py-4 shrink-0"
-              style={{ borderColor: 'var(--border-subtle)' }}
-            >
-              <div className="flex min-w-0 items-center gap-3">
-                <span
-                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
-                  style={{
-                    borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 45%)',
-                    background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 90%)',
-                    color: 'var(--accent-secondary)',
-                  }}
-                >
-                  <ScrollText className="h-4 w-4" />
-                </span>
-                <div className="min-w-0">
-                  <h3 className="text-sm font-semibold truncate" style={{ color: 'var(--text-strong)' }}>
-                    <Trans>Release notes — v{info.version}</Trans>
-                  </h3>
-                </div>
-              </div>
-              <button
-                type="button"
-                onClick={() => setShowReleaseNotesModal(false)}
-                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border transition-colors hover:brightness-110"
-                style={{
-                  borderColor: 'var(--border-subtle)',
-                  background: 'color-mix(in srgb, var(--surface-1), transparent 6%)',
-                  color: 'var(--text-muted)',
-                }}
-                aria-label={_(msg`Close release notes`)}
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-
-            {/* Body — scrollable */}
-            <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar p-5 space-y-4">
-              <div
-                className="rounded-lg border p-3"
-                style={{
-                  borderColor: 'var(--border-subtle)',
-                  background: 'var(--surface-1)',
-                }}
-              >
-                <div
-                  className="text-[13px] leading-relaxed prose prose-invert prose-sm max-w-none"
-                  style={{ color: 'var(--text-strong)' }}
-                >
-                  <ReactMarkdown>{info.body}</ReactMarkdown>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      </div>
+    </div>
     </>
   );
 }

--- a/src/features/updater/GlobalUpdateIndicator.tsx
+++ b/src/features/updater/GlobalUpdateIndicator.tsx
@@ -8,6 +8,7 @@ import { Trans } from '@lingui/react/macro';
 import ReactMarkdown from 'react-markdown';
 import { fetchUpdateInfo, downloadAndInstall, getUpdateChannel, updatesAreExternal, type UpdateInfo, type DownloadProgress, type UpdateChannel } from '@/features/updater/updateBridge';
 import { openSettingsModal } from '@/components/settings/settingsModalEvents';
+import { pushSystemNotification, dismissSystemNotification } from '@/features/notifications/systemNotificationStore';
 import { isAllowSameVersionEnabled, enableAllowSameVersionForSession } from '@/features/updater/debugForceSession';
 // ---------------------------------------------------------------------------
 
@@ -179,147 +180,66 @@ export function GlobalUpdateIndicator() {
     });
   }, [triggerExit]);
 
-  // Auto-exit after 30s expiry bar
+  // Push to reusable System Notification stack (bottom-right, frosted, 30s expiry)
+  // This makes the update notification reusable for future system notifications like "Print is Done"
   useEffect(() => {
-    if (state.status !== 'available' || isExiting) return;
-    if (isSettingsOpen()) return;
-    const timer = window.setTimeout(() => {
-      handleDismiss();
-    }, 30_000);
-    return () => window.clearTimeout(timer);
-  }, [state.status, isExiting, handleDismiss]);
+    if (state.status === 'available' && state.info) {
+      if (isSettingsOpen()) {
+        dismissSystemNotification('update-available');
+        return;
+      }
+      const info = state.info;
+      const parsedDate = info.date ? new Date(info.date) : null;
+      const releaseDate = parsedDate && !Number.isNaN(parsedDate.getTime())
+        ? parsedDate.toLocaleDateString(i18n.locale, { year: 'numeric', month: 'long', day: 'numeric' })
+        : null;
+      const subtitle = releaseDate ? _(msg`Released ${releaseDate}`) : undefined;
+      pushSystemNotification({
+        id: 'update-available',
+        title: 'Update Available!',
+        subtitle: subtitle ? (subtitle as string).replace('Released ', 'Release ') : undefined,
+        tone: 'accent-secondary',
+        hideIcon: true,
+        versionChip: `Version ${info.version}`,
+        expiryMs: 30_000,
+        onClose: handleClose,
+        actions: [
+          { label: 'Remind me later', variant: 'secondary', onClick: handleDismiss },
+          { label: 'View in Settings', variant: 'accent-secondary', onClick: () => { openSettingsModal('updates'); handleClose(); } },
+        ],
+      });
+      return;
+    }
+    if (state.status === 'downloading') {
+      const pct = state.pct;
+      pushSystemNotification({
+        id: 'update-available',
+        title: 'Downloading update',
+        subtitle: `${pct}%`,
+        tone: 'accent',
+        progressPct: pct,
+        expiryMs: null,
+        actions: [],
+      });
+      return;
+    }
+    if (state.status === 'error') {
+      const msg = state.message;
+      pushSystemNotification({
+        id: 'update-available',
+        title: 'Update failed',
+        subtitle: msg,
+        tone: 'error',
+        expiryMs: null,
+        actions: [
+          { label: 'Dismiss', variant: 'secondary', onClick: handleClose },
+          { label: 'Try again', variant: 'danger', onClick: handleClose },
+        ],
+      });
+      return;
+    }
+    dismissSystemNotification('update-available');
+  }, [state, i18n, handleDismiss, handleClose]);
 
-
-  // ── Render ──────────────────────────────────────────────────────────
-  const isNotificationVisible = state.status === 'available' || state.status === 'downloading' || state.status === 'error';
-  if (!isNotificationVisible) return null;
-  // Don't show global notification when already in Settings → Updates (handled in-page)
-  if (isSettingsOpen()) return null;
-
-  const info = state.status === 'available' ? state.info : null;
-  const isDownloading = state.status === 'downloading';
-  const isError = state.status === 'error';
-  const errorMessage = state.status === 'error' ? state.message : null;
-  const pct = state.status === 'downloading' ? state.pct : 0;
-  const parsedDate = info?.date ? new Date(info.date) : null;
-  const releaseDate = parsedDate && !Number.isNaN(parsedDate.getTime())
-    ? parsedDate.toLocaleDateString(i18n.locale, { year: 'numeric', month: 'long', day: 'numeric' })
-    : null;
-  const subtitle = releaseDate ? _(msg`Released ${releaseDate}`) : undefined;
-  const version = info?.version ?? '?';
-
-  const openSettingsUpdates = () => {
-    openSettingsModal('updates');
-    handleClose();
-  };
-
-  return (
-    <>
-      <style>{`@keyframes df-update-expiry { from { transform: scaleX(1); } to { transform: scaleX(0); } } @keyframes df-fly-in-right { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } } @keyframes df-fly-out-right { from { transform: translateX(0); opacity: 1; } to { transform: translateX(100%); opacity: 0; } }`}</style>
-      <div className="fixed bottom-6 right-6 z-[130] w-[22rem]" style={{ animation: isExiting ? 'df-fly-out-right 0.18s ease-in forwards' : 'df-fly-in-right 0.2s ease-out forwards' }}>
-        <div
-          className="relative overflow-hidden rounded-xl border shadow-2xl backdrop-blur-2xl supports-[backdrop-filter]:backdrop-blur-2xl"
-          style={{
-            background: 'color-mix(in srgb, var(--surface-0), transparent 12%)',
-            borderColor: 'color-mix(in srgb, var(--border-subtle), transparent 8%)',
-            boxShadow: '0 18px 48px rgba(0,0,0,0.42)',
-            backdropFilter: 'blur(32px) saturate(1.5)',
-            WebkitBackdropFilter: 'blur(32px) saturate(1.5)',
-          }}
-        >
-          <div className="flex flex-col items-center gap-1.5 p-3.5 text-center">
-            <div className="min-w-0">
-              <div className="text-base font-bold leading-tight" style={{ color: isDownloading || isError ? 'var(--text-strong)' : 'var(--accent-secondary)' }}>
-                {isDownloading ? _(msg`Downloading update`) : isError ? _(msg`Update failed`) : _(msg`Update Available!`)}
-              </div>
-              {subtitle && !isDownloading && !isError && (
-                <div className="mt-1 text-xs font-medium" style={{ color: 'var(--text-muted)' }}>
-                  {subtitle.replace('Released ', 'Release ')}
-                </div>
-              )}
-              {isDownloading && (
-                <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full" style={{ background: 'var(--surface-1)' }}>
-                  <div className="h-full rounded-full transition-all duration-300" style={{ width: `${pct}%`, background: 'var(--accent)' }} />
-                </div>
-              )}
-              {isError && errorMessage && (
-                <div className="mt-1 text-xs" style={{ color: '#fca5a5' }}>
-                  {errorMessage}
-                </div>
-              )}
-            </div>
-          </div>
-        {!isDownloading && !isError && info && (
-          <div className="px-3.5 pb-2 -mt-1 text-center">
-            <span className="inline-flex items-center justify-center rounded-full border px-2.5 py-1 text-[11px] font-semibold" style={{ borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)', background: 'color-mix(in srgb, var(--accent), var(--surface-1) 85%)', color: 'var(--accent)' }}>
-              Version {info.version}
-            </span>
-          </div>
-        )}
-        <div className="relative flex items-center gap-3 border-t px-4 py-3 overflow-hidden" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}>
-          {!isDownloading && !isError && (
-            <div className="absolute inset-x-0 top-0 h-0.5 overflow-hidden" style={{ background: 'transparent' }}>
-              <div
-                className="h-full w-full origin-left"
-                style={{
-                  background: 'var(--accent)',
-                  animation: 'df-update-expiry 30s linear forwards',
-                }}
-              />
-            </div>
-          )}
-          <button
-            type="button"
-            onClick={handleDismiss}
-            className="flex-1 ui-button ui-button-secondary !h-9 px-4 text-sm inline-flex items-center justify-center gap-1.5"
-          >
-            <Trans>Remind me later</Trans>
-          </button>
-          <button
-            type="button"
-            onClick={isDownloading || isError ? handleClose : isError ? handleClose : openSettingsUpdates}
-            className="flex-1 ui-button !h-9 px-4 text-sm inline-flex items-center justify-center gap-1.5"
-            style={
-              isError
-                ? {
-                    borderColor: 'color-mix(in srgb, #ef4444, var(--border-subtle) 45%)',
-                    background: 'color-mix(in srgb, #ef4444, var(--surface-1) 86%)',
-                    color: 'var(--danger)',
-                  }
-                : isDownloading
-                  ? {
-                      borderColor: 'var(--border-subtle)',
-                      background: 'var(--surface-1)',
-                      color: 'var(--text-muted)',
-                    }
-                  : {
-                      borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 45%)',
-                      background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 86%)',
-                      color: 'var(--accent-secondary)',
-                    }
-            }
-            disabled={isDownloading}
-          >
-            {isError ? (
-              <>
-                <RotateCcw className="h-3.5 w-3.5" />
-                <Trans>Try again</Trans>
-              </>
-            ) : isDownloading ? (
-              <>
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                <Trans>Downloading… {pct}%</Trans>
-              </>
-            ) : (
-              <>
-                <Download className="h-3.5 w-3.5" />
-                <Trans>View in Settings</Trans>
-              </>
-            )}
-          </button>
-        </div>
-      </div>
-    </div>
-    </>
-  );
+  return null;
 }

--- a/src/features/updater/UpdateCheckerSection.tsx
+++ b/src/features/updater/UpdateCheckerSection.tsx
@@ -13,10 +13,11 @@ import {
   RotateCcw,
 } from 'lucide-react';
 import { FLATPAK_APP_ID, LINUX_RELEASES_URL } from '@/features/updater/updateBridge';
+import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
 import { useUpdateChecker } from '@/features/updater/useUpdateChecker';
 import type { UpdateState } from '@/features/updater/useUpdateChecker';
+import { isAllowSameVersionEnabled, enableAllowSameVersionForSession } from '@/features/updater/debugForceSession';
 
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -58,62 +59,47 @@ function ProgressBar({ pct }: { pct: number }) {
 
 function IdleState({ onCheck }: { onCheck: () => void }) {
   return (
-    <button
-      type="button"
-      onClick={onCheck}
-      className="w-full rounded-md border p-2.5 text-left transition-all duration-150 hover:brightness-110"
-      style={{
-        borderColor: 'var(--border-subtle)',
-        background: 'var(--surface-0)',
-      }}
-    >
-      <div className="flex items-center gap-2.5">
-        <span
-          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
-          style={{
-            borderColor: 'var(--border-subtle)',
-            background: 'color-mix(in srgb, var(--surface-2), transparent 8%)',
-          }}
-        >
-          <CloudDownload className="h-4 w-4" style={{ color: 'var(--accent)' }} />
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
-            Check for Updates
-          </span>
-          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
-            See if a newer version of DragonFruit is available
-          </span>
-        </span>
-      </div>
-    </button>
+    <div className="grid grid-cols-2 gap-2">
+      <button
+        type="button"
+        onClick={onCheck}
+        className="ui-button ui-button-secondary !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+      >
+        <RotateCcw className="h-3.5 w-3.5" />
+        Check for Updates
+      </button>
+      <button
+        type="button"
+        disabled
+        className="ui-button ui-button-secondary !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5 opacity-50 cursor-not-allowed"
+        title="No update available"
+      >
+        <Download className="h-3.5 w-3.5" />
+        Install
+      </button>
+    </div>
   );
 }
 
 function CheckingState() {
   return (
-    <div
-      className="w-full rounded-md border p-2.5"
-      style={{
-        borderColor: 'var(--border-subtle)',
-        background: 'var(--surface-0)',
-      }}
-    >
-      <div className="flex items-center gap-2.5">
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 py-16">
+      <div className="flex flex-col items-center gap-3 text-center">
         <span
-          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
+          className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border"
           style={{
-            borderColor: 'var(--border-subtle)',
-            background: 'color-mix(in srgb, var(--surface-2), transparent 8%)',
+            borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)',
+            background: 'color-mix(in srgb, var(--accent), var(--surface-1) 82%)',
+            color: 'var(--accent)',
           }}
         >
-          <Loader2 className="h-4 w-4 animate-spin" style={{ color: 'var(--accent)' }} />
+          <Loader2 className="h-6 w-6 animate-spin" />
         </span>
-        <span className="min-w-0 flex-1">
-          <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
-            Checking for updates…
+        <span className="min-w-0">
+          <span className="block text-lg font-bold" style={{ color: 'var(--text-strong)' }}>
+            Checking for Updates…
           </span>
-          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
+          <span className="block text-sm mt-1.5 font-medium" style={{ color: 'var(--text-muted)' }}>
             Querying GitHub releases
           </span>
         </span>
@@ -124,45 +110,35 @@ function CheckingState() {
 
 function UpToDateState({ onCheck }: { onCheck: () => void }) {
   return (
-    <div
-      className="w-full rounded-md border p-2.5"
-      style={{
-        borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 50%)',
-        background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-0) 92%)',
-      }}
-    >
-      <div className="flex items-center gap-2.5">
+    <div className="flex flex-1 flex-col items-center justify-center gap-8 py-16">
+      <div className="flex flex-col items-center gap-3 text-center">
         <span
-          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
+          className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border"
           style={{
-            borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 38%)',
-            background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 85%)',
+            borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 40%)',
+            background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 82%)',
+            color: 'var(--accent-secondary)',
           }}
         >
-          <Check className="h-4 w-4" style={{ color: 'var(--accent-secondary)' }} />
+          <Check className="h-6 w-6" />
         </span>
-        <span className="min-w-0 flex-1">
-          <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
-            Up To Date!
+        <span className="min-w-0">
+          <span className="block text-lg font-bold" style={{ color: 'var(--accent-secondary)' }}>
+            Up to date
           </span>
-          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
-            You're running the latest version of DragonFruit.
+          <span className="block text-sm mt-1.5 font-medium" style={{ color: 'var(--text-muted)' }}>
+            You’re on the latest version
           </span>
         </span>
-        <button
-          type="button"
-          onClick={onCheck}
-          className="inline-flex shrink-0 items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-all duration-150"
-          style={{
-            color: 'var(--accent-secondary-action-color)',
-            borderColor: 'var(--accent-secondary-action-border)',
-            background: 'var(--accent-secondary-action-bg-92)',
-          }}
-        >
-          <RotateCcw className="h-3.5 w-3.5" />
-          Check Again
-        </button>
       </div>
+      <button
+        type="button"
+        onClick={onCheck}
+        className="ui-button ui-button-secondary !h-10 px-8 text-sm inline-flex items-center justify-center gap-1.5"
+      >
+        <RotateCcw className="h-4 w-4" />
+        Check Again
+      </button>
     </div>
   );
 }
@@ -170,106 +146,115 @@ function UpToDateState({ onCheck }: { onCheck: () => void }) {
 function AvailableState({
   state: s,
   onDownload,
-  onDismiss,
+  onCheck,
 }: {
   state: UpdateState & { status: 'available' };
   onDownload: () => void;
-  onDismiss: () => void;
+  onCheck: () => void;
 }) {
   const info = s.info;
+  const [showWarning, setShowWarning] = React.useState(false);
 
   return (
-    <div
-      className="w-full rounded-md border overflow-hidden"
-      style={{
-        borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)',
-        background: 'color-mix(in srgb, var(--accent), var(--surface-0) 90%)',
-      }}
-    >
-      {/* Header */}
-      <div className="flex items-center gap-2.5 p-2.5">
+    <div className="flex min-h-0 flex-1 flex-col space-y-2">
+      <div className="flex flex-col items-center gap-2.5 text-center">
         <span
           className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
           style={{
-            borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
-            background: 'color-mix(in srgb, var(--accent), var(--surface-1) 82%)',
+            borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 40%)',
+            background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 82%)',
+            color: 'var(--accent-secondary)',
           }}
         >
-          <Download className="h-4 w-4" style={{ color: 'var(--accent)' }} />
+          <Download className="h-4 w-4" />
         </span>
-        <span className="min-w-0 flex-1">
-          <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
+        <span className="min-w-0">
+          <span className="block text-base font-bold" style={{ color: 'var(--accent-secondary)' }}>
             Update Available
           </span>
-          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
-            DragonFruit v{info.version} is available (you have v{info.currentVersion})
+          <span className="block text-xs mt-1 font-medium" style={{ color: 'var(--text-muted)' }}>
+            {info.version === info.currentVersion ? (
+              <>Version {info.version}</>
+            ) : (
+              <>Version {info.version} • update ready</>
+            )}
           </span>
         </span>
       </div>
 
-      {/* Release notes */}
       {info.body && (
         <div
-          className="mx-0 mb-2 max-h-28 overflow-y-auto custom-scrollbar rounded-md border px-2.5 py-2 text-[11px] leading-relaxed"
+          className="flex-1 min-h-0 overflow-y-auto custom-scrollbar rounded-md border px-3 py-3 text-xs leading-relaxed"
           style={{
             borderColor: 'var(--border-subtle)',
-            background: 'color-mix(in srgb, var(--surface-1), transparent 30%)',
+            background: 'var(--surface-0)',
             color: 'var(--text-muted)',
           }}
         >
-          <div className="prose prose-invert prose-sm max-h-none text-[11px] leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+          <div className="prose prose-invert max-w-none prose-sm prose-headings:font-semibold prose-headings:text-[13px] prose-headings:text-[var(--text-strong)] prose-h2:text-sm prose-h3:text-xs prose-p:text-xs prose-p:leading-relaxed prose-p:text-[var(--text-muted)] prose-li:text-xs prose-li:leading-relaxed prose-a:text-[var(--accent)] prose-a:underline-offset-2 hover:prose-a:underline prose-strong:text-[var(--text-strong)] prose-code:font-mono prose-code:text-[11px] prose-code:font-medium prose-code:text-[var(--text-strong)] prose-code:bg-[var(--surface-1)] prose-code:border prose-code:border-[var(--border-subtle)] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none prose-pre:bg-[var(--surface-1)] prose-pre:border prose-pre:border-[var(--border-subtle)] prose-pre:p-3 prose-pre:rounded-md prose-pre:overflow-x-auto prose-pre:text-[11px] prose-pre:leading-relaxed prose-pre:prose-code:bg-transparent prose-pre:prose-code:border-0 prose-pre:prose-code:p-0 prose-pre:prose-code:text-[var(--text-muted)] prose-hr:my-2 prose-hr:border-[var(--border-subtle)]" style={{ color: 'var(--text-muted)' }}>
             <ReactMarkdown>{info.body}</ReactMarkdown>
           </div>
         </div>
       )}
 
-      {/* Actions — single "Download & Install" button using the plugin */}
-      <div className="flex items-center gap-2 px-0 pb-0">
+      <div className="grid grid-cols-3 gap-2">
         <button
           type="button"
-          onClick={onDownload}
-          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[12px] font-semibold transition-all duration-150"
-          style={{
-            color: 'var(--accent-contrast)',
-            borderColor: 'color-mix(in srgb, var(--accent), white 18%)',
-            background: 'color-mix(in srgb, var(--accent), transparent 12%)',
-          }}
+          onClick={onCheck}
+          className="ui-button ui-button-secondary !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
         >
-          <Download className="h-3.5 w-3.5" />
-          Download &amp; Install
+          <RotateCcw className="h-3.5 w-3.5" />
+          Check for Updates
         </button>
-
         <button
+          type="button"
           onClick={() => {
-            void openExternal(
-              `https://github.com/Open-Resin-Alliance/DragonFruit/releases/tag/v${info.version}`,
-            );
+            void openExternal(`https://github.com/Open-Resin-Alliance/DragonFruit/releases/tag/v${info.version}`);
           }}
-          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-[12px] transition-all duration-150"
+          className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
           style={{
-            color: 'var(--text-muted)',
-            borderColor: 'var(--border-subtle)',
-            background: 'var(--surface-2)',
-            cursor: 'pointer',
+            borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 45%)',
+            background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-1) 86%)',
+            color: 'var(--accent-secondary)',
           }}
         >
           <ExternalLink className="h-3.5 w-3.5" />
           View on GitHub
         </button>
-
         <button
           type="button"
-          onClick={onDismiss}
-          className="ml-auto inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] transition-all duration-150"
+          onClick={() => setShowWarning(true)}
+          className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
           style={{
-            color: 'var(--text-muted)',
-            borderColor: 'var(--border-subtle)',
-            background: 'var(--surface-2)',
+            borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+            background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+            color: 'var(--accent)',
           }}
         >
-          Dismiss
+          <Download className="h-3.5 w-3.5" />
+          Install
         </button>
       </div>
+      <StructuredDialogModal
+        open={showWarning}
+        ariaLabel="Confirm update and restart"
+        title="Update & Restart?"
+        subtitle={`Version ${info.version} is ready to install`}
+        icon={<Download className="h-4 w-4" />}
+        iconTone="warning"
+        onClose={() => setShowWarning(false)}
+        onBackdropClick={() => setShowWarning(false)}
+        actions={
+          <>
+            <button type="button" onClick={() => setShowWarning(false)} className="ui-button ui-button-secondary !h-9 px-4 text-xs">Cancel</button>
+            <button type="button" onClick={async () => { setShowWarning(false); try { await (window as unknown as { __df_flushAutosave?: () => Promise<void> }).__df_flushAutosave?.(); } catch {} try { await new Promise<void>((r) => setTimeout(r, 400)); } catch {} onDownload(); }} className="ui-button !h-9 px-4 text-xs inline-flex items-center justify-center gap-1.5" style={{ borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)', background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)', color: 'var(--accent)' }}>Update & Restart</button>
+          </>
+        }
+      >
+        <p className="text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+          DragonFruit will download, verify and install the update, then restart. Please <span style={{ color: 'var(--text-strong)', fontWeight: 600 }}>save your scene and any unsaved progress</span> before continuing. Unsaved changes may be lost.
+        </p>
+      </StructuredDialogModal>
     </div>
   );
 }
@@ -285,61 +270,53 @@ function DownloadingState({
     : '0.0';
 
   return (
-    <div
-      className="w-full rounded-md border p-2.5"
-      style={{
-        borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)',
-        background: 'color-mix(in srgb, var(--accent), var(--surface-0) 90%)',
-      }}
-    >
-      <div className="flex items-center gap-2.5 mb-2">
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 py-16">
+      <div className="flex flex-col items-center gap-3 text-center">
         <span
-          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
+          className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border"
           style={{
-            borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
+            borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)',
             background: 'color-mix(in srgb, var(--accent), var(--surface-1) 82%)',
+            color: 'var(--accent)',
           }}
         >
-          <Loader2 className="h-4 w-4 animate-spin" style={{ color: 'var(--accent)' }} />
+          <Loader2 className="h-6 w-6 animate-spin" />
         </span>
-        <span className="min-w-0 flex-1">
-          <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
+        <span className="min-w-0">
+          <span className="block text-lg font-bold" style={{ color: 'var(--text-strong)' }}>
             Downloading Update
           </span>
-          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
+          <span className="block text-sm mt-1.5 font-medium" style={{ color: 'var(--text-muted)' }}>
             {formatBytes(downloaded)} / {formatBytes(contentLength)} ({pct}%)
           </span>
         </span>
       </div>
-      <ProgressBar pct={parseFloat(pct)} />
+      <div className="w-full max-w-sm">
+        <ProgressBar pct={parseFloat(pct)} />
+      </div>
     </div>
   );
 }
 
 function InstallingState() {
   return (
-    <div
-      className="w-full rounded-md border p-2.5"
-      style={{
-        borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)',
-        background: 'color-mix(in srgb, var(--accent), var(--surface-0) 90%)',
-      }}
-    >
-      <div className="flex items-center gap-2.5">
+    <div className="flex flex-col items-center justify-center gap-4 py-16">
+      <div className="flex flex-col items-center gap-3 text-center">
         <span
-          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
+          className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border"
           style={{
-            borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
+            borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)',
             background: 'color-mix(in srgb, var(--accent), var(--surface-1) 82%)',
+            color: 'var(--accent)',
           }}
         >
-          <Loader2 className="h-4 w-4 animate-spin" style={{ color: 'var(--accent)' }} />
+          <Loader2 className="h-6 w-6 animate-spin" />
         </span>
-        <span className="min-w-0 flex-1">
-          <span className="block text-sm font-semibold" style={{ color: 'var(--text-strong)' }}>
+        <span className="min-w-0">
+          <span className="block text-lg font-bold" style={{ color: 'var(--text-strong)' }}>
             Installing Update…
           </span>
-          <span className="block text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
+          <span className="block text-sm mt-1.5 font-medium" style={{ color: 'var(--text-muted)' }}>
             The update is being installed. DragonFruit will restart automatically.
           </span>
         </span>
@@ -347,6 +324,7 @@ function InstallingState() {
     </div>
   );
 }
+
 
 function InstalledState() {
   return (
@@ -500,22 +478,83 @@ export function UpdateCheckerSection({
     checkForUpdates,
     downloadAndInstall,
     dismiss,
+    channel,
   } = useUpdateChecker();
+  const [debugForceAvailable, setDebugForceAvailable] = React.useState<UpdateState | null>(null);
+
+  // Persist session
+
+
+
+  // Dev shortcut: just enables allow_same_version for regular logic until reload
+  React.useEffect(() => {
+    const handleKeyDown = async (e: CustomEvent) => {
+      console.log('[updater] checker hotkey raw', (e as CustomEvent).detail);
+      const detail = e.detail as unknown;
+      if (!detail || typeof detail !== 'object' || !('key' in detail) || !('ctrlKey' in detail) || !('shiftKey' in detail)) return;
+      const key = (detail as { key: unknown }).key;
+      const ctrlKey = (detail as { ctrlKey: unknown }).ctrlKey;
+      const shiftKey = (detail as { shiftKey: unknown }).shiftKey;
+      if (ctrlKey !== true || shiftKey !== true || typeof key !== 'string' || key.toLowerCase() !== 'u') return;
+      enableAllowSameVersionForSession();
+      console.log('[updater] debug Ctrl+Shift+U -> allow_same_version enabled for session, channel:', channel);
+      try {
+        const { fetchUpdateInfo } = await import('@/features/updater/updateBridge');
+        const info = await fetchUpdateInfo(channel, true);
+        console.log('[updater] debug fetch result:', info);
+        if (info) setDebugForceAvailable({ status: 'available', info } as UpdateState);
+      } catch {}
+    };
+    window.addEventListener('app-hotkey-keydown', handleKeyDown as unknown as EventListener);
+    return () => window.removeEventListener('app-hotkey-keydown', handleKeyDown as unknown as EventListener);
+  }, [channel]);
+
+  // Auto-check when opening Updates tab
+  React.useEffect(() => {
+    checkForUpdates();
+  }, [checkForUpdates]);
+  const effectiveState = debugForceAvailable ?? state;
+  const handleDismissDebug = React.useCallback(() => {
+    if (debugForceAvailable) setDebugForceAvailable(null);
+    dismiss();
+  }, [debugForceAvailable, dismiss]);
+  const handleForceInstall = React.useCallback(async () => {
+    if (debugForceAvailable?.status === 'available') return;
+    enableAllowSameVersionForSession();
+    console.log('[updater] Install in Up to date clicked, fetching allowSameVersion=true, channel:', channel);
+    try {
+      const { fetchUpdateInfo } = await import('@/features/updater/updateBridge');
+      const info = await fetchUpdateInfo(channel, true);
+      console.log('[updater] forceInstall fetch result:', info);
+      if (info) {
+        setDebugForceAvailable({ status: 'available', info } as UpdateState);
+        return;
+      }
+    } catch {
+      // ignore
+    }
+  }, [channel, debugForceAvailable]);
 
   return (
     <div className={className}>
-      {state.status === 'external' && <ExternalState />}
-      {state.status === 'idle' && <IdleState onCheck={checkForUpdates} />}
-      {state.status === 'checking' && <CheckingState />}
-      {state.status === 'up-to-date' && <UpToDateState onCheck={checkForUpdates} />}
-      {state.status === 'available' && (
-        <AvailableState state={state} onDownload={downloadAndInstall} onDismiss={dismiss} />
+      {effectiveState.status === 'external' && <ExternalState />}
+      {effectiveState.status === 'idle' && <IdleState onCheck={checkForUpdates} />}
+      {effectiveState.status === 'checking' && <CheckingState />}
+      {effectiveState.status === 'up-to-date' && (
+        <UpToDateState onCheck={checkForUpdates} />
       )}
-      {state.status === 'downloading' && <DownloadingState state={state} />}
-      {state.status === 'installing' && <InstallingState />}
-      {state.status === 'installed' && <InstalledState />}
-      {state.status === 'error' && (
-        <ErrorState message={state.message} onRetry={checkForUpdates} />
+      {effectiveState.status === 'available' && (
+        <AvailableState
+          state={effectiveState as UpdateState & { status: 'available' }}
+          onDownload={downloadAndInstall}
+          onCheck={checkForUpdates}
+        />
+      )}
+      {effectiveState.status === 'downloading' && <DownloadingState state={effectiveState as UpdateState & { status: 'downloading' }} />}
+      {effectiveState.status === 'installing' && <InstallingState />}
+      {effectiveState.status === 'installed' && <InstalledState />}
+      {effectiveState.status === 'error' && (
+        <ErrorState message={(effectiveState as UpdateState & { status: 'error' }).message} onRetry={checkForUpdates} />
       )}
     </div>
   );

--- a/src/features/updater/UpdatesSettingsTab.tsx
+++ b/src/features/updater/UpdatesSettingsTab.tsx
@@ -1,11 +1,17 @@
 'use client';
 
 import React, { useCallback } from 'react';
-import { CloudDownload, GitBranch } from 'lucide-react';
+import { AlertTriangle, FlaskConical, Settings, ShieldCheck } from 'lucide-react';
 import { useIsLinux } from '@/hooks/usePlatform';
 import { UpdateCheckerSection } from '@/features/updater/UpdateCheckerSection';
 import { setUpdateChannel } from '@/features/updater/updateBridge';
 import type { UpdateChannel } from '@/features/updater/updateBridge';
+import { StructuredDialogModal } from '@/components/ui/StructuredDialogModal';
+const activeChannelStyle: React.CSSProperties = {
+  borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 30%)',
+  background: 'color-mix(in srgb, var(--accent), var(--surface-1) 85%)',
+  color: 'var(--text-strong)',
+};
 
 interface UpdatesSettingsTabProps {
   channel: UpdateChannel;
@@ -16,124 +22,147 @@ export function UpdatesSettingsTab({
   channel,
   onChannelChange,
 }: UpdatesSettingsTabProps) {
-  // Linux updates through Flatpak, so the feed the app would poll is moot.
   const isLinux = useIsLinux();
+  const [showChannelSettings, setShowChannelSettings] = React.useState(false);
+  const [pendingChannel, setPendingChannel] = React.useState<UpdateChannel>(channel);
 
-  const handleChannelSelect = useCallback(
+  const commitChannel = useCallback(
     (newChannel: UpdateChannel) => {
       onChannelChange(newChannel);
       void setUpdateChannel(newChannel);
     },
     [onChannelChange],
   );
+  const handleChannelSelect = useCallback(
+    (newChannel: UpdateChannel) => {
+      setPendingChannel(newChannel);
+    },
+    [],
+  );
+
+  const handleApplyChannel = useCallback(() => {
+    if (pendingChannel === channel) {
+      setShowChannelSettings(false);
+      return;
+    }
+    commitChannel(pendingChannel);
+    setShowChannelSettings(false);
+  }, [pendingChannel, channel, commitChannel]);
+
+  React.useEffect(() => {
+    if (showChannelSettings) setPendingChannel(channel);
+  }, [showChannelSettings, channel]);
+
+  const isPendingDevSwitch = pendingChannel === 'dev' && channel !== 'dev';
 
   return (
-    <div className="space-y-3">
-      {/* Release Channel */}
-      {!isLinux && (
-        <section
-          className="rounded-lg border p-3"
-          style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
-        >
-          <div className="flex items-start gap-2.5">
-            <span
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
-              style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-2), transparent 8%)' }}
-            >
-              <GitBranch className="h-4 w-4" style={{ color: 'var(--accent)' }} />
-            </span>
-            <div className="min-w-0 flex-1">
-              <h3 className="text-xs font-semibold" style={{ color: 'var(--text-strong)' }}>
-                Release Channel
-              </h3>
-              <p className="mt-0.5 text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
-                Choose which update feed to check for new versions.
-              </p>
-            </div>
-          </div>
-
-          <div className="mt-2 rounded-md border p-2.5" style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)' }}>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={() => handleChannelSelect('stable')}
-                className="flex-1 rounded-md border px-3 py-2 text-left transition-all duration-150"
-                style={
-                  channel === 'stable'
-                    ? {
-                        borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 35%)',
-                        background: 'color-mix(in srgb, var(--accent), var(--surface-0) 84%)',
-                        boxShadow: '0 0 0 1px color-mix(in srgb, var(--accent), transparent 76%) inset',
-                      }
-                    : {
-                        borderColor: 'var(--border-subtle)',
-                        background: 'var(--surface-1)',
-                      }
-                }
-              >
-                <div className="text-sm font-semibold" style={{ color: channel === 'stable' ? 'var(--accent)' : 'var(--text-strong)' }}>
-                  Stable
-                </div>
-                <div className="mt-0.5 text-[10px]" style={{ color: 'var(--text-muted)' }}>
-                  Production releases only. Recommended for most users.
-                </div>
-              </button>
-
-              <button
-                type="button"
-                onClick={() => handleChannelSelect('dev')}
-                className="flex-1 rounded-md border px-3 py-2 text-left transition-all duration-150"
-                style={
-                  channel === 'dev'
-                    ? {
-                        borderColor: 'color-mix(in srgb, var(--accent-secondary), var(--border-subtle) 35%)',
-                        background: 'color-mix(in srgb, var(--accent-secondary), var(--surface-0) 84%)',
-                        boxShadow: '0 0 0 1px color-mix(in srgb, var(--accent-secondary), transparent 76%) inset',
-                      }
-                    : {
-                        borderColor: 'var(--border-subtle)',
-                        background: 'var(--surface-1)',
-                      }
-                }
-              >
-                <div className="text-sm font-semibold" style={{ color: channel === 'dev' ? 'var(--accent-secondary)' : 'var(--text-strong)' }}>
-                  Dev
-                </div>
-                <div className="mt-0.5 text-[10px]" style={{ color: 'var(--text-muted)' }}>
-                  Pre-release builds from the dev branch. May be unstable.
-                </div>
-              </button>
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* Update Checker */}
+    <div className="flex h-full min-h-0 flex-col space-y-3">
       <section
-        className="rounded-lg border p-3"
+        className="relative flex min-h-0 flex-1 flex-col rounded-lg border p-3"
         style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
       >
-        <div className="flex items-start gap-2.5">
-          <span
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
-            style={{ borderColor: 'var(--border-subtle)', background: 'color-mix(in srgb, var(--surface-2), transparent 8%)' }}
+        {!isLinux && (
+          <button
+            type="button"
+            onClick={() => setShowChannelSettings(true)}
+            className="absolute right-3 top-3 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border transition-colors hover:brightness-110"
+            style={{ borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 40%)', background: 'color-mix(in srgb, var(--accent), var(--surface-1) 85%)', color: 'var(--accent)' }}
+            aria-label="Release channel settings"
+            title="Release channel settings"
           >
-            <CloudDownload className="h-4 w-4" style={{ color: 'var(--accent)' }} />
-          </span>
-          <div className="min-w-0 flex-1">
-            <h3 className="text-xs font-semibold" style={{ color: 'var(--text-strong)' }}>
-              Updates
-            </h3>
-            <p className="mt-0.5 text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
-              Check for and install new versions of DragonFruit.
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-2">
-          <UpdateCheckerSection />
+            <Settings className="h-4 w-4" />
+          </button>
+        )}
+        <div className="flex min-h-0 flex-1 flex-col">
+          <UpdateCheckerSection className="flex min-h-0 flex-1 flex-col" />
         </div>
       </section>
+      <StructuredDialogModal
+        open={showChannelSettings}
+        ariaLabel="Release channel settings"
+        title="Release Channel"
+        subtitle="Choose which update feed to check for new versions."
+        icon={<Settings className="h-5 w-5" style={{ color: 'var(--accent)' }} />}
+        iconTone="neutral"
+        onClose={() => setShowChannelSettings(false)}
+        onBackdropClick={() => setShowChannelSettings(false)}
+        actions={
+          <>
+            <button
+              type="button"
+              className="ui-button ui-button-secondary !h-9 px-3 text-xs"
+              onClick={() => setShowChannelSettings(false)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="ui-button !h-9 px-3 text-xs inline-flex items-center justify-center gap-1.5"
+              style={
+                pendingChannel === channel
+                  ? { borderColor: 'var(--border-subtle)', background: 'var(--surface-1)', color: 'var(--text-muted)', opacity: 0.6 as unknown as string }
+                  : isPendingDevSwitch
+                    ? { borderColor: 'color-mix(in srgb, #f59e0b, var(--border-subtle) 45%)', background: 'color-mix(in srgb, #f59e0b, var(--surface-1) 86%)', color: '#f59e0b' }
+                    : { borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)', background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)', color: 'var(--accent)' }
+              }
+              onClick={handleApplyChannel}
+              disabled={pendingChannel === channel}
+            >
+              {isPendingDevSwitch ? (
+                <>
+                  <FlaskConical className="w-3.5 h-3.5" />
+                  Switch to Previews
+                </>
+              ) : (
+                'Apply'
+              )}
+            </button>
+          </>
+        }
+      >
+        <div className="grid gap-2.5" role="tablist" aria-label="Release channel">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={pendingChannel === 'stable'}
+            onClick={() => handleChannelSelect('stable')}
+            className="ui-button ui-button-secondary flex flex-col items-center justify-center gap-1.5 px-2 py-6 text-center min-h-[64px]"
+            style={pendingChannel === 'stable' ? activeChannelStyle : undefined}
+          >
+            <span className="inline-flex items-center gap-1.5 text-sm font-semibold leading-none">
+              <ShieldCheck className="h-3.5 w-3.5 shrink-0" />
+              Stable Builds
+            </span>
+            <span className="text-xs font-normal leading-tight" style={{ color: 'var(--text-muted)' }}>
+              Recommended · Production
+            </span>
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={pendingChannel === 'dev'}
+            onClick={() => handleChannelSelect('dev')}
+            className="ui-button ui-button-secondary flex flex-col items-center justify-center gap-1.5 px-2 py-6 text-center min-h-[64px]"
+            style={pendingChannel === 'dev' ? activeChannelStyle : undefined}
+          >
+            <span className="inline-flex items-center gap-1.5 text-sm font-semibold leading-none">
+              <FlaskConical className="h-3.5 w-3.5 shrink-0" />
+              Development Previews
+            </span>
+            <span className="text-xs font-normal leading-tight" style={{ color: 'var(--text-muted)' }}>
+              Early access · May be unstable
+            </span>
+          </button>
+        </div>
+        {isPendingDevSwitch && (
+          <div className="mt-3 rounded-md border px-3 py-2.5 flex gap-2.5" style={{ borderColor: 'color-mix(in srgb, #f59e0b, var(--border-subtle) 40%)', background: 'color-mix(in srgb, #f59e0b, var(--surface-1) 90%)' }}>
+            <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" style={{ color: '#f59e0b' }} />
+            <div className="text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+              <span style={{ color: 'var(--text-strong)', fontWeight: 600 }}>Development Previews</span> are built from the <span style={{ color: 'var(--text-strong)', fontWeight: 600 }}>dev</span> branch for early testing. Expect bugs and breaking changes — switch back to Stable Builds at any time.
+            </div>
+          </div>
+        )}
+      </StructuredDialogModal>
     </div>
   );
 }

--- a/src/features/updater/debugForceSession.ts
+++ b/src/features/updater/debugForceSession.ts
@@ -1,0 +1,15 @@
+// Per-session flag (Ctrl+Shift+U) to allow installing the same version via regular update logic
+// Once triggered anywhere, all checks until reload use allow_same_version=true, so regular
+// updater returns current version as available with real changelog, no fabricated debug states.
+let allowSameVersionUntilReload = false;
+
+export function isAllowSameVersionEnabled(): boolean { return allowSameVersionUntilReload; }
+export function enableAllowSameVersionForSession(): void { allowSameVersionUntilReload = true; }
+export function clearAllowSameVersion(): void { allowSameVersionUntilReload = false; }
+
+// Back-compat shims for old callers (now no-ops, kept so imports don't break until callers updated)
+export function getGlobalDebugInfo(): unknown { return null; }
+export function setSessionDebug(_info: unknown): void { enableAllowSameVersionForSession(); }
+export function getCheckerDebugState(): unknown { return null; }
+export function setCheckerDebugState(_state: unknown): void {}
+export function clearSessionDebug(): void { clearAllowSameVersion(); }

--- a/src/features/updater/updateBridge.ts
+++ b/src/features/updater/updateBridge.ts
@@ -101,6 +101,7 @@ export async function setUpdateChannel(channel: UpdateChannel): Promise<void> {
  */
 export async function fetchUpdateInfo(
   channel?: UpdateChannel,
+  allowSameVersion = false,
 ): Promise<UpdateInfo | null> {
   if (!isTauriAvailable()) {
     return null;
@@ -109,7 +110,7 @@ export async function fetchUpdateInfo(
     console.log('[updater] Linux ships as a Flatpak — skipping the update check');
     return null;
   }
-  console.log('[updater] fetchUpdateInfo called, channel:', channel ?? 'null (Rust default)');
+  console.log('[updater] fetchUpdateInfo called, channel:', channel ?? 'null (Rust default)', 'allowSameVersion:', allowSameVersion);
   try {
     const result = await invoke<{
       updateAvailable: boolean;
@@ -117,8 +118,7 @@ export async function fetchUpdateInfo(
       currentVersion: string;
       body: string | null;
       date: string | null;
-    } | null>('check_updates', { channel: channel ?? null });
-
+    } | null>('check_updates', { channel: channel ?? null, allow_same_version: allowSameVersion, allowSameVersion: allowSameVersion } as unknown as Record<string, unknown>);
     console.log('[updater] check_updates result:', result);
 
     if (!result?.updateAvailable) return null;

--- a/src/features/updater/useUpdateChecker.ts
+++ b/src/features/updater/useUpdateChecker.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useIsLinux } from '@/hooks/usePlatform';
+import { isAllowSameVersionEnabled } from '@/features/updater/debugForceSession';
 import {
   fetchUpdateInfo,
   downloadAndInstall,
@@ -61,7 +62,9 @@ export function useUpdateChecker() {
     console.log('[updater] checking for updates on channel:', channel);
 
     try {
-      const info = await fetchUpdateInfo(channel);
+      const allowSame = isAllowSameVersionEnabled();
+      if (allowSame) console.log('[updater] handleCheck with allow_same_version=true');
+      const info = await fetchUpdateInfo(channel, allowSame);
 
       if (!info) {
         // Couldn't reach the update server or no release exists yet.
@@ -72,6 +75,17 @@ export function useUpdateChecker() {
       }
 
       // If we got info back, the plugin found a newer version.
+      // Enrich body if missing (same-version reinstall has no notes in feed)
+      if (info && !info.body) {
+        try {
+          const ghRes = await fetch(`https://api.github.com/repos/Open-Resin-Alliance/DragonFruit/releases/tags/v${info.version}`);
+          if (ghRes.ok) {
+            const gh = await ghRes.json() as { body?: string; published_at?: string };
+            if (gh.body) info.body = gh.body as string;
+            if (gh.published_at && !info.date) info.date = gh.published_at as string;
+          }
+        } catch {}
+      }
       setState({ status: 'available', info });
 
       // Persist the last check timestamp.

--- a/src/supports/Settings/components/PresetSelector.tsx
+++ b/src/supports/Settings/components/PresetSelector.tsx
@@ -466,7 +466,12 @@ export function PresetSelector({
                         </button>
                         <button
                             type="button"
-                            className="ui-button ui-button-primary !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                            className="ui-button !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
+                            style={{
+                                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
+                                background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
+                                color: 'var(--accent)',
+                            }}
                             onClick={() => {
                                 if (selectedPreset) {
                                     savePreset(selectedPreset.id);
@@ -561,7 +566,7 @@ export function PresetSelector({
                             type="button"
                             className="ui-button !h-9 w-full px-3 text-xs inline-flex items-center justify-center gap-1.5"
                             style={{
-                                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 25%)',
+                                borderColor: 'color-mix(in srgb, var(--accent), var(--border-subtle) 45%)',
                                 background: 'color-mix(in srgb, var(--accent), var(--surface-1) 86%)',
                                 color: 'var(--accent)',
                             }}


### PR DESCRIPTION
## Summary

Batch of settings, updater and notification work that landed on this branch. Selection and hover colors were resetting to the dragonfruit accent after reload, theme and mesh swatches showed an inset square, sponsors needed tiered rings and high res avatars, and the updater and notifications got a refresh alongside hydration and backup polish.

---

## What changed

### Sponsors
- Tiered donation rings in SponsorsCarousel via getSponsorRank, gold >=100, silver >=30, bronze >=10 with conic gradients and glow, plus high res avatars downscaled from 512 with anti aliased circular clipping and transform scale
- Avatar and sponsor list caching to localStorage with 6h TTL, Tauri Rust fetch for avatars and Open Collective to bypass WebView CORS, fallback to proxy and original src

### Notifications and updater
- Reusable SystemNotificationStack with hideIcon, documented at docs/dev/system-notifications.md and registered in mkdocs.yml
- Updater channel now supports dev channel switching, same version reinstall until reload, real changelog, and debugForceSession helper. GlobalUpdateIndicator, UpdatesSettingsTab and UpdateCheckerSection reworked with frosted bottom right notification, fly animation, progress and auto check

### Settings and themes
- Selection and hover colors now persist in mesh-appearance-settings and stay independent of the theme accent. Draft theme colors hydrate from the active profile instead of stale saved colors
- Theme color swatches in UI and Themes and mesh selection and hover swatches now fill their h-7 and h-8 box edge to edge, no double border
- Backups, autosave and experiments, local backups and scene autosave tabs polished, slicing engine version is now fetched live via Tauri get_slicer_engine_version with 3.2.1 fallback

### Scene and file handling
- Scene file input accept strings are hydration safe via useSyncExternalStore and derived from the filtered plugin registry, prevents SSR mismatch for chitubox and other formats
- Plugin file type extensions now filter disabled experiments from drop targets, MIME resolution and labels

### UI polish
- Dialogs, AutoSupport and Islands panels, preset selectors and modals received spacing, border and control tweaks for consistency
- LutCurveEditor, PresetSelector and TopBar file input handling updated

---

## Notes

- No new plugin contracts, only persistence and UI fixes. Run npm run check:docs before merge, allowlist is at scripts/docs-accuracy-allowlist.json.
