### PR TITLE
Fix dithering downgrading 8-bit panels to 7-bit

### DIFF
--- a/rust/dragonfruit-slicing-engine/src/dither.rs
+++ b/rust/dragonfruit-slicing-engine/src/dither.rs
@@ -28,7 +28,18 @@ pub struct DitherPaletteV3 {
 
 impl DitherPaletteV3 {
     /// Create and precompute a new dithering palette with binned lookup structures.
+    ///
+    /// `bit_depth` must already be in the 2..=7 range dithering is defined for;
+    /// callers get that from [`SliceJobV3::effective_dither_bit_depth`], which
+    /// declines to dither at all outside it. The clamp below is only a last-resort
+    /// guard against a palette with 1 or 256 levels — reaching it means the caller
+    /// skipped that gate, so it trips a debug assertion rather than quietly
+    /// degrading the layer.
     pub fn new(lut: &[u8; 256], gamma: f64, bit_depth: u32) -> Self {
+        debug_assert!(
+            (2..=7).contains(&bit_depth),
+            "dither bit depth {bit_depth} is outside the 2..=7 range dithering is defined for",
+        );
         let bit_depth = bit_depth.clamp(2, 7);
         let mut source_energy = [0.0f32; 256];
         for i in 0..256 {

--- a/rust/dragonfruit-slicing-engine/src/engine.rs
+++ b/rust/dragonfruit-slicing-engine/src/engine.rs
@@ -1761,8 +1761,7 @@ fn rasterize_vertical_aa_streaming_v3(
     let blur_sigma_x = job.blur_brush_sigma_x();
     let blur_sigma_y = job.blur_brush_sigma_y();
     let tail_cure_lut = job.normalized_tail_cure_lut();
-    let dither_palette = if job.dither_enabled {
-        let bit_depth = job.dither_bit_depth.unwrap_or(3);
+    let dither_palette = if let Some(bit_depth) = job.effective_dither_bit_depth() {
         let active_lut = job.normalized_tail_cure_lut().unwrap_or_else(|| {
             let mut identity = [0u8; 256];
             for (i, v) in identity.iter_mut().enumerate() {
@@ -4075,8 +4074,7 @@ pub fn slice_and_rasterize_perturb_3daa_rle_v3(
         job.z_blur_sigma(),
     );
     let tail_cure_lut = job.normalized_tail_cure_lut();
-    let dither_palette = if job.dither_enabled {
-        let bit_depth = job.dither_bit_depth.unwrap_or(3);
+    let dither_palette = if let Some(bit_depth) = job.effective_dither_bit_depth() {
         let active_lut = job.normalized_tail_cure_lut().unwrap_or_else(|| {
             let mut identity = [0u8; 256];
             for (i, v) in identity.iter_mut().enumerate() {
@@ -4625,8 +4623,10 @@ pub fn slice_and_rasterize_rle_encoded_v3(
     // downstream encoders (CTB threshold, 1-bit PNG) undo any multi-level
     // output, making the Floyd-Steinberg pass pure overhead.
     let output_is_binary = job.produces_binary_output();
-    let dither_palette = if job.dither_enabled && !output_is_binary {
-        let bit_depth = job.dither_bit_depth.unwrap_or(3);
+    let dither_palette = if let Some(bit_depth) = job
+        .effective_dither_bit_depth()
+        .filter(|_| !output_is_binary)
+    {
         let active_lut = job.normalized_tail_cure_lut().unwrap_or_else(|| {
             let mut identity = [0u8; 256];
             for (i, v) in identity.iter_mut().enumerate() {
@@ -4651,7 +4651,7 @@ pub fn slice_and_rasterize_rle_encoded_v3(
             ) -> Result<Vec<u8>, SlicerV3Error>
             + Send
             + Sync,
-    > = if ssaa_factor > 1 || blur_radius > 0 || (job.dither_enabled && !output_is_binary) {
+    > = if ssaa_factor > 1 || blur_radius > 0 || dither_palette.is_some() {
         let super_width = raster_job.effective_render_width_px() as usize;
         let super_height = raster_job.source_height_px as usize;
         let out_width = job.effective_render_width_px() as usize;

--- a/rust/dragonfruit-slicing-engine/src/types.rs
+++ b/rust/dragonfruit-slicing-engine/src/types.rs
@@ -364,6 +364,26 @@ impl SliceJobV3 {
         self.z_blur_sigma.max(0.05)
     }
 
+    /// Bit depth the dither palette should target, or `None` when dithering must
+    /// not run at all.
+    ///
+    /// Dithering exists to fake grey levels the panel cannot emit, so it is only
+    /// meaningful below 8 bits. A job that declares 8 bits or more gets `None`
+    /// instead of a palette clamped down to 7, which would quantize the layer
+    /// *below* the panel's own resolution. A missing bit depth also disables it:
+    /// substituting a default would silently quantize to a depth nobody asked for.
+    #[inline]
+    pub fn effective_dither_bit_depth(&self) -> Option<u32> {
+        if !self.dither_enabled {
+            return None;
+        }
+        match self.dither_bit_depth {
+            Some(bits) if bits >= 8 => None,
+            Some(bits) => Some(bits.max(2)),
+            None => None,
+        }
+    }
+
     #[inline]
     pub fn normalized_custom_cure_lut(&self) -> Option<[u8; 256]> {
         let custom = self.z_blend_custom_lut.as_ref()?;
@@ -391,7 +411,43 @@ impl SliceJobV3 {
 
 #[cfg(test)]
 mod tests {
-    use super::dynamic_minimum_alpha_lut;
+    use super::{dynamic_minimum_alpha_lut, SliceJobV3};
+
+    fn dither_job(enabled: bool, bit_depth: Option<u32>) -> SliceJobV3 {
+        SliceJobV3 {
+            dither_enabled: enabled,
+            dither_bit_depth: bit_depth,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn effective_dither_bit_depth_passes_through_low_bit_depths() {
+        assert_eq!(dither_job(true, Some(3)).effective_dither_bit_depth(), Some(3));
+        assert_eq!(dither_job(true, Some(7)).effective_dither_bit_depth(), Some(7));
+        // Below the 2-bit floor there is no meaningful palette; clamp up rather
+        // than build one with a single level.
+        assert_eq!(dither_job(true, Some(1)).effective_dither_bit_depth(), Some(2));
+    }
+
+    #[test]
+    fn effective_dither_bit_depth_refuses_to_dither_at_8_bits_or_deeper() {
+        // Clamping 8 down to 7 would quantize a panel that can already emit
+        // every grey level, so the whole dither pass is skipped instead.
+        assert_eq!(dither_job(true, Some(8)).effective_dither_bit_depth(), None);
+        assert_eq!(dither_job(true, Some(10)).effective_dither_bit_depth(), None);
+        assert_eq!(dither_job(true, Some(12)).effective_dither_bit_depth(), None);
+    }
+
+    #[test]
+    fn effective_dither_bit_depth_refuses_to_guess_a_missing_depth() {
+        assert_eq!(dither_job(true, None).effective_dither_bit_depth(), None);
+    }
+
+    #[test]
+    fn effective_dither_bit_depth_is_none_when_dithering_is_off() {
+        assert_eq!(dither_job(false, Some(3)).effective_dither_bit_depth(), None);
+    }
 
     #[test]
     fn dynamic_minimum_alpha_lut_maps_nonzero_to_minimum_window() {

--- a/src/components/settings/ProfileSettingsModal.tsx
+++ b/src/components/settings/ProfileSettingsModal.tsx
@@ -561,6 +561,14 @@ export function ProfileSettingsModal({
     return Math.max(2, Math.min(7, Math.round(printerBitDepth)));
   }, [selectedPrinter?.bitDepth?.bits]);
 
+  // Raw declared depth: lets the AA section tell an 8-bit-or-deeper panel (where
+  // dithering is forced off) apart from a printer that declares nothing.
+  const printerPanelBitDepth = React.useMemo<number | null>(() => {
+    const printerBitDepth = Number(selectedPrinter?.bitDepth?.bits);
+    if (!Number.isFinite(printerBitDepth) || printerBitDepth <= 0) return null;
+    return Math.round(printerBitDepth);
+  }, [selectedPrinter?.bitDepth?.bits]);
+
   const selectedFormatVersionOptions = React.useMemo(() => {
     if (!selectedPrinter) return [] as Array<{ value: string; label: string; isDefault?: boolean }>;
     return getAvailableFormatVersionOptions(selectedPrinter.display.outputFormat);
@@ -4787,6 +4795,7 @@ export function ProfileSettingsModal({
                     draft={editMaterialDraft}
                     onDraftChange={setEditMaterialDraft}
                     printerDitherBitDepth={printerDitherBitDepth}
+                    printerPanelBitDepth={printerPanelBitDepth}
                     outputFormat={selectedPrinter?.display.outputFormat ?? '.lys'}
                     settingsMode={selectedResolvedSettingsMode}
                     adapter={selectedLocalMaterialSettingsAdapter}
@@ -4800,6 +4809,7 @@ export function ProfileSettingsModal({
                       draft={editMaterialDraft}
                       onChange={setEditMaterialDraft}
                       printerDitherBitDepth={printerDitherBitDepth}
+                      printerPanelBitDepth={printerPanelBitDepth}
                     />
                     <PluginLocalMaterialSettingsSections
                       outputFormat={selectedPrinter?.display.outputFormat ?? '.lys'}
@@ -5495,6 +5505,7 @@ export function ProfileSettingsModal({
                     draft={newMaterialDraft}
                     onDraftChange={setNewMaterialDraft}
                     printerDitherBitDepth={printerDitherBitDepth}
+                    printerPanelBitDepth={printerPanelBitDepth}
                     outputFormat={selectedPrinter.display.outputFormat}
                     settingsMode={selectedResolvedSettingsMode}
                     adapter={selectedLocalMaterialSettingsAdapter}
@@ -5508,6 +5519,7 @@ export function ProfileSettingsModal({
                       draft={newMaterialDraft}
                       onChange={setNewMaterialDraft}
                       printerDitherBitDepth={printerDitherBitDepth}
+                      printerPanelBitDepth={printerPanelBitDepth}
                     />
                     <PluginLocalMaterialSettingsSections
                       outputFormat={selectedPrinter.display.outputFormat}

--- a/src/components/settings/profileFormAtoms.tsx
+++ b/src/components/settings/profileFormAtoms.tsx
@@ -715,6 +715,8 @@ type MaterialAntiAliasingSectionProps = {
     onChange: React.Dispatch<React.SetStateAction<MaterialDraft>>;
     lockActivationToggles?: boolean;
     printerDitherBitDepth?: number | null;
+    /** Raw bit depth declared by the printer profile, before the 2..7 dither clamp. */
+    printerPanelBitDepth?: number | null;
 };
 
 const AA_STRENGTH_PRESETS = [4, 8, 16, 32] as const;
@@ -872,7 +874,7 @@ function AaInlineHelp({ children }: { children: React.ReactNode }) {
     return <p className="text-xs leading-snug" style={{ color: 'var(--text-muted)' }}>{children}</p>;
 }
 
-export function MaterialAntiAliasingSection({ draft, onChange, lockActivationToggles = false, printerDitherBitDepth = null }: MaterialAntiAliasingSectionProps) {
+export function MaterialAntiAliasingSection({ draft, onChange, lockActivationToggles = false, printerDitherBitDepth = null, printerPanelBitDepth = null }: MaterialAntiAliasingSectionProps) {
     const settings = {
         ...DEFAULT_MATERIAL_ANTI_ALIASING_SETTINGS,
         ...(draft.antiAliasingSettings ?? {}),
@@ -896,15 +898,30 @@ export function MaterialAntiAliasingSection({ draft, onChange, lockActivationTog
     const duplicateZEnabled = is3daa && sampleSteps >= 16;
     const customZBlurEnabled = is3daa && settings.useCustomZBlurRadius;
     const gaussianZEnabled = customZBlurEnabled && settings.zBlurKernel === 'gaussian' && settings.zBlurRadiusLayers > 0;
-    const hasKnownPrinterDitherBitDepth = Number.isFinite(printerDitherBitDepth)
+    // `printerDitherBitDepth` is already narrowed by the callers to the 2..7 range
+    // dithering can actually target, so a non-null value means "this panel cannot
+    // emit every 8-bit grey level" and dithering is mandatory.
+    const knownPrinterBitDepth = (Number.isFinite(printerDitherBitDepth)
         && printerDitherBitDepth != null
         && printerDitherBitDepth >= 2
-        && printerDitherBitDepth <= 7;
-    const knownPrinterBitDepth = hasKnownPrinterDitherBitDepth
+        && printerDitherBitDepth <= 7)
         ? Math.round(printerDitherBitDepth as number)
         : null;
-    const isNon8BitPrinter = knownPrinterBitDepth != null && knownPrinterBitDepth !== 8;
-    const effectiveDitherEnabled = isNon8BitPrinter ? true : settings.ditherEnabled;
+    const printerForcesDitherOn = knownPrinterBitDepth != null;
+    // An 8-bit (or deeper) panel emits the whole 8-bit ramp already, so dithering
+    // could only quantize the layer below the hardware's own resolution.
+    const panelBitDepth = (Number.isFinite(printerPanelBitDepth)
+        && printerPanelBitDepth != null
+        && printerPanelBitDepth > 0)
+        ? Math.round(printerPanelBitDepth as number)
+        : null;
+    const printerForcesDitherOff = panelBitDepth != null && panelBitDepth >= 8;
+    const ditherLockedByPrinter = printerForcesDitherOn || printerForcesDitherOff;
+    const effectiveDitherEnabled = printerForcesDitherOn
+        ? true
+        : printerForcesDitherOff
+            ? false
+            : settings.ditherEnabled;
     const [savedCurves, setSavedCurves] = React.useState<SavedCurve[]>(() => resolveMaterialAaSavedCurves());
     const [editingTarget, setEditingTarget] = React.useState<string | null>(null);
 
@@ -965,7 +982,7 @@ export function MaterialAntiAliasingSection({ draft, onChange, lockActivationTog
                             updateAaSettings({
                                 enableCustomSettings: next,
                                 enableOverride: next ? overrideEnabled : false,
-                                ditherEnabled: next && isNon8BitPrinter ? true : settings.ditherEnabled,
+                                ditherEnabled: next ? effectiveDitherEnabled : settings.ditherEnabled,
                             });
                         }}
                         className="ui-input w-full h-[36px] px-2.5 leading-tight text-sm inline-flex items-center justify-between disabled:cursor-not-allowed disabled:opacity-45"
@@ -1361,13 +1378,15 @@ export function MaterialAntiAliasingSection({ draft, onChange, lockActivationTog
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-2 items-end">
                             <LabeledToggleInput
                                 label="Enable Dithering"
-                                helpText={isNon8BitPrinter
+                                helpText={printerForcesDitherOn
                                     ? `Automatically enabled for this printer because its LCD is ${knownPrinterBitDepth}-bit. Dithering bit depth is derived from the active printer profile.`
-                                    : 'Enable energy-based dithering to eliminate banding on shallow slopes. Dithering bit depth is derived from the active printer profile.'}
+                                    : printerForcesDitherOff
+                                        ? `Automatically disabled because this printer's LCD is ${panelBitDepth}-bit and can already emit every grayscale level. Dithering would quantize layers below the panel's own resolution.`
+                                        : 'Enable energy-based dithering to eliminate banding on shallow slopes. Dithering bit depth is derived from the active printer profile.'}
                                 checked={effectiveDitherEnabled}
-                                disabled={isNon8BitPrinter}
+                                disabled={ditherLockedByPrinter}
                                 onChange={(value) => {
-                                    if (isNon8BitPrinter) return;
+                                    if (ditherLockedByPrinter) return;
                                     updateAaSettings({ ditherEnabled: value });
                                 }}
                             />
@@ -2378,6 +2397,7 @@ type ReplacementMaterialEditorShellProps = {
     draft: MaterialDraft;
     onDraftChange: React.Dispatch<React.SetStateAction<MaterialDraft>>;
     printerDitherBitDepth?: number | null;
+    printerPanelBitDepth?: number | null;
     activeTabStyle?: React.CSSProperties;
     outputFormat: string;
     settingsMode?: string;
@@ -2393,6 +2413,7 @@ export function ReplacementMaterialEditorShell({
     draft,
     onDraftChange,
     printerDitherBitDepth = null,
+    printerPanelBitDepth = null,
     outputFormat,
     activeTabStyle,
     settingsMode,
@@ -2414,6 +2435,7 @@ export function ReplacementMaterialEditorShell({
                     draft={draft}
                     onChange={onDraftChange}
                     printerDitherBitDepth={printerDitherBitDepth}
+                    printerPanelBitDepth={printerPanelBitDepth}
                 />
             );
         }
@@ -2430,7 +2452,7 @@ export function ReplacementMaterialEditorShell({
                 showTabBar={false}
             />
         );
-    }, [adapter, draft, localSettingsByOutput, onDraftChange, onLocalSettingsByOutputChange, outputFormat, printerDitherBitDepth, settingsMode]);
+    }, [adapter, draft, localSettingsByOutput, onDraftChange, onLocalSettingsByOutputChange, outputFormat, printerDitherBitDepth, printerPanelBitDepth, settingsMode]);
 
     React.useLayoutEffect(() => {
         const root = measureRootRef.current;

--- a/src/features/slicing/__tests__/ditherPolicy.test.ts
+++ b/src/features/slicing/__tests__/ditherPolicy.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveEffectiveDitherPolicy, type DitherPolicyInput } from '../resolveEffectiveDitherPolicy';
+
+/**
+ * The dither policy is the only place that reconciles the user's toggle with
+ * the panel's declared bit depth. Getting the 8-bit case wrong is silent and
+ * physically backwards: it quantizes a panel that can already emit every grey
+ * level down to 7 bits, doubling the worst-case energy step between adjacent
+ * levels at the default gamma.
+ */
+function policyInput(overrides: Partial<DitherPolicyInput> & { bits?: number | undefined } = {}) {
+    const { bits, ...rest } = overrides;
+    return {
+        printerProfile: bits === undefined ? {} : { bitDepth: { bits } },
+        materialProfile: {},
+        ...rest,
+    } as DitherPolicyInput;
+}
+
+test('a sub-8-bit panel forces dithering on at the panel bit depth', () => {
+    const policy = resolveEffectiveDitherPolicy(policyInput({ bits: 3, ditherEnabled: false }));
+
+    assert.equal(policy.ditherEnabled, true);
+    assert.equal(policy.ditherBitDepth, 3);
+});
+
+test('an 8-bit panel forces dithering off even when the user turned it on', () => {
+    const policy = resolveEffectiveDitherPolicy(policyInput({ bits: 8, ditherEnabled: true }));
+
+    assert.equal(policy.ditherEnabled, false);
+});
+
+test('a panel deeper than 8 bits also forces dithering off instead of quantizing to 7', () => {
+    for (const bits of [10, 12, 16]) {
+        const policy = resolveEffectiveDitherPolicy(policyInput({ bits, ditherEnabled: true }));
+
+        assert.equal(policy.ditherEnabled, false, `${bits}-bit panel should not dither`);
+    }
+});
+
+test('an 8-bit panel never derives a bit depth from the panel itself', () => {
+    // The old policy clamped the panel depth into 2..7, so an 8-bit display
+    // silently produced a 7-bit palette.
+    const policy = resolveEffectiveDitherPolicy(policyInput({ bits: 8, ditherBitDepth: 4 }));
+
+    assert.equal(policy.ditherBitDepth, 4);
+});
+
+test('an undeclared panel bit depth leaves the toggle and depth to the user', () => {
+    const enabled = resolveEffectiveDitherPolicy(policyInput({ ditherEnabled: true, ditherBitDepth: 5 }));
+    assert.equal(enabled.ditherEnabled, true);
+    assert.equal(enabled.ditherBitDepth, 5);
+
+    const disabled = resolveEffectiveDitherPolicy(policyInput({ ditherEnabled: false }));
+    assert.equal(disabled.ditherEnabled, false);
+});
+
+test('material anti-aliasing settings supply the fallback when the caller passes nothing', () => {
+    const policy = resolveEffectiveDitherPolicy({
+        printerProfile: {},
+        materialProfile: {
+            antiAliasingSettings: {
+                ditherEnabled: true,
+                ditherBitDepth: 6,
+                ditherDeviceGamma: 2.2,
+            },
+        },
+    } as DitherPolicyInput);
+
+    assert.equal(policy.ditherEnabled, true);
+    assert.equal(policy.ditherBitDepth, 6);
+    assert.equal(policy.ditherDeviceGamma, 2.2);
+});
+
+test('device gamma is clamped to the range the engine accepts', () => {
+    assert.equal(resolveEffectiveDitherPolicy(policyInput({ ditherDeviceGamma: 9 })).ditherDeviceGamma, 4.0);
+    assert.equal(resolveEffectiveDitherPolicy(policyInput({ ditherDeviceGamma: 0.1 })).ditherDeviceGamma, 0.5);
+});

--- a/src/features/slicing/components/SlicingPanel.tsx
+++ b/src/features/slicing/components/SlicingPanel.tsx
@@ -1183,10 +1183,22 @@ export function SlicingPanel({
     if (Math.round(printerBitDepth) >= 8) return null;
     return Math.max(2, Math.min(7, Math.round(printerBitDepth)));
   }, [activePrinterProfile?.bitDepth?.bits]);
-  const autoDitherRequiredForPrinter = printerDitherBitDepth != null && printerDitherBitDepth !== 8;
+  // Raw declared depth, kept separate from the clamped dither depth above so the
+  // UI can tell "8-bit or deeper panel" apart from "printer declares nothing".
+  const printerPanelBitDepth = useMemo<number | null>(() => {
+    const printerBitDepth = Number(activePrinterProfile?.bitDepth?.bits);
+    if (!Number.isFinite(printerBitDepth) || printerBitDepth <= 0) return null;
+    return Math.round(printerBitDepth);
+  }, [activePrinterProfile?.bitDepth?.bits]);
+  const autoDitherRequiredForPrinter = printerDitherBitDepth != null;
+  // An 8-bit (or deeper) panel emits every grayscale level on its own, so
+  // dithering there can only quantize the layer below the panel's resolution.
+  const ditherForcedOffForPrinter = printerPanelBitDepth != null && printerPanelBitDepth >= 8;
   const effectiveDitherEnabledForSlice = autoDitherRequiredForPrinter
     ? true
-    : profileAntiAliasingSettings.ditherEnabled;
+    : ditherForcedOffForPrinter
+      ? false
+      : profileAntiAliasingSettings.ditherEnabled;
   const effectiveDitherBitDepthForSlice = printerDitherBitDepth
     ?? Math.max(2, Math.min(7, Math.round(profileAntiAliasingSettings.ditherBitDepth ?? 3)));
   const effectiveDitherDeviceGammaForSlice = Math.max(
@@ -3772,6 +3784,7 @@ export function SlicingPanel({
               <MaterialAntiAliasingSection
                 draft={materialAaEditorDraft}
                 printerDitherBitDepth={printerDitherBitDepth}
+                printerPanelBitDepth={printerPanelBitDepth}
                 onChange={(next) => {
                   setMaterialAaEditorDraft((current) => {
                     if (!current) return current;
@@ -3843,6 +3856,7 @@ export function SlicingPanel({
                 draft={editingSessionAaOverrideDraft}
                 lockActivationToggles
                 printerDitherBitDepth={printerDitherBitDepth}
+                printerPanelBitDepth={printerPanelBitDepth}
                 onChange={(next) => {
                   setEditingSessionAaOverrideDraft((current) => {
                     if (!current) return current;

--- a/src/features/slicing/resolveEffectiveDitherPolicy.ts
+++ b/src/features/slicing/resolveEffectiveDitherPolicy.ts
@@ -1,0 +1,61 @@
+import type { MaterialAntiAliasingSettings, PrinterBitDepth } from '@/features/profiles/profileStore';
+
+export type DitherPolicyInput = {
+    printerProfile: { bitDepth?: PrinterBitDepth };
+    materialProfile: { antiAliasingSettings?: MaterialAntiAliasingSettings };
+    ditherEnabled?: boolean;
+    ditherBitDepth?: number;
+    ditherDeviceGamma?: number;
+};
+
+export type EffectiveDitherPolicy = {
+    ditherEnabled: boolean;
+    ditherBitDepth: number;
+    ditherDeviceGamma: number;
+};
+
+/**
+ * Resolves the dithering policy actually handed to the slicing engine.
+ *
+ * Dithering trades spatial resolution for grey levels the panel cannot emit on
+ * its own, so the declared panel bit depth decides it outright:
+ *
+ *   - below 8 bits: forced on, dithering to the panel's own depth.
+ *   - 8 bits or deeper: forced off. The panel already emits the whole 8-bit
+ *     ramp, so dithering could only quantize the layer *below* what the
+ *     hardware supports — at the default gamma of 3.0, a 7-bit palette doubles
+ *     the largest energy step between adjacent levels (1.17% -> 2.33%).
+ *   - undeclared: the user's choice, at the configured bit depth.
+ */
+export function resolveEffectiveDitherPolicy(options: DitherPolicyInput): EffectiveDitherPolicy {
+    const materialDitherEnabled = options.materialProfile.antiAliasingSettings?.ditherEnabled ?? false;
+    const materialDitherBitDepth = options.materialProfile.antiAliasingSettings?.ditherBitDepth ?? 3;
+    const materialDitherGamma = options.materialProfile.antiAliasingSettings?.ditherDeviceGamma ?? 3.0;
+
+    const configuredDitherEnabled = options.ditherEnabled ?? materialDitherEnabled;
+    const configuredDitherBitDepth = options.ditherBitDepth ?? materialDitherBitDepth;
+    const configuredDitherGamma = options.ditherDeviceGamma ?? materialDitherGamma;
+
+    const printerBitDepthRaw = Number(options.printerProfile.bitDepth?.bits);
+    const printerBitDepth = Number.isFinite(printerBitDepthRaw)
+        ? Math.round(printerBitDepthRaw)
+        : null;
+
+    const hasKnownDisplayBitDepth = printerBitDepth != null && printerBitDepth > 0;
+    const displayNeedsDither = hasKnownDisplayBitDepth && printerBitDepth < 8;
+    const displayCoversFullGreyscale = hasKnownDisplayBitDepth && printerBitDepth >= 8;
+
+    const derivedBitDepth = displayNeedsDither
+        ? Math.max(2, Math.min(7, printerBitDepth as number))
+        : Math.max(2, Math.min(7, Math.round(configuredDitherBitDepth)));
+
+    return {
+        ditherEnabled: displayNeedsDither
+            ? true
+            : displayCoversFullGreyscale
+                ? false
+                : configuredDitherEnabled,
+        ditherBitDepth: derivedBitDepth,
+        ditherDeviceGamma: Math.max(0.5, Math.min(4.0, Number(configuredDitherGamma))),
+    };
+}

--- a/src/features/slicing/sliceExportOrchestrator.ts
+++ b/src/features/slicing/sliceExportOrchestrator.ts
@@ -2,6 +2,7 @@ import type { MaterialProfile, PrinterProfile } from '@/features/profiles/profil
 import type { LoadedModel } from '@/features/scene/useSceneCollectionManager';
 import { buildSolidSliceMeshForWasm } from './rasterLayerZipExport';
 import { clampSliceJobNumber } from './sliceJobLimits';
+import { resolveEffectiveDitherPolicy } from './resolveEffectiveDitherPolicy';
 import { prepareLoadedModelsForOutput } from '@/features/mesh-modifiers/prepareModelGeometry';
 import { resolveOutputFileExtension, resolveOutputFormatVersion, resolveOutputSettingsMode, resolveSlicingFormatDefinition } from './formats/registry';
 import { getSavedSlicingPerformanceSettings, type PngCompressionStrategy } from '@/components/settings/performancePreferences';
@@ -430,36 +431,6 @@ function mergeMetadataOverridesIntoMetadata(
     } catch {
         return metadataJson;
     }
-}
-
-function resolveEffectiveDitherPolicy(options: SliceExportOrchestratorOptions): {
-    ditherEnabled: boolean;
-    ditherBitDepth: number;
-    ditherDeviceGamma: number;
-} {
-    const materialDitherEnabled = options.materialProfile.antiAliasingSettings?.ditherEnabled ?? false;
-    const materialDitherBitDepth = options.materialProfile.antiAliasingSettings?.ditherBitDepth ?? 3;
-    const materialDitherGamma = options.materialProfile.antiAliasingSettings?.ditherDeviceGamma ?? 3.0;
-
-    const configuredDitherEnabled = options.ditherEnabled ?? materialDitherEnabled;
-    const configuredDitherBitDepth = options.ditherBitDepth ?? materialDitherBitDepth;
-    const configuredDitherGamma = options.ditherDeviceGamma ?? materialDitherGamma;
-
-    const printerBitDepthRaw = Number(options.printerProfile.bitDepth?.bits);
-    const printerBitDepth = Number.isFinite(printerBitDepthRaw)
-        ? Math.round(printerBitDepthRaw)
-        : null;
-
-    const hasKnownNon8BitDisplay = printerBitDepth != null && printerBitDepth > 0 && printerBitDepth !== 8;
-    const derivedBitDepth = (printerBitDepth != null && printerBitDepth > 0)
-        ? Math.max(2, Math.min(7, printerBitDepth))
-        : Math.max(2, Math.min(7, Math.round(configuredDitherBitDepth)));
-
-    return {
-        ditherEnabled: hasKnownNon8BitDisplay ? true : configuredDitherEnabled,
-        ditherBitDepth: derivedBitDepth,
-        ditherDeviceGamma: Math.max(0.5, Math.min(4.0, Number(configuredDitherGamma))),
-    };
 }
 
 /**


### PR DESCRIPTION
There is a bug in src/features/slicing/sliceExportOrchestrator.ts:435, in function `resolveEffectiveDitherPolicy`.  If a printer profile declares `bitDepth.bits = 8`:
- `hasKnownNon8BitDisplay` is `false`, so `ditherEnabled` remains as an election for the user.  Correct.
- But `derivedBitDepth` goes through the first code branch (`printerBitDepth > 0` is `true`) and then it runs `Math.min(7, 8) = 7`.

This diff forces dithering on for `bitDepth.bits < 8` and disables it in the UI (without the ability to enable it) for `bitDepth.bits >= 8`.  On the Rust side, it adds `effective_dither_bit_depth()` to SliceJobV3 to control this on the slicing engine.

It also adds 7 new tests to make sure this never happens again (770 pass/0 fail).
