### PR TITLE
fix: Prevent subpixel winding leaks across model instances

### DIFF
--- a/rust/dragonfruit-cli/Cargo.lock
+++ b/rust/dragonfruit-cli/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfruit-slicing-engine"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "aes",
  "base64",

--- a/rust/dragonfruit-cli/Cargo.lock
+++ b/rust/dragonfruit-cli/Cargo.lock
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfruit-slicing-engine"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "aes",
  "base64",

--- a/rust/dragonfruit-islands/Cargo.lock
+++ b/rust/dragonfruit-islands/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfruit-slicing-engine"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "aes",
  "base64",

--- a/rust/dragonfruit-islands/Cargo.lock
+++ b/rust/dragonfruit-islands/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfruit-slicing-engine"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "aes",
  "base64",

--- a/rust/dragonfruit-slicing-engine/Cargo.lock
+++ b/rust/dragonfruit-slicing-engine/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfruit-slicing-engine"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "aes",
  "base64",

--- a/rust/dragonfruit-slicing-engine/Cargo.lock
+++ b/rust/dragonfruit-slicing-engine/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfruit-slicing-engine"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "aes",
  "base64",

--- a/rust/dragonfruit-slicing-engine/Cargo.toml
+++ b/rust/dragonfruit-slicing-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dragonfruit-slicing-engine"
-version = "3.2.1"
+version = "3.2.2"
 edition = "2021"
 
 [lib]

--- a/rust/dragonfruit-slicing-engine/Cargo.toml
+++ b/rust/dragonfruit-slicing-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dragonfruit-slicing-engine"
-version = "3.2.2"
+version = "3.2.3"
 edition = "2021"
 
 [lib]

--- a/rust/dragonfruit-slicing-engine/README.md
+++ b/rust/dragonfruit-slicing-engine/README.md
@@ -1,6 +1,6 @@
 # dragonfruit-slicing-engine
 
-Native Rust slicing backend for DragonFruit Desktop (Tauri), currently at **v3.2.1**.
+Native Rust slicing backend for DragonFruit Desktop (Tauri), currently at **v3.2.2**.
 
 This crate is the production slicing engine that converts triangle geometry into printer-ready layer containers. Format output is dispatched through a plugin-driven encoder registry (currently `.nanodlp`, `.ctb`, `.goo`, and others).
 

--- a/rust/dragonfruit-slicing-engine/README.md
+++ b/rust/dragonfruit-slicing-engine/README.md
@@ -1,6 +1,6 @@
 # dragonfruit-slicing-engine
 
-Native Rust slicing backend for DragonFruit Desktop (Tauri), currently at **v3.2.2**.
+Native Rust slicing backend for DragonFruit Desktop (Tauri), currently at **v3.2.3**.
 
 This crate is the production slicing engine that converts triangle geometry into printer-ready layer containers. Format output is dispatched through a plugin-driven encoder registry (currently `.nanodlp`, `.ctb`, `.goo`, and others).
 

--- a/rust/dragonfruit-slicing-engine/docs/PIPELINE.md
+++ b/rust/dragonfruit-slicing-engine/docs/PIPELINE.md
@@ -57,6 +57,7 @@ This path is still bounded/cancelable and useful for encoders not exposing paral
 
 - handles overlapping/intersecting solids robustly
 - removes opposite-winding crossings less than one source pixel apart before span construction, preventing unrenderable features or gaps from leaking across repeated instances
+- keeps unmatched exit/entry gap signatures local when the entry is closer to the orphan exit than its next possible closing exit
 - AA off => strict binary 0/255 writes
 - AA on => subscanline coverage accumulation to grayscale
 - output is row-major `Vec<RleRun>`

--- a/rust/dragonfruit-slicing-engine/docs/PIPELINE.md
+++ b/rust/dragonfruit-slicing-engine/docs/PIPELINE.md
@@ -56,6 +56,7 @@ This path is still bounded/cancelable and useful for encoders not exposing paral
 `raster::rasterize_layer_rle` uses scanline winding unions:
 
 - handles overlapping/intersecting solids robustly
+- removes opposite-winding crossings less than one source pixel apart before span construction, preventing unrenderable features or gaps from leaking across repeated instances
 - AA off => strict binary 0/255 writes
 - AA on => subscanline coverage accumulation to grayscale
 - output is row-major `Vec<RleRun>`

--- a/rust/dragonfruit-slicing-engine/src/raster.rs
+++ b/rust/dragonfruit-slicing-engine/src/raster.rs
@@ -351,12 +351,47 @@ fn spans_total_px(spans: &[RowSpan]) -> u64 {
     spans.iter().map(|s| (s.end - s.start + 1) as u64).sum()
 }
 
