### PR TITLE
Slicing benchmark suite, plus an x86-64 codegen sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 /dist/
 /out/
 **/target/
+# per-variant build dirs from scripts/bench/run-slicing-bench.sh --codegen
+**/target-codegen-*/
 src-tauri/frontend-dist/**
 src-tauri/gen/
 

--- a/rust/dragonfruit-cli/Cargo.lock
+++ b/rust/dragonfruit-cli/Cargo.lock
@@ -309,6 +309,7 @@ dependencies = [
  "dragonfruit-islands",
  "dragonfruit-slicing-engine",
  "flate2",
+ "libc",
  "libdeflater",
  "proptest",
  "serde",
@@ -320,7 +321,6 @@ dependencies = [
 name = "dragonfruit-islands"
 version = "0.1.0"
 dependencies = [
- "clap",
  "dragonfruit-slicing-engine",
  "indexmap",
  "log",

--- a/rust/dragonfruit-cli/Cargo.toml
+++ b/rust/dragonfruit-cli/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
+libc = "0.2"
 base64 = "0.22"
 libdeflater = "1"
 flate2 = "1"

--- a/rust/dragonfruit-cli/docs/CLI.md
+++ b/rust/dragonfruit-cli/docs/CLI.md
@@ -40,7 +40,30 @@ Every command produces JSON output (`--json`) and reports timing metrics.
 
 Binary: `rust/dragonfruit-cli/target/release/dragonfruit-cli`
 
-Build: `cargo build --release` (from `rust/dragonfruit-cli/`)
+Build (from `rust/dragonfruit-cli/`):
+
+```bash
+cargo build --release
+```
+
+**On a fresh clone this fails**, because `dragonfruit-slicing-engine` will not compile until the
+plugin encoder registry exists:
+
+```
+error[E0583]: file not found for module `generated_plugin_encoders`
+```
+
+That module is generated and gitignored, and it pulls the encoder sources in via `#[path]` from
+`plugins/`, which are submodules. So from the repo root, first:
+
+```bash
+git submodule update --init
+npm run generate:plugin-registry
+```
+
+`npm run build` and `npm run build:tauri` already do the generating half through their `prebuild`
+hooks, so a checkout you have been building the app from is fine. A bare clone used only for the
+CLI is not — `npm ci` alone does not generate it.
 
 Every command prints `[command] Xms` timing to stderr.
 

--- a/rust/dragonfruit-cli/src/main.rs
+++ b/rust/dragonfruit-cli/src/main.rs
@@ -365,6 +365,18 @@ enum SliceCommands {
         /// Minimum AA alpha threshold (percent, 0-100)
         #[arg(long, default_value = "0.0")]
         min_aa_alpha: f32,
+        /// Enable Floyd-Steinberg dithering (low-bit-depth panels, e.g. 3-bit mono)
+        #[arg(long)]
+        dither: bool,
+        /// Dither target bit depth (2-7); defaults to the panel bit depth when dithering
+        #[arg(long)]
+        dither_bit_depth: Option<u32>,
+        /// Device panel gamma used by the dithering pass
+        #[arg(long, default_value = "3.0")]
+        dither_device_gamma: f64,
+        /// Periodic RSS/CPU sampling interval in ms (0 disables the time series)
+        #[arg(long, default_value = "250")]
+        sample_interval_ms: u64,
         /// Metadata JSON string
         #[arg(long, default_value = "{}")]
         metadata_json: String,
@@ -1048,6 +1060,74 @@ fn cmd_rle_subtract(mask_a: &PathBuf, mask_b: &PathBuf, output: &PathBuf) -> Res
 // Slice command implementations — wraps engine::slice_with_progress_v3_to_path
 // ===========================================================================
 
+/// Whole-process CPU seconds (user+system, aggregated across all threads).
+fn cpu_total_seconds() -> f64 {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    if unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } != 0 {
+        return 0.0;
+    }
+    let u = unsafe { usage.assume_init() };
+    u.ru_utime.tv_sec as f64 + u.ru_utime.tv_usec as f64 / 1e6
+        + u.ru_stime.tv_sec as f64 + u.ru_stime.tv_usec as f64 / 1e6
+}
+
+/// Slicer-process CPU + RSS. Peak RSS is the kernel high-water mark (ru_maxrss),
+/// so it captures transient peaks without a sampler thread. CPU time aggregates
+/// all rayon worker threads, so cpu_percent can exceed 100% under parallelism.
+/// `samples` is the periodic RSS/CPU time series gathered during the run.
+fn capture_resources(
+    wall_s: f64,
+    samples: Vec<serde_json::Value>,
+    sample_interval_ms: u64,
+) -> serde_json::Value {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage>::uninit();
+    let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
+    if rc != 0 {
+        return serde_json::json!({ "error": "getrusage failed" });
+    }
+    let u = unsafe { usage.assume_init() };
+    let cpu_user_s = u.ru_utime.tv_sec as f64 + u.ru_utime.tv_usec as f64 / 1e6;
+    let cpu_sys_s = u.ru_stime.tv_sec as f64 + u.ru_stime.tv_usec as f64 / 1e6;
+    let cpu_total_s = cpu_user_s + cpu_sys_s;
+
+    // ru_maxrss: kilobytes on Linux, bytes on macOS.
+    #[cfg(target_os = "macos")]
+    let peak_rss_bytes = u.ru_maxrss as u64;
+    #[cfg(not(target_os = "macos"))]
+    let peak_rss_bytes = (u.ru_maxrss as u64) * 1024;
+
+    // Peak CPU% across the sampled series (transient spikes the average hides).
+    let peak_sample_cpu = samples
+        .iter()
+        .filter_map(|s| s.get("cpu_percent").and_then(|v| v.as_f64()))
+        .fold(0.0_f64, f64::max);
+
+    serde_json::json!({
+        "cpu_user_s": cpu_user_s,
+        "cpu_system_s": cpu_sys_s,
+        "cpu_total_s": cpu_total_s,
+        "cpu_percent": if wall_s > 0.0 { cpu_total_s / wall_s * 100.0 } else { 0.0 },
+        "peak_sample_cpu_percent": peak_sample_cpu,
+        "peak_rss_bytes": peak_rss_bytes,
+        "end_rss_bytes": read_vmrss_bytes().unwrap_or(0),
+        "sample_interval_ms": sample_interval_ms,
+        "sample_count": samples.len(),
+        "samples": samples,
+    })
+}
+
+/// Current resident set size from /proc/self/status (Linux). Returns None elsewhere.
+fn read_vmrss_bytes() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            let kb: u64 = rest.split_whitespace().next()?.parse().ok()?;
+            return Some(kb * 1024);
+        }
+    }
+    None
+}
+
 fn cmd_slice_run(
     input: &PathBuf,
     output: &PathBuf,
@@ -1073,6 +1153,10 @@ fn cmd_slice_run(
     mirror_y: bool,
     format_version: &Option<String>,
     min_aa_alpha: f32,
+    dither: bool,
+    dither_bit_depth: Option<u32>,
+    dither_device_gamma: f64,
+    sample_interval_ms: u64,
     metadata_json: &str,
     json_output: bool,
 ) -> Result<(), String> {
@@ -1184,9 +1268,9 @@ fn cmd_slice_run(
         zaa_kernel: None,
         zaa_pattern: None,
         zaa_duplicate_z: None,
-        dither_enabled: false,
-        dither_bit_depth: None,
-        dither_device_gamma: 3.0,
+        dither_enabled: dither,
+        dither_bit_depth,
+        dither_device_gamma,
         triangles_xyz: flat,
         metadata_json: metadata_json.to_string(),
         format_version: format_version.clone(),
@@ -1194,10 +1278,69 @@ fn cmd_slice_run(
         ..Default::default()
     };
 
+    // Periodic RSS/CPU sampler: a background thread records the process's
+    // resident memory and CPU% every `sample_interval_ms` for the duration of
+    // the slice, so the run can be diagnosed over time (not just peak/total).
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+    let samples = Arc::new(Mutex::new(Vec::<serde_json::Value>::new()));
+    let stop = Arc::new(AtomicBool::new(false));
+    let sampler = if sample_interval_ms > 0 {
+        let samples = Arc::clone(&samples);
+        let stop = Arc::clone(&stop);
+        let interval = std::time::Duration::from_millis(sample_interval_ms.max(10));
+        let start = Instant::now();
+        // Optional sidecar: stream each sample to disk (flushed per line) so the series
+        // survives a kill that prevents the final --json emit — e.g. a cgroup OOM under a
+        // MemoryMax cap. Enabled by the DF_RESOURCE_LOG env var (set by the bench harness).
+        let log_path = std::env::var_os("DF_RESOURCE_LOG").map(PathBuf::from);
+        Some(std::thread::spawn(move || {
+            use std::io::Write;
+            let mut log = log_path.and_then(|p| match std::fs::File::create(&p) {
+                Ok(f) => Some(f),
+                Err(e) => { eprintln!("resource-log: cannot create {}: {e}", p.display()); None }
+            });
+            let mut last = Instant::now();
+            let mut last_cpu = cpu_total_seconds();
+            while !stop.load(Ordering::Relaxed) {
+                std::thread::sleep(interval);
+                let now = Instant::now();
+                let cpu = cpu_total_seconds();
+                let dt = now.duration_since(last).as_secs_f64();
+                let cpu_pct = if dt > 0.0 { (cpu - last_cpu) / dt * 100.0 } else { 0.0 };
+                let rss = read_vmrss_bytes().unwrap_or(0);
+                let sample = serde_json::json!({
+                    "t_ms": start.elapsed().as_millis() as u64,
+                    "rss_bytes": rss,
+                    "rss_mb": rss as f64 / 1_048_576.0,
+                    "cpu_percent": cpu_pct,
+                });
+                if let Some(f) = log.as_mut() {
+                    let _ = writeln!(f, "{}", serde_json::to_string(&sample).unwrap());
+                    let _ = f.flush(); // per-line flush: a mid-run kill keeps everything so far
+                }
+                samples.lock().unwrap().push(sample);
+                last = now;
+                last_cpu = cpu;
+            }
+        }))
+    } else {
+        None
+    };
+
     let t0 = Instant::now();
-    let perf = slice_with_progress_v3_to_path(&job, output, None, None)
-        .map_err(|e| format!("Slice failed: {e}"))?;
+    let slice_result = slice_with_progress_v3_to_path(&job, output, None, None);
     let wall_s = t0.elapsed().as_secs_f64();
+
+    // Stop the sampler regardless of slice success, then surface any error.
+    stop.store(true, Ordering::Relaxed);
+    if let Some(handle) = sampler {
+        let _ = handle.join();
+    }
+    let samples_vec = Arc::try_unwrap(samples)
+        .map(|m| m.into_inner().unwrap())
+        .unwrap_or_default();
+    let perf = slice_result.map_err(|e| format!("Slice failed: {e}"))?;
 
     let result = serde_json::json!({
         "output": output.display().to_string(),
@@ -1207,8 +1350,14 @@ fn cmd_slice_run(
         "build_width_mm": build_width_mm,
         "build_depth_mm": build_depth_mm,
         "resolution_px": [source_width_px, source_height_px],
+        "x_packing_mode": x_packing_mode,
         "model_triangle_count": job.model_triangle_count,
         "mesh_encoding": mesh_encoding,
+        "anti_aliasing": { "level": anti_aliasing, "mode": anti_aliasing_mode,
+            "blur_brush_radius_px": blur_brush_radius_px,
+            "z_blur_radius_layers": z_blur_radius_layers,
+            "z_blend_look_back": z_blend_look_back },
+        "dither": { "enabled": dither, "bit_depth": dither_bit_depth, "device_gamma": dither_device_gamma },
         "total_s": perf.total_s(),
         "wall_s": wall_s,
         "layers_per_second": perf.layers_per_second(),
@@ -1219,7 +1368,18 @@ fn cmd_slice_run(
             "render_ns": perf.render_ns,
             "png_encode_ns": perf.png_encode_ns,
             "archive_encode_ns": perf.archive_encode_ns,
+            "z_blend_backward_ns": perf.z_blend_backward_ns,
+            "z_blend_forward_ns": perf.z_blend_forward_ns,
+            "cross_blend_ns": perf.cross_blend_ns,
+            "cross_blend_touched_pixels": perf.cross_blend_touched_pixels,
+            "cross_blend_contributing_layers": perf.cross_blend_contributing_layers,
+            "post_blur_ns": perf.post_blur_ns,
+            "support_merge_ns": perf.support_merge_ns,
+            "daa_post_threads": perf.daa_post_threads,
+            "daa_post_buffer_depth": perf.daa_post_buffer_depth,
+            "layers": perf.layers,
         },
+        "resources": capture_resources(wall_s, samples_vec, sample_interval_ms),
     });
 
     if json_output {
@@ -1304,6 +1464,7 @@ fn cmd_print_inspect(input: &PathBuf, json_output: bool) -> Result<(), String> {
 
     let total_entries = archive.len();
     let mut layer_count = 0u32;
+    let mut numeric_layer_count = 0u32;
     let mut total_uncompressed = 0u64;
     let mut entries_info: Vec<serde_json::Value> = Vec::new();
     let mut manifest: Option<serde_json::Value> = None;
@@ -1318,6 +1479,13 @@ fn cmd_print_inspect(input: &PathBuf, json_output: bool) -> Result<(), String> {
 
             if name.ends_with(".png") {
                 layer_count += 1;
+                // Numeric-stemmed PNGs (e.g. "1.png") are true layers; named ones
+                // like "3d.png"/"preview.png" are thumbnails. Used for the bench
+                // correctness gate (numeric count must equal reported layers).
+                let stem = &name[..name.len() - 4];
+                if !stem.is_empty() && stem.bytes().all(|b| b.is_ascii_digit()) {
+                    numeric_layer_count += 1;
+                }
             }
             if name == "manifest.json" || name == "metadata.json" {
                 manifest_index = Some(i);
@@ -1352,6 +1520,7 @@ fn cmd_print_inspect(input: &PathBuf, json_output: bool) -> Result<(), String> {
             "format": "zip",
             "total_entries": total_entries,
             "layer_count": layer_count,
+            "numeric_layer_count": numeric_layer_count,
             "total_uncompressed_bytes": total_uncompressed,
             "compression_ratio": format!("{:.2}", compression_ratio),
         });
@@ -1761,14 +1930,16 @@ fn main() {
                 anti_aliasing_mode, blur_brush_radius_px, blur_brush_kernel, blur_brush_sigma_x,
                 blur_brush_sigma_y, z_blur_radius_layers, z_blur_kernel, z_blur_sigma,
                 z_blend_look_back, aa_on_supports, x_packing_mode, mirror_x, mirror_y,
-                format_version, min_aa_alpha, metadata_json, json } =>
+                format_version, min_aa_alpha, dither, dither_bit_depth, dither_device_gamma,
+                sample_interval_ms, metadata_json, json } =>
                 cmd_slice_run(&input, &output, layer_height, build_width_mm, build_depth_mm,
                     source_width_px, source_height_px, &png_compression, &anti_aliasing,
                     &anti_aliasing_mode, blur_brush_radius_px, &blur_brush_kernel,
                     blur_brush_sigma_x, blur_brush_sigma_y, z_blur_radius_layers,
                     &z_blur_kernel, z_blur_sigma, z_blend_look_back, aa_on_supports,
                     &x_packing_mode, mirror_x, mirror_y, &format_version,
-                    min_aa_alpha, &metadata_json, json),
+                    min_aa_alpha, dither, dither_bit_depth, dither_device_gamma,
+                    sample_interval_ms, &metadata_json, json),
             SliceCommands::Formats => { cmd_slice_formats(); Ok(()) },
             SliceCommands::PreviewLayer { input, layer, output } =>
                 extract_layer_png(&input, layer, &output),

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -1,0 +1,249 @@
+# Slicing benchmark suite
+
+Drives the DragonFruit CLI to slice `.voxl` scenes across a matrix of
+**printer × layer-height × AA preset**, exactly the way the desktop app would
+for each printer, and records timing + resource stats to a JSONL file — one row
+per case. It can optionally run that whole matrix across **several git
+versions/branches/PRs** of the software, and **validate** each produced slice
+against a known-good reference.
+
+## What it measures per run
+
+- **Full `SliceStatsV3`** — all 16 engine perf fields (render wall/CPU, PNG
+  encode, archive encode, z-blend, cross-blend, post-blur, support-merge, …).
+- **CPU + RAM** — total CPU seconds, CPU%, peak RSS (kernel high-water mark),
+  end RSS, and a **periodic RSS/CPU time series** (`resources.samples`, default
+  every 250 ms) so a run can be diagnosed over its lifetime, not just at peak.
+  Each repeat's full resource record is kept separately under `runs[]` (see below).
+- **Hardware config** — when `--hw-configs` is used, every row carries `hw`,
+  `hw_cpus`, `hw_mem` naming the simulated machine (core count + RAM ceiling) the
+  case ran under, so results are directly comparable across hardware.
+- **Correctness gate** — `ok: true/false`. For zip formats (`.nanodlp`) the
+  `numeric_layer_count` read back from the archive must equal the reported layer
+  count (`gate: "numeric-layer-count"`). Binary formats (`.ctb`/`.goo`/`.aff`/
+  `.azf`) can't be decoded back to rasters, so the gate degrades to a
+  non-empty-file check (`gate: "file-nonempty"`) — use `--validate` for real
+  content verification of those.
+- **git ref** — every row carries `ref` and `git_sha` so results stay comparable
+  across versions.
+
+## Output format per printer
+
+Each case is written in the format the printer profile asks for
+(`display.outputFormat`): `nanodlp`, `ctb`, `goo`, `aff`, `azf`, …. `nanodlp` is
+a zip of layer PNGs and is fully introspectable; the others are proprietary
+binary containers. The output extension is derived exactly like the app/TS CLI
+(`outputFormatToExt`), and each row records the resolved `format`.
+
+## Fidelity to the UI
+
+`scene slice --printer <profile>` derives slice parameters the same way the app
+does when you pick that printer:
+
+| From the printer profile | Drives |
+|---|---|
+| `display.resolutionX/Y` | source raster resolution |
+| `bitDepth.bits` | X packing (`gray3_div2` for 3-bit, `rgb8_div3` for 8-bit) **and** dithering (a low-bit-depth panel forces dither on with the panel bit depth) |
+| `pixelSize.{x,y}` (µm) | physical XY pixel pitch — honors **non-square pixels** |
+| `buildVolumeMm.{width,depth}` | build plate dims |
+| `display.mirrorX/Y`, `display.outputFormat`/`formatVersion` | mirroring, archive format |
+
+The named AA presets (`sharp`/`balanced`/`smooth`) are resolved through the
+app's own `computePhysicalAaConfig` (imported directly from
+`src/features/slicing/autoAaPhysics.ts`), producing byte-identical AA steps,
+backend mode, blur radius, z-blur, and 3DAA look-back. `raw` disables AA. Each
+result row records the **preset name** (`aa_preset`, and `anti_aliasing.preset`)
+so cases are identified by the preset a user would pick, not the resolved
+engine mode.
+
+> Note: the printer-packing and dither-policy mappings are currently **ported**
+> into `scripts/dragonfruit-ts-cli.ts` rather than imported, because the app
+> originals aren't exported and their modules pull in the Tauri/THREE dependency
+> chain. Consolidating into a shared pure module is a deferred design decision.
+
+## Layout
+
+```
+scripts/bench/
+  run-slicing-bench.sh      the driver
+  printers/*.json           printer profiles (example provided)
+  fixtures/*.voxl           your scenes (+ referenced STLs, via --mesh-dir)
+```
+
+Fixtures are yours to provide: each `.voxl` references its meshes by filename,
+which must be resolvable under `--mesh-dir` (defaults to the fixtures dir).
+
+## Usage
+
+```bash
+scripts/bench/run-slicing-bench.sh \
+  --fixtures scripts/bench/fixtures \
+  --printers scripts/bench/printers \
+  --layer-heights 0.05,0.03 \
+  --aa-presets sharp,balanced,smooth \
+  --repeats 3 \
+  --out bench-results.jsonl
+```
+
+Core options: `--fixtures`, `--printers`, `--mesh-dir`, `--layer-heights` (CSV),
+`--aa-presets` (CSV, default `sharp,balanced,smooth,raw`), `--repeats`
+(averaged, with min/max spread kept), `--out`, `--no-build`. Requires `jq`
+(and `sha256sum` + `unzip` when validating).
+
+Repeats are **averaged** (every scalar + every perf field) into the row's
+top-level summary, with `total_s_min`/`total_s_max` for the spread — but every
+repeat is **also kept un-averaged** under `runs[]` (its own timing, CPU, peak
+RSS, full perf block, and RSS/CPU sample series), so nothing is lost to the
+average. Failed repeats are logged with their error and, if all repeats of a
+case fail, an `{"error": ...}` row is written.
+
+### Sweeping hardware configurations
+
+The driver re-runs the **whole matrix** under several simulated machines, so you
+can compare "how does this slice run on a Pi vs a workstation" in one pass. **By
+default it sweeps `@common`** — a spread of common PC and Raspberry Pi machines —
+so you get the cross-hardware picture without passing any flag:
+
+```bash
+scripts/bench/run-slicing-bench.sh --layer-heights 0.05 --out hw-sweep.jsonl
+```
+
+Built-in preset groups (reference with `@name`; approximate real machines):
+
+| Preset | Machines (`name` cpus×mem) |
+|---|---|
+| `@pis` | `rpi-zero2` 4×512M · `rpi3b` 4×1G · `rpi4` 4×4G · `rpi5` 4×8G |
+| `@pcs` | `pc-lowend` 2×4G · `pc-budget` 4×8G · `pc-mainstream` 8×16G · `pc-workstation` 16×32G |
+| `@common` | `@pis` + `@pcs` (the default) |
+
+Override with your own list, mix presets and explicit configs, or opt out of the
+sweep entirely:
+
+```bash
+# just a couple of machines
+--hw-configs "rpi4:cpus=4,mem=4G; nuc:cpus=8,mem=8G"
+# a preset plus a custom monster box
+--hw-configs "@pis; threadripper:cpus=16,mem=64G"
+# a single unconstrained run on the real host (no taskset/systemd needed)
+--hw-configs host
+```
+
+Each config is `name:cpus=N,mem=SIZE` (both keys optional), separated by `;`:
+
+| Key | Effect |
+|---|---|
+| `cpus=N` | **True core emulation** — the slice (and its Rust child) get an N-core CPU affinity mask via `taskset`. The engine sizes its rayon pools from `available_parallelism()` (= the affinity mask), so it genuinely runs as if on an N-core box, not via an env-var hint. |
+| `mem=SIZE` | A hard RAM ceiling (`512M`, `2G`, …) imposed by a transient `systemd-run --user --scope` (`MemoryMax` + no swap). Exceeding it **OOM-kills the slice**, recorded as a failure for that machine (logged with `exit 137` / "likely OOM"). |
+
+A config with neither key (e.g. `host`) is the unconstrained host. Every row is
+tagged `hw`, `hw_cpus`, `hw_mem`. `cpus=N` needs `taskset` (util-linux); `mem=SIZE`
+needs a systemd user manager with the memory cgroup controller delegated. For an
+**explicit** list the driver verifies this up front and fails loudly if a cap
+can't be enforced (rather than silently ignoring it); for the **default**
+`@common` sweep it instead degrades to a single unconstrained `host` run with a
+warning, so the tool still works on hosts that can't impose caps. The sweep nests
+**inside** each git target: a ref is built once, then run under every machine.
+
+> Note: the default sweep is thorough — the full matrix runs once per machine (8
+> by default), and the low-core Pi/low-end configs are the slowest. Narrow it with
+> `--hw-configs`, or trim the matrix (`--layer-heights`, `--aa-presets`, fixtures)
+> when you just want a quick check.
+
+### Benchmarking several versions (git)
+
+Run the same matrix against multiple refs/branches/PRs. Only the
+software-under-test (Rust CLI + TS CLI + `src/`) varies per ref — the harness
+(this script, fixtures, printers, goldens) always runs from your current
+checkout. Each ref is checked out into its own `git worktree`, built, and torn
+down afterward.
+
+```bash
+scripts/bench/run-slicing-bench.sh \
+  --refs main,dev --prs 418,424 \
+  --layer-heights 0.05 --out cross-version.jsonl
+```
+
+| Flag | Effect |
+|---|---|
+| `--refs CSV` | git refs to benchmark: branches/tags/commits (e.g. `main,dev,v1.2.0`) |
+| `--prs CSV` | GitHub PR numbers (fetched via `pull/N/head`) |
+| `--worktree-base DIR` | where to create per-ref worktrees (default: a temp dir, removed on exit) |
+| `--keep-worktrees` | don't delete the worktrees on exit (for inspection) |
+| `--install-deps` | run `npm ci` in each worktree instead of symlinking your `node_modules` |
+| `--overlay-uncommitted` | apply your working-tree diff (`git diff HEAD`) onto each worktree before building — use this to benchmark refs that predate the bench harness |
+
+With no `--refs`/`--prs`, the current working tree is the single target (`ref:
+"working-tree"`, original behavior). Filter results per version with
+`jq 'select(.ref=="main")'`.
+
+### Validating against known-good slices
+
+`--validate <dir>` compares each produced slice to a golden reference and records
+a `validation:{status,method,…}` block on the row. Goldens are matched by name:
+
+```
+<voxl>__<printer>__lh<lh>__<preset>.<ext>
+# e.g.  bust__elegoo-saturn__lh0.05__sharp.ctb
+```
+
+Comparison is format-aware:
+
+- **zip (`.nanodlp`)** — `method: "layer-hash"`: the numeric layer PNGs are
+  content-hashed and compared by name. Container metadata, timestamps, and the
+  `3d.png` thumbnail are ignored, so only the actual per-layer pixels matter.
+  Reports `mismatched_layers`, `only_in_golden`, `only_in_produced`.
+- **binary (`.ctb`/`.goo`/`.aff`/`.azf`)** — `method: "file-sha256"`: the whole
+  file is SHA-256 compared (these can't be decoded back to rasters). Requires the
+  encoder to be byte-deterministic across the versions you compare.
+
+`status` is one of `match` / `mismatch` / `missing` / `error`. A `mismatch` or
+`error` forces `ok=false`; a `missing` golden is ignored unless you pass
+`--require-golden` (then it also fails the case). Validation runs once per case
+(slicing is deterministic). `unzip` is required for meaningful `.nanodlp`
+validation — without it those goldens degrade to timestamp-sensitive whole-file
+SHA-256 and the driver warns.
+
+## Visualizing results
+
+`visualize-stats.mjs` turns a results JSONL into a single self-contained HTML
+dashboard — styled like the app's in-UI **Slice Performance Metrics (V3)** modal,
+but surfacing *everything the benchmark records*, not just the SliceStatsV3 perf
+fields: the imposed hardware envelope (cpus/mem), CPU + RAM, the **RSS/CPU
+time-series** drawn as a chart (with the `mem=` cap marked when set), every
+un-averaged repeat under `runs[]`, the correctness gate + validation, and output
+size.
+
+```bash
+node scripts/bench/visualize-stats.mjs bench-results.jsonl --out report.html --open
+# multiple files are merged (e.g. compare a cross-version run beside a hw sweep):
+node scripts/bench/visualize-stats.mjs hw-sweep.jsonl cross-version.jsonl --out report.html
+```
+
+The page has a **sortable overview table** (click a header to sort by throughput,
+peak RSS, CPU, …; click a case to jump to it) over a **per-case detail card** each
+carrying the V3-style metric cards, a pipeline-timing pie, the resource-over-time
+chart, a per-repeat `runs[]` table, and the correctness/output panel. Options:
+`--out <file.html>`, `--title <text>`, `--open`. Node built-ins only — no deps.
+
+## Analyzing results
+
+```bash
+# throughput + peak memory per case (with hw config, ref + output format)
+jq -r '[.hw,.ref,.printer,.format,.aa_preset,.layer_height,.layers_per_second,.peak_rss_mb,.ok]|@tsv' bench-results.jsonl
+
+# compare one case across hardware configs ("how does it run under each machine")
+jq -r 'select(.printer=="elegoo-saturn" and .aa_preset=="sharp")|[.hw,.hw_cpus,.hw_mem,.total_s,.layers_per_second,.peak_rss_mb,.ok]|@tsv' hw-sweep.jsonl
+
+# compare one case across versions
+jq -r 'select(.printer=="elegoo-saturn" and .aa_preset=="sharp")|[.ref,.git_sha,.total_s,.layers_per_second]|@tsv' cross-version.jsonl
+
+# validation failures only
+jq -c 'select(.validation.status | IN("mismatch","error"))|{ref,printer,aa_preset,validation}' bench-results.jsonl
+
+# per-repeat spread for a case (each run kept separate under runs[], not just averaged)
+jq -r 'select(.aa_preset=="smooth")|.runs[]|[.run,.total_s,.peak_rss_mb,.peak_sample_cpu_percent]|@csv' bench-results.jsonl
+
+# RSS-over-time for one case (feed to a plot). Series live per-repeat under
+# runs[].samples[]; each sample also carries its own `run`.
+jq -r 'select(.aa_preset=="smooth").runs[].samples[]|[.run,.t_ms,.rss_mb,.cpu_percent]|@csv' bench-results.jsonl
+```

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -87,8 +87,8 @@ scripts/bench/run-slicing-bench.sh \
 
 Core options: `--fixtures`, `--printers`, `--mesh-dir`, `--layer-heights` (CSV),
 `--aa-presets` (CSV, default `sharp,balanced,smooth,raw`), `--repeats`
-(averaged, with min/max spread kept), `--out`, `--no-build`. Requires `jq`
-(and `sha256sum` + `unzip` when validating).
+(averaged, with min/max spread kept), `--codegen` (CSV, see below), `--out`,
+`--no-build`. Requires `jq` (and `sha256sum` + `unzip` when validating).
 
 Repeats are **averaged** (every scalar + every perf field) into the row's
 top-level summary, with `total_s_min`/`total_s_max` for the spread — but every
@@ -96,6 +96,50 @@ repeat is **also kept un-averaged** under `runs[]` (its own timing, CPU, peak
 RSS, full perf block, and RSS/CPU sample series), so nothing is lost to the
 average. Failed repeats are logged with their error and, if all repeats of a
 case fail, an `{"error": ...}` row is written.
+
+### Sweeping codegen variants
+
+The driver can also re-run the whole matrix against the **same source built with different
+`RUSTFLAGS`**, which is how you find out what an x86_64 baseline actually costs rather than
+arguing about it:
+
+```bash
+scripts/bench/run-slicing-bench.sh --codegen shipped,v2,v3 --layer-heights 0.05 --out codegen.jsonl
+```
+
+Every row carries `codegen`, so a variant is directly comparable against the others across every
+printer, layer height and AA preset in the matrix.
+
+| Preset | RUSTFLAGS |
+|---|---|
+| `v1` | `-C target-cpu=x86-64` (baseline; runs on every x86-64 CPU) |
+| `v2` | `-C target-cpu=x86-64-v2` (SSE4.2; Nehalem 2008 / Bulldozer 2011 and up) |
+| `v3` | `-C target-cpu=x86-64-v3` (AVX2 + FMA + BMI; Haswell 2013 / Zen 2017 and up) |
+| `shipped` | `-C target-feature=+avx2,+fma` (what `.cargo/config.toml` ships today) |
+| `v2avx2` | `-C target-cpu=x86-64-v2 -C target-feature=+avx2,+fma` |
+| `native` | `-C target-cpu=native` — reference ceiling only, **never shippable** |
+
+Anything starting with `-C` is passed through verbatim, so you are not limited to the presets.
+
+`target-cpu` and `target-feature` are **not** the same knob, which is why both `v3` and
+`v2avx2` are in that list. `target-feature=+avx2` tells LLVM the instructions are *available*;
+the cost model and instruction scheduling still come from `target-cpu`, which stays at generic
+`x86-64` unless you set it. The two combinations generate visibly different amounts of vector
+code from identical source.
+
+Each variant builds into its own `target-codegen-<name>` directory, so variants never reuse each
+other's artifacts. `RUSTFLAGS` fully overrides the `rustflags` in `.cargo/config.toml` — cargo
+treats the two as mutually exclusive — so no variant silently inherits the shipped flags. A
+variant the host CPU cannot execute is skipped with a message rather than crashed into.
+
+Results are **per microarchitecture**: an Intel and an AMD part can disagree, and on Zen 1/2 the
+BMI2 `PDEP`/`PEXT` instructions `v3` permits are microcoded and very slow, so treat `v3` on
+those parts with extra suspicion. Running this on more than one machine is the point.
+
+Note that a slice total is dominated by PNG encoding, which codegen flags barely touch — read
+the per-stage perf fields (`render_wall`, and the rest of `SliceStatsV3`) rather than `total_s`
+alone, and use `--repeats` with the recorded `total_s_min`/`total_s_max` spread to check that a
+difference is bigger than the run-to-run noise before calling it a result.
 
 ### Sweeping hardware configurations
 

--- a/scripts/bench/printers/saturn_2-bundle.json
+++ b/scripts/bench/printers/saturn_2-bundle.json
@@ -1,0 +1,124 @@
+{
+  "version": 1,
+  "exportedAt": "2026-07-27T19:05:54.210Z",
+  "printer": {
+    "id": "printer-mrbmn4ce-y0878ox",
+    "name": "Saturn 2",
+    "manufacturer": "ELEGOO",
+    "imageDataUrl": "/api/profile-assets/plugins/elegoo/printers/assets/saturn/saturn-2.png",
+    "antiAliasing": true,
+    "hasCamera": false,
+    "networkFilter": "Saturn 2",
+    "pixelSize": {
+      "x": 28.5,
+      "y": 28.5
+    },
+    "buildDimensionMode": "auto",
+    "officialPresetId": "elegoo-saturn-2-ctb",
+    "officialPresetVersion": 1,
+    "isOfficial": true,
+    "isCustom": false,
+    "buildVolumeMm": {
+      "width": 218.88,
+      "depth": 123.12,
+      "height": 250
+    },
+    "display": {
+      "resolutionX": 7680,
+      "resolutionY": 4320,
+      "outputFormat": ".ctb",
+      "formatVersion": "v5enc",
+      "settingsMode": "twostage",
+      "webcamRotationDeg": 0,
+      "mirrorX": true,
+      "mirrorY": false
+    },
+    "network": {
+      "discoveryEnabled": true,
+      "ipAddress": ""
+    }
+  },
+  "materials": [
+    {
+      "id": "material-mrbmn4ce-h2s02ov",
+      "printerProfileId": "printer-mrbmn4ce-y0878ox",
+      "officialTemplateVersion": 1,
+      "name": "Standard 405nm",
+      "brand": "Default",
+      "currencyCode": "USD",
+      "bottlePrice": 24.99,
+      "bottleCapacityMl": 1000,
+      "resinFamily": "standard",
+      "scaleCompensationPct": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "layerHeightMm": 0.03,
+      "normalExposureSec": 2,
+      "bottomExposureSec": 25,
+      "bottomLayerCount": 5,
+      "liftDistanceMm": 1,
+      "liftSpeedMmMin": 60,
+      "retractSpeedMmMin": 240,
+      "minimumAaAlphaPercent": 35,
+      "antiAliasingSettings": {
+        "enableCustomSettings": false,
+        "enableOverride": false,
+        "mode": "Blur",
+        "level": "4x",
+        "useCustomLevel": false,
+        "blurBrushRadiusPx": 1,
+        "useCustomBlurBrushRadius": false,
+        "blurBrushKernel": "gaussian",
+        "blurBrushSigmaX": 0.5,
+        "blurBrushSigmaY": 0.5,
+        "zBlurRadiusLayers": 0,
+        "useCustomZBlurRadius": false,
+        "zBlurKernel": "box",
+        "zBlurSigma": 0.5,
+        "zBlendLookBack": 2,
+        "useCustomZBlendLookBack": false,
+        "zBlendFadePx": 20,
+        "zBlendFadeMode": "auto",
+        "zBlendAutoMode": true,
+        "useCustomZBlendFadePx": false,
+        "zaaPattern": "halton",
+        "zaaDuplicateZ": true,
+        "blurGraySourceMode": "lut",
+        "zBlendResinType": "opaque",
+        "selectedLutCurveId": "default",
+        "aaOnSupports": false,
+        "ditherEnabled": false,
+        "ditherBitDepth": 3,
+        "ditherDeviceGamma": 3
+      },
+      "localSettingsByOutput": {
+        ".ctb": {
+          "layerHeightMm": 0.03,
+          "bottomLayerCount": 5,
+          "transitionLayerCount": 0,
+          "bottomExposureSec": 25,
+          "bottomLiftDistanceMm": 3,
+          "bottomLiftSpeedMmMin": 60,
+          "bottomRetractSpeedMmMin": 180,
+          "normalExposureSec": 2,
+          "liftDistanceMm": 1,
+          "liftSpeedMmMin": 60,
+          "retractSpeedMmMin": 240,
+          "waitTimeBeforeCureSec": 0,
+          "waitTimeAfterCureSec": 0,
+          "waitTimeAfterLiftSec": 0,
+          "projectorPwmPercent": 100,
+          "bottomProjectorPwmPercent": 100,
+          "bottomLiftDistance2Mm": 4,
+          "bottomLiftSpeed2MmMin": 180,
+          "bottomRetractSpeed2MmMin": 60,
+          "liftDistance2Mm": 4,
+          "liftSpeed2MmMin": 240,
+          "retractSpeed2MmMin": 60
+        }
+      }
+    }
+  ]
+}

--- a/scripts/bench/printers/saturn_4_ultra_16k-bundle.json
+++ b/scripts/bench/printers/saturn_4_ultra_16k-bundle.json
@@ -1,0 +1,115 @@
+{
+  "version": 1,
+  "exportedAt": "2026-07-27T17:57:28.745Z",
+  "printer": {
+    "id": "printer-mreixqxi-c13h4g5",
+    "name": "Saturn 4 Ultra 16K",
+    "manufacturer": "ELEGOO",
+    "imageDataUrl": "/api/profile-assets/plugins/elegoo/printers/assets/saturn/saturn-4-ultra-16k.png",
+    "antiAliasing": true,
+    "networkSupport": "sdcp",
+    "hasCamera": false,
+    "networkFilter": "Saturn 4",
+    "pixelSize": {
+      "x": 14,
+      "y": 19
+    },
+    "bitDepth": {
+      "bits": 3,
+      "description": "3-bit color depth, suboptimal for grayscale"
+    },
+    "buildDimensionMode": "auto",
+    "officialPresetId": "elegoo-saturn-4-ultra-16k-ctb",
+    "officialPresetVersion": 4,
+    "isOfficial": true,
+    "isCustom": false,
+    "buildVolumeMm": {
+      "width": 211.68,
+      "depth": 118.37,
+      "height": 220
+    },
+    "display": {
+      "resolutionX": 15120,
+      "resolutionY": 6230,
+      "outputFormat": ".ctb",
+      "formatVersion": "v5enc",
+      "settingsMode": "tilting",
+      "webcamRotationDeg": 0,
+      "mirrorX": true,
+      "mirrorY": false
+    },
+    "network": {
+      "discoveryEnabled": true,
+      "ipAddress": ""
+    },
+    "networkFleet": [],
+    "networkConnection": {
+      "mode": "sdcp",
+      "connected": false,
+      "hostName": "",
+      "ipAddress": "",
+      "port": 80,
+      "lastCheckedAt": "",
+      "statusText": "",
+      "selectedMaterialId": "",
+      "selectedMaterialName": ""
+    }
+  },
+  "materials": [
+    {
+      "id": "material-mreixqxi-elc9w4k",
+      "printerProfileId": "printer-mreixqxi-c13h4g5",
+      "officialTemplateVersion": 1,
+      "name": "Standard 405nm",
+      "brand": "Default",
+      "currencyCode": "USD",
+      "bottlePrice": 24.99,
+      "bottleCapacityMl": 1000,
+      "resinFamily": "standard",
+      "scaleCompensationPct": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "layerHeightMm": 0.05,
+      "normalExposureSec": 2.5,
+      "bottomExposureSec": 28,
+      "bottomLayerCount": 5,
+      "liftDistanceMm": 6,
+      "liftSpeedMmMin": 60,
+      "retractSpeedMmMin": 150,
+      "minimumAaAlphaPercent": 35,
+      "antiAliasingSettings": {
+        "enableCustomSettings": false,
+        "enableOverride": false,
+        "mode": "Blur",
+        "level": "4x",
+        "useCustomLevel": false,
+        "blurBrushRadiusPx": 1,
+        "useCustomBlurBrushRadius": false,
+        "blurBrushKernel": "gaussian",
+        "blurBrushSigmaX": 0.5,
+        "blurBrushSigmaY": 0.5,
+        "zBlurRadiusLayers": 0,
+        "useCustomZBlurRadius": false,
+        "zBlurKernel": "box",
+        "zBlurSigma": 0.5,
+        "zBlendLookBack": 2,
+        "useCustomZBlendLookBack": false,
+        "zBlendFadePx": 20,
+        "zBlendFadeMode": "auto",
+        "zBlendAutoMode": true,
+        "useCustomZBlendFadePx": false,
+        "zaaPattern": "halton",
+        "zaaDuplicateZ": true,
+        "blurGraySourceMode": "lut",
+        "zBlendResinType": "opaque",
+        "selectedLutCurveId": "default",
+        "aaOnSupports": false,
+        "ditherEnabled": false,
+        "ditherBitDepth": 3,
+        "ditherDeviceGamma": 3
+      }
+    }
+  ]
+}

--- a/scripts/bench/run-slicing-bench.sh
+++ b/scripts/bench/run-slicing-bench.sh
@@ -1,0 +1,665 @@
+#!/usr/bin/env bash
+#
+# Slicing benchmark suite — drives the DragonFruit CLI over a matrix of
+# .voxl fixtures × printer profiles × layer heights × AA presets, optionally
+# across several git versions/branches/PRs of the software, and optionally
+# validating each sliced output against a known-good reference archive.
+#
+# Each run slices exactly like the UI would for that printer (resolution,
+# bit-depth packing, non-square pixel pitch, named AA preset, dithering) and
+# records the full SliceStatsV3 perf block plus CPU/RAM (RSS + peak) into a
+# JSONL results file — one row per case. Every row is tagged with the git
+# `ref`/`git_sha` it was produced by, so results across versions stay
+# comparable.
+#
+# Usage:
+#   scripts/bench/run-slicing-bench.sh [options]
+#
+# Options (all have defaults):
+#   --fixtures <dir>     dir of *.voxl scenes         (default: scripts/bench/fixtures)
+#   --printers <dir>     dir of *.json printer profiles (default: scripts/bench/printers)
+#   --mesh-dir <dir>     STL mesh dir for the voxls    (default: <fixtures>)
+#   --layer-heights CSV  e.g. 0.05,0.03               (default: 0.05)
+#   --aa-presets CSV     sharp,balanced,smooth,raw    (default: sharp,balanced,smooth,raw)
+#   --out <file>         JSONL output                 (default: bench-results.jsonl)
+#   --repeats N          runs per case, averaged      (default: 1)
+#   --no-build           skip cargo build
+#
+#  Git multi-version options (measure several versions of the software):
+#   --refs CSV           git refs to benchmark: branches/tags/commits, e.g. main,dev,v1.2.0
+#   --prs CSV            GitHub PR numbers, e.g. 418,424 (fetched via pull/N/head)
+#   --worktree-base DIR  where to create per-ref worktrees   (default: a temp dir)
+#   --keep-worktrees     don't delete the worktrees on exit (for inspection)
+#   --install-deps       run `npm ci` in each worktree instead of symlinking node_modules
+#   --overlay-uncommitted apply the current working-tree diff (git diff HEAD) onto each
+#                        worktree before building — use this to benchmark refs that don't
+#                        yet contain the bench harness (e.g. before it is merged)
+#
+#  Validation options (compare output to a known-good slice):
+#   --validate <dir>     dir of golden files named <voxl>__<printer>__lh<lh>__<preset>.<ext>;
+#                        each case is compared to its golden. For zip formats (.nanodlp) the
+#                        per-layer PNG content is hashed (container metadata ignored); for
+#                        binary formats (.ctb/.goo/.aff/.azf) the whole file is SHA-256 compared.
+#                        Records validation:{status,method,...} on the row.
+#   --require-golden     treat a missing golden reference as a case failure (ok=false)
+#
+#  Hardware sweep (run the whole matrix under several simulated machines):
+#   --hw-configs LIST    ';'-separated hardware envelopes, each "name:cpus=N,mem=SIZE", OR a
+#                        built-in preset group referenced as "@name". Presets: @pis (a few
+#                        Raspberry Pis), @pcs (low-end→workstation), @common (= @pis;@pcs).
+#                        e.g.  "@common"  or  "@pis; workstation:cpus=16,mem=32G".
+#                        cpus=N pins the run to N cores via `taskset` (the slicing engine sizes
+#                        its rayon pools from available_parallelism(), so it genuinely behaves
+#                        like an N-core box). mem=SIZE imposes a hard RAM ceiling via a transient
+#                        systemd user scope (MemoryMax + no swap); a breach OOM-kills the slice and
+#                        is logged as a failure for that machine. Either key may be omitted (a
+#                        config with neither = the unconstrained host). Every row is tagged
+#                        hw / hw_cpus / hw_mem.
+#                        DEFAULT: "@common" — the whole matrix is swept across common PC + Pi
+#                        machines. Pass "--hw-configs host" for a single unconstrained run, or an
+#                        explicit list. (If the host can't enforce the caps, the default degrades
+#                        to a single "host" run with a warning; an explicit list hard-fails.)
+#
+# Output format per case follows the printer profile's display.outputFormat (nanodlp/ctb/goo/…);
+# nanodlp is a zip of layer PNGs (fully introspectable), the others are proprietary binary
+# containers (correctness gate falls back to a non-empty-file check — see --validate for content).
+#
+# When neither --refs nor --prs is given, the current working tree is used (as before).
+# The driver/harness (this script, fixtures, printers, goldens) always runs from the
+# invoking checkout; only the software-under-test (Rust CLI + TS CLI + src/) varies per ref.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+FIXTURES="scripts/bench/fixtures"
+PRINTERS="scripts/bench/printers"
+MESH_DIR=""
+LAYER_HEIGHTS="0.05"
+AA_PRESETS="raw,sharp,balanced,smooth"
+OUT="bench-results.jsonl"
+REPEATS=1
+DO_BUILD=1
+REFS=""
+PRS=""
+WORKTREE_BASE=""
+KEEP_WT=0
+INSTALL_DEPS=0
+OVERLAY=0
+VALIDATE_DIR=""
+REQUIRE_GOLDEN=0
+HW_CONFIGS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fixtures) FIXTURES="$2"; shift 2;;
+    --printers) PRINTERS="$2"; shift 2;;
+    --mesh-dir) MESH_DIR="$2"; shift 2;;
+    --layer-heights) LAYER_HEIGHTS="$2"; shift 2;;
+    --aa-presets) AA_PRESETS="$2"; shift 2;;
+    --out) OUT="$2"; shift 2;;
+    --repeats) REPEATS="$2"; shift 2;;
+    --no-build) DO_BUILD=0; shift;;
+    --refs) REFS="$2"; shift 2;;
+    --prs) PRS="$2"; shift 2;;
+    --worktree-base) WORKTREE_BASE="$2"; shift 2;;
+    --keep-worktrees) KEEP_WT=1; shift;;
+    --install-deps) INSTALL_DEPS=1; shift;;
+    --overlay-uncommitted) OVERLAY=1; shift;;
+    --validate) VALIDATE_DIR="$2"; shift 2;;
+    --require-golden) REQUIRE_GOLDEN=1; shift;;
+    --hw-configs) HW_CONFIGS="$2"; shift 2;;
+    *) echo "Unknown option: $1" >&2; exit 2;;
+  esac
+done
+
+MESH_DIR="${MESH_DIR:-$FIXTURES}"
+
+# Expose V8's gc() to the TS "frontend" so it can actively reclaim the merged
+# geometry after handing positions.bin to the Rust slicer — the slice then runs
+# with the node process holding ~nothing, keeping the measurement to purely the
+# slicing engine's footprint. (The Rust CLI already measures itself via
+# getrusage(RUSAGE_SELF); this keeps the whole process tree honest too.)
+export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--expose-gc"
+
+# Per-case temp artifacts (the sliced .ctb/.goo/… outputs and the JSON capture files) all
+# live under one bench-owned scratch dir, swept on exit — including a hard kill mid-case —
+# so an interrupted run can't strand a multi-hundred-MB output archive in /tmp. Worktrees
+# are cleaned on their own path so --keep-worktrees still works.
+BENCH_SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/df-bench-scratch.XXXXXX")"
+
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+if [[ -n "$VALIDATE_DIR" ]]; then
+  command -v sha256sum >/dev/null || { echo "sha256sum is required for --validate" >&2; exit 1; }
+  # unzip is only needed for zip-format (.nanodlp) goldens; binary formats fall back to
+  # whole-file sha256 (see validate_case), so its absence is not fatal. But WITHOUT unzip a
+  # zip golden also degrades to whole-file sha256, which is timestamp-sensitive and will
+  # report a spurious "mismatch" — warn so the degradation isn't silent.
+  command -v unzip >/dev/null || echo "WARN: unzip not found; .nanodlp goldens will be compared by whole-file sha256 (timestamp-sensitive), not per-layer content" >&2
+  [[ -d "$VALIDATE_DIR" ]] || { echo "--validate dir not found: $VALIDATE_DIR" >&2; exit 1; }
+fi
+
+# ---------------------------------------------------------------------------
+# Hardware sweep: parse --hw-configs into parallel arrays HW_LABEL/HW_CPUS/HW_MEM.
+# Each config re-runs the whole matrix inside an imposed hardware envelope:
+#   cpus=N  -> `taskset -c 0-(N-1)` gives the process (and its Rust slice child) a
+#             real N-core affinity mask. The engine derives its rayon pool sizes from
+#             std::thread::available_parallelism() (= sched affinity), so this is true
+#             core emulation, not an env-var hint.
+#   mem=SIZE-> a transient `systemd-run --user --scope` with a hard MemoryMax + no swap.
+#             Exceeding it OOM-kills the slice (surfaced as a case failure for that machine).
+#
+# Built-in preset groups (referenced as @name; approximate real machines). Pi core counts
+# reflect current quad-core boards; RAM is the imposed ceiling. PCs span a low-end mini-PC to
+# a workstation. cpus are later clamped to the host's nproc. @common is the default sweep.
+# ---------------------------------------------------------------------------
+declare -A HW_PRESETS=(
+  [pis]="rpi-zero2:cpus=4,mem=512M; rpi3b:cpus=4,mem=1G; rpi4:cpus=4,mem=4G; rpi5:cpus=4,mem=8G"
+  [pcs]="pc-lowend:cpus=2,mem=4G; pc-budget:cpus=4,mem=8G; pc-mainstream:cpus=8,mem=16G; pc-workstation:cpus=16,mem=32G"
+)
+HW_PRESETS[common]="${HW_PRESETS[pis]}; ${HW_PRESETS[pcs]}"
+
+# Expand any @preset tokens in a raw --hw-configs string into concrete "name:spec" entries.
+expand_hw_presets() { # <raw-hw-configs> -> expanded ';'-joined string
+  local out="" part key
+  local IFS=';'; read -ra _parts <<< "$1"
+  for part in "${_parts[@]}"; do
+    part="$(echo "$part" | tr -d '[:space:]')"; [[ -n "$part" ]] || continue
+    if [[ "$part" == @* ]]; then
+      key="${part#@}"
+      [[ -n "${HW_PRESETS[$key]:-}" ]] || { echo "unknown hw preset '@$key' (known: ${!HW_PRESETS[*]})" >&2; exit 2; }
+      out="${out:+$out; }${HW_PRESETS[$key]}"
+    else
+      out="${out:+$out; }$part"
+    fi
+  done
+  printf '%s' "$out"
+}
+
+declare -a HW_LABEL HW_CPUS HW_MEM
+HOST_CPUS="$(nproc 2>/dev/null || echo 1)"
+need_taskset=0; need_systemd=0
+# Default to the common PC + Pi sweep; remember it was defaulted so we can degrade gracefully
+# (rather than hard-fail) if this host can't actually enforce the caps.
+HW_IS_DEFAULT=0
+[[ -z "$HW_CONFIGS" ]] && { HW_CONFIGS="@common"; HW_IS_DEFAULT=1; }
+HW_CONFIGS="$(expand_hw_presets "$HW_CONFIGS")"
+
+IFS=';' read -ra _hwentries <<< "$HW_CONFIGS"
+for entry in "${_hwentries[@]}"; do
+  entry="$(echo "$entry" | tr -d '[:space:]')"; [[ -n "$entry" ]] || continue
+  local_name="${entry%%:*}"; spec=""
+  [[ "$entry" == *:* ]] && spec="${entry#*:}"
+  cpus=""; mem=""
+  if [[ -n "$spec" ]]; then
+    IFS=',' read -ra _kvs <<< "$spec"
+    for kv in "${_kvs[@]}"; do
+      case "$kv" in
+        cpus=*) cpus="${kv#cpus=}";;
+        mem=*)  mem="${kv#mem=}";;
+        "" ) ;;
+        *) echo "WARN: hw-config '$local_name': ignoring unknown key '$kv' (want cpus= / mem=)" >&2;;
+      esac
+    done
+  fi
+  if [[ -n "$cpus" ]]; then
+    [[ "$cpus" =~ ^[0-9]+$ && "$cpus" -ge 1 ]] || { echo "hw-config '$local_name': cpus must be a positive integer" >&2; exit 2; }
+    if (( cpus > HOST_CPUS )); then
+      echo "WARN: hw-config '$local_name': cpus=$cpus > host cores ($HOST_CPUS); clamping to $HOST_CPUS" >&2
+      cpus="$HOST_CPUS"
+    fi
+    need_taskset=1
+  fi
+  [[ -n "$mem" ]] && need_systemd=1
+  HW_LABEL+=("$local_name"); HW_CPUS+=("$cpus"); HW_MEM+=("$mem")
+done
+[[ ${#HW_LABEL[@]} -gt 0 ]] || { echo "--hw-configs parsed to zero configs" >&2; exit 2; }
+
+# Probe whether this host can actually enforce the requested constraints.
+hw_can_taskset=1; hw_can_mem=1
+[[ "$need_taskset" == 1 ]] && { command -v taskset >/dev/null || hw_can_taskset=0; }
+if [[ "$need_systemd" == 1 ]]; then
+  if ! command -v systemd-run >/dev/null \
+     || ! systemd-run --user --scope --quiet -p MemoryMax=64M -p MemorySwapMax=0 -- true >/dev/null 2>&1; then
+    hw_can_mem=0   # no systemd-run, or the memory cgroup controller isn't delegated to the user manager
+  fi
+fi
+
+if { [[ "$need_taskset" == 1 && "$hw_can_taskset" == 0 ]]; } \
+   || { [[ "$need_systemd" == 1 && "$hw_can_mem" == 0 ]]; }; then
+  if [[ "$HW_IS_DEFAULT" == 1 ]]; then
+    echo "WARN: the default hardware sweep (@common) needs taskset + an enforceable systemd --user" >&2
+    echo "      MemoryMax; this host can't provide them, so falling back to a single unconstrained" >&2
+    echo "      'host' run. Install util-linux/systemd (with the memory cgroup delegated), or pass" >&2
+    echo "      --hw-configs explicitly to force the sweep." >&2
+    HW_LABEL=("host"); HW_CPUS=(""); HW_MEM=(""); need_taskset=0; need_systemd=0
+  else
+    [[ "$need_taskset" == 1 && "$hw_can_taskset" == 0 ]] && echo "taskset (util-linux) is required for hw-configs with cpus=" >&2
+    [[ "$need_systemd" == 1 && "$hw_can_mem" == 0 ]] && echo "an enforceable systemd --user MemoryMax is required for hw-configs with mem= (is the memory cgroup controller delegated to your user manager?)" >&2
+    exit 1
+  fi
+fi
+
+# Emit the command-prefix tokens imposing one hardware config's constraints (may be empty).
+# Order matters: the systemd scope wraps everything, taskset sets affinity on the wrapped cmd.
+hw_prefix_for() { # <cpus-or-empty> <mem-or-empty> -> prints prefix tokens
+  local cpus="$1" mem="$2" pre=""
+  [[ -n "$mem" ]] && pre="systemd-run --user --scope --quiet -p MemoryMax=$mem -p MemorySwapMax=0 --"
+  if [[ -n "$cpus" ]]; then
+    local list; (( cpus <= 1 )) && list="0" || list="0-$((cpus-1))"
+    pre="${pre:+$pre }taskset -c $list"
+  fi
+  printf '%s' "$pre"
+}
+
+# Map a printer profile's output format to the archive extension the way the app /
+# TS CLI does (outputFormatToExt): ctb/nanodlp are named; anything else passes through.
+printer_ext() { # <printer.json>
+  local fmt
+  fmt="$(jq -r '((.printer.display.outputFormat // .display.outputFormat // .outputFormat // "") | tostring | ascii_downcase)' "$1" 2>/dev/null || echo "")"
+  case "$fmt" in
+    *ctb*)          echo ".ctb";;
+    *nanodlp*)      echo ".nanodlp";;
+    "")             echo "printer_ext: no outputFormat in $1 (bundle not unwrapped?)" >&2; return 1;;
+    .*)             echo "$fmt";;
+    *)              echo ".$fmt";;
+  esac
+}
+
+file_size() { stat -c%s "$1" 2>/dev/null || stat -f%z "$1" 2>/dev/null || echo 0; }
+is_zip()    { command -v unzip >/dev/null 2>&1 && unzip -l "$1" >/dev/null 2>&1; }
+
+shopt -s nullglob
+voxls=("$FIXTURES"/*.voxl)
+printers=("$PRINTERS"/*.json)
+[[ ${#voxls[@]}   -gt 0 ]] || { echo "No .voxl fixtures in $FIXTURES" >&2; exit 1; }
+[[ ${#printers[@]} -gt 0 ]] || { echo "No printer profiles in $PRINTERS" >&2; exit 1; }
+
+IFS=',' read -ra LHS <<< "$LAYER_HEIGHTS"
+IFS=',' read -ra AAS <<< "$AA_PRESETS"
+
+: > "$OUT"
+runs=0; fails=0
+# jq: average an array of repeat rows into one case row. Scalars + every perf
+# field are averaged; the time-series samples are kept from the repeat whose
+# total_s is closest to the mean (a representative run for over-time diagnosis).
+read -r -d '' AVG_JQ <<'JQ' || true
+def avg(f): (map(f) | add) / length;
+[.[].perf] as $ps
+| {
+    ref: .[0].ref, git_sha: .[0].git_sha,
+    hw: .[0].hw, hw_cpus: .[0].hw_cpus, hw_mem: .[0].hw_mem,
+    voxl: .[0].voxl, printer: .[0].printer, format: .[0].format,
+    layer_height: .[0].layer_height,
+    aa_preset: .[0].aa_preset, x_packing_mode: .[0].x_packing_mode,
+    anti_aliasing: .[0].anti_aliasing, dither: .[0].dither,
+    triangles: .[0].triangles, layers: .[0].layers,
+    layer_count: .[0].layer_count, numeric_layer_count: .[0].numeric_layer_count,
+    gate: .[0].gate,
+    ok: all(.[]; .ok), file_bytes: .[0].file_bytes,
+    repeats: length,
+    total_s: avg(.total_s), total_s_min: (map(.total_s) | min), total_s_max: (map(.total_s) | max),
+    wall_s: avg(.wall_s), layers_per_second: avg(.layers_per_second),
+    cpu_total_s: avg(.cpu_total_s), cpu_percent: avg(.cpu_percent),
+    peak_sample_cpu_percent: avg(.peak_sample_cpu_percent),
+    peak_rss_mb: avg(.peak_rss_mb), end_rss_mb: avg(.end_rss_mb),
+    perf: (($ps[0] | keys_unsorted) | reduce .[] as $k ({}; . + { ($k): (($ps | map(.[$k]) | add) / ($ps | length)) })),
+    # Every repeat kept separate and un-averaged: its own timing, CPU, peak RSS, full
+    # perf block and RSS/CPU sample series. The scalars above are just a convenience
+    # summary — `runs[]` is the source of truth for "how it ran under this config".
+    runs: [ .[] | {
+      run, ok, total_s, wall_s, layers_per_second,
+      cpu_total_s, cpu_percent, peak_sample_cpu_percent,
+      peak_rss_mb, end_rss_mb, perf, samples
+    } ]
+  }
+JQ
+
+# ---------------------------------------------------------------------------
+# Validation helpers. Two methods, chosen by container:
+#  - zip (.nanodlp): content-hash the numeric layer PNGs; container metadata /
+#    timestamps are ignored, only per-layer pixel bytes are compared by name.
+#  - binary (.ctb/.goo/.aff/.azf): the CLI can't decode these back to rasters,
+#    so the whole file is SHA-256 compared (exact match) against the golden.
+# ---------------------------------------------------------------------------
+hash_layers() { # <zip-archive> -> "<layer>\t<sha256>" per numeric-stem PNG, sorted numerically
+  local arc="$1" d; d="$(mktemp -d)"
+  if ! unzip -qq -o "$arc" -d "$d" >/dev/null 2>&1; then rm -rf "$d"; return 1; fi
+  ( cd "$d" && find . -type f -name '*.png' | while read -r f; do
+      local b; b="$(basename "$f" .png)"
+      [[ "$b" =~ ^[0-9]+$ ]] || continue           # skip 3d.png / thumbnails
+      printf '%s\t%s\n' "$b" "$(sha256sum "$f" | cut -d' ' -f1)"
+    done | sort -n )
+  rm -rf "$d"
+}
+
+find_golden() { # <voxl> <printer> <lh> <preset> -> path or empty
+  shopt -s nullglob
+  local g=( "$VALIDATE_DIR/$1__$2__lh$3__$4".* )
+  shopt -u nullglob
+  [[ ${#g[@]} -gt 0 ]] && printf '%s' "${g[0]}"
+}
+
+validate_case() { # <produced-file> <voxl> <printer> <lh> <preset> -> prints validation JSON
+  local arc="$1" golden; golden="$(find_golden "$2" "$3" "$4" "$5")"
+  if [[ -z "$golden" ]]; then
+    jq -c -n --arg dir "$VALIDATE_DIR" '{status:"missing", golden:null}'
+    return
+  fi
+
+  if is_zip "$arc" && is_zip "$golden"; then
+    # ---- zip (.nanodlp): per-layer PNG content comparison ----
+    local gh ph; gh="$(mktemp)"; ph="$(mktemp)"
+    if ! hash_layers "$golden" > "$gh" || ! hash_layers "$arc" > "$ph"; then
+      rm -f "$gh" "$ph"
+      jq -c -n --arg g "$golden" '{status:"error", method:"layer-hash", golden:$g, detail:"could not extract an archive"}'
+      return
+    fi
+    jq -c -n --arg g "$golden" --rawfile goldp "$gh" --rawfile prodp "$ph" '
+      def rows($s): ($s|split("\n")|map(select(length>0))|map(split("\t")|{key:.[0],val:.[1]}));
+      (rows($goldp)) as $G | (rows($prodp)) as $P
+      | ($G|map(.key)) as $gk | ($P|map(.key)) as $pk
+      | ($G|map({(.key):.val})|add // {}) as $gm
+      | ($P|map({(.key):.val})|add // {}) as $pm
+      | [ $gk[] | select( ($pm[.] != null) and ($pm[.] != $gm[.]) ) ] as $diff
+      | [ $gk[] | select( $pm[.] == null ) ] as $only_golden
+      | [ $pk[] | select( $gm[.] == null ) ] as $only_produced
+      | { status: (if (($diff|length)+($only_golden|length)+($only_produced|length))==0 then "match" else "mismatch" end),
+          method: "layer-hash",
+          golden: $g,
+          layers_compared: ($gk|length),
+          mismatched_layers: ($diff|sort|.[0:50]),
+          mismatched_count: ($diff|length),
+          only_in_golden: ($only_golden|length),
+          only_in_produced: ($only_produced|length) }'
+    rm -f "$gh" "$ph"
+  else
+    # ---- binary (.ctb/.goo/.aff/.azf): whole-file exact SHA-256 comparison ----
+    local ph gh ps gs
+    ph="$(sha256sum "$arc"    | cut -d' ' -f1)"
+    gh="$(sha256sum "$golden" | cut -d' ' -f1)"
+    ps="$(file_size "$arc")"; gs="$(file_size "$golden")"
+    jq -c -n --arg g "$golden" --arg ph "$ph" --arg gh "$gh" \
+       --argjson ps "$ps" --argjson gs "$gs" '
+      { status: (if $ph==$gh then "match" else "mismatch" end),
+        method: "file-sha256",
+        golden: $g,
+        produced_sha256: $ph, golden_sha256: $gh,
+        produced_bytes: $ps, golden_bytes: $gs,
+        byte_delta: ($ps - $gs) }'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Git target resolution: build a list of (label, sha, ts-cmd, rust-binary).
+# A "target" is one version of the software to benchmark. With no --refs/--prs
+# there is a single target: the current working tree.
+# ---------------------------------------------------------------------------
+declare -a TARGET_LABEL TARGET_SHA TARGET_TS TARGET_RUST
+WORKTREES=()
+CREATED_WT_BASE=0
+
+cleanup_worktrees() {
+  if [[ "$KEEP_WT" == 1 ]]; then
+    [[ ${#WORKTREES[@]} -gt 0 ]] && echo "==> keeping worktrees: ${WORKTREES[*]}" >&2
+    return
+  fi
+  for wt in "${WORKTREES[@]:-}"; do
+    [[ -n "$wt" ]] || continue
+    git -C "$REPO_ROOT" worktree remove --force "$wt" >/dev/null 2>&1 || rm -rf "$wt"
+  done
+  [[ "$CREATED_WT_BASE" == 1 && -n "$WORKTREE_BASE" ]] && rmdir "$WORKTREE_BASE" 2>/dev/null || true
+}
+# Wrap worktree cleanup so the scratch sweep runs on the same EXIT path, and route INT/TERM
+# through `exit` so an interrupted run (Ctrl-C / kill / OOM) still fires both cleanups.
+cleanup_all() { cleanup_worktrees; rm -rf "$BENCH_SCRATCH" 2>/dev/null || true; }
+trap cleanup_all EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+build_rust() { # <checkout-dir>
+  ( cd "$1/rust/dragonfruit-cli" && cargo build --release >/dev/null )
+}
+
+if [[ -z "$REFS" && -z "$PRS" ]]; then
+  # ---- single target: the current working tree (original behavior) ----
+  if [[ "$DO_BUILD" == 1 ]]; then
+    echo "==> building dragonfruit-cli (release)" >&2
+    build_rust "$REPO_ROOT"
+  fi
+  rbin="$REPO_ROOT/rust/dragonfruit-cli/target/release/dragonfruit-cli"
+  [[ -x "$rbin" ]] || { echo "CLI binary not found: $rbin (drop --no-build or build it)" >&2; exit 1; }
+  TARGET_LABEL+=("working-tree")
+  TARGET_SHA+=("$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)")
+  TARGET_TS+=("npx tsx scripts/dragonfruit-ts-cli.ts")
+  TARGET_RUST+=("$rbin")
+else
+  # ---- multiple targets: one git worktree per ref/PR ----
+  if [[ -z "$WORKTREE_BASE" ]]; then WORKTREE_BASE="$(mktemp -d)"; CREATED_WT_BASE=1; fi
+  mkdir -p "$WORKTREE_BASE"
+
+  declare -a REFLIST=()
+  IFS=',' read -ra _refs <<< "$REFS"; for x in "${_refs[@]}"; do [[ -n "$x" ]] && REFLIST+=("ref:$x"); done
+  IFS=',' read -ra _prs  <<< "$PRS";  for x in "${_prs[@]}";  do [[ -n "$x" ]] && REFLIST+=("pr:$x");  done
+
+  for entry in "${REFLIST[@]}"; do
+    kind="${entry%%:*}"; val="${entry#*:}"
+    if [[ "$kind" == pr ]]; then
+      label="pr-$val"
+      echo "==> fetching PR #$val" >&2
+      if ! git -C "$REPO_ROOT" fetch -q origin "pull/$val/head"; then
+        echo "  SKIP pr-$val: git fetch pull/$val/head failed" >&2; continue
+      fi
+      committish="FETCH_HEAD"
+    else
+      label="$val"; committish="$val"
+    fi
+
+    if ! sha="$(git -C "$REPO_ROOT" rev-parse --short "$committish" 2>/dev/null)"; then
+      echo "  SKIP $label: cannot resolve '$committish' (fetch it first?)" >&2; continue
+    fi
+
+    safe="$(echo "$label" | tr '/:@ ' '____')"
+    wt="$WORKTREE_BASE/$safe"
+    echo "==> worktree $label ($sha) -> $wt" >&2
+    if ! git -C "$REPO_ROOT" worktree add -q --detach "$wt" "$committish"; then
+      echo "  SKIP $label: git worktree add failed" >&2; continue
+    fi
+    WORKTREES+=("$wt")
+
+    # Node deps: symlink the primary node_modules (fast) or install fresh.
+    if [[ "$INSTALL_DEPS" == 1 ]]; then
+      echo "  installing node deps for $label" >&2
+      ( cd "$wt" && { npm ci >/dev/null 2>&1 || npm install >/dev/null 2>&1; } ) \
+        || echo "  WARN: npm install failed for $label (TS CLI may not run)" >&2
+    else
+      ln -s "$REPO_ROOT/node_modules" "$wt/node_modules" 2>/dev/null || true
+    fi
+
+    # Optionally overlay the working-tree diff so refs without the bench harness
+    # still get instrumented (thin shim over the ref's engine code).
+    if [[ "$OVERLAY" == 1 ]]; then
+      patch="$wt/.bench-overlay.patch"
+      git -C "$REPO_ROOT" diff HEAD > "$patch" 2>/dev/null || true
+      if [[ -s "$patch" ]]; then
+        if git -C "$wt" apply --3way "$patch" >/dev/null 2>&1; then
+          echo "  overlaid uncommitted changes onto $label" >&2
+        else
+          echo "  WARN: overlay did not apply cleanly on $label — building as-is" >&2
+        fi
+      fi
+    fi
+
+    if [[ "$DO_BUILD" == 1 ]]; then
+      echo "  building dragonfruit-cli for $label" >&2
+      if ! build_rust "$wt"; then echo "  SKIP $label: cargo build failed" >&2; continue; fi
+    fi
+    rbin="$wt/rust/dragonfruit-cli/target/release/dragonfruit-cli"
+    [[ -x "$rbin" ]] || { echo "  SKIP $label: CLI binary not found (drop --no-build or build it)" >&2; continue; }
+
+    TARGET_LABEL+=("$label")
+    TARGET_SHA+=("$sha")
+    TARGET_TS+=("npx tsx $wt/scripts/dragonfruit-ts-cli.ts")
+    TARGET_RUST+=("$rbin")
+  done
+
+  [[ ${#TARGET_LABEL[@]} -gt 0 ]] || { echo "No usable git targets to benchmark" >&2; exit 1; }
+fi
+
+# ---------------------------------------------------------------------------
+# Run the full fixture × printer × layer-height × AA-preset matrix for one
+# target (one version of the software). Rows are tagged with ref/git_sha, and
+# optionally carry a validation:{...} block vs a known-good archive.
+# ---------------------------------------------------------------------------
+run_matrix() { # <label> <sha> <ts-cmd> <rust-binary> <hw-label> <hw-cpus> <hw-mem>
+  local REF="$1" SHA="$2" TS="$3" RUST="$4" HWL="$5" HWC="$6" HWM="$7"
+  local prefix=""
+  [[ ${#TARGET_LABEL[@]} -gt 1 || "$REF" != "working-tree" ]] && prefix="[$REF] "
+  [[ ${#HW_LABEL[@]} -gt 1 ]] && prefix="${prefix}{$HWL} "
+
+  # Command prefix that imposes this machine's CPU/RAM envelope on the slice (and its
+  # Rust child). Empty for the unconstrained host. The systemd scope, when present, caps
+  # the whole process subtree's RAM — the TS frontend already wipes its heap before the
+  # blocking slice, so the cap effectively bounds the slicing engine's footprint.
+  local HWPRE; HWPRE="$(hw_prefix_for "$HWC" "$HWM")"
+
+  local voxl printer lh aa vname pname pext repfile ok_repeats r tmp errf resf inspf reslog fsize row rc
+  local valjson valfile hwcjson hwmjson fail_diag oom
+  hwcjson="$([[ -n "$HWC" ]] && printf '%s' "$HWC" || printf 'null')"
+  hwmjson="$([[ -n "$HWM" ]] && printf '"%s"' "$HWM" || printf 'null')"
+  for voxl in "${voxls[@]}"; do
+   for printer in "${printers[@]}"; do
+    pext="$(printer_ext "$printer")"        # output format follows the printer profile
+    for lh in "${LHS[@]}"; do
+     for aa in "${AAS[@]}"; do
+      vname="$(basename "$voxl" .voxl)"; pname="$(basename "$printer" .json)"
+      repfile="$(mktemp -p "$BENCH_SCRATCH")"; ok_repeats=0; valjson=""; valfile=""; fail_diag=""
+      for ((r=1; r<=REPEATS; r++)); do
+        tmp="$(mktemp -u -p "$BENCH_SCRATCH" --suffix="$pext")"; errf="$(mktemp -p "$BENCH_SCRATCH")"; resf="$(mktemp -p "$BENCH_SCRATCH")"; inspf="$(mktemp -p "$BENCH_SCRATCH")"; reslog="$(mktemp -p "$BENCH_SCRATCH")"
+        # Stream the CLI's JSON to a file, not a shell var: a long slice's `samples`
+        # time-series can exceed the single-argv limit, and `--argjson s "$res"` then
+        # dies with "Argument list too long". jq reads it back via `input` below.
+        # DF_RESOURCE_LOG makes the slicer stream each RSS/CPU sample to $reslog as it goes,
+        # so the series survives an OOM SIGKILL that never reaches the final --json emit; the
+        # failure branch below folds it into the error row for post-mortem debugging.
+        if DF_RESOURCE_LOG="$reslog" $HWPRE $TS scene slice "$voxl" --o "$tmp" --mesh-dir "$MESH_DIR" \
+                   --printer "$printer" --layer-height "$lh" --aa-preset "$aa" \
+                   --json >"$resf" 2>"$errf"; then
+          # print inspect is zip-only; on binary formats (.ctb/.goo/…) it fails and
+          # we fall back to a non-empty-file gate. fsize is always available via stat.
+          $RUST print inspect "$tmp" --json >"$inspf" 2>/dev/null || echo '{}' >"$inspf"
+          fsize="$(file_size "$tmp")"
+          if jq -c -n \
+                --arg voxl "$vname" --arg printer "$pname" --arg fmt "$pext" \
+                --arg lh "$lh" --arg aa "$aa" --argjson r "$r" --argjson fsize "$fsize" \
+                --arg ref "$REF" --arg sha "$SHA" \
+                --arg hw "$HWL" --argjson hwc "$hwcjson" --argjson hwm "$hwmjson" '
+            input as $s | input as $i
+            | ($i.numeric_layer_count) as $nlc
+            | {
+            ref:$ref, git_sha:$sha,
+            hw:$hw, hw_cpus:$hwc, hw_mem:$hwm,
+            voxl:$voxl, printer:$printer, format:$fmt,
+            layer_height:($lh|tonumber), aa_preset:$aa, run:$r,
+            layers:$s.layers, layer_count:($i.layer_count // null),
+            numeric_layer_count:($nlc // null),
+            gate:(if $nlc != null then "numeric-layer-count" else "file-nonempty" end),
+            ok:(if $nlc != null then ($nlc == $s.layers) else ($fsize > 0) end),
+            x_packing_mode:$s.x_packing_mode, anti_aliasing:$s.anti_aliasing, dither:$s.dither,
+            total_s:$s.total_s, wall_s:$s.wall_s, layers_per_second:$s.layers_per_second,
+            perf:$s.perf,
+            cpu_total_s:$s.resources.cpu_total_s, cpu_percent:$s.resources.cpu_percent,
+            peak_sample_cpu_percent:($s.resources.peak_sample_cpu_percent // 0),
+            peak_rss_mb:(($s.resources.peak_rss_bytes // 0)/1048576),
+            end_rss_mb:(($s.resources.end_rss_bytes // 0)/1048576),
+            samples:[ ($s.resources.samples // [])[] | {run:$r} + . ],
+            triangles:($s.scene.total_triangles // null), file_bytes:($i.file_size_bytes // $fsize)
+          }' "$resf" "$inspf" >> "$repfile"; then
+            ok_repeats=$((ok_repeats+1))
+            # Validate once per case (slicing is deterministic): keep the first
+            # good archive for the content comparison, delete the rest.
+            if [[ -n "$VALIDATE_DIR" && -z "$valfile" ]]; then valfile="$tmp"; else rm -f "$tmp"; fi
+          else
+            # jq built no row (e.g. malformed CLI JSON) — count the repeat as failed so the
+            # per-case average isn't taken over a short set and the row reads honestly.
+            fails=$((fails+1))
+            echo "  ${prefix}FAILED: $vname / $pname lh=$lh preset=$aa (run $r/$REPEATS, row-build error)" >&2
+            rm -f "$tmp"
+          fi
+        else
+          rc=$?
+          fails=$((fails+1))
+          # Under a mem cap, a cgroup OOM tears the systemd scope down and the slice exits via a
+          # signal (137=SIGKILL or 143=SIGTERM, i.e. rc>128) — a genuine slice error would exit
+          # with a small code instead. Flag it so the failure reads as "didn't fit this machine's
+          # RAM" rather than a generic error.
+          local why=""
+          oom=false; [[ -n "$HWM" && "$rc" -gt 128 ]] && { oom=true; why=" — likely OOM (mem cap=$HWM)"; }
+          # The slicer streamed each sample to $reslog as it ran, so even an OOM SIGKILL leaves
+          # the RSS/CPU climb on disk. Fold it (+ derived peaks) into a diagnostic and keep the
+          # richest (last) failure's copy — attached to this case's error row further down.
+          fail_diag="$(jq -c -s --argjson rc "$rc" --argjson oom "$oom" --argjson run "$r" '
+              (map({run:$run} + .)) as $s
+              | { exit_code:$rc, oom:$oom, sample_count:($s|length),
+                  peak_rss_bytes:  ($s|map(.rss_bytes)|max // 0),
+                  peak_rss_mb:     (($s|map(.rss_bytes)|max // 0)/1048576),
+                  peak_sample_cpu_percent: ($s|map(.cpu_percent)|max // 0),
+                  samples:$s }' "$reslog" 2>/dev/null || echo '{}')"
+          echo "  ${prefix}FAILED: $vname / $pname lh=$lh preset=$aa (run $r/$REPEATS, exit $rc)$why" >&2
+          tail -n 3 "$errf" | sed 's/^/      | /' >&2
+          rm -f "$tmp"
+        fi
+        rm -f "$errf" "$resf" "$inspf" "$reslog"
+      done
+
+      if [[ -n "$valfile" ]]; then
+        valjson="$(validate_case "$valfile" "$vname" "$pname" "$lh" "$aa")"
+        rm -f "$valfile"
+      fi
+
+      runs=$((runs+1))
+      if [[ "$ok_repeats" -gt 0 ]]; then
+        row="$(jq -s -c "$AVG_JQ" "$repfile")"
+        if [[ -n "$valjson" ]]; then
+          row="$(echo "$row" | jq -c --argjson v "$valjson" --argjson req "$REQUIRE_GOLDEN" '
+            . + {validation:$v}
+            | if ($v.status=="mismatch" or $v.status=="error"
+                  or ($req==1 and $v.status=="missing")) then .ok=false else . end')"
+        fi
+        echo "$row" >> "$OUT"
+        printf '  %s%-14s %-20s lh=%-5s preset=%-9s %s\n' "$prefix" "$vname" "$pname" "$lh" "$aa" \
+          "$(echo "$row" | jq -r '"\(.format) \(.layers)L avg \(.total_s*10|round/10)s (\(.repeats)x) \(.layers_per_second|round)lps peakRSS=\(.peak_rss_mb|round)MB peakCPU=\(.peak_sample_cpu_percent|round)% dither=\(.dither.enabled)\(if .validation then " valid=\(.validation.status)" else "" end) ok=\(.ok)"')" >&2
+      else
+        # Merge the last failure's resource diagnostic ($fail_diag) so an OOM row carries its
+        # RSS/CPU samples + peaks + exit_code/oom for debugging, not just "all repeats failed".
+        [[ -n "$fail_diag" ]] || fail_diag='{}'
+        jq -c -n --arg ref "$REF" --arg sha "$SHA" --arg voxl "$vname" --arg printer "$pname" \
+          --arg fmt "$pext" --arg lh "$lh" --arg aa "$aa" \
+          --arg hw "$HWL" --argjson hwc "$hwcjson" --argjson hwm "$hwmjson" \
+          --argjson diag "$fail_diag" \
+          '{ref:$ref,git_sha:$sha,hw:$hw,hw_cpus:$hwc,hw_mem:$hwm,voxl:$voxl,printer:$printer,format:$fmt,layer_height:($lh|tonumber),aa_preset:$aa,error:"all repeats failed"} + $diag' >> "$OUT"
+        printf '  %s%-14s %-20s lh=%-5s preset=%-9s ERROR (all %s repeats failed%s)\n' "$prefix" "$vname" "$pname" "$lh" "$aa" "$REPEATS" \
+          "$(echo "$fail_diag" | jq -r 'if .oom then ", OOM peakRSS=\(.peak_rss_mb|round)MB \(.sample_count) samples" else "" end' 2>/dev/null)" >&2
+      fi
+      rm -f "$repfile"
+     done
+    done
+   done
+  done
+}
+
+# Build once per git target, then sweep every hardware envelope under it (the software
+# is fixed per ref; only the imposed CPU/RAM machine changes between hw configs).
+for ti in "${!TARGET_LABEL[@]}"; do
+  [[ ${#TARGET_LABEL[@]} -gt 1 ]] && echo "==> benchmarking ${TARGET_LABEL[$ti]} (${TARGET_SHA[$ti]})" >&2
+  for hi in "${!HW_LABEL[@]}"; do
+    if [[ ${#HW_LABEL[@]} -gt 1 || -n "${HW_CPUS[$hi]}${HW_MEM[$hi]}" ]]; then
+      echo "==> hw config '${HW_LABEL[$hi]}' (cpus=${HW_CPUS[$hi]:-host} mem=${HW_MEM[$hi]:-unbounded})" >&2
+    fi
+    run_matrix "${TARGET_LABEL[$ti]}" "${TARGET_SHA[$ti]}" "${TARGET_TS[$ti]}" "${TARGET_RUST[$ti]}" \
+               "${HW_LABEL[$hi]}" "${HW_CPUS[$hi]}" "${HW_MEM[$hi]}"
+  done
+done
+
+echo "==> ${#TARGET_LABEL[@]} target(s) × ${#HW_LABEL[@]} hw config(s), $runs cases, $fails failed repeats -> $OUT" >&2

--- a/scripts/bench/run-slicing-bench.sh
+++ b/scripts/bench/run-slicing-bench.sh
@@ -26,6 +26,11 @@
 #   --no-build           skip cargo build
 #
 #  Git multi-version options (measure several versions of the software):
+#   --codegen CSV        x86_64 codegen variants to sweep, e.g. shipped,v2,v3. Builds the
+#                        CLI once per variant (same source, different RUSTFLAGS) and runs
+#                        the whole matrix against each. Presets: v1, v2, v3, shipped,
+#                        v2avx2, native. Anything else is passed to RUSTFLAGS verbatim.
+#                        Variants this CPU cannot execute are skipped, not crashed into.
 #   --refs CSV           git refs to benchmark: branches/tags/commits, e.g. main,dev,v1.2.0
 #   --prs CSV            GitHub PR numbers, e.g. 418,424 (fetched via pull/N/head)
 #   --worktree-base DIR  where to create per-ref worktrees   (default: a temp dir)
@@ -82,6 +87,7 @@ OUT="bench-results.jsonl"
 REPEATS=1
 DO_BUILD=1
 REFS=""
+CODEGEN=""
 PRS=""
 WORKTREE_BASE=""
 KEEP_WT=0
@@ -101,6 +107,7 @@ while [[ $# -gt 0 ]]; do
     --out) OUT="$2"; shift 2;;
     --repeats) REPEATS="$2"; shift 2;;
     --no-build) DO_BUILD=0; shift;;
+    --codegen) CODEGEN="$2"; shift 2;;
     --refs) REFS="$2"; shift 2;;
     --prs) PRS="$2"; shift 2;;
     --worktree-base) WORKTREE_BASE="$2"; shift 2;;
@@ -288,7 +295,7 @@ read -r -d '' AVG_JQ <<'JQ' || true
 def avg(f): (map(f) | add) / length;
 [.[].perf] as $ps
 | {
-    ref: .[0].ref, git_sha: .[0].git_sha,
+    ref: .[0].ref, git_sha: .[0].git_sha, codegen: .[0].codegen,
     hw: .[0].hw, hw_cpus: .[0].hw_cpus, hw_mem: .[0].hw_mem,
     voxl: .[0].voxl, printer: .[0].printer, format: .[0].format,
     layer_height: .[0].layer_height,
@@ -396,7 +403,7 @@ validate_case() { # <produced-file> <voxl> <printer> <lh> <preset> -> prints val
 # A "target" is one version of the software to benchmark. With no --refs/--prs
 # there is a single target: the current working tree.
 # ---------------------------------------------------------------------------
-declare -a TARGET_LABEL TARGET_SHA TARGET_TS TARGET_RUST
+declare -a TARGET_LABEL TARGET_SHA TARGET_TS TARGET_RUST TARGET_CHECKOUT TARGET_CODEGEN
 WORKTREES=()
 CREATED_WT_BASE=0
 
@@ -418,8 +425,45 @@ trap cleanup_all EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
-build_rust() { # <checkout-dir>
-  ( cd "$1/rust/dragonfruit-cli" && cargo build --release >/dev/null )
+# Codegen presets. `target-feature` only tells LLVM the instructions exist; the
+# cost model and scheduling still come from `target-cpu`, so the two knobs are
+# not interchangeable and the matrix carries both shapes on purpose.
+codegen_flags() { # <name> -> RUSTFLAGS on stdout, non-zero if unknown
+  case "$1" in
+    v1)      printf -- '-C target-cpu=x86-64' ;;
+    v2)      printf -- '-C target-cpu=x86-64-v2' ;;
+    v3)      printf -- '-C target-cpu=x86-64-v3' ;;
+    shipped) printf -- '-C target-feature=+avx2,+fma' ;;
+    v2avx2)  printf -- '-C target-cpu=x86-64-v2 -C target-feature=+avx2,+fma' ;;
+    native)  printf -- '-C target-cpu=native' ;;
+    -C*)     printf -- '%s' "$1" ;;
+    *)       return 1 ;;
+  esac
+}
+
+# A variant the host cannot execute dies with an illegal instruction partway
+# through the matrix. Saying so up front is friendlier than the crash.
+codegen_runnable() { # <name> -> non-zero (and a reason on stdout) if unrunnable
+  local name="$1" flags cpuflags
+  flags="$(codegen_flags "$name")" || return 0
+  [[ -r /proc/cpuinfo ]] || return 0
+  cpuflags=" $(sed -n 's/^flags[[:space:]]*:[[:space:]]*//p' /proc/cpuinfo | head -1) "
+  if [[ "$flags" == *avx2* || "$flags" == *x86-64-v3* ]] && [[ "$cpuflags" != *" avx2 "* ]]; then
+    echo "needs AVX2, which this CPU does not have"; return 1
+  fi
+  if [[ "$flags" == *x86-64-v* ]] && [[ "$cpuflags" != *" sse4_2 "* ]]; then
+    echo "needs SSE4.2, which this CPU does not have"; return 1
+  fi
+  return 0
+}
+
+build_rust() { # <checkout-dir> [rustflags] [target-dir]
+  # An empty CARGO_TARGET_DIR is not the same as an unset one, so the variables
+  # are only exported when a codegen variant actually asked for them.
+  ( cd "$1/rust/dragonfruit-cli" || exit 1
+    if [[ -n "${2-}" ]]; then export RUSTFLAGS="$2"; fi
+    if [[ -n "${3-}" ]]; then export CARGO_TARGET_DIR="$3"; fi
+    cargo build --release >/dev/null )
 }
 
 if [[ -z "$REFS" && -z "$PRS" ]]; then
