### PR TITLE
Skip notarization when there is no Developer ID certificate

### DIFF
--- a/.github/workflows/pr-check-build.yml
+++ b/.github/workflows/pr-check-build.yml
@@ -88,10 +88,17 @@ jobs:
           echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
           echo "commit_hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Export Apple notarization credentials for nightly builds
+      - name: Export Apple notarization credentials for preview builds
+        # Also gated on the certificate, not just the label. Without a Developer
+        # ID the build falls back to ad-hoc signing, which Apple will not
+        # notarize at all — and exporting an empty APPLE_ID is worse than
+        # exporting none: tauri-action reads the variable being set as "notarize
+        # this", tries to authenticate with nothing, and fails the build with an
+        # HTTP 401. Same reason as the TAURI_SIGNING_PRIVATE_KEY guard below.
         if: >-
-          contains(github.event.pull_request.labels.*.name, 'preview-build') ||
-          contains(github.event.pull_request.labels.*.name, 'nightly-build')
+          steps.apple_cert.outputs.available == 'true' &&
+          (contains(github.event.pull_request.labels.*.name, 'preview-build') ||
+           contains(github.event.pull_request.labels.*.name, 'nightly-build'))
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}


### PR DESCRIPTION
*Depends on #636.*

The macOS PR check fails with `HTTP status code: 401. Invalid credentials` on
pull requests from forks that carry the preview label.

Forks get no secrets, so `secrets.APPLE_ID` resolves to an empty string — and
the export step wrote it into `$GITHUB_ENV` anyway. `tauri-action` reads the
variable merely being *set* as "notarization is enabled", tries to authenticate
with nothing, and fails the build. This is the same trap the
`TAURI_SIGNING_PRIVATE_KEY` guard a few lines below already documents.

The export is now also gated on the Developer ID certificate being available,
which is the honest condition: without it the build falls back to ad-hoc
signing, and Apple will not notarize an ad-hoc signature under any
circumstances. Fork PRs get an ad-hoc bundle and the check does what its name
says: proves the app compiles.

After #636 a fork should not carry the label at all, but nothing stops a
maintainer applying one by hand. This makes the failure impossible rather than
merely unlikely.