+fn collapse_subpixel_pairs(active_edges: &[ActiveEdge]) -> Option<Vec<ActiveEdge>> {
+    let has_subpixel_pair = active_edges.windows(2).any(|pair| {
+        pair[0].x.is_finite()
+            && pair[1].x.is_finite()
+            && pair[0].wind + pair[1].wind == 0
+            && pair[1].x - pair[0].x < 1.0
+    });
+    if !has_subpixel_pair {
+        return None;
+    }
+
+    let mut collapsed = Vec::with_capacity(active_edges.len());
+    for &edge in active_edges {
+        let cancels_previous = collapsed.last().is_some_and(|previous: &ActiveEdge| {
+            previous.x.is_finite()
+                && edge.x.is_finite()
+                && previous.wind + edge.wind == 0
+                && edge.x - previous.x < 1.0
+        });
+        if cancels_previous {
+            collapsed.pop();
+        } else {
+            collapsed.push(edge);
+        }
+    }
+
+    Some(collapsed)
+}
+
 fn build_row_spans_nonzero_inner(
     active_edges: &[ActiveEdge],
     width: usize,
     snap_to_integer: bool,
     prev_spans: Option<&[RowSpan]>,
 ) -> (Vec<RowSpan>, bool) {
+    // Opposite crossings below the source raster's X resolution have zero
+    // printable extent. Remove them before winding repair so one crossing
+    // cannot be matched against another instance across the plate.
+    let collapsed_edges = collapse_subpixel_pairs(active_edges);
+    let active_edges = collapsed_edges.as_deref().unwrap_or(active_edges);
+
     let mut spans = Vec::with_capacity(active_edges.len() / 2 + 1);
     let mut winding = 0i32;
     let n = active_edges.len();
@@ -4583,6 +4618,71 @@ mod tests {
         assert_eq!(spans.len(), 2, "orphan entries must not pair across matched fill");
         assert_eq!((spans[0].start, spans[0].end), (30, 49));
         assert_eq!((spans[1].start, spans[1].end), (100, 119));
+    }
+
+    #[test]
+    fn repeated_subpixel_gap_pairs_do_not_bridge_in_any_raster_mode() {
+        let prev = build_row_spans_nonzero(
+            &[
+                edge(10.0, 1),
+                edge(20.0, -1),
+                edge(30.0, 1),
+                edge(40.0, -1),
+                edge(110.0, 1),
+                edge(120.0, -1),
+                edge(130.0, 1),
+                edge(140.0, -1),
+                edge(210.0, 1),
+                edge(220.0, -1),
+                edge(230.0, 1),
+                edge(240.0, -1),
+            ],
+            300,
+            true,
+        );
+        let defective = [
+            edge(10.0, 1),
+            edge(20.0, -1),
+            edge(30.0, 1),
+            edge(40.0, -1),
+            edge(50.0, -1),
+            edge(50.02, 1),
+            edge(110.0, 1),
+            edge(120.0, -1),
+            edge(130.0, 1),
+            edge(140.0, -1),
+            edge(150.0, -1),
+            edge(150.02, 1),
+            edge(210.0, 1),
+            edge(220.0, -1),
+            edge(230.0, 1),
+            edge(240.0, -1),
+            edge(250.0, -1),
+            edge(250.02, 1),
+        ];
+
+        for snap_to_integer in [true, false] {
+            let spans = super::build_row_spans_nonzero_ctx(
+                &defective,
+                300,
+                snap_to_integer,
+                Some(&prev),
+            );
+
+            assert_eq!(spans.len(), 6);
+            assert!(
+                spans.iter().all(|span| span.b - span.a <= 10.0),
+                "subpixel gaps must not bridge repeated instances: {spans:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn complete_subpixel_features_are_dropped_in_all_raster_modes() {
+        let edges = [edge(10.1, 1), edge(10.9, -1)];
+
+        assert!(build_row_spans_nonzero(&edges, 256, true).is_empty());
+        assert!(build_row_spans_nonzero(&edges, 256, false).is_empty());
     }
 
     #[test]

--- a/rust/dragonfruit-slicing-engine/src/raster.rs
+++ b/rust/dragonfruit-slicing-engine/src/raster.rs
@@ -180,7 +180,9 @@ fn build_row_spans_matched(
     let mut pairs: Vec<(f32, f32)> = Vec::with_capacity(active_edges.len() / 2 + 1);
     let mut orphans: Vec<(f32, i32)> = Vec::new();
 
-    for edge in active_edges {
+    let mut edge_index = 0usize;
+    while edge_index < active_edges.len() {
+        let edge = active_edges[edge_index];
         if !edge.x.is_finite() {
             break;
         }
@@ -188,6 +190,25 @@ fn build_row_spans_matched(
         // Normalize so w > 0 opens fill and w < 0 closes it, regardless of
         // the mesh's dominant orientation.
         let mut w = edge.wind * entry_wind;
+        if w == -1 && open.is_empty() {
+            // A nearby entry belongs to this unmatched exit when its next
+            // possible closing exit is farther away. Consume that local gap
+            // instead of carrying the entry into another model instance.
+            let next_entry = active_edges.get(edge_index + 1).filter(|next| {
+                next.x.is_finite() && next.wind * entry_wind == 1 && next.x > edge.x
+            });
+            if let Some(next_entry) = next_entry {
+                let next_exit = active_edges[edge_index + 2..].iter().find(|candidate| {
+                    candidate.x.is_finite() && candidate.wind * entry_wind < 0
+                });
+                if next_exit.is_some_and(|next_exit| {
+                    next_entry.x - edge.x < next_exit.x - next_entry.x
+                }) {
+                    edge_index += 2;
+                    continue;
+                }
+            }
+        }
         while w > 0 {
             open.push(edge.x);
             w -= 1;
@@ -203,6 +224,7 @@ fn build_row_spans_matched(
                 None => orphans.push((edge.x, -1)),
             }
         }
+        edge_index += 1;
     }
     for &x in &open {
         orphans.push((x, 1));
@@ -4675,6 +4697,55 @@ mod tests {
                 "subpixel gaps must not bridge repeated instances: {spans:?}"
             );
         }
+    }
+
+    #[test]
+    fn repeated_local_gap_signatures_do_not_bridge_between_instances() {
+        let mut prev_edges = Vec::new();
+        let mut edges = Vec::new();
+        for offset in [0.0, 100.0, 200.0] {
+            prev_edges.extend_from_slice(&[
+                edge(offset + 10.0, 1),
+                edge(offset + 20.0, -1),
+                edge(offset + 30.0, 1),
+                edge(offset + 40.0, -1),
+            ]);
+            edges.extend_from_slice(&[
+                edge(offset + 10.0, 1),
+                edge(offset + 20.0, -1),
+                edge(offset + 30.0, 1),
+                edge(offset + 40.0, -1),
+                edge(offset + 50.0, -1),
+                edge(offset + 55.0, 1),
+            ]);
+        }
+        let prev = build_row_spans_nonzero(&prev_edges, 300, true);
+
+        for snap_to_integer in [true, false] {
+            let spans = super::build_row_spans_nonzero_ctx(
+                &edges,
+                300,
+                snap_to_integer,
+                Some(&prev),
+            );
+            assert_eq!(spans.len(), 6);
+            assert!(
+                spans.iter().all(|span| span.b - span.a <= 10.0),
+                "local gap signatures must not bridge repeated instances: {spans:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unmatched_exit_does_not_consume_the_next_real_object() {
+        let spans = build_row_spans_nonzero(
+            &[edge(10.0, -1), edge(100.0, 1), edge(130.0, -1)],
+            256,
+            true,
+        );
+
+        assert_eq!(spans.len(), 1);
+        assert_eq!((spans[0].start, spans[0].end), (100, 129));
     }
 
     #[test]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfruit-slicing-engine"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "aes",
  "base64 0.22.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "dragonfruit-slicing-engine"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "aes",
  "base64 0.22.1",


### PR DESCRIPTION
## Summary

Prevents tiny and malformed scanline features from creating long exposure streaks between repeated model instances.

---

## What changed

### Rasterization

- Removes opposite-winding crossings separated by less than one source pixel.
- Keeps unmatched exit/entry gaps local when the next closing exit is farther away.
- Preserves the existing global orientation selection used by large and defective models.
- Applies the containment behavior to binary, Coverage, and 3DAA rasterization.

### Regression coverage

- Covers repeated subpixel gaps in binary and AA modes.
- Covers wider taper gaps observed in the supplied reproduction.
- Verifies an unmatched exit does not consume the next real object.
- Retains existing overlap, flipped-winding, open-wall, and block-raster tests.

### Release metadata

- Bumps `dragonfruit-slicing-engine` from `3.2.1` to `3.2.3`.
- Updates dependent lockfiles and raster pipeline documentation.

---

## Validation notes

- Exact VOXL replay reports zero long spans for AA-off layer 1043.
- Exact VOXL replay reports zero long spans at half exposure for 16x 3DAA layer 1048.
- All 38 raster tests pass.
- Engine, CLI, and islands crates pass `cargo check`.
- Documentation accuracy check passes.
- Desktop compilation reaches the application crate, then stops because generated `frontend-dist` is absent.
- The full engine suite has one unrelated existing Elegoo metadata timing failure.