### PR TITLE
Fix branch support tip drags, prewarming and improper dimensions

### DIFF
--- a/src/supports/SupportPrimitives/Knot/useKnotInteraction.ts
+++ b/src/supports/SupportPrimitives/Knot/useKnotInteraction.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import * as THREE from 'three';
 import { useThree, useFrame } from '@react-three/fiber';
 import { usePicking } from '@/components/picking';
-import { getBranches, getKnotById, getLeaves, getRootById, getTrunks, getTwigs, getSticks, getBraces, setInteractionWarning, updateKnot, updateLeaf, updateBranch, getBranchById, subscribe } from '../../state';
+import { getBranches, getKnotById, getLeaves, getRootById, getSnapshot, getTrunks, getTwigs, getSticks, getBraces, setInteractionWarning, updateKnot, updateLeaf, updateBranch, getBranchById, subscribe } from '../../state';
 import { Branch, Brace, Knot, Roots, Trunk, Twig, Stick, Vec3 } from '../../types';
 import { getKickstandSnapshot } from '../../SupportTypes/Kickstand/kickstandStore';
 import type { Kickstand } from '../../SupportTypes/Kickstand/types';
@@ -37,6 +37,28 @@ interface ActiveHost {
     initialTopology: Record<string, 'UP' | 'DOWN'>;
 }
 
