### PR TITLE
Accept /preview and preview-build alongside the nightly names

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -33,15 +33,21 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # "nightly" is being retired in favour of "preview" (see docs/dev/releases.md).
+  # Both spellings are accepted while the old one is phased out; the new label is
+  # the one this workflow applies.
+  PREVIEW_LABEL: preview-build
   NIGHTLY_LABEL: nightly-build
 
 jobs:
-  # ── Comment handler: /nightly or @github-actions build nightly ──────────
+  # ── Comment handler: /preview (or the deprecated /nightly) ──────────────
   activate-nightly:
     if: >
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      (startsWith(github.event.comment.body, '/nightly') ||
+      (startsWith(github.event.comment.body, '/preview') ||
+       startsWith(github.event.comment.body, '/nightly') ||
+       startsWith(github.event.comment.body, '@github-actions build preview') ||
        startsWith(github.event.comment.body, '@github-actions build nightly'))
     runs-on: ubuntu-latest
     permissions:
@@ -132,25 +138,35 @@ jobs:
           result-encoding: string
           script: |
             const body = context.payload.comment.body;
-            // Everything after "/nightly " (with trailing space) is the custom name
-            const prefix = '/nightly';
-            if (body.startsWith(prefix)) {
+            // Everything after the command (with trailing space) is the custom
+            // name. Both spellings are accepted, and the prefix that actually
+            // matched is the one stripped — slicing a hard-coded '/nightly' off
+            // a '/preview' comment silently drops the name.
+            for (const prefix of ['/preview', '/nightly']) {
+              if (!body.startsWith(prefix)) continue;
               const rest = body.slice(prefix.length).trim();
               if (rest) {
                 core.info(`Custom release name detected: "${rest}"`);
                 return rest;
               }
+              break;
             }
             core.info('No custom release name in comment.');
             return '';
 
-      - name: Add nightly-build label
+      - name: Add preview-build label
         if: steps.check_access.outputs.result == 'granted'
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.issue.number }}
         run: |
-          gh issue edit "$PR" --add-label "${{ env.NIGHTLY_LABEL }}" --repo "${{ github.repository }}"
+          gh issue edit "$PR" --add-label "${{ env.PREVIEW_LABEL }}" --repo "${{ github.repository }}"
+
+          # Drop the old label as the new one goes on, so a PR never carries
+          # both and "remove the label to stop rebuilding" stays unambiguous.
+          # Removing a label the PR does not have is a no-op; do not let it fail
+          # the run either way.
+          gh issue edit "$PR" --remove-label "${{ env.NIGHTLY_LABEL }}" --repo "${{ github.repository }}" || true
 
       - name: Trigger immediate nightly build
         if: steps.check_access.outputs.result == 'granted'
@@ -181,7 +197,7 @@ jobs:
         run: |
           gh issue comment "$PR" \
             --repo "${{ github.repository }}" \
-            --body $'### 🚀 Nightly Build Triggered\n\nA nightly build has been dispatched for branch **`'"${BRANCH}"$'**\n\n| What | How |\n|------|-----|\n| **This build** | Check the [Actions tab]('"${{ github.server_url }}/${{ github.repository }}/actions/workflows/build-nightly.yml"$') for progress |\n| **Future commits** | Each new push will rebuild after macOS check passes |\n| **Deactivate** | Remove the `nightly-build` label to stop auto-builds |\n\n> The pre-release tag will be updated in-place so the download link stays the same.'
+            --body $'### 🚀 Preview build triggered\n\nA branch-preview build has been dispatched for branch **`'"${BRANCH}"$'**\n\n| What | How |\n|------|-----|\n| **This build** | Check the [Actions tab]('"${{ github.server_url }}/${{ github.repository }}/actions/workflows/build-nightly.yml"$') for progress |\n| **Future commits** | Each new push will rebuild after macOS check passes |\n| **Deactivate** | Remove the `preview-build` label to stop auto-builds |\n\n> The pre-release tag will be updated in-place so the download link stays the same.'
 
   # ── Derive metadata (branch, tag, names) ────────────────────────────────
   derive:

