### PR TITLE
Harden the preview pipeline against a compromised build job

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -468,7 +468,11 @@ jobs:
       - fetch-macos-artifacts
     runs-on: macos-latest
     permissions:
-      actions: write
+      # Deliberately no actions: write. This job compiles whatever ref it is
+      # handed (npm ci, build.rs) with the Apple certificate and the updater
+      # signing key in scope. With actions: write it could dispatch docs-pages
+      # and have a poisoned latest.json published to Pages. It makes no calls
+      # to the Actions API.
       contents: write
     steps:
       - name: Checkout

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -28,7 +28,13 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Release chains into this workflow through workflow_run; workflow_dispatch
+    # is only the manual button. A GITHUB_TOKEN with actions: write can fire a
+    # workflow_dispatch — it is exempt from the rule that token-driven events do
+    # not chain — so that path requires a human actor.
+    if: >-
+      (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') &&
+      (github.event_name != 'workflow_dispatch' || github.triggering_actor != 'github-actions[bot]')
     permissions:
       actions: write
       contents: read
@@ -109,12 +115,70 @@ jobs:
                 `refusing to deploy a site without it.`);
             }
 
+            // What ends up on Pages is the feed every installation's updater
+            // reads. It comes from a release asset, and contents: write allows
+            // replacing assets on *any* release in the repo — so a compromised
+            // token can plant a latest.json and wait for this workflow to
+            // publish it. Validate before writing: if anything is off, fail the
+            // deploy instead of serving it.
+            function assertReleaseUrl(name, platform, raw) {
+              let url;
+              try {
+                url = new URL(raw);
+              } catch (e) {
+                throw new Error(`${name}: platform ${platform} has an unparseable url: ${raw}`);
+              }
+              // new URL normalises ".." segments, so the prefix check cannot be
+              // sidestepped with relative path segments.
+              const prefix = `/${context.repo.owner}/${context.repo.repo}/releases/`;
+              if (url.protocol !== 'https:' ||
+                  url.host !== 'github.com' ||
+                  !url.pathname.startsWith(prefix)) {
+                throw new Error(
+                  `${name}: platform ${platform} points outside this repo's releases: ${raw}`);
+              }
+            }
+
+            function validateUpdaterFeed(name, text) {
+              let feed;
+              try {
+                feed = JSON.parse(text);
+              } catch (e) {
+                throw new Error(`${name} is not valid JSON: ${e.message}`);
+              }
+
+              if (typeof feed.version !== 'string' || !feed.version) {
+                throw new Error(`${name} has no version string`);
+              }
+              if (!feed.platforms || typeof feed.platforms !== 'object') {
+                throw new Error(`${name} has no platforms object`);
+              }
+
+              const entries = Object.entries(feed.platforms);
+              if (entries.length === 0) {
+                throw new Error(`${name} lists no platforms`);
+              }
+
+              for (const [platform, entry] of entries) {
+                if (!entry || typeof entry.url !== 'string') {
+                  throw new Error(`${name}: platform ${platform} has no url`);
+                }
+                assertReleaseUrl(name, platform, entry.url);
+                if (typeof entry.signature !== 'string' || !entry.signature) {
+                  throw new Error(`${name}: platform ${platform} has no signature`);
+                }
+              }
+
+              core.info(`${name} validated — v${feed.version}, ${entries.length} platform(s)`);
+            }
+
             const results = await Promise.all([
               fetchUpdaterJson(false),
               fetchUpdaterJson(true),
             ]);
 
             for (const result of results) {
+              validateUpdaterFeed(result.name, result.content);
               fs.writeFileSync(`site/${result.name}`, result.content);
               core.info(`Wrote site/${result.name}`);
             }

--- a/.github/workflows/pr-build-followup.yml
+++ b/.github/workflows/pr-build-followup.yml
@@ -164,8 +164,26 @@ jobs:
               return;
             }
 
+            // The label persists across pushes and build-nightly checks out
+            // refs/pull/N/head, which always points at the fork's current tip.
+            // Labelling an external PR once would hand its author code execution
+            // with every secret in scope (Apple certificate, updater signing
+            // key) on every later push. Fork previews are authorised by a
+            // maintainer one command at a time instead.
+            //
+            // head.repo is null once a fork has been deleted, so an unknown head
+            // repo counts as a fork and the check fails closed.
+            const isFork =
+              pr.head.repo?.full_name !== `${context.repo.owner}/${context.repo.repo}`;
             const hasNightlyLabel = pr.labels.some((label) => label.name === 'nightly-build');
-            core.setOutput('should_dispatch', hasNightlyLabel ? 'true' : 'false');
+
+            if (isFork && hasNightlyLabel) {
+              core.warning(
+                `PR #${pr.number} is from ${pr.head.repo?.full_name ?? 'a deleted fork'}: ` +
+                `the nightly-build label does not auto-dispatch for forks.`);
+            }
+
+            core.setOutput('should_dispatch', (hasNightlyLabel && !isFork) ? 'true' : 'false');
             core.setOutput('number', String(pr.number));
             core.setOutput('head_ref', pr.head.ref);
             core.setOutput('base_ref', pr.base.ref);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,9 +34,6 @@
   "plugins": {
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEU0NjE2N0VERDQ3RjYwMDcKUldRSFlIL1U3V2RoNVBnc0hoWnU5NnZSdkhSRys5OFFRVXpHNWhsd3ZwRGYwc1N1UkpLR3htWmkK",
-      "endpoints": [
-        "https://github.com/Open-Resin-Alliance/DragonFruit/releases/latest/download/latest.json"
-      ],
       "windows": {
         "installMode": "passive"
       }


### PR DESCRIPTION
A `nightly-build` label on a pull request from a fork means "build whatever the
author pushes next". The build checks out `refs/pull/N/head`, which follows the
fork's tip, and runs `npm ci` and `cargo build` in a job that holds the Apple
Developer ID certificate and the updater signing key. One label, applied once,
hands its author code execution with those secrets on every later push.

Four changes, in order of what they close:

- **`dispatch-nightly` no longer auto-dispatches fork PRs.** The label keeps
  working for branches that live in this repository.
- **`docs-pages` validates the updater feed before publishing it.** The feed is
  copied verbatim out of a release asset, and `contents: write` allows replacing
  assets on *any* release: this means that a compromised token can plant a
  `latest.json` and wait for this workflow to publish it to Pages. It is now parsed,
  required to carry a signature per platform, and rejected unless every URL is
  an `https://github.com/<this repo>/releases/` one.
- **`build-macos-fallback` loses `actions: write`.** It never called the Actions
  API; with the permission it could dispatch `docs-pages` directly instead of
  waiting for a release.
- **The dead `endpoints` entry leaves `tauri.conf.json`.** `updater_channel.rs`
  picks the endpoint per channel at runtime, so this one was never read — and it
  pointed at a release asset rather than the Pages feed the app actually uses,
  which made the config actively misleading to anyone auditing this.

### Verification

The validator was extracted from the YAML and run against the two feeds Pages
serves today (`latest.json` v0.1.9, `latest-dev.json` v0.1.15): both pass, so
the next deploy is unaffected. It rejects a foreign host, another github.com
repository, a `..` path escape, plain `http://`, an empty signature, an empty
platform map, and non-JSON.

Removing `endpoints` is safe because the field is `#[serde(default)]` in
`tauri-plugin-updater` 2.10.1, and `EmptyEndpoints` is only raised when neither
the builder nor the config supplies one — both call sites in
`updater_channel.rs` always call `.endpoints(...)`.