+export type SupportGeometryToken = Record<string, unknown>;
+
+/** Identity of every collection the host lookup and the elastic capture read. */
+export function captureSupportGeometryToken(): SupportGeometryToken {
+    const snapshot = getSnapshot();
+    return {
+        trunks: snapshot.trunks,
+        branches: snapshot.branches,
+        leaves: snapshot.leaves,
+        twigs: snapshot.twigs,
+        sticks: snapshot.sticks,
+        braces: snapshot.braces,
+        knots: snapshot.knots,
+        kickstands: getKickstandSnapshot().kickstands,
+    };
+}
+
+export function isSameSupportGeometry(a: SupportGeometryToken | null, b: SupportGeometryToken): boolean {
+    if (!a) return false;
+    return Object.keys(b).every((key) => a[key] === b[key]);
+}
+
 export function useKnotInteraction(enabled: boolean = true) {
     const MIN_DRAG_DELTA_SQ = 1e-6; // ~0.001mm epsilon to drop high-frequency jitter churn
     const BEZIER_PROJECTION_STEPS = 36;
@@ -58,6 +80,14 @@ export function useKnotInteraction(enabled: boolean = true) {
     const prewarmedKnotIdRef = useRef<string | null>(null);
     const prewarmedHostRef = useRef<ActiveHost | null>(null);
     const prewarmedElasticStateRef = useRef<Record<string, ElasticChainInitialState> | null>(null);
+    // The geometry the prewarm was taken from. The prewarmed host endpoints and
+    // elastic capture are a photo of support geometry: any edit in between (a tip
+    // drag rebuilding a branch, an undo, a deletion) makes them stale, and
+    // replaying a stale capture drags the chain back to the geometry it
+    // snapshotted. Hover and selection rewrite the store too, so the token holds
+    // the geometry collections rather than the whole snapshot — otherwise every
+    // hover would throw the prewarm away.
+    const prewarmedGeometryRef = useRef<SupportGeometryToken | null>(null);
     const lastAppliedKnotPosRef = useRef<THREE.Vector3 | null>(null);
     const previewBranchSegmentsByIdRef = useRef<Record<string, Branch['segments']>>({});
     const previewKnotRef = useRef<Knot | null>(null);
@@ -686,7 +716,12 @@ export function useKnotInteraction(enabled: boolean = true) {
         if (hit.category !== 'knot' || !hit.objectId) return;
 
         const knotId = hit.objectId;
-        if (prewarmedKnotIdRef.current === knotId && prewarmedHostRef.current && prewarmedElasticStateRef.current) {
+        if (
+            prewarmedKnotIdRef.current === knotId
+            && prewarmedHostRef.current
+            && prewarmedElasticStateRef.current
+            && isSameSupportGeometry(prewarmedGeometryRef.current, captureSupportGeometryToken())
+        ) {
             return;
         }
 
@@ -700,6 +735,7 @@ export function useKnotInteraction(enabled: boolean = true) {
         prewarmedKnotIdRef.current = knotId;
         prewarmedHostRef.current = host;
         prewarmedElasticStateRef.current = captureElasticState(knotId);
+        prewarmedGeometryRef.current = captureSupportGeometryToken();
     }, [enabled, isDragging, hit.category, hit.objectId]);
 
     useEffect(() => {
@@ -710,7 +746,9 @@ export function useKnotInteraction(enabled: boolean = true) {
             if (!knot) {
                 return;
             }
-            const host = prewarmedKnotIdRef.current === knot.id && prewarmedHostRef.current
+            const prewarmIsFresh = prewarmedKnotIdRef.current === knot.id
+                && isSameSupportGeometry(prewarmedGeometryRef.current, captureSupportGeometryToken());
+            const host = prewarmIsFresh && prewarmedHostRef.current
                 ? prewarmedHostRef.current
                 : findHost(knot);
             if (!host) {
@@ -734,13 +772,14 @@ export function useKnotInteraction(enabled: boolean = true) {
             clearKnotDragPreview();
 
             // Capture/restore state
-            elasticState.current = prewarmedKnotIdRef.current === knot.id && prewarmedElasticStateRef.current
+            elasticState.current = prewarmIsFresh && prewarmedElasticStateRef.current
                 ? prewarmedElasticStateRef.current
                 : captureElasticState(knot.id);
 
             prewarmedKnotIdRef.current = null;
             prewarmedHostRef.current = null;
             prewarmedElasticStateRef.current = null;
+            prewarmedGeometryRef.current = null;
         }
 
         const shouldEndDrag = (!isDragging || forceEndDragRef.current) && !!activeKnotId.current;

--- a/src/supports/SupportTypes/Anchor/AnchorRenderer.tsx
+++ b/src/supports/SupportTypes/Anchor/AnchorRenderer.tsx
@@ -42,6 +42,15 @@ export const AnchorRenderer = React.memo(function AnchorRenderer({
     const beforeHistoryRef = React.useRef<ReturnType<typeof captureSupportEditSnapshot> | null>(null);
     const [, setDragTick] = React.useState(0);
 
+    React.useEffect(() => {
+        return () => {
+            dragSessionRef.current?.stop();
+            dragSessionRef.current = null;
+            liveDragConeRef.current = null;
+            beforeHistoryRef.current = null;
+        };
+    }, []);
+
     const { pickRef, visuals, isPickingHovered } = useHighlight({
         id: anchor.id,
         category: 'support',

--- a/src/supports/SupportTypes/Branch/BranchRenderer.tsx
+++ b/src/supports/SupportTypes/Branch/BranchRenderer.tsx
@@ -14,6 +14,8 @@ import { useHighlight } from '../../interaction/useHighlight';
 import { usePartDragUpdate } from '../../interaction/partDragPreview';
 import { KnotRenderer } from '../../SupportPrimitives/Knot/KnotRenderer';
 import { getSnapshot, updateBranch } from '../../state';
+import { getSettings } from '../../Settings';
+import { decodeSupportSettingsHex } from '../../Settings/supportSettingsCodec';
 import { captureSupportEditSnapshot, pushSupportEditHistory } from '../../history/supportEditHistory';
 import { buildBranchData, remapBranchGeometryIds } from './branchBuilder';
 
@@ -110,12 +112,22 @@ export const BranchRenderer = React.memo(function BranchRenderer({
       onHit: ({ point, surfaceNormal, mesh }: ContactDiskDragHit) => {
         const latest = getSnapshot().branches[branch.id];
         if (!latest?.contactCone) return;
+        // Size the rebuild from the branch's own settings and its existing
+        // geometry, not from whatever the global preset says now: moving a tip
+        // must not resize the support. The stored cone length is the solved one,
+        // so the nominal comes from the branch's own band instead.
+        const ownSettings = (latest.settingsCodeHex
+          ? decodeSupportSettingsHex(latest.settingsCodeHex, getSettings())
+          : null) ?? getSettings();
         const rebuilt = remapBranchGeometryIds(buildBranchData({
           tipPos: point,
           tipNormal: surfaceNormal,
           modelId: branch.modelId,
           parentKnot,
           mesh,
+          settings: ownSettings,
+          shaftDiameterMm: latest.segments[0]?.diameter,
+          tipProfile: { ...latest.contactCone.profile, lengthMm: ownSettings.tip.lengthMm },
         }).branch, latest);
         liveDragBranchRef.current = {
           ...rebuilt,

--- a/src/supports/SupportTypes/Branch/BranchRenderer.tsx
+++ b/src/supports/SupportTypes/Branch/BranchRenderer.tsx
@@ -15,7 +15,7 @@ import { usePartDragUpdate } from '../../interaction/partDragPreview';
 import { KnotRenderer } from '../../SupportPrimitives/Knot/KnotRenderer';
 import { getSnapshot, updateBranch } from '../../state';
 import { captureSupportEditSnapshot, pushSupportEditHistory } from '../../history/supportEditHistory';
-import { buildBranchData } from './branchBuilder';
+import { buildBranchData, remapBranchGeometryIds } from './branchBuilder';
 
 interface BranchRendererProps {
   branch: Branch;
@@ -65,6 +65,15 @@ export const BranchRenderer = React.memo(function BranchRenderer({
   const beforeHistoryRef = React.useRef<ReturnType<typeof captureSupportEditSnapshot> | null>(null);
   const [, setDragTick] = React.useState(0);
 
+  React.useEffect(() => {
+    return () => {
+      dragSessionRef.current?.stop();
+      dragSessionRef.current = null;
+      liveDragBranchRef.current = null;
+      beforeHistoryRef.current = null;
+    };
+  }, []);
+
   // Use universal highlight hook (matches TrunkRenderer pattern)
   const { pickRef, visuals, isPickingHovered } = useHighlight({
     id: branch.id,
@@ -101,13 +110,13 @@ export const BranchRenderer = React.memo(function BranchRenderer({
       onHit: ({ point, surfaceNormal, mesh }: ContactDiskDragHit) => {
         const latest = getSnapshot().branches[branch.id];
         if (!latest?.contactCone) return;
-        const rebuilt = buildBranchData({
+        const rebuilt = remapBranchGeometryIds(buildBranchData({
           tipPos: point,
           tipNormal: surfaceNormal,
           modelId: branch.modelId,
           parentKnot,
           mesh,
-        }).branch;
+        }).branch, latest);
         liveDragBranchRef.current = {
           ...rebuilt,
           contactCone: rebuilt.contactCone

--- a/src/supports/SupportTypes/Branch/branchBuilder.ts
+++ b/src/supports/SupportTypes/Branch/branchBuilder.ts
@@ -7,6 +7,7 @@ import { calculateDiskThickness } from '../../SupportPrimitives/ContactDisk/cont
 import { recomputeContactConeForMovedDisk } from '../../SupportPrimitives/ContactDisk';
 import type { SupportData } from '../../rendering/SupportBuilder';
 import { getSettings } from '../../Settings';
+import type { SupportSettings } from '../../Settings/types';
 import { applySizingOverridesToSettings } from '../../autoSupport/parameterSizing';
 import { getJointDiameter } from '../../constants';
 import { resolveConeAxisPolicy, normalizeVectorOrFallback } from '../../PlacementLogic/ConeAxisPolicy';
@@ -257,6 +258,15 @@ export interface BranchBuildInput {
     shaftDiameterMm?: number;
     tipContactDiameterMm?: number;
     rootsDiameterMm?: number;
+    /** Settings band to size from. Defaults to the live global settings, which is
+     *  what a fresh placement wants. Rebuilding an existing branch passes that
+     *  branch's own band instead, so editing it does not resize it to whatever
+     *  the active preset happens to be. */
+    settings?: SupportSettings;
+    /** Contact tip profile to reuse verbatim instead of deriving one from
+     *  `settings`. Its `lengthMm` is the nominal the socket search starts from;
+     *  the solved length replaces it in the returned cone. */
+    tipProfile?: SupportTipProfile;
 }
 
 export interface BranchBuildResult {
@@ -274,7 +284,7 @@ export interface BranchBuildResult {
 export function buildBranchData(input: BranchBuildInput): BranchBuildResult {
     const { tipPos, tipNormal, modelId, parentKnot, mesh } = input;
 
-    const settings = getSettings();
+    const settings = input.settings ?? getSettings();
     const settingsCodeHex = encodeSupportSettingsHex(applySizingOverridesToSettings(settings, {
         shaftDiameterMm: input.shaftDiameterMm,
         tipContactDiameterMm: input.tipContactDiameterMm,
@@ -290,7 +300,7 @@ export function buildBranchData(input: BranchBuildInput): BranchBuildResult {
     });
 
     const effectiveConeAxis = coneAxis ?? tipNormal;
-    const tipProfile: SupportTipProfile = {
+    const tipProfile: SupportTipProfile = input.tipProfile ?? {
         type: 'disk',
         contactDiameterMm: input.tipContactDiameterMm ?? settings.tip.contactDiameterMm,
         bodyDiameterMm: settings.tip.bodyDiameterMm,

--- a/src/supports/SupportTypes/Branch/branchBuilder.ts
+++ b/src/supports/SupportTypes/Branch/branchBuilder.ts
@@ -423,3 +423,48 @@ export function buildBranchData(input: BranchBuildInput): BranchBuildResult {
 
     return { branch, supportData };
 }
+
+/**
+ * Re-stamps rebuilt branch geometry with the ids the branch already carried.
+ *
+ * A tip drag rebuilds the whole branch on every pointer move. Fresh ids there
+ * change the contact cone's id, which drops its selection and unmounts the
+ * drag HUD mid-drag, and would detach any knot hosted on the branch's own
+ * shafts once the drag commits. Segments and joints are matched by position:
+ * geometry the rebuild adds keeps its new ids.
+ */
+export function remapBranchGeometryIds(rebuilt: Branch, previous: Branch): Branch {
+    const jointIdMap = new Map<string, string>();
+
+    rebuilt.segments.forEach((segment, index) => {
+        const previousTopJoint = previous.segments[index]?.topJoint;
+        if (segment.topJoint && previousTopJoint) {
+            jointIdMap.set(segment.topJoint.id, previousTopJoint.id);
+        }
+    });
+
+    const remapJoint = (joint?: Joint): Joint | undefined => {
+        if (!joint) return joint;
+        const mappedId = jointIdMap.get(joint.id);
+        return mappedId ? { ...joint, id: mappedId } : joint;
+    };
+
+    const segments: Segment[] = rebuilt.segments.map((segment, index) => ({
+        ...segment,
+        id: previous.segments[index]?.id ?? segment.id,
+        topJoint: remapJoint(segment.topJoint),
+        bottomJoint: remapJoint(segment.bottomJoint),
+    }));
+
+    const contactCone: ContactCone | undefined = rebuilt.contactCone
+        ? {
+            ...rebuilt.contactCone,
+            id: previous.contactCone?.id ?? rebuilt.contactCone.id,
+            socketJointId: rebuilt.contactCone.socketJointId
+                ? jointIdMap.get(rebuilt.contactCone.socketJointId) ?? rebuilt.contactCone.socketJointId
+                : rebuilt.contactCone.socketJointId,
+        }
+        : rebuilt.contactCone;
+
+    return { ...rebuilt, segments, contactCone };
+}

--- a/src/supports/SupportTypes/Leaf/LeafRenderer.tsx
+++ b/src/supports/SupportTypes/Leaf/LeafRenderer.tsx
@@ -79,6 +79,15 @@ export const LeafRenderer = React.memo(function LeafRenderer({
     const beforeHistoryRef = React.useRef<ReturnType<typeof captureSupportEditSnapshot> | null>(null);
     const [, setDragTick] = React.useState(0);
 
+    React.useEffect(() => {
+        return () => {
+            dragSessionRef.current?.stop();
+            dragSessionRef.current = null;
+            liveDragConeRef.current = null;
+            beforeHistoryRef.current = null;
+        };
+    }, []);
+
     const { pickRef, visuals } = useHighlight({
         id: leaf.id,
         category: 'support',

--- a/src/supports/SupportTypes/Stick/StickRenderer.tsx
+++ b/src/supports/SupportTypes/Stick/StickRenderer.tsx
@@ -63,6 +63,16 @@ export const StickRenderer = React.memo(function StickRenderer({
   const beforeHistoryRef = React.useRef<ReturnType<typeof captureSupportEditSnapshot> | null>(null);
   const [, setDragTick] = React.useState(0);
 
+  React.useEffect(() => {
+    return () => {
+      dragSessionRef.current?.stop();
+      dragSessionRef.current = null;
+      liveDragConeARef.current = null;
+      liveDragConeBRef.current = null;
+      beforeHistoryRef.current = null;
+    };
+  }, []);
+
   const { pickRef, visuals } = useHighlight({
     id: stick.id,
     category: 'support',

--- a/src/supports/SupportTypes/Trunk/TrunkRenderer.tsx
+++ b/src/supports/SupportTypes/Trunk/TrunkRenderer.tsx
@@ -50,6 +50,15 @@ export const TrunkRenderer = React.memo(function TrunkRenderer({ trunk: baseTrun
     const beforeHistoryRef = React.useRef<ReturnType<typeof captureSupportEditSnapshot> | null>(null);
     const [, setDragTick] = React.useState(0);
 
+    React.useEffect(() => {
+        return () => {
+            dragSessionRef.current?.stop();
+            dragSessionRef.current = null;
+            liveDragConeRef.current = null;
+            beforeHistoryRef.current = null;
+        };
+    }, []);
+
     // Use universal highlight hook
     const { pickRef, visuals, isPickingHovered } = useHighlight({
         id: trunk.id,

--- a/src/supports/__tests__/branchTipDragIdentity.test.ts
+++ b/src/supports/__tests__/branchTipDragIdentity.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildBranchData, remapBranchGeometryIds } from '../SupportTypes/Branch/branchBuilder';
+import type { Knot } from '../types';
+
+const parentKnot: Knot = {
+    id: 'knot-1',
+    parentShaftId: 'trunk-seg-1',
+    pos: { x: 1.6, y: 0, z: 3 },
+};
+
+function buildAt(tipPos: { x: number; y: number; z: number }) {
+    return buildBranchData({
+        tipPos,
+        tipNormal: { x: 1, y: 0, z: 0 },
+        modelId: 'model-1',
+        parentKnot,
+    }).branch;
+}
+
+test('a rebuilt branch keeps the contact cone id the drag started with', () => {
+    const original = buildAt({ x: 0, y: 0, z: 0 });
+    const rebuilt = buildAt({ x: 0, y: 0.8, z: 0.4 });
+
+    const remapped = remapBranchGeometryIds(rebuilt, original);
+
+    assert.equal(remapped.contactCone!.id, original.contactCone!.id);
+    assert.notEqual(rebuilt.contactCone!.id, original.contactCone!.id);
+    assert.deepEqual(remapped.contactCone!.pos, rebuilt.contactCone!.pos);
+});
+
+test('a rebuilt branch keeps its segment and joint ids so hosted knots stay attached', () => {
+    const original = buildAt({ x: 0, y: 0, z: 0 });
+    const rebuilt = buildAt({ x: 0, y: 0.8, z: 0.4 });
+
+    const remapped = remapBranchGeometryIds(rebuilt, original);
+
+    const sharedSegmentCount = Math.min(original.segments.length, remapped.segments.length);
+    for (let i = 0; i < sharedSegmentCount; i++) {
+        assert.equal(remapped.segments[i].id, original.segments[i].id);
+        assert.equal(remapped.segments[i].topJoint?.id, original.segments[i].topJoint?.id);
+    }
+
+    const lastSegment = remapped.segments[remapped.segments.length - 1];
+    assert.equal(remapped.contactCone!.socketJointId, lastSegment.topJoint!.id);
+    for (let i = 1; i < remapped.segments.length; i++) {
+        assert.equal(remapped.segments[i].bottomJoint?.id, remapped.segments[i - 1].topJoint?.id);
+    }
+});
+
+test('geometry the rebuild adds keeps its own ids', () => {
+    const original = buildAt({ x: 0, y: 0, z: 0 });
+    const rebuilt = buildAt({ x: 0, y: 0.8, z: 0.4 });
+    const truncated = { ...original, segments: original.segments.slice(0, 1) };
+
+    const remapped = remapBranchGeometryIds(rebuilt, truncated);
+
+    assert.equal(remapped.segments[0].id, truncated.segments[0].id);
+    assert.equal(remapped.segments[1].id, rebuilt.segments[1].id);
+    assert.equal(remapped.contactCone!.socketJointId, rebuilt.contactCone!.socketJointId);
+});
+

--- a/src/supports/__tests__/branchTipDragIdentity.test.ts
+++ b/src/supports/__tests__/branchTipDragIdentity.test.ts
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { buildBranchData, remapBranchGeometryIds } from '../SupportTypes/Branch/branchBuilder';
-import type { Knot } from '../types';
+import { getSettings } from '../Settings';
+import { decodeSupportSettingsHex } from '../Settings/supportSettingsCodec';
+import type { Branch, Knot } from '../types';
 
 const parentKnot: Knot = {
     id: 'knot-1',
@@ -61,3 +63,70 @@ test('geometry the rebuild adds keeps its own ids', () => {
     assert.equal(remapped.contactCone!.socketJointId, rebuilt.contactCone!.socketJointId);
 });
 
+/** What BranchRenderer does on every pointer move of a tip drag. */
+function rebuildForTipDrag(previous: Branch, tipPos: { x: number; y: number; z: number }) {
+    const ownSettings = (previous.settingsCodeHex
+        ? decodeSupportSettingsHex(previous.settingsCodeHex, getSettings())
+        : null) ?? getSettings();
+
+    return remapBranchGeometryIds(buildBranchData({
+        tipPos,
+        tipNormal: { x: 1, y: 0, z: 0 },
+        modelId: previous.modelId,
+        parentKnot,
+        settings: ownSettings,
+        shaftDiameterMm: previous.segments[0]?.diameter,
+        tipProfile: { ...previous.contactCone!.profile, lengthMm: ownSettings.tip.lengthMm },
+    }).branch, previous);
+}
+
+test('a tip drag keeps the sizing the branch was authored with', () => {
+    const globals = getSettings();
+    const ownBand = {
+        ...globals,
+        shaft: { ...globals.shaft, diameterMm: globals.shaft.diameterMm + 0.4 },
+        tip: {
+            ...globals.tip,
+            contactDiameterMm: globals.tip.contactDiameterMm - 0.02,
+            bodyDiameterMm: globals.tip.bodyDiameterMm + 0.3,
+        },
+    };
+
+    const original = buildBranchData({
+        tipPos: { x: 0, y: 0, z: 0 },
+        tipNormal: { x: 1, y: 0, z: 0 },
+        modelId: 'model-1',
+        parentKnot,
+        settings: ownBand,
+    }).branch;
+
+    const dragged = rebuildForTipDrag(original, { x: 0, y: 0.8, z: 0.4 });
+
+    assert.equal(dragged.segments[0].diameter, original.segments[0].diameter);
+    assert.equal(dragged.segments[0].topJoint!.diameter, original.segments[0].topJoint!.diameter);
+    assert.equal(dragged.contactCone!.profile.contactDiameterMm, original.contactCone!.profile.contactDiameterMm);
+    assert.equal(dragged.contactCone!.profile.bodyDiameterMm, original.contactCone!.profile.bodyDiameterMm);
+    assert.equal(dragged.settingsCodeHex, original.settingsCodeHex);
+    assert.notDeepEqual(dragged.contactCone!.pos, original.contactCone!.pos);
+});
+
+test('without its own band the rebuild drifts to the global preset', () => {
+    const globals = getSettings();
+    const original = buildBranchData({
+        tipPos: { x: 0, y: 0, z: 0 },
+        tipNormal: { x: 1, y: 0, z: 0 },
+        modelId: 'model-1',
+        parentKnot,
+        settings: {
+            ...globals,
+            tip: { ...globals.tip, contactDiameterMm: globals.tip.contactDiameterMm - 0.02 },
+        },
+    }).branch;
+
+    const drifted = buildAt({ x: 0, y: 0.8, z: 0.4 });
+
+    assert.notEqual(
+        drifted.contactCone!.profile.contactDiameterMm,
+        original.contactCone!.profile.contactDiameterMm,
+    );
+});

--- a/src/supports/__tests__/knotPrewarmInvalidation.test.ts
+++ b/src/supports/__tests__/knotPrewarmInvalidation.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { captureSupportGeometryToken, isSameSupportGeometry } from '../SupportPrimitives/Knot/useKnotInteraction';
+import { addBranch, addKnot, setHoveredState, updateBranch } from '../state';
+import type { Branch, Knot } from '../types';
+
+const knot: Knot = {
+    id: 'knot-prewarm',
+    parentShaftId: 'trunk-seg-1',
+    pos: { x: 0, y: 0, z: 3 },
+};
+
+const branch: Branch = {
+    id: 'branch-prewarm',
+    modelId: 'model-1',
+    parentKnotId: knot.id,
+    segments: [
+        { id: 'seg-1', diameter: 1, topJoint: { id: 'joint-1', pos: { x: 0, y: 0, z: 5 }, diameter: 1.1 } },
+    ],
+};
+
+test('hovering does not invalidate the prewarmed knot-drag capture', () => {
+    addKnot(knot);
+    addBranch(branch);
+
+    const prewarmed = captureSupportGeometryToken();
+    setHoveredState('knot', knot.id);
+
+    assert.equal(isSameSupportGeometry(prewarmed, captureSupportGeometryToken()), true);
+});
+
+test('editing branch geometry invalidates the prewarmed knot-drag capture', () => {
+    addKnot(knot);
+    addBranch(branch);
+
+    const prewarmed = captureSupportGeometryToken();
+    updateBranch({
+        ...branch,
+        segments: [{ ...branch.segments[0], topJoint: { id: 'joint-1', pos: { x: 0, y: 0, z: 8 }, diameter: 1.1 } }],
+    });
+
+    assert.equal(isSameSupportGeometry(prewarmed, captureSupportGeometryToken()), false);
+});


### PR DESCRIPTION
Dragging the tip of a branch support snapped it back on release, because the movement rebuilds the branch on every pointer move, minting fresh UUIDs on each pixel. That drops the contact cone's selection, so the drag HUD unmounts
mid-drag and takes with it the `pointerup` that commits the drag. The rebuild now reuses ids, which also keeps knots hosted on its shafts attached instead of orphaning them on commit.

Making the drag commit exposed two latent bugs:

- The elastic capture that the knot drag prewarms on hover was never invalidated. It used to be harmless because stale joint ids matched nothing; with stable ids it matched, and dragging a knot yanked the branch back to the geometry the snapshot was taken from. It is now stamped with the identity of the geometry collections, which hover and selection leave untouched, so the prewarm still pays off.
- The rebuild sized itself from the live global preset, so moving a tip resized the support to whatever band was active. It now sizes from the branch's own `settingsCodeHex`, taking static dimensions from the branch's geometry, which does not always agree with that band.

Verified against a minimal scene reproducing the report, 290 tests in `src/supports` pass.

Closes #612.