@@ -434,6 +478,8 @@ if [[ -z "$REFS" && -z "$PRS" ]]; then
   TARGET_SHA+=("$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)")
   TARGET_TS+=("npx tsx scripts/dragonfruit-ts-cli.ts")
   TARGET_RUST+=("$rbin")
+  TARGET_CHECKOUT+=("$REPO_ROOT")
+  TARGET_CODEGEN+=("")
 else
   # ---- multiple targets: one git worktree per ref/PR ----
   if [[ -z "$WORKTREE_BASE" ]]; then WORKTREE_BASE="$(mktemp -d)"; CREATED_WT_BASE=1; fi
@@ -502,9 +548,56 @@ else
     TARGET_SHA+=("$sha")
     TARGET_TS+=("npx tsx $wt/scripts/dragonfruit-ts-cli.ts")
     TARGET_RUST+=("$rbin")
+    TARGET_CHECKOUT+=("$wt")
+    TARGET_CODEGEN+=("")
   done
 
   [[ ${#TARGET_LABEL[@]} -gt 0 ]] || { echo "No usable git targets to benchmark" >&2; exit 1; }
+fi
+
+# ---------------------------------------------------------------------------
+# Codegen sweep: multiply every target by the requested codegen variants. Same
+# source, same checkout — only RUSTFLAGS differs, each into its own target dir
+# so variants never reuse each other's artifacts. RUSTFLAGS fully overrides the
+# rustflags in .cargo/config.toml (cargo treats them as mutually exclusive), so
+# no variant silently inherits the flags we ship.
+# ---------------------------------------------------------------------------
+if [[ -n "$CODEGEN" ]]; then
+  declare -a CG_LABEL=() CG_SHA=() CG_TS=() CG_RUST=() CG_CHECKOUT=() CG_CODEGEN=()
+  IFS=',' read -ra CGLIST <<< "$CODEGEN"
+  for ti in "${!TARGET_LABEL[@]}"; do
+    for cg in "${CGLIST[@]}"; do
+      [[ -n "$cg" ]] || continue
+      if ! flags="$(codegen_flags "$cg")"; then
+        echo "  SKIP codegen '$cg': unknown preset (try v1, v2, v3, shipped, v2avx2, native, or -C flags)" >&2
+        continue
+      fi
+      if ! reason="$(codegen_runnable "$cg")"; then
+        echo "  SKIP codegen '$cg': $reason" >&2
+        continue
+      fi
+      co="${TARGET_CHECKOUT[$ti]}"
+      # printf, not echo: echo's trailing newline is outside the accepted set and
+      # tr -c would turn it into a trailing underscore, so the directory looked
+      # for and the directory built would not match.
+      safe_cg="$(printf '%s' "$cg" | tr -c 'A-Za-z0-9._-' '_')"
+      tdir="$co/rust/dragonfruit-cli/target-codegen-$safe_cg"
+      if [[ "$DO_BUILD" == 1 ]]; then
+        echo "==> building ${TARGET_LABEL[$ti]} with codegen '$cg' ($flags)" >&2
+        if ! build_rust "$co" "$flags" "$tdir"; then
+          echo "  SKIP codegen '$cg' on ${TARGET_LABEL[$ti]}: cargo build failed" >&2; continue
+        fi
+      fi
+      rbin="$tdir/release/dragonfruit-cli"
+      [[ -x "$rbin" ]] || { echo "  SKIP codegen '$cg' on ${TARGET_LABEL[$ti]}: binary not found (drop --no-build)" >&2; continue; }
+      CG_LABEL+=("${TARGET_LABEL[$ti]}");   CG_SHA+=("${TARGET_SHA[$ti]}")
+      CG_TS+=("${TARGET_TS[$ti]}");         CG_RUST+=("$rbin")
+      CG_CHECKOUT+=("$co");                 CG_CODEGEN+=("$cg")
+    done
+  done
+  [[ ${#CG_LABEL[@]} -gt 0 ]] || { echo "No usable codegen variants to benchmark" >&2; exit 1; }
+  TARGET_LABEL=("${CG_LABEL[@]}"); TARGET_SHA=("${CG_SHA[@]}"); TARGET_TS=("${CG_TS[@]}")
+  TARGET_RUST=("${CG_RUST[@]}");   TARGET_CHECKOUT=("${CG_CHECKOUT[@]}"); TARGET_CODEGEN=("${CG_CODEGEN[@]}")
 fi
 
 # ---------------------------------------------------------------------------
@@ -512,10 +605,11 @@ fi
 # target (one version of the software). Rows are tagged with ref/git_sha, and
 # optionally carry a validation:{...} block vs a known-good archive.
 # ---------------------------------------------------------------------------
-run_matrix() { # <label> <sha> <ts-cmd> <rust-binary> <hw-label> <hw-cpus> <hw-mem>
-  local REF="$1" SHA="$2" TS="$3" RUST="$4" HWL="$5" HWC="$6" HWM="$7"
+run_matrix() { # <label> <sha> <ts-cmd> <rust-binary> <hw-label> <hw-cpus> <hw-mem> <codegen>
+  local REF="$1" SHA="$2" TS="$3" RUST="$4" HWL="$5" HWC="$6" HWM="$7" CG="${8-}"
   local prefix=""
   [[ ${#TARGET_LABEL[@]} -gt 1 || "$REF" != "working-tree" ]] && prefix="[$REF] "
+  [[ -n "$CG" ]] && prefix="${prefix}<$CG> "
   [[ ${#HW_LABEL[@]} -gt 1 ]] && prefix="${prefix}{$HWL} "
 
   # Command prefix that imposes this machine's CPU/RAM envelope on the slice (and its
@@ -526,6 +620,7 @@ run_matrix() { # <label> <sha> <ts-cmd> <rust-binary> <hw-label> <hw-cpus> <hw-m
 
   local voxl printer lh aa vname pname pext repfile ok_repeats r tmp errf resf inspf reslog fsize row rc
   local valjson valfile hwcjson hwmjson fail_diag oom
+  local cgjson; cgjson="$([[ -n "$CG" ]] && printf '"%s"' "$CG" || printf 'null')"
   hwcjson="$([[ -n "$HWC" ]] && printf '%s' "$HWC" || printf 'null')"
   hwmjson="$([[ -n "$HWM" ]] && printf '"%s"' "$HWM" || printf 'null')"
   for voxl in "${voxls[@]}"; do
@@ -553,12 +648,12 @@ run_matrix() { # <label> <sha> <ts-cmd> <rust-binary> <hw-label> <hw-cpus> <hw-m
           if jq -c -n \
                 --arg voxl "$vname" --arg printer "$pname" --arg fmt "$pext" \
                 --arg lh "$lh" --arg aa "$aa" --argjson r "$r" --argjson fsize "$fsize" \
-                --arg ref "$REF" --arg sha "$SHA" \
+                --arg ref "$REF" --arg sha "$SHA" --argjson codegen "$cgjson" \
                 --arg hw "$HWL" --argjson hwc "$hwcjson" --argjson hwm "$hwmjson" '
             input as $s | input as $i
             | ($i.numeric_layer_count) as $nlc
             | {
-            ref:$ref, git_sha:$sha,
+            ref:$ref, git_sha:$sha, codegen:$codegen,
             hw:$hw, hw_cpus:$hwc, hw_mem:$hwm,
             voxl:$voxl, printer:$printer, format:$fmt,
             layer_height:($lh|tonumber), aa_preset:$aa, run:$r,
@@ -634,11 +729,12 @@ run_matrix() { # <label> <sha> <ts-cmd> <rust-binary> <hw-label> <hw-cpus> <hw-m
         # Merge the last failure's resource diagnostic ($fail_diag) so an OOM row carries its
         # RSS/CPU samples + peaks + exit_code/oom for debugging, not just "all repeats failed".
         [[ -n "$fail_diag" ]] || fail_diag='{}'
-        jq -c -n --arg ref "$REF" --arg sha "$SHA" --arg voxl "$vname" --arg printer "$pname" \
+        jq -c -n --arg ref "$REF" --arg sha "$SHA" --argjson codegen "$cgjson" \
+          --arg voxl "$vname" --arg printer "$pname" \
           --arg fmt "$pext" --arg lh "$lh" --arg aa "$aa" \
           --arg hw "$HWL" --argjson hwc "$hwcjson" --argjson hwm "$hwmjson" \
           --argjson diag "$fail_diag" \
-          '{ref:$ref,git_sha:$sha,hw:$hw,hw_cpus:$hwc,hw_mem:$hwm,voxl:$voxl,printer:$printer,format:$fmt,layer_height:($lh|tonumber),aa_preset:$aa,error:"all repeats failed"} + $diag' >> "$OUT"
+          '{ref:$ref,git_sha:$sha,codegen:$codegen,hw:$hw,hw_cpus:$hwc,hw_mem:$hwm,voxl:$voxl,printer:$printer,format:$fmt,layer_height:($lh|tonumber),aa_preset:$aa,error:"all repeats failed"} + $diag' >> "$OUT"
         printf '  %s%-14s %-20s lh=%-5s preset=%-9s ERROR (all %s repeats failed%s)\n' "$prefix" "$vname" "$pname" "$lh" "$aa" "$REPEATS" \
           "$(echo "$fail_diag" | jq -r 'if .oom then ", OOM peakRSS=\(.peak_rss_mb|round)MB \(.sample_count) samples" else "" end' 2>/dev/null)" >&2
       fi
@@ -652,13 +748,13 @@ run_matrix() { # <label> <sha> <ts-cmd> <rust-binary> <hw-label> <hw-cpus> <hw-m
 # Build once per git target, then sweep every hardware envelope under it (the software
 # is fixed per ref; only the imposed CPU/RAM machine changes between hw configs).
 for ti in "${!TARGET_LABEL[@]}"; do
-  [[ ${#TARGET_LABEL[@]} -gt 1 ]] && echo "==> benchmarking ${TARGET_LABEL[$ti]} (${TARGET_SHA[$ti]})" >&2
+  [[ ${#TARGET_LABEL[@]} -gt 1 ]] && echo "==> benchmarking ${TARGET_LABEL[$ti]} (${TARGET_SHA[$ti]})${TARGET_CODEGEN[$ti]:+ codegen '${TARGET_CODEGEN[$ti]}'}" >&2
   for hi in "${!HW_LABEL[@]}"; do
     if [[ ${#HW_LABEL[@]} -gt 1 || -n "${HW_CPUS[$hi]}${HW_MEM[$hi]}" ]]; then
       echo "==> hw config '${HW_LABEL[$hi]}' (cpus=${HW_CPUS[$hi]:-host} mem=${HW_MEM[$hi]:-unbounded})" >&2
     fi
     run_matrix "${TARGET_LABEL[$ti]}" "${TARGET_SHA[$ti]}" "${TARGET_TS[$ti]}" "${TARGET_RUST[$ti]}" \
-               "${HW_LABEL[$hi]}" "${HW_CPUS[$hi]}" "${HW_MEM[$hi]}"
+               "${HW_LABEL[$hi]}" "${HW_CPUS[$hi]}" "${HW_MEM[$hi]}" "${TARGET_CODEGEN[$ti]}"
   done
 done
 

--- a/scripts/bench/visualize-stats.mjs
+++ b/scripts/bench/visualize-stats.mjs
@@ -1,0 +1,525 @@
+#!/usr/bin/env node
+// visualize-stats.mjs — turn a slicing-benchmark JSONL into a single
+// self-contained HTML dashboard, styled like the app's in-UI "Slice Performance
+// Metrics (V3)" modal (src/features/slicing/components/SliceMetricsDebugModal.tsx
+// — used only as a visual reference).
+//
+// It surfaces *everything the benchmark records*, not just the SliceStatsV3 perf
+// fields: the imposed hardware envelope (cpus/mem), CPU + RAM resources, the
+// periodic RSS/CPU time-series, every un-averaged repeat under runs[], the
+// correctness gate + validation, and output size.
+//
+// Usage:
+//   scripts/bench/visualize-stats.mjs [options] <results.jsonl>...
+//
+//   --out <file.html>   output page (default: bench-report.html)
+//   --title <text>      page title / header
+//   --open              open the page in the default browser when done
+//
+// Dependencies: node built-ins only.
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { resolve, basename } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// args
+// ---------------------------------------------------------------------------
+function parseArgs(argv) {
+  const opts = { inputs: [], out: 'bench-report.html', title: 'Slicing benchmark', open: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case '--out': opts.out = argv[++i]; break;
+      case '--title': opts.title = argv[++i]; break;
+      case '--open': opts.open = true; break;
+      case '-h': case '--help': printHelp(); process.exit(0); break;
+      default:
+        if (a.startsWith('--')) { console.error(`unknown option: ${a}`); process.exit(2); }
+        opts.inputs.push(a);
+    }
+  }
+  if (opts.inputs.length === 0) { printHelp(); process.exit(2); }
+  return opts;
+}
+
+function printHelp() {
+  for (const line of readFileSync(new URL(import.meta.url)).toString().split('\n')) {
+    if (line.startsWith('#!')) continue;
+    if (!line.startsWith('//')) break;
+    console.log(line.replace(/^\/\/ ?/, ''));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// input
+// ---------------------------------------------------------------------------
+function loadRows(paths) {
+  const rows = [];
+  for (const p of paths) {
+    const r = resolve(p);
+    if (!existsSync(r)) { console.error(`WARN: not found: ${p}`); continue; }
+    for (const line of readFileSync(r, 'utf8').split('\n')) {
+      const s = line.trim();
+      if (!s) continue;
+      try { rows.push(JSON.parse(s)); } catch { console.error(`WARN: skipping unparseable line in ${p}`); }
+    }
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// normalization
+// ---------------------------------------------------------------------------
+const num = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : null);
+
+function normalize(row) {
+  const res = row.resources || {};
+  const rssMb = num(row.peak_rss_mb) ?? (num(res.peak_rss_bytes) != null ? res.peak_rss_bytes / 1048576 : null);
+  const endRssMb = num(row.end_rss_mb) ?? (num(res.end_rss_bytes) != null ? res.end_rss_bytes / 1048576 : null);
+
+  const runs = Array.isArray(row.runs) && row.runs.length
+    ? row.runs.map((r) => ({
+        run: r.run, total_s: num(r.total_s), wall_s: num(r.wall_s),
+        layers_per_second: num(r.layers_per_second),
+        cpu_percent: num(r.cpu_percent), peak_cpu_percent: num(r.peak_sample_cpu_percent),
+        peak_rss_mb: num(r.peak_rss_mb), end_rss_mb: num(r.end_rss_mb),
+        samples: Array.isArray(r.samples) ? r.samples : [],
+      }))
+    : [];
+  const samples = runs.find((r) => r.samples && r.samples.length)?.samples
+    || (Array.isArray(row.samples) ? row.samples : []);
+
+  return {
+    error: row.error || null,
+    oom: !!row.oom, exit_code: num(row.exit_code),
+    voxl: row.voxl ?? '?', printer: row.printer ?? '?', format: row.format || null,
+    layer_height: num(row.layer_height), aa_preset: row.aa_preset ?? '?',
+    ref: row.ref || null, git_sha: row.git_sha || null,
+    hw: row.hw || null, hw_cpus: row.hw_cpus ?? null, hw_mem: row.hw_mem ?? null,
+    layers: num(row.layers), layer_count: num(row.layer_count), numeric_layer_count: num(row.numeric_layer_count),
+    total_s: num(row.total_s), wall_s: num(row.wall_s),
+    total_s_min: num(row.total_s_min), total_s_max: num(row.total_s_max),
+    layers_per_second: num(row.layers_per_second),
+    cpu_total_s: num(row.cpu_total_s) ?? num(res.cpu_total_s),
+    cpu_percent: num(row.cpu_percent) ?? num(res.cpu_percent),
+    peak_cpu_percent: num(row.peak_sample_cpu_percent) ?? num(res.peak_sample_cpu_percent),
+    peak_rss_mb: rssMb, end_rss_mb: endRssMb,
+    samples, runs,
+    perf: row.perf || null,
+    anti_aliasing: row.anti_aliasing || null, dither: row.dither || null,
+    x_packing_mode: row.x_packing_mode || null, triangles: num(row.triangles),
+    file_bytes: num(row.file_bytes),
+    ok: typeof row.ok === 'boolean' ? row.ok : null, gate: row.gate || null,
+    validation: row.validation || null, repeats: num(row.repeats),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// formatting (mirrors the modal's helpers)
+// ---------------------------------------------------------------------------
+const DASH = '—';
+const fmtMs = (ms, d = 2) => ms == null || !Number.isFinite(ms) ? DASH : ms >= 1000 ? `${(ms / 1000).toFixed(2)} s` : `${ms.toFixed(d)} ms`;
+const nsToMs = (ns) => ns == null || !Number.isFinite(ns) ? null : ns / 1e6;
+const fmtNs = (ns) => ns == null || !Number.isFinite(ns) ? DASH : `${Math.round(ns).toLocaleString()} ns`;
+const fmtRate = (v) => v == null || !Number.isFinite(v) ? DASH : v >= 100 ? `${Math.round(v).toLocaleString()} L/s` : `${v.toFixed(2)} L/s`;
+const fmtPct = (v) => v == null || !Number.isFinite(v) ? DASH : `${v.toFixed(1)}%`;
+const fmtInt = (v) => v == null || !Number.isFinite(v) ? DASH : Math.round(v).toLocaleString();
+const fmtMb = (v) => v == null || !Number.isFinite(v) ? DASH : `${v.toFixed(1)} MB`;
+const fmtSec = (v) => v == null || !Number.isFinite(v) ? DASH : `${v.toFixed(2)} s`;
+const fmtBytes = (v) => {
+  if (v == null || !Number.isFinite(v)) return DASH;
+  if (v < 1024) return `${Math.round(v)} B`;
+  if (v < 1048576) return `${(v / 1024).toFixed(1)} KB`;
+  return `${(v / 1048576).toFixed(2)} MB`;
+};
+const ratioPct = (a, b) => (a == null || b == null || !Number.isFinite(a) || !Number.isFinite(b) || b <= 0) ? null : (a / b) * 100;
+const esc = (s) => String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+function parseMemMb(mem) {
+  if (!mem) return null;
+  const m = String(mem).match(/^([\d.]+)\s*([kmg]?)i?b?$/i);
+  if (!m) return null;
+  const n = parseFloat(m[1]);
+  const u = m[2].toLowerCase();
+  return u === 'g' ? n * 1024 : u === 'k' ? n / 1024 : u === 'm' || u === '' ? n : n;
+}
+
+// ---------------------------------------------------------------------------
+// html fragments
+// ---------------------------------------------------------------------------
+const stat = (k, v) => `<div class="stat"><span class="stat-k">${esc(k)}</span><span class="stat-v">${esc(v)}</span></div>`;
+const metric = (k, v, compact = false) => `<div class="metric${compact ? ' compact' : ''}"><div class="metric-k">${esc(k)}</div><div class="metric-v">${esc(v)}</div></div>`;
+
+const PIE_COLORS = { 'Index build': '#60a5fa', 'Render pipeline': '#f472b6', 'Archive encode': '#f59e0b', 'Other / overhead': '#94a3b8' };
+function pipelinePie(perf) {
+  const total = nsToMs(perf?.total_ns);
+  const slices = [
+    { name: 'Index build', ms: nsToMs(perf?.index_build_ns) },
+    { name: 'Render pipeline', ms: nsToMs(perf?.render_wall_ns) },
+    { name: 'Archive encode', ms: nsToMs(perf?.archive_encode_ns) },
+  ];
+  const known = slices.reduce((a, s) => a + (s.ms || 0), 0);
+  slices.push({ name: 'Other / overhead', ms: total != null ? Math.max(0, total - known) : null });
+  const has = total != null && total > 0;
+  for (const s of slices) s.pct = has ? Math.max(0, ratioPct(s.ms, total) ?? 0) : 0;
+  let cur = 0; const stops = [];
+  for (const s of slices) {
+    const end = Math.min(100, cur + s.pct);
+    if (end > cur) stops.push(`${PIE_COLORS[s.name]} ${cur.toFixed(2)}% ${end.toFixed(2)}%`);
+    cur = end;
+  }
+  const bg = stops.length ? `conic-gradient(${stops.join(', ')})` : 'conic-gradient(var(--surface-2) 0% 100%)';
+  const legend = slices.map((s) => `<div class="stat"><span class="stat-k"><i class="dot" style="background:${PIE_COLORS[s.name]}"></i>${esc(s.name)}</span><span class="stat-v">${fmtMs(s.ms, 2)} • ${fmtPct(s.pct)}</span></div>`).join('')
+    + stat('Native total', `${fmtMs(total, 2)} • ${has ? '100.0%' : DASH}`);
+  return `<div class="pie-wrap"><div class="pie" style="background:${bg}"><div class="pie-hole">${has ? 'Timing' : DASH}</div></div><div class="pie-legend">${legend}</div></div>`;
+}
+
+// SVG dual-axis time-series: RSS (MB) + CPU (%) vs t_ms, with an optional mem-cap line.
+function resourceChart(s) {
+  const pts = (s.samples || []).filter((p) => num(p.t_ms) != null).map((p) => ({
+    t: p.t_ms, rss: num(p.rss_mb) ?? (num(p.rss_bytes) != null ? p.rss_bytes / 1048576 : null), cpu: num(p.cpu_percent),
+  }));
+  if (pts.length < 2) return '';
+  const W = 560, H = 150, PL = 6, PR = 6, PT = 10, PB = 18;
+  const tMax = Math.max(...pts.map((p) => p.t)) || 1;
+  const capMb = parseMemMb(s.hw_mem);
+  const rssVals = pts.map((p) => p.rss).filter((v) => v != null);
+  let rssMax = Math.max(s.peak_rss_mb ?? 0, ...rssVals, 1);
+  if (capMb) rssMax = Math.max(rssMax, capMb);
+  const cpuMax = Math.max(s.peak_cpu_percent ?? 0, ...pts.map((p) => p.cpu ?? 0), 100);
+  const x = (t) => PL + (t / tMax) * (W - PL - PR);
+  const yR = (v) => H - PB - (v / rssMax) * (H - PT - PB);
+  const yC = (v) => H - PB - (v / cpuMax) * (H - PT - PB);
+  const line = (sel, y) => pts.filter((p) => sel(p) != null).map((p, i) => `${i ? 'L' : 'M'}${x(p.t).toFixed(1)},${y(sel(p)).toFixed(1)}`).join(' ');
+  const rssPath = line((p) => p.rss, yR);
+  const rssArea = `${rssPath} L${x(pts[pts.length - 1].t).toFixed(1)},${(H - PB).toFixed(1)} L${x(pts[0].t).toFixed(1)},${(H - PB).toFixed(1)} Z`;
+  const cpuPath = line((p) => p.cpu, yC);
+  const capLine = capMb ? `<line x1="${PL}" y1="${yR(capMb).toFixed(1)}" x2="${W - PR}" y2="${yR(capMb).toFixed(1)}" stroke="#ef4444" stroke-width="1" stroke-dasharray="4 3" opacity="0.8"/><text x="${W - PR}" y="${(yR(capMb) - 3).toFixed(1)}" text-anchor="end" fill="#ef4444" font-size="9">mem cap ${esc(s.hw_mem)}</text>` : '';
+  return `<div class="subpanel"><div class="subhead">Resource usage over time
+      <span class="legend-inline"><i class="ls rss"></i>RSS &nbsp;<i class="ls cpu"></i>CPU%</span></div>
+    <svg viewBox="0 0 ${W} ${H}" class="chart" preserveAspectRatio="none">
+      <path d="${rssArea}" fill="var(--accent)" opacity="0.14"/>
+      <path d="${rssPath}" fill="none" stroke="var(--accent)" stroke-width="1.6"/>
+      <path d="${cpuPath}" fill="none" stroke="#f59e0b" stroke-width="1.4" stroke-dasharray="3 2" opacity="0.9"/>
+      ${capLine}
+      <text x="${PL}" y="${H - 5}" fill="var(--text-muted)" font-size="9">0</text>
+      <text x="${W - PR}" y="${H - 5}" text-anchor="end" fill="var(--text-muted)" font-size="9">${Math.round(tMax / 1000)}s</text>
+    </svg>
+    <div class="chart-scale"><span>peak RSS ${fmtMb(s.peak_rss_mb)}</span><span>peak CPU ${fmtPct(s.peak_cpu_percent)}</span><span>${pts.length} samples</span></div>
+  </div>`;
+}
+
+function repeatsTable(s) {
+  if (!s.runs || s.runs.length < 1) return '';
+  const rows = s.runs.map((r) => `<tr>
+    <td>${r.run ?? DASH}</td><td>${fmtSec(r.total_s)}</td><td>${fmtRate(r.layers_per_second)}</td>
+    <td>${fmtMb(r.peak_rss_mb)}</td><td>${fmtPct(r.peak_cpu_percent)}</td><td>${fmtPct(r.cpu_percent)}</td></tr>`).join('');
+  const spread = (s.total_s_min != null && s.total_s_max != null)
+    ? `<span class="spread">spread ${fmtSec(s.total_s_min)}–${fmtSec(s.total_s_max)}</span>` : '';
+  return `<div class="subpanel"><div class="subhead">Per-repeat runs <span class="dim">(${s.runs.length}×, kept separate)</span> ${spread}</div>
+    <table class="mini"><thead><tr><th>run</th><th>total</th><th>throughput</th><th>peak RSS</th><th>peak CPU</th><th>avg CPU</th></tr></thead>
+    <tbody>${rows}</tbody></table></div>`;
+}
+
+function correctnessPanel(s) {
+  const vs = s.validation;
+  return `<div class="subpanel"><div class="subhead">Correctness &amp; output</div>
+    ${stat('Result', s.ok == null ? DASH : s.ok ? 'ok' : 'FAIL')}
+    ${stat('Gate', s.gate ?? DASH)}
+    ${stat('Reported layers', fmtInt(s.layers))}
+    ${stat('Layer count (meta)', fmtInt(s.layer_count))}
+    ${stat('Numeric layer count', fmtInt(s.numeric_layer_count))}
+    ${stat('Output size', fmtBytes(s.file_bytes))}
+    ${vs ? stat('Validation', `${vs.status}${vs.method ? ` (${vs.method})` : ''}`) : ''}
+    ${vs && vs.mismatched_layers != null ? stat('Mismatched layers', fmtInt(vs.mismatched_layers)) : ''}
+  </div>`;
+}
+
+function statsPanel(s) {
+  const perf = s.perf || {};
+  const renderWallPct = ratioPct(nsToMs(perf.render_wall_ns), nsToMs(perf.total_ns));
+  const pl = s.layers && s.layers > 0
+    ? { rw: nsToMs(perf.render_wall_ns) / s.layers, png: nsToMs(perf.png_encode_ns) / s.layers, tot: nsToMs(perf.total_ns) / s.layers }
+    : {};
+
+  const head = [
+    metric('Total time', fmtMs(s.total_s != null ? s.total_s * 1000 : null)),
+    metric('Throughput', fmtRate(s.layers_per_second)),
+    metric('Layers', fmtInt(s.layers)),
+    metric('Peak RSS', fmtMb(s.peak_rss_mb)),
+  ].join('');
+  const head2 = [
+    metric('Peak CPU', fmtPct(s.peak_cpu_percent), true),
+    metric('CPU time', fmtSec(s.cpu_total_s), true),
+    metric('Avg CPU', fmtPct(s.cpu_percent), true),
+    metric('Output', fmtBytes(s.file_bytes), true),
+  ].join('');
+
+  const perLayer = `<div class="subpanel"><div class="subhead">Per-layer KPIs</div>
+    ${stat('Render wall / layer', fmtMs(pl.rw, 3))}
+    ${stat('PNG encode / layer (CPU)', fmtMs(pl.png, 3))}
+    ${stat('Native total / layer', fmtMs(pl.tot, 3))}
+    ${stat('Render wall share', fmtPct(renderWallPct))}
+  </div>`;
+
+  const config = `<div class="subpanel"><div class="subhead">Render configuration</div>
+    ${stat('Format', s.format ?? DASH)}
+    ${stat('Layer height', s.layer_height != null ? `${s.layer_height} mm` : DASH)}
+    ${stat('AA preset', s.aa_preset ?? DASH)}
+    ${stat('AA level', s.anti_aliasing?.level ?? DASH)}
+    ${stat('AA mode', s.anti_aliasing?.mode ?? DASH)}
+    ${stat('Z-blend look-back', s.anti_aliasing?.z_blend_look_back ?? DASH)}
+    ${stat('Dither', s.dither ? (s.dither.enabled ? `on (${s.dither.bit_depth}-bit, γ${s.dither.device_gamma})` : 'off') : DASH)}
+    ${stat('X packing', s.x_packing_mode ?? DASH)}
+    ${stat('Triangles', fmtInt(s.triangles))}
+  </div>`;
+
+  const counters = `<div class="subpanel"><div class="subhead">Raw perf counters</div><div class="counters">
+    ${stat('total_ns', fmtNs(perf.total_ns))}
+    ${stat('index_build_ns', fmtNs(perf.index_build_ns))}
+    ${stat('render_wall_ns', fmtNs(perf.render_wall_ns))}
+    ${stat('render_ns', fmtNs(perf.render_ns))}
+    ${stat('png_encode_ns', fmtNs(perf.png_encode_ns))}
+    ${stat('archive_encode_ns', fmtNs(perf.archive_encode_ns))}
+    ${stat('z_blend_backward_ns', fmtNs(perf.z_blend_backward_ns))}
+    ${stat('z_blend_forward_ns', fmtNs(perf.z_blend_forward_ns))}
+    ${stat('cross_blend_ns', fmtNs(perf.cross_blend_ns))}
+    ${stat('cross_blend_touched_px', fmtInt(perf.cross_blend_touched_pixels))}
+    ${stat('post_blur_ns', fmtNs(perf.post_blur_ns))}
+    ${stat('support_merge_ns', fmtNs(perf.support_merge_ns))}
+    ${stat('daa_post_threads', perf.daa_post_threads ?? DASH)}
+    ${stat('daa_post_buffer_depth', perf.daa_post_buffer_depth ?? DASH)}
+  </div></div>`;
+
+  return `<div class="panel">
+    <div class="metrics-grid">${head}</div>
+    <div class="metrics-grid">${head2}</div>
+    ${resourceChart(s)}
+    <div class="panel-title">Pipeline timing</div>
+    ${pipelinePie(perf)}
+    <div class="two-col">${perLayer}${config}</div>
+    <div class="two-col">${repeatsTable(s)}${correctnessPanel(s)}</div>
+    ${counters}
+  </div>`;
+}
+
+function hwBadge(s) {
+  if (s.hw == null && s.hw_cpus == null && s.hw_mem == null) return '';
+  const spec = [s.hw_cpus != null ? `${s.hw_cpus}c` : null, s.hw_mem ? esc(s.hw_mem) : null].filter(Boolean).join('/');
+  return `<span class="badge hw">${[s.hw ? esc(s.hw) : null, spec || null].filter(Boolean).join(' · ')}</span>`;
+}
+function okBadge(s) {
+  if (s.ok == null) return '';
+  return s.ok ? `<span class="badge ok">ok</span>` : `<span class="badge bad">fail${s.validation?.status && s.validation.status !== 'match' ? ` · ${esc(s.validation.status)}` : ''}</span>`;
+}
+function refBadge(s) { return s.ref && s.ref !== 'working-tree' ? `<span class="badge ref">${esc(s.ref)}</span>` : ''; }
+
+function caseTitle(s) {
+  return [s.voxl, s.printer, s.layer_height != null ? `lh${s.layer_height}` : null, s.aa_preset].filter(Boolean).join(' · ');
+}
+
+function card(id, s) {
+  if (s.error) {
+    // A failed case — always flagged as such. OOM kills now carry the streamed RSS/CPU
+    // series, so render the run-up-to-death chart when present (it's the whole point of
+    // capturing OOM samples) while keeping the card unmistakably marked failed.
+    const failLabel = s.oom ? 'OOM' : 'error';
+    const detail = s.oom
+      ? `OOM-killed${s.exit_code != null ? ` (exit ${s.exit_code})` : ''}${s.hw_mem ? ` under mem cap ${esc(s.hw_mem)}` : ''} — ${esc(s.error)}`
+      : esc(s.error);
+    return `<section class="card error-card" id="c${id}"><div class="card-head"><div class="card-title">${esc(caseTitle(s))}</div>
+      <div class="badges">${refBadge(s)}${hwBadge(s)}<span class="badge bad">${failLabel}</span></div></div>
+      <div class="card-body"><div class="error-body">${detail}</div>${resourceChart(s)}</div></section>`;
+  }
+  return `<section class="card" id="c${id}"><div class="card-head">
+      <div class="card-title">${esc(caseTitle(s))}</div>
+      <div class="badges">${refBadge(s)}${hwBadge(s)}${okBadge(s)}</div>
+    </div><div class="card-body">${statsPanel(s)}</div></section>`;
+}
+
+// overview table --------------------------------------------------------------
+function overviewTable(list) {
+  const cols = [
+    ['#', null], ['case', 't'], ['ref', 't'], ['hw', 't'], ['fmt', 't'],
+    ['layers', 'n'], ['total s', 'n'], ['L/s', 'n'], ['peak RSS', 'n'], ['peak CPU', 'n'], ['CPU s', 'n'], ['out', 'n'], ['ok', 't'],
+  ];
+  const head = cols.map((c, i) => `<th data-col="${i}"${c[1] ? ` class="sortable" data-type="${c[1]}"` : ''}>${esc(c[0])}${c[1] ? '<span class="arrow"></span>' : ''}</th>`).join('');
+  const body = list.map(({ s, id }, i) => {
+    const cells = [
+      [i + 1, i + 1],
+      [`<a href="#c${id}">${esc(caseTitle(s))}</a>`, caseTitle(s)],
+      [s.ref ? esc(s.ref) : DASH, s.ref || ''],
+      [hwLabel(s), hwLabel(s)],
+      [s.format ? esc(s.format) : DASH, s.format || ''],
+      [fmtInt(s.layers), s.layers ?? -1],
+      [fmtSec(s.total_s), s.total_s ?? -1],
+      [fmtRate(s.layers_per_second), s.layers_per_second ?? -1],
+      [fmtMb(s.peak_rss_mb), s.peak_rss_mb ?? -1],
+      [fmtPct(s.peak_cpu_percent), s.peak_cpu_percent ?? -1],
+      [fmtSec(s.cpu_total_s), s.cpu_total_s ?? -1],
+      [fmtBytes(s.file_bytes), s.file_bytes ?? -1],
+      [s.oom ? '<span class="pill bad">OOM</span>' : s.error ? '<span class="pill bad">err</span>' : s.ok == null ? DASH : s.ok ? '<span class="pill ok">ok</span>' : '<span class="pill bad">fail</span>', (s.error || s.ok === false) ? 0 : (s.ok ? 1 : 0)],
+    ];
+    return `<tr>${cells.map((c, ci) => `<td data-sort="${esc(String(c[1]))}"${cols[ci][1] === 'n' ? ' class="numcol"' : ''}>${c[0]}</td>`).join('')}</tr>`;
+  }).join('');
+  return `<table id="ov"><thead><tr>${head}</tr></thead><tbody>${body}</tbody></table>`;
+}
+const hwLabel = (s) => s.hw ? s.hw : (s.hw_cpus != null || s.hw_mem != null ? [s.hw_cpus != null ? `${s.hw_cpus}c` : '', s.hw_mem || ''].filter(Boolean).join('/') : 'host');
+
+// ---------------------------------------------------------------------------
+// page
+// ---------------------------------------------------------------------------
+const CSS = `
+:root{--surface-0:#0e1420;--surface-1:#161d2b;--surface-2:#212b3d;--border-subtle:#2a3549;
+  --text-strong:#e7eef7;--text-muted:#8b97a8;--accent:#5b9dd9;}
+*{box-sizing:border-box}
+body{margin:0;background:var(--surface-0);color:var(--text-strong);
+  font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}
+code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;background:var(--surface-2);padding:1px 5px;border-radius:4px;font-size:.85em}
+a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}
+.page-head{position:sticky;top:0;z-index:20;display:flex;align-items:center;gap:14px;padding:14px 22px;
+  background:var(--surface-0);border-bottom:1px solid var(--border-subtle)}
+.page-head .icon{width:40px;height:40px;border-radius:10px;border:1px solid var(--border-subtle);display:flex;
+  align-items:center;justify-content:center;background:color-mix(in srgb,var(--accent),var(--surface-1) 86%);font-size:20px}
+.page-head h1{margin:0;font-size:18px;font-weight:650}
+.page-head .sub{margin:0;font-size:12px;color:var(--text-muted)}
+.wrap{padding:18px 22px;display:flex;flex-direction:column;gap:18px;max-width:1500px;margin:0 auto}
+.section-title{font-size:13px;font-weight:650;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin:4px 0 -6px}
+/* overview table */
+.ov-wrap{border:1px solid var(--border-subtle);border-radius:12px;overflow:auto;background:var(--surface-1)}
+table#ov{border-collapse:collapse;width:100%;font-size:12.5px;white-space:nowrap}
+table#ov th,table#ov td{padding:7px 12px;text-align:left;border-bottom:1px solid var(--border-subtle)}
+table#ov th{position:sticky;top:0;background:var(--surface-2);color:var(--text-muted);font-weight:600;font-size:11px;
+  text-transform:uppercase;letter-spacing:.03em;z-index:1}
+table#ov th.sortable{cursor:pointer;user-select:none}
+table#ov th.sortable:hover{color:var(--text-strong)}
+table#ov .arrow{display:inline-block;width:9px;margin-left:3px;opacity:.5}
+table#ov th.asc .arrow::after{content:"▲"}table#ov th.desc .arrow::after{content:"▼"}
+table#ov td.numcol{text-align:right;font-variant-numeric:tabular-nums;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+table#ov tbody tr:hover{background:color-mix(in srgb,var(--accent),var(--surface-1) 90%)}
+.pill{font-size:10px;padding:1px 7px;border-radius:999px}
+.pill.ok{background:color-mix(in srgb,#22c55e,var(--surface-1) 78%);color:#c9f7d8}
+.pill.bad{background:color-mix(in srgb,#ef4444,var(--surface-1) 76%);color:#ffd7d3}
+/* cards */
+.cards{display:flex;flex-direction:column;gap:16px}
+.card{border:1px solid var(--border-subtle);border-radius:14px;background:var(--surface-0);overflow:hidden;scroll-margin-top:70px}
+.error-card{border-color:color-mix(in srgb,#ef4444,var(--border-subtle) 55%);box-shadow:inset 3px 0 0 #ef4444}
+.card-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:11px 16px;
+  border-bottom:1px solid var(--border-subtle);background:var(--surface-1)}
+.card-title{font-weight:600;font-size:14px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.badges{display:flex;gap:6px;flex-wrap:wrap}
+.badge{font-size:11px;padding:2px 9px;border-radius:999px;border:1px solid var(--border-subtle);color:var(--text-muted);white-space:nowrap}
+.badge.hw{background:color-mix(in srgb,var(--accent),var(--surface-1) 86%);color:#cfe3f5;border-color:transparent}
+.badge.ref{background:var(--surface-2);color:#cbd5e1}
+.badge.ok{background:color-mix(in srgb,#22c55e,var(--surface-1) 80%);color:#c9f7d8;border-color:transparent}
+.badge.bad{background:color-mix(in srgb,#ef4444,var(--surface-1) 78%);color:#ffd7d3;border-color:transparent}
+.card-body{padding:16px}
+.error-body{color:#ffb4ad;font-family:ui-monospace,Menlo,monospace;font-size:12.5px}
+.panel{display:flex;flex-direction:column;gap:12px}
+.metrics-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px}
+@media(max-width:640px){.metrics-grid{grid-template-columns:repeat(2,1fr)}}
+.metric{border:1px solid var(--border-subtle);border-radius:10px;background:var(--surface-1);padding:9px 11px;display:flex;flex-direction:column;gap:3px}
+.metric.compact{padding:7px 9px}
+.metric-k{font-size:10px;text-transform:uppercase;letter-spacing:.04em;color:var(--text-muted)}
+.metric-v{font-size:17px;font-weight:650;font-variant-numeric:tabular-nums}
+.metric.compact .metric-v{font-size:14px}
+.panel-title{font-size:13px;font-weight:650;margin-top:2px}
+.pie-wrap{display:flex;gap:14px;align-items:center;border:1px solid var(--border-subtle);border-radius:10px;background:var(--surface-1);padding:12px}
+.pie{width:84px;height:84px;border-radius:50%;border:1px solid var(--border-subtle);position:relative;flex:none}
+.pie-hole{position:absolute;inset:26%;border-radius:50%;background:var(--surface-1);border:1px solid var(--border-subtle);display:flex;align-items:center;justify-content:center;font-size:10px;color:var(--text-muted)}
+.pie-legend{flex:1;min-width:0}
+.two-col{display:grid;grid-template-columns:1fr 1fr;gap:10px}
+@media(max-width:640px){.two-col{grid-template-columns:1fr}}
+.subpanel{border:1px solid var(--border-subtle);border-radius:10px;background:var(--surface-1);padding:10px 12px}
+.subhead{font-size:12px;font-weight:650;margin-bottom:6px;display:flex;justify-content:space-between;align-items:center;gap:8px}
+.counters{columns:2;column-gap:16px}
+@media(max-width:640px){.counters{columns:1}}
+.stat{display:flex;justify-content:space-between;gap:10px;padding:3px 0;border-bottom:1px solid color-mix(in srgb,var(--border-subtle),transparent 45%);break-inside:avoid}
+.stat:last-child{border-bottom:0}
+.stat-k{font-size:12px;color:var(--text-muted);min-width:0;display:flex;align-items:center;gap:6px}
+.stat-v{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;color:var(--text-strong);text-align:right;word-break:break-word}
+.dot{width:8px;height:8px;border-radius:2px;display:inline-block;flex:none}
+.dim{opacity:.55;font-weight:400}
+.spread{font-size:11px;color:var(--text-muted);font-weight:400}
+.chart{width:100%;height:150px;display:block}
+.chart-scale{display:flex;justify-content:space-between;gap:8px;font-size:10px;color:var(--text-muted);margin-top:2px}
+.legend-inline{font-size:10px;color:var(--text-muted);font-weight:400;display:flex;align-items:center;gap:3px}
+.ls{width:14px;height:0;border-top:2px solid;display:inline-block;vertical-align:middle}
+.ls.rss{border-color:var(--accent)}.ls.cpu{border-color:#f59e0b;border-top-style:dashed}
+table.mini{border-collapse:collapse;width:100%;font-size:11.5px}
+table.mini th,table.mini td{padding:3px 6px;text-align:right;border-bottom:1px solid color-mix(in srgb,var(--border-subtle),transparent 45%)}
+table.mini th:first-child,table.mini td:first-child{text-align:left}
+table.mini th{color:var(--text-muted);font-weight:600}
+table.mini td{font-family:ui-monospace,Menlo,monospace}
+`;
+
+const JS = `
+(function(){
+  var tbl=document.getElementById('ov'); if(!tbl) return;
+  var tb=tbl.tBodies[0];
+  tbl.querySelectorAll('th.sortable').forEach(function(th){
+    th.addEventListener('click',function(){
+      var idx=[].indexOf.call(th.parentNode.children,th);
+      var type=th.getAttribute('data-type');
+      var asc=!th.classList.contains('asc');
+      tbl.querySelectorAll('th').forEach(function(o){o.classList.remove('asc','desc');});
+      th.classList.add(asc?'asc':'desc');
+      var rows=[].slice.call(tb.rows);
+      rows.sort(function(a,b){
+        var x=a.cells[idx].getAttribute('data-sort'),y=b.cells[idx].getAttribute('data-sort');
+        if(type==='n'){x=parseFloat(x);y=parseFloat(y);if(isNaN(x))x=-Infinity;if(isNaN(y))y=-Infinity;return asc?x-y:y-x;}
+        return asc?String(x).localeCompare(String(y)):String(y).localeCompare(String(x));
+      });
+      rows.forEach(function(r){tb.appendChild(r);});
+    });
+  });
+})();
+`;
+
+function buildPage(list, opts, meta) {
+  const cards = list.map(({ s, id }) => card(id, s)).join('\n');
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${esc(opts.title)}</title><style>${CSS}</style></head><body>
+<div class="page-head"><div class="icon">📊</div><div>
+  <h1>${esc(opts.title)}</h1>
+  <p class="sub">${meta.n} case${meta.n === 1 ? '' : 's'} • ${meta.refs} ref(s) • ${meta.hws} hw config(s) • ${meta.printers} printer(s) • ${meta.fails} failed • generated ${esc(meta.when)}</p>
+</div></div>
+<div class="wrap">
+  <div class="section-title">Overview — click a header to sort, a case to jump</div>
+  <div class="ov-wrap">${overviewTable(list)}</div>
+  <div class="section-title">Per-case detail</div>
+  <div class="cards">${cards}</div>
+</div>
+<script>${JS}</script>
+</body></html>`;
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const raw = loadRows(opts.inputs);
+  if (raw.length === 0) { console.error('no rows found in input JSONL'); process.exit(1); }
+  const list = raw.map((r, i) => ({ s: normalize(r), id: i }));
+
+  const meta = {
+    n: list.length,
+    refs: new Set(list.map(({ s }) => s.ref || 'working-tree')).size,
+    hws: new Set(list.map(({ s }) => hwLabel(s))).size,
+    printers: new Set(list.map(({ s }) => s.printer)).size,
+    fails: list.filter(({ s }) => s.error || s.ok === false).length,
+    when: new Date().toISOString().replace('T', ' ').slice(0, 16) + 'Z',
+  };
+  const html = buildPage(list, opts, meta);
+  writeFileSync(opts.out, html);
+  process.stderr.write(`==> wrote ${opts.out} (${(Buffer.byteLength(html) / 1024).toFixed(0)} KB, ${list.length} cases)\n`);
+
+  if (opts.open) {
+    const opener = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+    try { spawn(opener, [resolve(opts.out)], { detached: true, stdio: 'ignore' }).unref(); } catch { /* ignore */ }
+  }
+}
+
+main();

--- a/scripts/dragonfruit-ts-cli.ts
+++ b/scripts/dragonfruit-ts-cli.ts
@@ -40,14 +40,27 @@ import type {
   Vec3,
   SupportEntity,
 } from '../src/supports/types';
+// Reuse the app's exact AA physics so `--aa-preset` matches the UI byte-for-byte.
+import { computePhysicalAaConfig, type AaPreset } from '../src/features/slicing/autoAaPhysics';
 
 // ---------------------------------------------------------------------------
 // VOXL File I/O
 // ---------------------------------------------------------------------------
 
+// Pre-decoded embedded mesh bytes (STL) from the most recently loaded VOXL,
+// keyed by model id. Populated by loadVoxl for `embedded-chunk`/`embedded-file`
+// models; the slice path prefers these over hitting the filesystem.
+let LOADED_MESH_BYTES = new Map<string, Uint8Array>();
+// Pre-decoded full-resolution original mesh bytes (ORIG chunk), keyed by model
+// id. Present only for VOXLs saved with "Save original model along with
+// decimated"; the slice path prefers these over the decimated MESH bytes so it
+// slices the same geometry the GUI would.
+let LOADED_ORIG_BYTES = new Map<string, Uint8Array>();
 function loadVoxl(path: string): VoxlDocumentV1 {
   const raw = readFileSync(path);
   const result = parseVoxlAuto(raw);
+  LOADED_MESH_BYTES = result.meshBytes;
+  LOADED_ORIG_BYTES = result.originalMeshBytes ?? new Map();
   return result.document;
 }
 
@@ -1184,7 +1197,10 @@ function sceneArrange(args: ReturnType<typeof parseArgs>): void {
  * Same logic as cli.rs load_binary_stl.
  */
 function loadBinaryStl(path: string): Float32Array {
-  const data = readFileSync(path);
+  return parseBinaryStl(readFileSync(path));
+}
+
+function parseBinaryStl(data: Buffer): Float32Array {
   if (data.length < 84) throw new Error(`STL file too small: ${data.length} bytes`);
 
   const numTriangles = data.readUInt32LE(80);
@@ -1282,15 +1298,245 @@ function writePositionsBin(path: string, positions: Float32Array): void {
   writeFileSync(path, Buffer.from(positions.buffer, positions.byteOffset, positions.byteLength));
 }
 
+/** Shared zero-length array to overwrite a reference we want dropped without a fresh alloc. */
+const EMPTY_F32 = new Float32Array(0);
+
+/**
+ * Best-effort hand of freed memory back to V8/OS. Only actually does anything when
+ * node was started with --expose-gc (the benchmark driver sets that via NODE_OPTIONS);
+ * otherwise it's a no-op and V8 reclaims dropped references on its own under pressure.
+ * Used to keep the CLI's heap small on low-resource machines — geometry buffers are
+ * released the moment the slicing engine no longer needs them.
+ */
+function releaseHeap(): void {
+  const g = (globalThis as { gc?: () => void }).gc;
+  if (typeof g === 'function') g();
+}
+
+// ---------------------------------------------------------------------------
+// NOTE: the functions below (packing, dither policy, pixel pitch) are ported
+// from the UI rather than imported. Reusing the originals directly is deferred
+// as a design decision — the app functions aren't currently exported and their
+// modules pull in the Tauri/THREE dependency chain. A future shared pure-module
+// extraction would let both the UI and this CLI import one source of truth.
+// ---------------------------------------------------------------------------
+// Printer-profile → slice-parameter mapping.
+// Mirrors the UI so `scene slice --printer` behaves like a user picking that
+// printer in the app:
+//   - bit-depth → x-packing : src/features/slicing/rasterLayerZipExport.ts:207
+//   - build volume → dims    : src/features/slicing/sliceExportOrchestrator.ts:111
+//   - pixel pitch            : src/features/slicing/components/SlicingPanel.tsx:1399
+// width_px itself is NOT passed: Rust `slice run` recomputes it from
+// source_width_px + x_packing_mode (main.rs), matching this mapping.
+// ---------------------------------------------------------------------------
+type XPackingMode = 'none' | 'rgb8_div3' | 'gray3_div2';
+
+interface PrinterSliceParams {
+  sourceWidthPx: number;
+  sourceHeightPx: number;
+  xPackingMode: XPackingMode;
+  buildWidthMm: number;
+  buildDepthMm: number;
+  mirrorX: boolean;
+  mirrorY: boolean;
+  outputExt: string;
+  formatVersion?: string;
+  /** Physical XY pixel pitch (mm), honoring non-square pixels. */
+  pitchXMm: number;
+  pitchYMm: number;
+  name: string;
+}
+
+function resolvePrinterProfile(raw: unknown, wantId?: string): any {
+  // App-exported bundles wrap the profile as { version, printer, materials, … };
+  // unwrap so downstream reads (.display, .buildVolumeMm, .name, …) hit the real object.
+  const unwrap = (p: any) => (p && p.printer && p.display == null ? p.printer : p);
+  const list = (Array.isArray(raw) ? raw : [raw]).map(unwrap);
+  if (wantId) {
+    const hit = list.find(
+      (p) => p?.id === wantId || p?.name === wantId || p?.officialPresetId === wantId,
+    );
+    if (!hit) {
+      throw new Error(
+        `Printer '${wantId}' not found (have: ${list.map((p) => p?.id ?? p?.name).join(', ')})`,
+      );
+    }
+    return hit;
+  }
+  if (list.length !== 1) {
+    throw new Error(`Printer profile has ${list.length} entries; pass --printer-id to choose one`);
+  }
+  return list[0];
+}
+
+function resolveBitDepth(printer: any): number {
+  const explicit = Number(printer?.bitDepth?.bits);
+  if (Number.isFinite(explicit) && explicit > 0) return Math.round(explicit);
+  // Fallback fingerprint / divisibility — mirrors rasterLayerZipExport.ts:221-251.
+  const fp = [printer?.name, printer?.manufacturer, printer?.officialPresetId, printer?.id]
+    .filter((v) => typeof v === 'string' && v.length)
+    .join(' ')
+    .toLowerCase();
+  if (/\b3\s*[-_ ]?bit\b|\b3b\b|16k3b|gray3/.test(fp)) return 3;
+  if (/\b8\s*[-_ ]?bit\b|\b8b\b|rgb8/.test(fp)) return 8;
+  const resX = Math.max(1, Math.round(Number(printer?.display?.resolutionX) || 0));
+  const by2 = resX % 2 === 0;
+  const by3 = resX % 3 === 0;
+  if (by2 && !by3) return 3;
+  if (by3 && !by2) return 8;
+  if (by2 && by3) return /rgb|color/.test(fp) ? 8 : 3;
+  return 3; // NanoDLP failsafe
+}
+
+function outputFormatToExt(fmt: unknown): string {
+  const f = String(fmt ?? '').toLowerCase();
+  if (f.includes('ctb')) return '.ctb';
+  if (f.includes('nanodlp') || f === '') return '.nanodlp';
+  return f.startsWith('.') ? f : `.${f}`;
+}
+
+// Physical XY pixel pitch (mm). Prefers explicit pixelSize (µm) for non-square
+// pixels; falls back to buildVolume ÷ resolution. Matches SlicingPanel.tsx:1399.
+function resolvePixelPitchMm(printer: any): { x: number; y: number } {
+  const pxX = Number(printer?.pixelSize?.x);
+  const pxY = Number(printer?.pixelSize?.y);
+  if (Number.isFinite(pxX) && Number.isFinite(pxY) && pxX > 0 && pxY > 0) {
+    return { x: pxX / 1000, y: pxY / 1000 }; // µm → mm
+  }
+  const resX = Number(printer?.display?.resolutionX);
+  const resY = Number(printer?.display?.resolutionY);
+  const buildW = Number(printer?.buildVolumeMm?.width);
+  const buildD = Number(printer?.buildVolumeMm?.depth);
+  const pitchX = Number.isFinite(resX) && Number.isFinite(buildW) && resX > 0 && buildW > 0 ? buildW / resX : null;
+  const pitchY = Number.isFinite(resY) && Number.isFinite(buildD) && resY > 0 && buildD > 0 ? buildD / resY : null;
+  return { x: pitchX ?? pitchY ?? 0.05, y: pitchY ?? pitchX ?? 0.05 };
+}
+
+interface DitherPolicy {
+  enabled: boolean;
+  bitDepth: number;
+  deviceGamma: number;
+}
+
+// Faithful port of sliceExportOrchestrator.ts:resolveDitherPolicy (line ~443).
+// A known non-8-bit panel (e.g. 3-bit mono) FORCES dithering on, with the
+// panel bit depth as the target — this is why "some printers utilize dithering".
+// Material defaults / explicit overrides only apply when the panel isn't a
+// known low-bit-depth display.
+function resolveDitherPolicy(
+  printer: any,
+  overrides: { enabled?: boolean; bitDepth?: number; gamma?: number; material?: any },
+): DitherPolicy {
+  const aa = overrides.material?.antiAliasingSettings ?? {};
+  const materialEnabled = aa.ditherEnabled ?? false;
+  const materialBitDepth = aa.ditherBitDepth ?? 3;
+  const materialGamma = aa.ditherDeviceGamma ?? 3.0;
+
+  const configuredEnabled = overrides.enabled ?? materialEnabled;
+  const configuredBitDepth = overrides.bitDepth ?? materialBitDepth;
+  const configuredGamma = overrides.gamma ?? materialGamma;
+
+  const raw = Number(printer?.bitDepth?.bits);
+  const printerBitDepth = Number.isFinite(raw) ? Math.round(raw) : null;
+  const hasKnownNon8BitDisplay = printerBitDepth != null && printerBitDepth > 0 && printerBitDepth !== 8;
+  const derivedBitDepth = printerBitDepth != null && printerBitDepth > 0
+    ? Math.max(2, Math.min(7, printerBitDepth))
+    : Math.max(2, Math.min(7, Math.round(configuredBitDepth)));
+
+  return {
+    enabled: hasKnownNon8BitDisplay ? true : configuredEnabled,
+    bitDepth: derivedBitDepth,
+    deviceGamma: Math.max(0.5, Math.min(4.0, Number(configuredGamma))),
+  };
+}
+
+function derivePrinterSliceParams(printer: any): PrinterSliceParams {
+  const d = printer?.display ?? {};
+  const sourceWidthPx = Math.max(1, Math.round(Number(d.resolutionX)));
+  const sourceHeightPx = Math.max(1, Math.round(Number(d.resolutionY)));
+  const bitDepth = resolveBitDepth(printer);
+  const xPackingMode: XPackingMode = bitDepth === 8 ? 'rgb8_div3' : 'gray3_div2';
+  const bv = printer?.buildVolumeMm ?? {};
+  const pitch = resolvePixelPitchMm(printer);
+  return {
+    sourceWidthPx,
+    sourceHeightPx,
+    xPackingMode,
+    buildWidthMm: Math.max(1, Number(bv.width) || 218),
+    buildDepthMm: Math.max(1, Number(bv.depth) || 122),
+    mirrorX: Boolean(d.mirrorX),
+    mirrorY: Boolean(d.mirrorY),
+    outputExt: outputFormatToExt(d.outputFormat),
+    formatVersion: typeof d.formatVersion === 'string' ? d.formatVersion : undefined,
+    pitchXMm: pitch.x,
+    pitchYMm: pitch.y,
+    name: String(printer?.name ?? printer?.id ?? 'printer'),
+  };
+}
+
 function sceneSlice(args: ReturnType<typeof parseArgs>): void {
   const voxlPath = args.positional[0];
-  if (!voxlPath) throw new Error('Usage: scene slice <scene.voxl> --o <output.nanodlp> [--mesh-dir <dir>]');
+  if (!voxlPath) {
+    throw new Error(
+      'Usage: scene slice <scene.voxl> --o <output> [--mesh-dir <dir>]\n'
+      + '  [--printer <profile.json>] [--printer-id <id>]  drive resolution/packing/build/mirror/format/pitch\n'
+      + '  [--aa-preset sharp|balanced|smooth|raw]          named AA (via computePhysicalAaConfig)\n'
+      + '  [--dither on|off] [--dither-bit-depth N] [--dither-device-gamma G] [--material <profile.json>]\n'
+      + '  [--layer-height 0.05] [--build-width-mm N] [--build-depth-mm N]',
+    );
+  }
 
   const output = requireFlag(args.flags, 'o');
   const meshDir = optionalFlag(args.flags, 'mesh-dir') ?? dirname(resolve(voxlPath));
   const layerHeight = optionalFlag(args.flags, 'layer-height') ?? '0.05';
-  const buildWidth = optionalFlag(args.flags, 'build-width-mm') ?? '218.0';
-  const buildDepth = optionalFlag(args.flags, 'build-depth-mm') ?? '122.0';
+  const aaPreset = optionalFlag(args.flags, 'aa-preset') as AaPreset | 'raw' | undefined; // sharp|balanced|smooth|raw
+
+  // Printer profile drives resolution, packing, build dims, mirror, format, and
+  // pixel pitch — just like selecting that printer in the UI.
+  const printerPath = optionalFlag(args.flags, 'printer');
+  let p: PrinterSliceParams | null = null;
+  let printer: any = null;
+  if (printerPath) {
+    const rawPrinter = JSON.parse(readFileSync(resolve(printerPath), 'utf-8'));
+    printer = resolvePrinterProfile(rawPrinter, optionalFlag(args.flags, 'printer-id'));
+    p = derivePrinterSliceParams(printer);
+    console.error(
+      `scene slice: printer '${p.name}' -> ${p.sourceWidthPx}x${p.sourceHeightPx} ${p.xPackingMode} `
+      + `build ${p.buildWidthMm}x${p.buildDepthMm}mm pitch ${p.pitchXMm.toFixed(4)}x${p.pitchYMm.toFixed(4)}mm fmt ${p.outputExt}`,
+    );
+  }
+  const buildWidth = optionalFlag(args.flags, 'build-width-mm') ?? String(p?.buildWidthMm ?? 218.0);
+  const buildDepth = optionalFlag(args.flags, 'build-depth-mm') ?? String(p?.buildDepthMm ?? 122.0);
+
+  // Resolve AA from the named preset using the app's exact physics function.
+  let aa: ReturnType<typeof computePhysicalAaConfig> | null = null;
+  if (aaPreset && aaPreset !== 'raw') {
+    if (!p) throw new Error('--aa-preset requires --printer (pixel pitch comes from the printer profile)');
+    aa = computePhysicalAaConfig(aaPreset, p.pitchXMm, Number(layerHeight), p.pitchYMm);
+    console.error(
+      `scene slice: AA '${aaPreset}' -> ${aa.aaSteps}x ${aa.antiAliasingMode} `
+      + `blur=${aa.blurBrushRadiusPx}px zblur=${aa.zBlurRadiusLayers} lookback=${aa.zBlendLookBack}`,
+    );
+  }
+
+  // Resolve dithering the way the UI does — a low-bit-depth panel forces it on.
+  let dither: DitherPolicy | null = null;
+  if (printer) {
+    const materialPath = optionalFlag(args.flags, 'material');
+    const material = materialPath ? JSON.parse(readFileSync(resolve(materialPath), 'utf-8')) : undefined;
+    const ditherFlag = optionalFlag(args.flags, 'dither'); // 'on' | 'off' | undefined
+    const bitDepthFlag = optionalFlag(args.flags, 'dither-bit-depth');
+    const gammaFlag = optionalFlag(args.flags, 'dither-device-gamma');
+    dither = resolveDitherPolicy(printer, {
+      enabled: ditherFlag === 'on' ? true : ditherFlag === 'off' ? false : undefined,
+      bitDepth: bitDepthFlag ? Number(bitDepthFlag) : undefined,
+      gamma: gammaFlag ? Number(gammaFlag) : undefined,
+      material,
+    });
+    console.error(
+      `scene slice: dither ${dither.enabled ? `on (${dither.bitDepth}-bit, gamma ${dither.deviceGamma})` : 'off'}`,
+    );
+  }
 
   const doc = loadVoxl(voxlPath);
   const visibleModels = doc.models.filter((m) => m.visible);
@@ -1304,21 +1550,50 @@ function sceneSlice(args: ReturnType<typeof parseArgs>): void {
   let totalTriangles = 0;
 
   for (const model of visibleModels) {
-    const meshFileName = model.mesh.fileName ?? model.name + '.stl';
-    // Try mesh-dir, then absolute path, then cwd
-    let meshPath: string | null = null;
-    const candidates = [
-      resolve(meshDir, meshFileName),
-      meshFileName,
-      resolve(meshFileName),
-    ];
-    for (const c of candidates) {
-      try { statSync(c); meshPath = c; break; } catch { /* try next */ }
-    }
-    if (!meshPath) throw new Error(`Mesh file not found for model '${model.name}': tried ${candidates.join(', ')}`);
+    let positions: Float32Array;
 
-    console.error(`  loading ${model.name}: ${meshPath}`);
-    const positions = loadBinaryStl(meshPath);
+    // Mesh modifiers (hollowing / hole punches) are reconstructed by the codec
+    // from the MODL JSON + the HSRC/CAVT/PSRC snapshot chunks. Only a modifier
+    // that is *baked into geometry* affects what we slice — its result already
+    // lives in the MESH chunk, so we slice MESH as-is and never re-apply the
+    // snapshot chunks. Unbaked hollowing / hole punches are ignored (the GUI
+    // bakes those via desktop IPC before slicing; headless we take the stored
+    // geometry as given).
+    const mm = model.meshModifiers;
+    const hollow = mm?.hollowing;
+    const modifiersBaked = Boolean((hollow?.enabled && hollow.bakedIntoGeometry) || mm?.holePunchesBakedIntoGeometry);
+
+    // Geometry source: prefer the full-res ORIG chunk, EXCEPT when a modifier is
+    // baked in — ORIG is the pristine pre-modifier original and would slice the
+    // solid / un-punched shape, so a baked model reads the modified MESH chunk.
+    const meshBytes = LOADED_MESH_BYTES.get(model.id);
+    const origBytes = LOADED_ORIG_BYTES.get(model.id);
+    const embedded = modifiersBaked ? (meshBytes ?? origBytes) : (origBytes ?? meshBytes);
+    if (embedded) {
+      // `embedded-chunk`/`embedded-file`: the codec already decoded the geometry
+      // to STL bytes — no filesystem lookup needed.
+      positions = parseBinaryStl(Buffer.from(embedded.buffer, embedded.byteOffset, embedded.byteLength));
+      const src = embedded === origBytes ? 'orig' : 'mesh';
+      console.error(`  loading ${model.name}: <embedded ${src}${modifiersBaked ? ', baked-modifiers' : ''}>`);
+    } else if (model.mesh.mode === 'external-file' || model.mesh.fileName) {
+      const meshFileName = model.mesh.fileName ?? model.name + '.stl';
+      // Try mesh-dir, then absolute path, then cwd
+      let meshPath: string | null = null;
+      const candidates = [
+        resolve(meshDir, meshFileName),
+        meshFileName,
+        resolve(meshFileName),
+      ];
+      for (const c of candidates) {
+        try { statSync(c); meshPath = c; break; } catch { /* try next */ }
+      }
+      if (!meshPath) throw new Error(`Mesh file not found for model '${model.name}': tried ${candidates.join(', ')}`);
+
+      console.error(`  loading ${model.name}: ${meshPath}`);
+      positions = loadBinaryStl(meshPath);
+    } else {
+      throw new Error(`Model '${model.name}' has mesh.mode='${model.mesh.mode}' but no embedded bytes and no fileName`);
+    }
 
     // Apply full scene transform (position + rotation + scale)
     applyVoxlTransform(positions, model.transform);
@@ -1334,14 +1609,22 @@ function sceneSlice(args: ReturnType<typeof parseArgs>): void {
     totalTriangles += positions.length / 9;
   }
 
-  // Phase 2: Merge into single positions buffer
+  // Phase 2: Merge into single positions buffer, releasing each per-model source
+  // array the moment it has been copied. Peak heap is then ~one merged copy plus
+  // the single model being copied, not (all sources + merged) — matters on
+  // low-resource machines where the scene's geometry may already be a large slice
+  // of available RAM.
   const totalFloats = allPositions.reduce((sum, p) => sum + p.length, 0);
-  const merged = new Float32Array(totalFloats);
+  let merged: Float32Array = new Float32Array(totalFloats);
   let writeOffset = 0;
-  for (const p of allPositions) {
+  for (let i = 0; i < allPositions.length; i++) {
+    const p = allPositions[i];
     merged.set(p, writeOffset);
     writeOffset += p.length;
+    allPositions[i] = EMPTY_F32; // drop the per-model copy immediately
   }
+  allPositions.length = 0;
+  releaseHeap();
 
   // Phase 3: Write merged positions.bin
   const tmpDir = `/tmp/df-scene-slice-${Date.now()}`;
@@ -1350,9 +1633,16 @@ function sceneSlice(args: ReturnType<typeof parseArgs>): void {
   writePositionsBin(mergedPath, merged);
   console.error(`  merged: ${totalTriangles} triangles -> ${mergedPath}`);
 
+  // Hand-off complete: positions.bin on disk now owns the geometry, and the
+  // slicing engine (Rust) reads it from there — node holds nothing the engine
+  // needs. Drop the merged copy (the last large buffer) before shelling out so
+  // the process sits near-idle in RAM during the blocking slice.
+  merged = EMPTY_F32;
+  releaseHeap();
+
   // Phase 4: Shell out to Rust slicer
   const rustCli = resolve(dirname(new URL(import.meta.url).pathname), '../rust/dragonfruit-cli/target/release/dragonfruit-cli');
-  const sliceCmd = [
+  const argv = [
     rustCli,
     'slice', 'run',
     mergedPath,
@@ -1360,8 +1650,29 @@ function sceneSlice(args: ReturnType<typeof parseArgs>): void {
     '--layer-height', layerHeight,
     '--build-width-mm', buildWidth,
     '--build-depth-mm', buildDepth,
-    '--json',
-  ].join(' ');
+  ];
+  if (p) {
+    argv.push('--source-width-px', String(p.sourceWidthPx));
+    argv.push('--source-height-px', String(p.sourceHeightPx));
+    argv.push('--x-packing-mode', p.xPackingMode);
+    if (p.mirrorX) argv.push('--mirror-x');
+    if (p.mirrorY) argv.push('--mirror-y');
+    if (p.formatVersion) argv.push('--format-version', p.formatVersion);
+  }
+  if (aa) {
+    argv.push('--anti-aliasing', `${aa.aaSteps}x`);
+    argv.push('--anti-aliasing-mode', aa.antiAliasingMode); // Coverage | Blur | Vertical2
+    argv.push('--blur-brush-radius-px', String(aa.blurBrushRadiusPx));
+    argv.push('--z-blur-radius-layers', String(aa.zBlurRadiusLayers));
+    argv.push('--z-blend-look-back', String(aa.zBlendLookBack));
+  }
+  if (dither?.enabled) {
+    argv.push('--dither');
+    argv.push('--dither-bit-depth', String(dither.bitDepth));
+    argv.push('--dither-device-gamma', String(dither.deviceGamma));
+  }
+  argv.push('--json');
+  const sliceCmd = argv.join(' ');
 
   console.error(`  slicing: ${sliceCmd}`);
   const result = execSync(sliceCmd, { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 });
@@ -1372,6 +1683,11 @@ function sceneSlice(args: ReturnType<typeof parseArgs>): void {
   if (jsonOutput(args.flags)) {
     // Parse and augment the Rust output with scene info
     const sliceResult = JSON.parse(result);
+    // Surface the named preset in the AA block — the Rust engine only knows the
+    // resolved level/mode, but the preset name is what a user reads in the log.
+    if (sliceResult.anti_aliasing && typeof sliceResult.anti_aliasing === 'object') {
+      sliceResult.anti_aliasing = { preset: aaPreset ?? 'raw', ...sliceResult.anti_aliasing };
+    }
     sliceResult.scene = {
       voxl: resolve(voxlPath),
       models: visibleModels.length,


### PR DESCRIPTION
Brings @SinXIV's slicing benchmark suite onto current `dev`, and adds a `--codegen` axis to it so the x86-64 baseline question in #638 can be answered with numbers from the same harness.

Three commits, each doing one thing:

| commit | author | what |
|---|---|---|
| `c7759db4` | SinXIV | the benchmark suite, replayed onto dev |
| `8267adda` | ender | the `--codegen` axis, on top |
| `74a84bab` | ender | a doc fix for building the CLI from a fresh clone |

### Why replayed and not merged

`sin/slicing-benchmark` cannot be rebased or merged cleanly. Its tip (`1df8d982`, "Merge branch 'dev' into sin/slicing-benchmark") has a **single parent**: it is a flattened copy of 861 dev commits recorded as an ordinary commit, so git does not see `dev` as an ancestor.  That flattening also lost things, all via `2c8244b5` ("refresh git cache").

Its useful content is all here: the eight commits squashed into `c7759db4`, listed in that commit's message.

Sin's `rust/dragonfruit-cli/src/main.rs` is a strict superset of @aaron1138's, and `scripts/dragonfruit-ts-cli.ts` merged with no conflicts. `cargo build --release` is clean and the resulting CLI carries both halves (`--blur-brush-*`, `--z-blur-*`,
`--aa-on-supports` and `--dither*`).

### The codegen axis

```bash
scripts/bench/run-slicing-bench.sh --codegen shipped,v2,v3 --out codegen.jsonl
```

Builds the CLI once per variant (same source, different `RUSTFLAGS`, one target dir each) and runs the whole matrix against each; every row carries `codegen`. Presets: `v1`, `v2`, `v3`, `shipped`, `v2avx2`, `native`; anything starting with `-C` passes through. A variant the host CPU cannot execute is skipped with a message rather than crashed into, so this is safe to run on old hardware, which is where it is most informative.

Results so far are in #638: across 2 printers × 4 AA presets × 5 variants, with and without dithering, **every cell is inside the run-to-run noise**.