--- a/.github/workflows/pr-build-followup.yml
+++ b/.github/workflows/pr-build-followup.yml
@@ -102,7 +102,7 @@ jobs:
               "",
               "---",
               "",
-              "> 💡 This check runs automatically on every push to the PR. The macOS DMG is handed off to the nightly workflow when the `nightly-build` label is set."
+              "> 💡 This check runs automatically on every push to the PR. The macOS DMG is handed off to the preview workflow when the `preview-build` label is set."
             ].join("\n");
 
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -175,15 +175,18 @@ jobs:
             // repo counts as a fork and the check fails closed.
             const isFork =
               pr.head.repo?.full_name !== `${context.repo.owner}/${context.repo.repo}`;
-            const hasNightlyLabel = pr.labels.some((label) => label.name === 'nightly-build');
+            // preview-build is the current name; nightly-build is still
+            // honoured until the old spelling is retired.
+            const PREVIEW_LABELS = ['preview-build', 'nightly-build'];
+            const hasPreviewLabel = pr.labels.some((label) => PREVIEW_LABELS.includes(label.name));
 
-            if (isFork && hasNightlyLabel) {
+            if (isFork && hasPreviewLabel) {
               core.warning(
                 `PR #${pr.number} is from ${pr.head.repo?.full_name ?? 'a deleted fork'}: ` +
-                `the nightly-build label does not auto-dispatch for forks.`);
+                `the preview label does not auto-dispatch for forks.`);
             }
 
-            core.setOutput('should_dispatch', (hasNightlyLabel && !isFork) ? 'true' : 'false');
+            core.setOutput('should_dispatch', (hasPreviewLabel && !isFork) ? 'true' : 'false');
             core.setOutput('number', String(pr.number));
             core.setOutput('head_ref', pr.head.ref);
             core.setOutput('base_ref', pr.base.ref);

--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -89,7 +89,9 @@ jobs:
           echo "commit_hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Export Apple notarization credentials for nightly builds
-        if: contains(github.event.pull_request.labels.*.name, 'nightly-build')
+        if: >-
+          contains(github.event.pull_request.labels.*.name, 'preview-build') ||
+          contains(github.event.pull_request.labels.*.name, 'nightly-build')
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}

--- a/docs/dev/releases.md
+++ b/docs/dev/releases.md
@@ -224,7 +224,8 @@ We are dropping the `nightly` codeword in favor of `preview` or
 
 Until we drop the term, the reality is this: Separate from all of the above:
 `build-nightly.yml` builds an arbitrary branch on demand (`workflow_dispatch`
-or a `/nightly` PR comment) and publishes a rolling `nightly_{branch}`
+or a `/preview` PR comment — `/nightly` still works but is deprecated) and
+publishes a rolling `nightly_{branch}`
 prerelease so a reviewer can download and try an exact commit. It is **not**
 a scheduled build of `dev`, doesn't participate in the versioning/channel
 model above, and isn't wired to the auto-updater at all. The name is


### PR DESCRIPTION
*Depends on #634.*

`nightly` has a specific meaning in software and these builds are not on a
schedule, so the codeword is becoming `preview`, but (for now) nothing is
retired here. `/preview` and `/nightly` both work, `@github-actions build preview`
and `... build nightly` both work, and both labels are honoured.
The handler applies `preview-build` and removes `nightly-build`, so a pull
request never carries both and "remove the label to stop rebuilding" stays true.

Fixes a bug that only appears once `/preview` is accepted: the custom release
name was extracted by slicing a hard-coded `'/nightly'` off the comment body, so
`/preview Feature: organic cut` would have dispatched the build and silently
dropped the name. The prefix that actually matched is now the one stripped.

A follow-up PR will retire `/nightly` and `nightly-build`.